### PR TITLE
GRPC Admin Utility + mobilecoind admin endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,6 +3545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-grpc-admin-tool"
+version = "1.0.0"
+dependencies = [
+ "grpcio",
+ "mc-common",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "percent-encoding 2.1.0",
+ "serde",
+ "structopt",
+]
+
+[[package]]
 name = "mc-util-grpc-token-generator"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ members = [
     "util/from-random",
     "util/generate-sample-ledger",
     "util/grpc",
+    "util/grpc-admin-tool",
     "util/grpc-token-generator",
     "util/host-cert",
     "util/keyfile",

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -141,7 +141,7 @@ pipeline {
             }
             container('kaniko'){
               sh '''
-                  for i in 1 2 3; do              
+                  for i in 1 2 3; do
                     /kaniko/executor -f $WORKSPACE/ops/Dockerfile-mobilecoind -c $WORKSPACE/ops \
                       --build-arg ORIGIN_DATA_DIR=sample_data \
                       --build-arg GIT_COMMIT=${GIT_COMMIT} \
@@ -190,7 +190,7 @@ pipeline {
 
                   // Update the 01* configs
                   sh(script: 'for i in 01*yaml; do kubectl apply -n ${NETWORK} -f ${i}; done')
-                  
+
                   // Launch the consensus node deployments
                   sh(script: 'for i in 03*yaml; do kubectl apply -n ${NETWORK} -f ${i}; done')
 

--- a/jenkins/packaging-pod.yaml
+++ b/jenkins/packaging-pod.yaml
@@ -20,7 +20,7 @@ spec:
           topologyKey: "kubernetes.io/hostname"
 
   containers:
-  
+
     - name: kaniko
       # Need the debug container to get busybox
       image: gcr.io/kaniko-project/executor:debug-v0.23.0

--- a/ops/Dockerfile-consensus
+++ b/ops/Dockerfile-consensus
@@ -72,6 +72,7 @@ COPY bin/consensus-service /usr/bin/
 COPY bin/ledger-distribution /usr/bin/
 COPY bin/mc-admin-http-gateway /usr/bin/
 COPY bin/mc-ledger-migration /usr/bin/
+COPY bin/mc-util-grpc-admin-tool /usr/bin/
 
 # Q: Why not use NODE_LEDGER_DIR here?
 # A: The ENV dictates where the app actually looks, and the ARG sets

--- a/ops/Dockerfile-mobilecoind
+++ b/ops/Dockerfile-mobilecoind
@@ -28,6 +28,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 WORKDIR /
 COPY bin/mobilecoind /usr/bin/
+COPY bin/mc-util-grpc-admin-tool /usr/bin/
 
 # Q: Why not use NODE_LEDGER_DIR here?
 # A: The ENV dictates where the app actually looks, and the ARG sets

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -410,7 +410,7 @@ class Network:
             )
 
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-mobilecoind {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-mobilecoind -p mc-util-grpc-admin-tool {CARGO_FLAGS}',
             shell=True,
             check=True,
         )

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mc-util-grpc-admin-tool"
+version = "1.0.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[[bin]]
+name = "mc-util-grpc-admin-tool"
+path = "src/bin/main.rs"
+
+[dependencies]
+mc-common = { path = "../../common", features = ["std"] }
+mc-util-grpc = { path = "../grpc" }
+mc-util-uri = { path = "../uri" }
+
+grpcio = "0.6.0"
+percent-encoding = "2.1.0"
+structopt = "0.3"
+
+[build-dependencies]
+# Even though this is unused, it needs to be here otherwise Cargo brings in some weird mixture of packages/features that refuses to compile.
+# Go figure ¯\_(ツ)_/¯
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }

--- a/util/grpc-admin-tool/src/bin/main.rs
+++ b/util/grpc-admin-tool/src/bin/main.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+//! A utility for issueing admin GRPC requests.
+
+use grpcio::ChannelBuilder;
+use mc_util_grpc::{
+    admin::SetRustLogRequest, admin_grpc::AdminApiClient, empty::Empty, ConnectionUriGrpcioChannel,
+};
+use mc_util_uri::AdminUri;
+use std::{str::FromStr, sync::Arc};
+use structopt::StructOpt;
+
+#[derive(Clone, StructOpt)]
+pub struct Config {
+    /// URI to connect to
+    #[structopt(long)]
+    pub uri: String,
+
+    #[structopt(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Clone, StructOpt)]
+pub enum Command {
+    /// Get Prometheus metrics.
+    Metrics,
+
+    /// Get information such as build info, logging configuration, etc.
+    GetInfo,
+
+    /// Update the logging level (RUST_LOG).
+    SetRustLog {
+        /// New RUST_LOG value to use
+        rust_log: String,
+    },
+
+    /// Logs a test error message.
+    TestLogError,
+}
+
+fn main() {
+    mc_common::setup_panic_handler();
+    let (logger, _global_logger_guard) =
+        mc_common::logger::create_app_logger(mc_common::logger::o!());
+    let config = Config::from_args();
+
+    let env = Arc::new(grpcio::EnvBuilder::new().build());
+    let uri = AdminUri::from_str(&config.uri).expect("failed to parse uri");
+    let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&uri, &logger);
+    let client = AdminApiClient::new(ch);
+
+    match config.cmd {
+        Command::Metrics => {
+            let response = client
+                .get_prometheus_metrics(&Empty::new())
+                .expect("failed calling get_prometheus_metrics");
+            println!("{}", response.metrics);
+        }
+
+        Command::GetInfo => {
+            let response = client
+                .get_info(&Empty::new())
+                .expect("failed calling get_info");
+
+            println!("Service name: {}", response.name);
+            println!("Service id:   {}", response.id);
+            println!("RUST_LOG:     {}", response.rust_log);
+            println!("Build info:   {}", response.build_info_json);
+            println!("Config json:  {}", response.config_json);
+        }
+
+        Command::SetRustLog { rust_log } => {
+            let mut request = SetRustLogRequest::new();
+            request.set_rust_log(rust_log);
+
+            let _ = client
+                .set_rust_log(&request)
+                .expect("failed calling set_rust_log");
+            println!("Done.");
+        }
+
+        Command::TestLogError => {
+            let _ = client
+                .test_log_error(&Empty::new())
+                .expect("failed calling test_log_error");
+            println!("Done.");
+        }
+    };
+
+    // Give logger a moment to flush :/
+    std::thread::sleep(std::time::Duration::from_millis(500));
+}


### PR DESCRIPTION
### Motivation

* The admin endpoint is useful for debugging and it's desirable to make it easy to use. This PR adds a small command line utility for making requests against an admin endpoint (e.g. `cargo run -p mc-util-grpc-admin-tool -- --uri insecure-mca://127.0.0.1:4444/ set-rust-log debug`
* It's desirable to be able to query a running `mobilecoind` for build information, and to change its log level. This can easily be achieved by having it package the grpc admin service into its rpc endpoint.

### In this PR
* Adding `mc-util-grpc-admin-tool`
* Adding `AdminService` to`mobilecoind`
* Including the `mc-util-grpc-admin-tool` binary in containers
* Cleaning up some whitespaces

### Future Work
* Include it in all the internal containers

