### PR TITLE
improve behavior of local debugging with enclaves in sw mode

### DIFF
--- a/sgx/urts/src/eprintln.rs
+++ b/sgx/urts/src/eprintln.rs
@@ -7,8 +7,10 @@
 //
 // We print them to slog because that is our logging infrastructure
 //
-// Note: This is deprecated and the eprintln should go away, the logger
-// API is what you should use.
+// Note: This should really only be used for local debugging of patches.
+// There is no global logger infrastructure in the enclave, so this eprintln
+// is all you get, especially when printf debugging something near the FFI layer
+// where you are unlikely to have a Logger object available.
 
 use mc_common::logger::global_log;
 use std::str;


### PR DESCRIPTION

### Motivation

These are some changes that I applied locally when trying to debug stuff at the enclave boundary. on the trusted side
via printf debugging.
Because there is no global logger in the enclave, `eprintln` is pretty much the only logging option for this.
And because the slog async logger can't be flushed, it is useful to ensure that critical messages get out over an additional channel besides the slog logs, otherwise all you get is "enclave SIGILL".

### In this PR

Make enclave panic messages go out on STDERR as well as slog, in debug builds.
Add improved comments about the enclave eprintln functionality.

### Future Work

Improve the slog backend