### PR TITLE
mobilecoinofficial -> mobilecoinfoundation [MCC-2022]

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -115,4 +115,4 @@ using the Remote Attestation process.
 
 If you want to download a prebuilt enclave, signed using the production signing key, in order use `IAS_MODE=PROD`
 and participate in a production-environment network, check out the `enclave-signing-material` instructions:
-https://github.com/mobilecoinofficial/mobilecoin/blob/master/consensus/service/BUILD.md#enclave-signing-material
+https://github.com/mobilecoinfoundation/mobilecoin/blob/master/consensus/service/BUILD.md#enclave-signing-material

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 MobileCoin is a prototype that is being actively developed.
 
-Please report issues to https://github.com/mobilecoinofficial/mobilecoin/issues.
+Please report issues to https://github.com/mobilecoinfoundation/mobilecoin/issues.
 
 1. Search both open and closed tickets to make sure your bug report is not a duplicate.
 1. Do not use github issues as a forum. To participate in community discussions, please use the community forum at [community.mobilecoin.com](https://community.mobilecoin.com).

--- a/TESTNET.md
+++ b/TESTNET.md
@@ -18,7 +18,7 @@ Register to participate in the MobileCoin TestNet to receive an allocation of *m
 
 You can make your first MobileCoin payment right now!
 
-1. Download the TestNet client package for [mac](https://github.com/mobilecoinofficial/mobilecoin/releases/latest/download/MobileCoin.TestNet.dmg) or [linux](https://github.com/mobilecoinofficial/mobilecoin/releases/latest/download/mobilecoin-testnet-linux.tar.gz).
+1. Download the TestNet client package for [mac](https://github.com/mobilecoinfoundation/mobilecoin/releases/latest/download/MobileCoin.TestNet.dmg) or [linux](https://github.com/mobilecoinfoundation/mobilecoin/releases/latest/download/mobilecoin-testnet-linux.tar.gz).
 
 1. Expand the package archive and launch the "MobileCoin TestNet" client, an app bundle (mac) or shell script (linux).
 
@@ -32,7 +32,7 @@ You can make your first MobileCoin payment right now!
 
 If you have a Linux-compatible home computer, or if you are willing to operate a Linux-compatible server in the cloud, you can run a *watcher node* in the MobileCoin TestNet.
 
-1. Clone the official MobileCoin repository at [Github](https://github.com/mobilecoinofficial/mobilecoin).
+1. Clone the official MobileCoin repository at [Github](https://github.com/mobilecoinfoundation/mobilecoin).
 
 1. Make sure you've installed [Docker](https://docs.docker.com/get-docker/) and [Python](https://www.python.org/downloads/).
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -12,9 +12,9 @@
 ORIGIN="$1"
 REMOTE_URL="$2"
 
-if [[ "$REMOTE_URL" == *"mobilecoinofficial/"* ]]; then
+if [[ "$REMOTE_URL" == *"mobilecoinfoundation/"* ]]; then
   echo
-  echo "Prevented pushing to mobilecoinofficial/mobilecoin. Please push to your fork instead."
+  echo "Prevented pushing to mobilecoinfoundation/mobilecoin. Please push to your fork instead."
   echo "If you really want to do this, use --no-verify to bypass this pre-push hook."
   echo
   exit 1

--- a/mobilecoind/clients/java/mob_client/README.md
+++ b/mobilecoind/clients/java/mob_client/README.md
@@ -4,7 +4,7 @@ This code serves both as an example of how to use the services provided by mobil
 in Java through gRPC and as a CLI tool to interact with mobilecoind.
 
 To use it, you must have an instance of mobilecoind running, this is typically run
-locally. You can find instructions at https://github.com/mobilecoinofficial/mobilecoin/tree/master/mobilecoind
+locally. You can find instructions at https://github.com/mobilecoinfoundation/mobilecoin/tree/master/mobilecoind
 
 A gradle wrapper is included, `gradlew` (or `gradlew.bat` on Windows). The most simple call, assuming you are running
 mobilecoind on port 4444 is to create a new root entropy key with the command

--- a/mobilecoind/clients/python/lib/README.md
+++ b/mobilecoind/clients/python/lib/README.md
@@ -2,7 +2,7 @@
 
 You must separately install and run `mobilecoind`.
 
-See https://github.com/mobilecoinofficial/mobilecoin/ for details.
+See https://github.com/mobilecoinfoundation/mobilecoin/ for details.
 
 ### Example
 

--- a/mobilecoind/clients/python/lib/setup.py
+++ b/mobilecoind/clients/python/lib/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     description="Python bindings for the MobileCoin daemon API.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/mobilecoinofficial/mobilecoin/tree/master/mobilecoind/clients/python/lib",
+    url="https://github.com/mobilecoinfoundation/mobilecoin/tree/master/mobilecoind/clients/python/lib",
     package_data={'mobilecoin': ['py.typed']},
     packages=['mobilecoin'],
     classifiers=[

--- a/mobilecoind/clients/python/start_mobilecoind.sh
+++ b/mobilecoind/clients/python/start_mobilecoind.sh
@@ -34,7 +34,7 @@ fi
 # install mobilecoind from the current TestNet release
 echo "Installing mobilecoind from latest $RELEASE_URL..."
 rm -rf $TMP_DIR/$RELEASE_DIR
-curl -L https://github.com/mobilecoinofficial/mobilecoin/releases/latest/download/$RELEASE_URL.tar.gz --output latest.tar.gz
+curl -L https://github.com/mobilecoinfoundation/mobilecoin/releases/latest/download/$RELEASE_URL.tar.gz --output latest.tar.gz
 tar -zxvf ./latest.tar.gz
 rm ./latest.tar.gz
 mv ./$RELEASE_DIR $TMP_DIR

--- a/sgx/ias-types/Cargo.toml
+++ b/sgx/ias-types/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 edition = "2018"
 
 [badges]
-circle-ci = { repository = "mobilecoinofficial/mobilecoin", branch = "master" }
+circle-ci = { repository = "mobilecoinfoundation/mobilecoin", branch = "master" }
 
 [package.metadata.docs.rs]
 features = ["use_prost"]

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -15,7 +15,7 @@ import time
 
 parser = argparse.ArgumentParser(description='Download and test mobilecoind / mirror and json gateway')
 parser.add_argument('entropy', metavar='e', type=str, help='Root entropy of account for testing')
-parser.add_argument('--url', metavar='u', type=str, help='URL of release tarball', default='https://github.com/mobilecoinofficial/mobilecoin/releases/latest/download/mobilecoind-mirror-tls.tar.gz')
+parser.add_argument('--url', metavar='u', type=str, help='URL of release tarball', default='https://github.com/mobilecoinfoundation/mobilecoin/releases/latest/download/mobilecoind-mirror-tls.tar.gz')
 parser.add_argument('--skip-clean', action='store_true', help='Do not delete ledger-db and mobilecoind-db on start')
 parser.add_argument('--services', action='store_true', help='Leave services up after test run is complete')
 args = parser.parse_args()

--- a/util/repr-bytes/README.md
+++ b/util/repr-bytes/README.md
@@ -244,10 +244,10 @@ References
 2. RustCrypto digest trait: https://github.com/RustCrypto/traits/blob/e020ecfd83c5d1f5d19b674d071b858ea1369088/digest/src/digest.rs#L9
 3. Dalek-cryptography curve25519 RistrettoPoint: https://github.com/dalek-cryptography/curve25519-dalek/blob/409ebd94c011472cb2d24bd4f957448d52065ab6/src/ristretto.rs#L227
 4. Dalek-cryptography x25519 implementation: https://github.com/dalek-cryptography/x25519-dalek/blob/be82bcb15b57ed6a07e92a0643b8355bd8d653a3/src/x25519.rs#L46
-5. Mobilecoin keys and Kex traits: https://github.com/mobilecoinofficial/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/crypto/keys/src/traits.rs#L195
-6. Mobilecoin transaction TxOut structure, showing use of Prost with Ristretto wrappers: https://github.com/mobilecoinofficial/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/transaction/core/src/tx.rs#L234
-7. Mobilecoin noise implementation: https://github.com/mobilecoinofficial/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/crypto/ake/mcnoise/src/handshake_state.rs#L128
-8. Mobilecoin cryptobox implementation: https://github.com/mobilecoinofficial/mobilecoin/pull/74
+5. Mobilecoin keys and Kex traits: https://github.com/mobilecoinfoundation/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/crypto/keys/src/traits.rs#L195
+6. Mobilecoin transaction TxOut structure, showing use of Prost with Ristretto wrappers: https://github.com/mobilecoinfoundation/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/transaction/core/src/tx.rs#L234
+7. Mobilecoin noise implementation: https://github.com/mobilecoinfoundation/mobilecoin/blob/a13fa2246c8df4054ef5bad69f0566c0161be8cb/crypto/ake/mcnoise/src/handshake_state.rs#L128
+8. Mobilecoin cryptobox implementation: https://github.com/mobilecoinfoundation/mobilecoin/pull/74
 9. Return value optimization in compilers: https://en.wikipedia.org/wiki/Copy_elision
     (This is a discussion of C++, but this has been a major focus of work in the optimizing
      backends such as llvm as well, for many years.)


### PR DESCRIPTION
### Motivation

We transferred ownership from mobilecoinofficial -> mobilecoinfoundation, and several references need to be updated. 

### In this PR
* updates references in documentation, the pre-push hook, and in scripts which look at release locations.

[MCC-2022](https://mobilecoin.atlassian.net/browse/MCC-2022)


