### PR TITLE
Build report.proto in mobilecoin python library, and expose

### DIFF
--- a/mobilecoind/clients/python/lib/mobilecoin/.gitignore
+++ b/mobilecoind/clients/python/lib/mobilecoin/.gitignore
@@ -2,3 +2,4 @@ mobilecoind_api_pb2_grpc.py
 mobilecoind_api_pb2.py
 external_pb2.py
 blockchain_pb2.py
+report_pb2.py

--- a/mobilecoind/clients/python/lib/mobilecoin/__init__.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/__init__.py
@@ -2,3 +2,4 @@
 
 from .client import *
 from .utilities import *
+from .fog import *

--- a/mobilecoind/clients/python/lib/mobilecoin/compile_proto.sh
+++ b/mobilecoind/clients/python/lib/mobilecoin/compile_proto.sh
@@ -19,6 +19,7 @@ MC_ROOT=../../../../..
 MC_API=$MC_ROOT/api/proto
 MCD_API=$MC_ROOT/mobilecoind/api/proto
 CONSENSUS_API=$MC_ROOT/consensus/api/proto
+MC_FOG_API=$MC_ROOT/fog/api/proto
 
 # compile protobuf for python
 case "$(uname -s)" in
@@ -26,12 +27,14 @@ case "$(uname -s)" in
     py.exe -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/external.proto
     py.exe -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/blockchain.proto
     py.exe -m grpc_tools.protoc -I$MCD_API -I$CONSENSUS_API -I$MC_API --python_out=. --grpc_python_out=. $MCD_API/mobilecoind_api.proto
+    py.exe -m grpc_tools.protoc -I$MC_FOG_API --python_out=. $MC_FOG_API/report.proto
   ;;
 
   *)
     python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/external.proto
     python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/blockchain.proto
     python3 -m grpc_tools.protoc -I$MCD_API -I$CONSENSUS_API -I$MC_API --python_out=. --grpc_python_out=. $MCD_API/mobilecoind_api.proto
+    python3 -m grpc_tools.protoc -I$MC_FOG_API --python_out=. $MC_FOG_API/report.proto
   ;;
 esac
 

--- a/mobilecoind/clients/python/lib/mobilecoin/fog.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/fog.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018-2020 MobileCoin Inc.
+
+# Python wrappers for fetching IAS reports from the gRPC service `Fog Report Service`
+# This is intended as a diagnostic.
+# It DOES NOT do IAS validation, and that will be difficult in python.
+# So it is dubious to use this in connection to creating new transactions.
+
+import grpc
+
+from .report_pb2 import *
+from .report_pb2_grpc import *
+
+# Fetch all available reports from the report server
+#
+# Arguments:
+# * url - the url of the fog report server
+# * ssl - bool indicating whether or not to use ssl when connecting
+#
+# Returns:
+# * The python representation of the ReportResponse from the report server
+def fetch_fog_reports(url, ssl):
+    if ssl:
+        credentials = grpc.ssl_channel_credentials()
+        channel = grpc.secure_channel(daemon, credentials)
+    else:
+        channel = grpc.insecure_channel(daemon)
+    stub = ReportAPIStub(channel)
+
+    request = ReportRequest()
+    return stub.GetReports(request)


### PR DESCRIPTION
This adds a `fog.py` module to the mobilecoin python library, and exposes
a simple `fetch_fog_reports` function which wraps the grpc API of the fog
report server.

This is useful because we can use this in the fog conformance tests, which
are also in python and need to know the fog public key.

That's not directly related to mobilecoind, but it is very convenient to be able to
`pip install mobilecoin` and have this functionality available.

Let me know what you think about this