### PR TITLE
MCC-2026 Make enclave errors always return PERMISSION_DENIED

### DIFF
--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -43,10 +43,8 @@ pub trait AttestedConnection: Connection {
 
         let result = func(self);
 
-        if let Err(GrpcError::RpcFailure(rpc_status)) = &result {
-            if rpc_status.status == RpcStatusCode::PERMISSION_DENIED {
-                self.deattest();
-            }
+        if let Err(GrpcError::RpcFailure(_rpc_status)) = &result {
+            self.deattest();
         }
 
         Ok(result?)

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -3,7 +3,7 @@
 //! Traits which connection implementations can implement.
 
 use crate::error::{Result, RetryResult};
-use grpcio::{Error as GrpcError, RpcStatusCode};
+use grpcio::Error as GrpcError;
 use mc_transaction_core::{tx::Tx, Block, BlockID, BlockIndex};
 use mc_util_uri::ConnectionUri;
 use std::{

--- a/util/grpc/src/lib.rs
+++ b/util/grpc/src/lib.rs
@@ -65,10 +65,11 @@ pub fn send_result<T>(
 /// database error
 #[inline]
 pub fn rpc_enclave_err<E: core::fmt::Debug>(err: E, logger: &Logger) -> RpcStatus {
+    // Return permission denied if there's anything wrong with the enclave, to force re-attestation.
     report_err_with_code(
         "Enclave Error",
         err,
-        RpcStatusCode::INVALID_ARGUMENT,
+        RpcStatusCode::PERMISSION_DENIED,
         logger,
     )
 }


### PR DESCRIPTION
### Motivation

Restarting a node on the network deletes any peer session IDs they have. As a result, the next time the peer goes to perform an action, it will receive an enclave error. Unfortunately this is translated into the INVALID_ARGUMENT gRPC status code, which does not trigger a re-attestation. Without re-attestation, enclaves within the network cannot communicate with each other, leading to network collapse.

### In this PR
* Treat any RPC failure of an attested call as cause to re-attest.
* Explicitly return PERMISSION_DENIED for enclave errors.

