### PR TITLE
add TimestampResultCode to mc_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ dependencies = [
  "mc-util-serial",
  "mc-util-test-helper",
  "mc-util-test-vector",
+ "mc-watcher-api",
  "prost",
  "protobuf",
  "rand 0.7.3",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,6 +13,7 @@ mc-crypto-keys = { path = "../crypto/keys" }
 mc-util-repr-bytes = { path = "../util/repr-bytes" }
 mc-util-serial = { path = "../util/serial" }
 mc-transaction-core = { path = "../transaction/core" }
+mc-watcher-api = { path = "../watcher/api" }
 
 bs58 = "0.3.0"
 crc = "1.8.1"

--- a/api/build.rs
+++ b/api/build.rs
@@ -14,6 +14,11 @@ fn main() {
 
     mc_util_build_grpc::compile_protos_and_generate_mod_rs(
         &[proto_str],
-        &["blockchain.proto", "external.proto", "printable.proto"],
+        &[
+            "blockchain.proto",
+            "external.proto",
+            "printable.proto",
+            "watcher.proto",
+        ],
     );
 }

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -267,3 +267,28 @@ message Receipt {
     // Note: This value is self-reported by the sender and is unverifiable.
     Amount amount = 4;
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// `watcher/api` crate
+///////////////////////////////////////////////////////////////////////////////
+
+/// The result code indicating whether the timestamp was found, can be tried again later, or will
+/// never be found with the current configuration of the service offering timestamps via the watcher.
+enum TimestampResultCode {
+    /// The default value for fixed32 is intentionally unused to avoid omitting this field.
+    UnusedField = 0;
+    /// The timestamp was found for at least one watched consensus validator.
+    TimestampFound = 1;
+    /// The timestamp was not found, but the watcher sync is behind for at least one watched consensus
+    /// validator. It is possible that the timestamp will be available once the watcher is fully synced.
+    WatcherBehind = 2;
+    /// The timestamp cannot be known with the service's current watcher configuration.
+    /// In this case, the watcher must be restarted to include in its watched URLs a sufficient
+    /// set of consensus validators so that at least one of those validators participated in
+    /// consensus for every block.
+    Unavailable = 3;
+    /// A WatcherDBError occurred when getting signatures and timestamps.
+    WatcherDatabaseError = 4;
+    /// A timestamp was requested for a block index out of bounds, e.g. 0.
+    BlockIndexOutOfBounds = 5;
+}

--- a/api/proto/watcher.proto
+++ b/api/proto/watcher.proto
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+// MUST BE KEPT IN SYNC WITH RUST CODE!
+
+syntax = "proto3";
+
+package watcher;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// `watcher/api` crate
+///////////////////////////////////////////////////////////////////////////////
+
+/// The result code indicating whether the timestamp was found, can be tried again later, or will
+/// never be found with the current configuration of the service offering timestamps via the watcher.
+enum TimestampResultCode {
+    /// The default value for fixed32 is intentionally unused to avoid omitting this field.
+    UnusedField = 0;
+    /// The timestamp was found for at least one watched consensus validator.
+    TimestampFound = 1;
+    /// The timestamp was not found, but the watcher sync is behind for at least one watched consensus
+    /// validator. It is possible that the timestamp will be available once the watcher is fully synced.
+    WatcherBehind = 2;
+    /// The timestamp cannot be known with the service's current watcher configuration.
+    /// In this case, the watcher must be restarted to include in its watched URLs a sufficient
+    /// set of consensus validators so that at least one of those validators participated in
+    /// consensus for every block.
+    Unavailable = 3;
+    /// A WatcherDBError occurred when getting signatures and timestamps.
+    WatcherDatabaseError = 4;
+    /// A timestamp was requested for a block index out of bounds, e.g. 0.
+    BlockIndexOutOfBounds = 5;
+}

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -35,6 +35,7 @@ mod tx_out_confirmation_number;
 mod tx_out_membership_element;
 mod tx_out_membership_proof;
 mod tx_prefix;
+mod watcher;
 
 pub use account_key::*;
 pub use amount::*;
@@ -61,6 +62,7 @@ pub use tx_out_confirmation_number::*;
 pub use tx_out_membership_element::*;
 pub use tx_out_membership_proof::*;
 pub use tx_prefix::*;
+pub use watcher::*;
 
 use std::path::PathBuf;
 

--- a/api/src/convert/watcher.rs
+++ b/api/src/convert/watcher.rs
@@ -1,0 +1,72 @@
+//! Convert to/from watcher_api::*
+
+use crate::{convert::ConversionError, external};
+use mc_watcher_api::TimestampResultCode;
+use std::convert::TryFrom;
+
+impl From<&TimestampResultCode> for external::TimestampResultCode {
+    fn from(src: &TimestampResultCode) -> Self {
+        match src {
+            TimestampResultCode::TimestampFound => external::TimestampResultCode::TimestampFound,
+            TimestampResultCode::WatcherBehind => external::TimestampResultCode::WatcherBehind,
+            TimestampResultCode::Unavailable => external::TimestampResultCode::Unavailable,
+            TimestampResultCode::WatcherDatabaseError => {
+                external::TimestampResultCode::WatcherDatabaseError
+            }
+            TimestampResultCode::BlockIndexOutOfBounds => {
+                external::TimestampResultCode::BlockIndexOutOfBounds
+            }
+        }
+    }
+}
+
+impl TryFrom<&external::TimestampResultCode> for TimestampResultCode {
+    type Error = ConversionError;
+
+    fn try_from(src: &external::TimestampResultCode) -> Result<Self, Self::Error> {
+        match src {
+            external::TimestampResultCode::UnusedField => Err(ConversionError::ObjectMissing),
+            external::TimestampResultCode::TimestampFound => {
+                Ok(TimestampResultCode::TimestampFound)
+            }
+            external::TimestampResultCode::WatcherBehind => Ok(TimestampResultCode::WatcherBehind),
+            external::TimestampResultCode::Unavailable => Ok(TimestampResultCode::Unavailable),
+            external::TimestampResultCode::WatcherDatabaseError => {
+                Ok(TimestampResultCode::WatcherDatabaseError)
+            }
+            external::TimestampResultCode::BlockIndexOutOfBounds => {
+                Ok(TimestampResultCode::BlockIndexOutOfBounds)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that .proto enum values matches the Rust code
+    #[test]
+    fn test_timestamp_result_code_enum_values() {
+        assert_eq!(
+            TimestampResultCode::TimestampFound as u32,
+            external::TimestampResultCode::TimestampFound as u32
+        );
+        assert_eq!(
+            TimestampResultCode::WatcherBehind as u32,
+            external::TimestampResultCode::WatcherBehind as u32
+        );
+        assert_eq!(
+            TimestampResultCode::Unavailable as u32,
+            external::TimestampResultCode::Unavailable as u32
+        );
+        assert_eq!(
+            TimestampResultCode::WatcherDatabaseError as u32,
+            external::TimestampResultCode::WatcherDatabaseError as u32
+        );
+        assert_eq!(
+            TimestampResultCode::BlockIndexOutOfBounds as u32,
+            external::TimestampResultCode::BlockIndexOutOfBounds as u32
+        );
+    }
+}

--- a/api/src/convert/watcher.rs
+++ b/api/src/convert/watcher.rs
@@ -1,40 +1,38 @@
 //! Convert to/from watcher_api::*
 
-use crate::{convert::ConversionError, external};
+use crate::{convert::ConversionError, watcher};
 use mc_watcher_api::TimestampResultCode;
 use std::convert::TryFrom;
 
-impl From<&TimestampResultCode> for external::TimestampResultCode {
+impl From<&TimestampResultCode> for watcher::TimestampResultCode {
     fn from(src: &TimestampResultCode) -> Self {
         match src {
-            TimestampResultCode::TimestampFound => external::TimestampResultCode::TimestampFound,
-            TimestampResultCode::WatcherBehind => external::TimestampResultCode::WatcherBehind,
-            TimestampResultCode::Unavailable => external::TimestampResultCode::Unavailable,
+            TimestampResultCode::TimestampFound => watcher::TimestampResultCode::TimestampFound,
+            TimestampResultCode::WatcherBehind => watcher::TimestampResultCode::WatcherBehind,
+            TimestampResultCode::Unavailable => watcher::TimestampResultCode::Unavailable,
             TimestampResultCode::WatcherDatabaseError => {
-                external::TimestampResultCode::WatcherDatabaseError
+                watcher::TimestampResultCode::WatcherDatabaseError
             }
             TimestampResultCode::BlockIndexOutOfBounds => {
-                external::TimestampResultCode::BlockIndexOutOfBounds
+                watcher::TimestampResultCode::BlockIndexOutOfBounds
             }
         }
     }
 }
 
-impl TryFrom<&external::TimestampResultCode> for TimestampResultCode {
+impl TryFrom<&watcher::TimestampResultCode> for TimestampResultCode {
     type Error = ConversionError;
 
-    fn try_from(src: &external::TimestampResultCode) -> Result<Self, Self::Error> {
+    fn try_from(src: &watcher::TimestampResultCode) -> Result<Self, Self::Error> {
         match src {
-            external::TimestampResultCode::UnusedField => Err(ConversionError::ObjectMissing),
-            external::TimestampResultCode::TimestampFound => {
-                Ok(TimestampResultCode::TimestampFound)
-            }
-            external::TimestampResultCode::WatcherBehind => Ok(TimestampResultCode::WatcherBehind),
-            external::TimestampResultCode::Unavailable => Ok(TimestampResultCode::Unavailable),
-            external::TimestampResultCode::WatcherDatabaseError => {
+            watcher::TimestampResultCode::UnusedField => Err(ConversionError::ObjectMissing),
+            watcher::TimestampResultCode::TimestampFound => Ok(TimestampResultCode::TimestampFound),
+            watcher::TimestampResultCode::WatcherBehind => Ok(TimestampResultCode::WatcherBehind),
+            watcher::TimestampResultCode::Unavailable => Ok(TimestampResultCode::Unavailable),
+            watcher::TimestampResultCode::WatcherDatabaseError => {
                 Ok(TimestampResultCode::WatcherDatabaseError)
             }
-            external::TimestampResultCode::BlockIndexOutOfBounds => {
+            watcher::TimestampResultCode::BlockIndexOutOfBounds => {
                 Ok(TimestampResultCode::BlockIndexOutOfBounds)
             }
         }
@@ -50,23 +48,23 @@ mod tests {
     fn test_timestamp_result_code_enum_values() {
         assert_eq!(
             TimestampResultCode::TimestampFound as u32,
-            external::TimestampResultCode::TimestampFound as u32
+            watcher::TimestampResultCode::TimestampFound as u32
         );
         assert_eq!(
             TimestampResultCode::WatcherBehind as u32,
-            external::TimestampResultCode::WatcherBehind as u32
+            watcher::TimestampResultCode::WatcherBehind as u32
         );
         assert_eq!(
             TimestampResultCode::Unavailable as u32,
-            external::TimestampResultCode::Unavailable as u32
+            watcher::TimestampResultCode::Unavailable as u32
         );
         assert_eq!(
             TimestampResultCode::WatcherDatabaseError as u32,
-            external::TimestampResultCode::WatcherDatabaseError as u32
+            watcher::TimestampResultCode::WatcherDatabaseError as u32
         );
         assert_eq!(
             TimestampResultCode::BlockIndexOutOfBounds as u32,
-            external::TimestampResultCode::BlockIndexOutOfBounds as u32
+            watcher::TimestampResultCode::BlockIndexOutOfBounds as u32
         );
     }
 }


### PR DESCRIPTION
### Motivation

Fog needs to communicate `TimestampResultCode` inside some of its proto objects. Currently the proto equivalent of `TimestampResultCode` lives in internal/fog, but the correct place for it is in this repository, next to all the other proto APIs bundled in `mc_api::external`.

### In this PR
* Add `TimestampResultCode` to `external.proto`
* Add appropriate `From`/`TryFrom` conversions. 

### Future Work
* Use this in internal fog code.