### PR TITLE
LedgerDb: A way to get TxOuts and proofs in one DB transaction

### DIFF
--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -51,6 +51,13 @@ pub trait Ledger: Clone + Send {
         indexes: &[u64],
     ) -> Result<Vec<TxOutMembershipProof>, Error>;
 
+    /// Gets tx outs and proof of memberships for TxOuts with indexes `indices`.
+    /// Returns None for those indices which are out-of-bounds.
+    fn get_tx_outs_and_proofs_of_membership(
+        &self,
+        indices: &[u64],
+    ) -> Result<Vec<Option<(TxOut, TxOutMembershipProof)>>, Error>;
+
     /// Returns true if the Ledger contains the given TxOut public key.
     fn contains_tx_out_public_key(
         &self,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -175,6 +175,13 @@ impl Ledger for MockLedger {
             })
             .collect()
     }
+
+    fn get_tx_outs_and_proofs_of_membership(
+        &self,
+        _indices: &[u64],
+    ) -> Result<Vec<Option<(TxOut, TxOutMembershipProof)>>, Error> {
+        unimplemented!()
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Soundtrack of this PR: https://www.youtube.com/watch?v=DEAz7IvVSMM

### Motivation

This is useful for some backend services that need to do this

### In this PR

Make a way to get multiple TxOuts and membership proofs by index in one db transaction