### PR TITLE
Implement HSM cold storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,7 @@ dependencies = [
 name = "mc-consensus-enclave-impl"
 version = "0.6.0"
 dependencies = [
+ "blake2",
  "cfg-if",
  "digest 0.9.0",
  "mbedtls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,7 @@ dependencies = [
  "mc-sgx-compat",
  "mc-sgx-report-cache-api",
  "mc-sgx-slog",
+ "mc-sgx-types",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-util-build-script",

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -230,12 +230,27 @@ message SignatureRctBulletproofs {
     bytes range_proofs = 3;
 }
 
+message HsmParams {
+    int32 tx_type = 1;
+
+    bytes input_signature = 2;
+    bytes input_ecdsa_key = 3;
+    bytes input_target_key = 4;
+
+    bytes output_signature = 5;
+    bytes output_ecdsa_key = 6;
+    bytes output_target_key = 7;
+}
+
 message Tx {
     // The actual contents of the transaction.
     TxPrefix prefix = 1;
 
     // The RingCT signature on the prefix.
     SignatureRctBulletproofs signature = 2;
+
+    // The HSM transaction parameters
+    HsmParams hsm_params = 3;
 }
 
 message TxHash {

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -371,7 +371,7 @@ impl TryFrom<&external::Tx> for tx::Tx {
         let signature = SignatureRctBulletproofs::try_from(source.get_signature())?;
         let mut hsm_params: Option<tx::HsmParams> = None;
         if source.get_hsm_params().get_tx_type() != tx::HsmTxType::None as i32 {
-            hsm_params = Some(tx::HsmParams{
+            hsm_params = Some(tx::HsmParams {
                 tx_type: source.get_hsm_params().get_tx_type(),
                 input_signature: source.get_hsm_params().get_input_signature().to_vec(),
                 input_ecdsa_key: source.get_hsm_params().get_input_ecdsa_key().to_vec(),
@@ -381,7 +381,11 @@ impl TryFrom<&external::Tx> for tx::Tx {
                 output_target_key: source.get_hsm_params().get_output_target_key().to_vec(),
             });
         }
-        Ok(tx::Tx { prefix, signature, hsm_params })
+        Ok(tx::Tx {
+            prefix,
+            signature,
+            hsm_params,
+        })
     }
 }
 

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -369,7 +369,19 @@ impl TryFrom<&external::Tx> for tx::Tx {
     fn try_from(source: &external::Tx) -> Result<Self, Self::Error> {
         let prefix = tx::TxPrefix::try_from(source.get_prefix())?;
         let signature = SignatureRctBulletproofs::try_from(source.get_signature())?;
-        Ok(tx::Tx { prefix, signature })
+        let mut hsm_params: Option<tx::HsmParams> = None;
+        if source.get_hsm_params().get_tx_type() != tx::HsmTxType::None as i32 {
+            hsm_params = Some(tx::HsmParams{
+                tx_type: source.get_hsm_params().get_tx_type(),
+                input_signature: source.get_hsm_params().get_input_signature().to_vec(),
+                input_ecdsa_key: source.get_hsm_params().get_input_ecdsa_key().to_vec(),
+                input_target_key: source.get_hsm_params().get_input_target_key().to_vec(),
+                output_signature: source.get_hsm_params().get_output_signature().to_vec(),
+                output_ecdsa_key: source.get_hsm_params().get_output_ecdsa_key().to_vec(),
+                output_target_key: source.get_hsm_params().get_output_target_key().to_vec(),
+            });
+        }
+        Ok(tx::Tx { prefix, signature, hsm_params })
     }
 }
 

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -386,7 +386,7 @@ impl TryFrom<&external::HsmParams> for tx::HsmParams {
     }
 }
 
-/// Convert mc_transaction_core::tx::Tx --> external::Tx.
+/// Convert mc_transaction_core::tx::HsmParams --> external::HsmParams.
 impl From<&tx::Tx> for external::Tx {
     fn from(source: &tx::Tx) -> Self {
         let mut tx = external::Tx::new();

--- a/api/src/conversions.rs
+++ b/api/src/conversions.rs
@@ -392,23 +392,7 @@ impl From<&tx::Tx> for external::Tx {
         let mut tx = external::Tx::new();
         tx.set_prefix(external::TxPrefix::from(&source.prefix));
         tx.set_signature(external::SignatureRctBulletproofs::from(&source.signature));
-
-        match &source.hsm_params {
-            Some(hsm_params) => tx.set_hsm_params(external::HsmParams::from(hsm_params)),
-            None => {
-                let mut params = external::HsmParams::new();
-                params.set_tx_type(tx::HsmTxType::None as i32);
-                params.set_input_signature(Vec::new());
-                params.set_input_ecdsa_key(Vec::new());
-                params.set_input_target_key(Vec::new());
-
-                params.set_output_signature(Vec::new());
-                params.set_output_ecdsa_key(Vec::new());
-                params.set_output_target_key(Vec::new());
-
-                tx.set_hsm_params(params);
-            }
-        }
+        tx.set_hsm_params(external::HsmParams::from(&source.hsm_params));
 
         tx
     }
@@ -421,10 +405,8 @@ impl TryFrom<&external::Tx> for tx::Tx {
     fn try_from(source: &external::Tx) -> Result<Self, Self::Error> {
         let prefix = tx::TxPrefix::try_from(source.get_prefix())?;
         let signature = SignatureRctBulletproofs::try_from(source.get_signature())?;
-        let mut hsm_params: Option<tx::HsmParams> = None;
-        if source.get_hsm_params().get_tx_type() != tx::HsmTxType::None as i32 {
-            hsm_params = Some(tx::HsmParams::try_from(source.get_hsm_params())?);
-        }
+        let hsm_params = tx::HsmParams::try_from(source.get_hsm_params())?;
+
         Ok(tx::Tx {
             prefix,
             signature,

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -58,6 +58,10 @@ pub enum Error {
     /// Key error
     #[fail(display = "Key error")]
     Key(KeyError),
+
+    /// HSM error
+    #[fail(display = "HSM error")]
+    Hsm,
 }
 
 impl From<MessageCipherError> for Error {
@@ -125,4 +129,3 @@ impl From<KeyError> for Error {
         Error::Key(src)
     }
 }
-

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -6,7 +6,7 @@ use alloc::string::String;
 use failure::Fail;
 use mc_attest_core::SgxError;
 use mc_attest_enclave_api::Error as AttestEnclaveError;
-use mc_crypto_keys::Ed25519SignatureError;
+use mc_crypto_keys::{Ed25519SignatureError, KeyError};
 use mc_crypto_message_cipher::CipherError as MessageCipherError;
 use mc_sgx_compat::sync::PoisonError;
 use mc_transaction_core::validation::TransactionValidationError;
@@ -54,6 +54,10 @@ pub enum Error {
     /// Signature error
     #[fail(display = "Signature error")]
     Signature,
+
+    /// Key error
+    #[fail(display = "Key error")]
+    Key(KeyError),
 }
 
 impl From<MessageCipherError> for Error {
@@ -115,3 +119,10 @@ impl From<Ed25519SignatureError> for Error {
         Error::Signature
     }
 }
+
+impl From<KeyError> for Error {
+    fn from(src: KeyError) -> Error {
+        Error::Key(src)
+    }
+}
+

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -40,6 +40,7 @@ mc-crypto-message-cipher = { path = "../../../crypto/message-cipher" }
 mc-sgx-compat = { path = "../../../sgx/compat" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
 mc-sgx-slog = { path = "../../../sgx/slog" }
+mc-sgx-types = { path = "../../../sgx/types" }
 mc-transaction-core = { path = "../../../transaction/core" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -47,6 +47,7 @@ mc-util-serial = { path = "../../../util/serial" }
 
 mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", tag = "mc-0.3", default-features = false, features = ["aesni", "rdrand", "force_aesni_support"] }
 
+blake2 = { version = "0.9.0", default-features = false, features = ["simd"] }
 cfg-if = "0.1"
 digest = { version = "0.9", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -328,7 +328,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         mc_transaction_core::validation::validate(&tx, block_index, &proofs, &mut csprng)?;
 
         // XXX TODO: check ECDSA signature on HsmParams
-        
+
         // Convert into a well formed encrypted transaction + context.
         let well_formed_tx_context = WellFormedTxContext::from(&tx);
         let well_formed_tx = WellFormedTx::from(tx);
@@ -399,7 +399,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             )?;
 
             // XXX TODO: check ECDSA signature on HsmParams
-            
+
             for proof in proofs {
                 let root_element = proof
                     .elements
@@ -465,8 +465,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         }
 
         // XXX TODO: alter TxOuts for HSM transactions
-        
-        
+
         // Create an aggregate fee output.
         let fee_tx_private_key = {
             let hash_value: [u8; 32] = {
@@ -497,7 +496,6 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         }
         outputs.push(fee_output);
 
-        
         // Sort outputs and key images. This removes ordering information which could be used to
         // infer the per-transaction relationships among outputs and/or key images.
         outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -327,6 +327,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let mut csprng = McRng::default();
         mc_transaction_core::validation::validate(&tx, block_index, &proofs, &mut csprng)?;
 
+        // XXX TODO: check ECDSA signature on HsmParams
+        
         // Convert into a well formed encrypted transaction + context.
         let well_formed_tx_context = WellFormedTxContext::from(&tx);
         let well_formed_tx = WellFormedTx::from(tx);
@@ -396,6 +398,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 &mut rng,
             )?;
 
+            // XXX TODO: check ECDSA signature on HsmParams
+            
             for proof in proofs {
                 let root_element = proof
                     .elements
@@ -460,6 +464,9 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             }
         }
 
+        // XXX TODO: alter TxOuts for HSM transactions
+        
+        
         // Create an aggregate fee output.
         let fee_tx_private_key = {
             let hash_value: [u8; 32] = {
@@ -490,6 +497,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         }
         outputs.push(fee_output);
 
+        
         // Sort outputs and key images. This removes ordering information which could be used to
         // infer the per-transaction relationships among outputs and/or key images.
         outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
 name = "mc-consensus-enclave-impl"
 version = "0.6.0"
 dependencies = [
+ "blake2 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mbedtls 0.5.1 (git+https://github.com/mobilecoinofficial/rust-mbedtls.git?tag=mc-0.3)",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "mc-sgx-compat 0.6.0",
  "mc-sgx-report-cache-api 0.6.0",
  "mc-sgx-slog 0.6.0",
+ "mc-sgx-types 0.6.0",
  "mc-transaction-core 0.6.0",
  "mc-util-build-script 0.6.0",
  "mc-util-from-random 0.6.0",

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -61,6 +61,13 @@ impl Digestible for u32 {
     }
 }
 
+impl Digestible for i32 {
+    #[inline]
+    fn digest<D: Digest>(&self, hasher: &mut D) {
+        hasher.input(&self.to_le_bytes())
+    }
+}
+
 impl Digestible for u64 {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -64,7 +64,7 @@ impl Digestible for u32 {
 impl Digestible for i32 {
     #[inline]
     fn digest<D: Digest>(&self, hasher: &mut D) {
-        hasher.input(&self.to_le_bytes())
+        hasher.update(&self.to_le_bytes())
     }
 }
 

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -15,7 +15,7 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
-use digest::generic_array::typenum::U32;
+use digest::{consts::U64, generic_array::typenum::U32};
 use hex_fmt::HexFmt;
 use mc_crypto_digestible::Digestible;
 use mc_util_from_random::FromRandom;
@@ -228,6 +228,11 @@ impl RistrettoPublic {
     // This is okay in non-generic code
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
+    }
+
+    pub fn hash_from_bytes<D: Digest<OutputSize = U64> + Default>(input: &[u8]) -> Self {
+        let point = RistrettoPoint::hash_from_bytes::<D>(input);
+        Self(point)
     }
 }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -114,7 +114,7 @@ pub enum HsmTxType {
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Message, Digestible)]
 pub struct HsmParams {
     /// The transaction type, use an int because prost doesn't deal well with rust enums
-    #[prost(enumeration="HsmTxType", required, tag = "1")]
+    #[prost(enumeration = "HsmTxType", required, tag = "1")]
     pub tx_type: i32,
 
     /// The ECDSA signature for the input txo, used for withdrawals and transfers
@@ -143,7 +143,11 @@ pub struct HsmParams {
 }
 
 impl HsmParams {
-    pub fn new_deposit(output_signature: Vec<u8>, output_ecdsa_key: Vec<u8>, output_target_key: Vec<u8>) -> Self {
+    pub fn new_deposit(
+        output_signature: Vec<u8>,
+        output_ecdsa_key: Vec<u8>,
+        output_target_key: Vec<u8>,
+    ) -> Self {
         Self {
             tx_type: HsmTxType::Deposit as i32,
             input_signature: Vec::new(),
@@ -155,7 +159,11 @@ impl HsmParams {
         }
     }
 
-    pub fn new_withdrawal(input_signature: Vec<u8>, input_ecdsa_key: Vec<u8>, input_target_key: Vec<u8>) -> Self {
+    pub fn new_withdrawal(
+        input_signature: Vec<u8>,
+        input_ecdsa_key: Vec<u8>,
+        input_target_key: Vec<u8>,
+    ) -> Self {
         Self {
             tx_type: HsmTxType::Withdrawal as i32,
             input_signature,
@@ -599,7 +607,11 @@ mod tests {
         // TODO: use a meaningful signature.
         let signature = SignatureRctBulletproofs::default();
 
-        let tx = Tx { prefix, signature, hsm_params: None };
+        let tx = Tx {
+            prefix,
+            signature,
+            hsm_params: None,
+        };
 
         let mut buf = Vec::new();
         tx.encode(&mut buf).expect("failed to serialize into slice");

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -143,6 +143,18 @@ pub struct HsmParams {
 }
 
 impl HsmParams {
+    pub fn new() -> HsmParams {
+        HsmParams {
+            tx_type: HsmTxType::None as i32,
+            input_signature: Vec::new(),
+            input_ecdsa_key: Vec::new(),
+            input_target_key: Vec::new(),
+            output_signature: Vec::new(),
+            output_ecdsa_key: Vec::new(),
+            output_target_key: Vec::new(),
+        }
+    }
+
     pub fn new_deposit(
         output_signature: Vec<u8>,
         output_ecdsa_key: Vec<u8>,
@@ -187,9 +199,11 @@ pub struct Tx {
     #[prost(message, required, tag = "2")]
     pub signature: SignatureRctBulletproofs,
 
-    /// Optional HSM transaction parameters
-    #[prost(message, tag = "3")]
-    pub hsm_params: Option<HsmParams>,
+    /// Optional HSM transaction parameters; set as
+    /// HsmParams::default() if not needed
+    ///
+    #[prost(message, required, tag = "3")]
+    pub hsm_params: HsmParams,
 }
 
 impl fmt::Display for Tx {
@@ -550,7 +564,7 @@ mod tests {
         constants::MINIMUM_FEE,
         encrypted_fog_hint::EncryptedFogHint,
         ring_signature::SignatureRctBulletproofs,
-        tx::{Tx, TxIn, TxOut, TxPrefix},
+        tx::{HsmParams, Tx, TxIn, TxOut, TxPrefix},
     };
     use alloc::vec::Vec;
     use mc_crypto_keys::RistrettoPublic;
@@ -610,7 +624,7 @@ mod tests {
         let tx = Tx {
             prefix,
             signature,
-            hsm_params: None,
+            hsm_params: HsmParams::new(),
         };
 
         let mut buf = Vec::new();

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -14,7 +14,7 @@ use mc_transaction_core::{
     fog_hint::FogHint,
     onetime_keys::compute_shared_secret,
     ring_signature::SignatureRctBulletproofs,
-    tx::{Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
+    tx::{HsmParams, Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
     CompressedCommitment,
 };
 use mc_util_from_random::FromRandom;
@@ -188,7 +188,7 @@ impl TransactionBuilder {
         Ok(Tx {
             prefix: tx_prefix,
             signature,
-            hsm_params: None,
+            hsm_params: HsmParams::new(),
         })
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -188,6 +188,7 @@ impl TransactionBuilder {
         Ok(Tx {
             prefix: tx_prefix,
             signature,
+            hsm_params: None,
         })
     }
 }


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Some partners require cold storage using an HSM in order to satisfy compliance. We will use the HSM to provide ECDSA signatures, allowing us to store the cold storage transactions on the chain but preventing them from being spent without the private keys on the HSM.

### In this PR
* Add HsmParams and use in transaction::tx::Tx and external::Tx
* Update consensus enclave to do ECDSA checks and alter TxOuts for HSM transactions

Fixes #MCC-1193

### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

