### PR TITLE
Replace ?region= in favor of AWS_REGION

### DIFF
--- a/deploy/03-node1.yaml
+++ b/deploy/03-node1.yaml
@@ -7,7 +7,7 @@ data:
   ledger_dist.conf: |
     [program:ledger-distribution]
     command=/usr/bin/ledger-distribution
-      --dest s3://mobilecoin.chain/node1.NETWORKNAME.mobilecoin.com?region=us-west-1
+      --dest s3://mobilecoin.chain/node1.NETWORKNAME.mobilecoin.com
       --ledger-path /ledger
 
     stdout_logfile=/dev/fd/1
@@ -207,7 +207,9 @@ spec:
             - name: MC_BRANCH
               value: "NETWORKNAME"
             - name: AWS_PATH
-              value: "AWS_PATH=s3://mobilecoin.chain/node1.NETWORKNAME.mobilecoin.com?region=us-west-1"
+              value: "AWS_PATH=s3://mobilecoin.chain/node1.NETWORKNAME.mobilecoin.com"
+            - name: AWS_REGION
+              value: "us-west-1"
             - name: PROD_IAS_SPID
               valueFrom:
                 secretKeyRef:

--- a/deploy/03-node2.yaml
+++ b/deploy/03-node2.yaml
@@ -7,7 +7,7 @@ data:
   ledger_dist.conf: |
     [program:ledger-distribution]
     command=/usr/bin/ledger-distribution
-      --dest s3://mobilecoin.chain/node2.NETWORKNAME.mobilecoin.com?region=us-west-1
+      --dest s3://mobilecoin.chain/node2.NETWORKNAME.mobilecoin.com
       --ledger-path /ledger
 
     stdout_logfile=/dev/fd/1
@@ -207,7 +207,9 @@ spec:
             - name: MC_BRANCH
               value: "NETWORKNAME"
             - name: AWS_PATH
-              value: "AWS_PATH=s3://mobilecoin.chain/node2.NETWORKNAME.mobilecoin.com?region=us-west-1"
+              value: "AWS_PATH=s3://mobilecoin.chain/node2.NETWORKNAME.mobilecoin.com"
+            - name: AWS_REGION
+              value: "us-west-1"
             - name: PROD_IAS_SPID
               valueFrom:
                 secretKeyRef:

--- a/deploy/03-node3.yaml
+++ b/deploy/03-node3.yaml
@@ -7,7 +7,7 @@ data:
   ledger_dist.conf: |
     [program:ledger-distribution]
     command=/usr/bin/ledger-distribution
-      --dest s3://mobilecoin.chain/node3.NETWORKNAME.mobilecoin.com?region=us-west-1
+      --dest s3://mobilecoin.chain/node3.NETWORKNAME.mobilecoin.com
       --ledger-path /ledger
 
     stdout_logfile=/dev/fd/1
@@ -207,7 +207,9 @@ spec:
             - name: MC_BRANCH
               value: "NETWORKNAME"
             - name: AWS_PATH
-              value: "AWS_PATH=s3://mobilecoin.chain/node3.NETWORKNAME.mobilecoin.com?region=us-west-1"
+              value: "AWS_PATH=s3://mobilecoin.chain/node3.NETWORKNAME.mobilecoin.com"
+            - name: AWS_REGION
+              value: "us-west-1"
             - name: PROD_IAS_SPID
               valueFrom:
                 secretKeyRef:

--- a/deploy/03-node4.yaml
+++ b/deploy/03-node4.yaml
@@ -7,7 +7,7 @@ data:
   ledger_dist.conf: |
     [program:ledger-distribution]
     command=/usr/bin/ledger-distribution
-      --dest s3://mobilecoin.chain/node4.NETWORKNAME.mobilecoin.com?region=us-west-1
+      --dest s3://mobilecoin.chain/node4.NETWORKNAME.mobilecoin.com
       --ledger-path /ledger
 
     stdout_logfile=/dev/fd/1
@@ -207,7 +207,9 @@ spec:
             - name: MC_BRANCH
               value: "NETWORKNAME"
             - name: AWS_PATH
-              value: "AWS_PATH=s3://mobilecoin.chain/node4.NETWORKNAME.mobilecoin.com?region=us-west-1"
+              value: "AWS_PATH=s3://mobilecoin.chain/node4.NETWORKNAME.mobilecoin.com"
+            - name: AWS_REGION
+              value: "us-west-1"
             - name: PROD_IAS_SPID
               valueFrom:
                 secretKeyRef:

--- a/deploy/03-node5.yaml
+++ b/deploy/03-node5.yaml
@@ -7,7 +7,7 @@ data:
   ledger_dist.conf: |
     [program:ledger-distribution]
     command=/usr/bin/ledger-distribution
-      --dest s3://mobilecoin.chain/node5.NETWORKNAME.mobilecoin.com?region=us-west-1
+      --dest s3://mobilecoin.chain/node5.NETWORKNAME.mobilecoin.com
       --ledger-path /ledger
 
     stdout_logfile=/dev/fd/1
@@ -207,7 +207,9 @@ spec:
             - name: MC_BRANCH
               value: "NETWORKNAME"
             - name: AWS_PATH
-              value: "AWS_PATH=s3://mobilecoin.chain/node5.NETWORKNAME.mobilecoin.com?region=us-west-1"
+              value: "AWS_PATH=s3://mobilecoin.chain/node5.NETWORKNAME.mobilecoin.com"
+            - name: AWS_REGION
+              value: "us-west-1"
             - name: PROD_IAS_SPID
               valueFrom:
                 secretKeyRef:

--- a/ledger/distribution/README.md
+++ b/ledger/distribution/README.md
@@ -9,6 +9,7 @@ You must obtain AWS credentials and set them in your env.
 ```
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=...
 ```
 
 ### Usage
@@ -16,5 +17,5 @@ export AWS_SECRET_ACCESS_KEY=...
 ```
 cargo run --release -p mc-ledger-distribution -- \
     ---ledger-path /tmp/ledger \
-    ---dest "s3://my_bucket/my_node.my_domain.com?region=us-west-1"
+    ---dest "s3://my_bucket/my_node.my_domain.com"
 ```


### PR DESCRIPTION
Its standard practice to use environment variables to control AWS parameters. Previously we were using a custom, non-standard `?region=` query param. This PR replaces that with the more standard `AWS_REGION` environment variable.
