### PR TITLE
Expose mrsigner/mrenclave verifiers in measurement crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ name = "mc-consensus-enclave-measurement"
 version = "1.0.0"
 dependencies = [
  "cargo-emit",
+ "mc-attest-core",
  "mc-sgx-css",
  "mc-util-build-enclave",
  "mc-util-build-script",

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -11,6 +11,7 @@ links = "consensus_enclave_measurement"
 sgx-sim = []
 
 [dependencies]
+mc-attest-core = { path = "../../../attest/core" }
 mc-sgx-css = { path = "../../../sgx/css" }
 
 [build-dependencies]

--- a/consensus/enclave/measurement/src/lib.rs
+++ b/consensus/enclave/measurement/src/lib.rs
@@ -5,9 +5,32 @@
 #![no_std]
 
 use core::convert::TryFrom;
+use mc_attest_core::{MrEnclaveVerifier, MrSignerVerifier, SecurityVersion};
 use mc_sgx_css::Signature;
 
 pub fn sigstruct() -> Signature {
     Signature::try_from(&include_bytes!(env!("MCBUILD_ENCLAVE_CSS_PATH"))[..])
         .expect("Could not read measurement signature")
+}
+
+pub const CONFIG_ADVISORIES: &[&str] = &[];
+pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334"];
+
+pub fn get_mr_signer_verifier(override_minimum_svn: Option<SecurityVersion>) -> MrSignerVerifier {
+    let signature = sigstruct();
+    let mut mr_signer_verifier = MrSignerVerifier::new(
+        signature.mrsigner().into(),
+        signature.product_id(),
+        override_minimum_svn.unwrap_or_else(|| signature.version()),
+    );
+    mr_signer_verifier.allow_config_advisories(CONFIG_ADVISORIES);
+    mr_signer_verifier.allow_hardening_advisories(HARDENING_ADVISORIES);
+    mr_signer_verifier
+}
+
+pub fn get_mr_enclave_verifier() -> MrEnclaveVerifier {
+    let mut mr_enclave_verifier = MrEnclaveVerifier::from(sigstruct());
+    mr_enclave_verifier.allow_config_advisories(CONFIG_ADVISORIES);
+    mr_enclave_verifier.allow_hardening_advisories(HARDENING_ADVISORIES);
+    mr_enclave_verifier
 }


### PR DESCRIPTION
This pattern was established in internal repo and avoids a bunch
of boilerplate

we should probably use these functions in mobilecoind also