### PR TITLE
MCC-2050 Update fs_extra, fix for semver break-ish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,9 +1148,9 @@ checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fsevent"

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -126,7 +126,7 @@ fn setup_ledger_dir(config_origin_path: &Option<PathBuf>, ledger_path: &PathBuf)
 
         // Copy the data.mdb file from the origin directory to the ledger
         data_file_path.push("data.mdb");
-        fs_extra::copy_items(&vec![data_file_path], ledger_path, &options)
+        fs_extra::copy_items(&[data_file_path], ledger_path, &options)
             .expect("Could not copy origin block");
     }
 }


### PR DESCRIPTION
### Motivation

The `fs_extra` crate changed their API during the transition from 1.1 -> 1.2, specifically changing an `&Vec<u8>` parameter to an `&[u8]` parameter. This is not a semver break in the traditional sense, because a reference to a `Vec` can be coerced into a slice of the `Vec`'s contents, but this does trigger a new `clippy` warning, which breaks the build.

### In this PR
* Create a slice instead of a vector.