### PR TITLE
allow mobilecoind-json to accept more than one payload (MCC-1887)

### DIFF
--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -20,6 +20,7 @@ rocket = { version = "0.4.5", default-features = false }
 rocket_contrib = { version = "0.4.5", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
+serde_json = "1.0"
 structopt = "0.3"
 protobuf = "2.12"
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -484,13 +484,12 @@ fn check_transfer_status(
     receipt: String,
 ) -> Result<Json<JsonStatusResponse>, String> {
     // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
-    let receipt: JsonSenderTxReceipt = match serde_json::from_str(&receipt) {
-        Ok(x) => Ok(x),
-        Err(_) => match serde_json::from_str::<JsonSendPaymentResponse>(&receipt) {
-            Ok(x) => Ok(x.sender_tx_receipt),
-            Err(x) => Err(x),
-        },
-    }.map_err(|err| format!("Failed to parse receipt: {}", err))?;
+    let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
+        .or_else({
+            let receipt: JsonSendPaymentResponse = serde_json::from_str(&receipt)?;
+            receipt.sender_tx_receipt
+        })
+        .map_err(|err| format!("Failed to parse receipt: {}", err))?;
 
     let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
     let mut key_images = Vec::new();

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -485,8 +485,10 @@ fn check_transfer_status(
 ) -> Result<Json<JsonStatusResponse>, String> {
     // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
     let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
-        .or_else(serde_json::from_str::<JsonSendPaymentResponse>(&receipt))
-        .map(|response| response.sender_tx_receipt)
+        .or_else(
+            || serde_json::from_str::<JsonSendPaymentResponse>(&receipt)
+            .map(|response| response.sender_tx_receipt)
+        )
         .map_err(|err| format!("Failed to parse receipt: {}", err))?;
 
     let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -485,10 +485,8 @@ fn check_transfer_status(
 ) -> Result<Json<JsonStatusResponse>, String> {
     // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
     let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
-        .or_else({
-            let receipt: JsonSendPaymentResponse = serde_json::from_str(&receipt)?;
-            receipt.sender_tx_receipt
-        })
+        .or_else(serde_json::from_str<JsonSendPaymentResponse>(&receipt))
+        .map(|response| response.sender_tx_receipt)
         .map_err(|err| format!("Failed to parse receipt: {}", err))?;
 
     let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -483,7 +483,7 @@ fn check_transfer_status(
     state: rocket::State<State>,
     receipt: String,
 ) -> Result<Json<JsonStatusResponse>, String> {
-    // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
+    // allow receipt to be either JsonSendPaymentResponse or JsonSenderTxReceipt
     let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
         .or_else(
             |_| serde_json::from_str::<JsonSendPaymentResponse>(&receipt)
@@ -516,7 +516,7 @@ fn check_transfer_status(
 /// Checks the status of a transfer given data for a specific receiver
 /// The sender of the transaction will take specific receipt data from the /transfer call
 /// and distribute it to the recipient(s) so they can verify that a transaction has been
-/// processed and the the person supplying the receipt can prove they intiated it
+/// processed and the the person supplying the receipt can prove they initiated it
 #[post("/tx/status-as-receiver", format = "json", data = "<receipt>")]
 fn check_receiver_transfer_status(
     state: rocket::State<State>,

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -69,7 +69,7 @@ fn account_key(
 }
 
 /// Creates a monitor. Data for the key and range is POSTed using the struct above.
-#[post("/monitors", format = "json", data = "<monitor>")]
+#[post("/monitors", format = "application/json", data = "<monitor>")]
 fn add_monitor(
     state: rocket::State<State>,
     monitor: Json<JsonMonitorRequest>,
@@ -216,7 +216,7 @@ fn public_address(
 }
 
 /// Generates a request code with an optional value and memo
-#[post("/codes/request", format = "json", data = "<request>")]
+#[post("/codes/request", format = "application/json", data = "<request>")]
 fn create_request_code(
     state: rocket::State<State>,
     request: Json<JsonCreateRequestCodeRequest>,
@@ -266,7 +266,7 @@ fn parse_request_code(
 }
 
 /// Generates an address code
-#[post("/codes/address", format = "json", data = "<request>")]
+#[post("/codes/address", format = "application/json", data = "<request>")]
 fn create_address_code(
     state: rocket::State<State>,
     request: Json<JsonCreateAddressCodeRequest>,
@@ -306,7 +306,7 @@ fn parse_address_code(
 /// Performs a transfer from a monitor and subaddress. The public keys and amount are in the POST data.
 #[post(
     "/monitors/<monitor_hex>/subaddresses/<subaddress_index>/build-and-submit",
-    format = "json",
+    format = "application/json",
     data = "<transfer>"
 )]
 fn build_and_submit(
@@ -358,7 +358,7 @@ fn build_and_submit(
 /// Performs a transfer from a monitor and subaddress to a given address code/amount.
 #[post(
     "/monitors/<monitor_hex>/subaddresses/<subaddress_index>/pay-address-code",
-    format = "json",
+    format = "application/json",
     data = "<transfer>"
 )]
 fn pay_address_code(
@@ -406,7 +406,7 @@ fn pay_address_code(
 /// machine for submission, via submit-tx.
 #[post(
     "/monitors/<monitor_hex>/subaddresses/<subaddress_index>/generate-request-code-transaction",
-    format = "json",
+    format = "application/json",
     data = "<request>"
 )]
 fn generate_request_code_transaction(
@@ -456,7 +456,7 @@ fn generate_request_code_transaction(
 }
 
 /// Submit a prepared TxProposal
-#[post("/submit-tx", format = "json", data = "<proposal>")]
+#[post("/submit-tx", format = "application/json", data = "<proposal>")]
 fn submit_tx(
     state: rocket::State<State>,
     proposal: Json<JsonTxProposalRequest>,
@@ -478,7 +478,7 @@ fn submit_tx(
 }
 
 /// Checks the status of a transfer given a key image and tombstone block
-#[post("/tx/status-as-sender", data = "<receipt>")]
+#[post("/tx/status-as-sender", format = "application/json", data = "<receipt>")]
 fn check_transfer_status(
     state: rocket::State<State>,
     receipt: String,
@@ -517,7 +517,7 @@ fn check_transfer_status(
 /// The sender of the transaction will take specific receipt data from the /transfer call
 /// and distribute it to the recipient(s) so they can verify that a transaction has been
 /// processed and the the person supplying the receipt can prove they initiated it
-#[post("/tx/status-as-receiver", format = "json", data = "<receipt>")]
+#[post("/tx/status-as-receiver", format = "application/json", data = "<receipt>")]
 fn check_receiver_transfer_status(
     state: rocket::State<State>,
     receipt: Json<JsonReceiverTxReceipt>,

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -485,7 +485,7 @@ fn check_transfer_status(
 ) -> Result<Json<JsonStatusResponse>, String> {
     // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
     let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
-        .or_else(serde_json::from_str<JsonSendPaymentResponse>(&receipt))
+        .or_else(serde_json::from_str::<JsonSendPaymentResponse>(&receipt))
         .map(|response| response.sender_tx_receipt)
         .map_err(|err| format!("Failed to parse receipt: {}", err))?;
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -486,7 +486,7 @@ fn check_transfer_status(
     // allow receipt to be submitted as either JsonSendPaymentResponse or JsonSenderTxReceipt
     let receipt: JsonSenderTxReceipt = serde_json::from_str(&receipt)
         .or_else(
-            || serde_json::from_str::<JsonSendPaymentResponse>(&receipt)
+            |_| serde_json::from_str::<JsonSendPaymentResponse>(&receipt)
             .map(|response| response.sender_tx_receipt)
         )
         .map_err(|err| format!("Failed to parse receipt: {}", err))?;


### PR DESCRIPTION
# Motivation

There are at least three APIs that would benefit from accepting either the complete output of a previous command, or just the relevant data that is required. I am opening this draft to invite discussion over what pattern we want to use for this.

fixes MCC-1887
