### PR TITLE
[MCC-1969] Removes pseudo_outputs from range proof

### DIFF
--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -11,10 +11,10 @@ pub const MAX_TRANSACTIONS_PER_BLOCK: usize = 5000;
 pub const RING_SIZE: usize = 11;
 
 /// Each transaction must contain no more than this many inputs (rings).
-pub const MAX_INPUTS: u64 = 16;
+pub const MAX_INPUTS: usize = 16;
 
 /// Each transaction must contain no more than this many outputs.
-pub const MAX_OUTPUTS: u64 = 16;
+pub const MAX_OUTPUTS: usize = 16;
 
 /// Maximum number of blocks in the future a transaction's tombstone block can be set to.
 pub const MAX_TOMBSTONE_BLOCKS: u64 = 100;

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -4,7 +4,7 @@
 #![macro_use]
 extern crate alloc;
 
-use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
+use crate::{constants::MAX_OUTPUTS, domain_separators::HASH_TO_POINT_DOMAIN_TAG};
 use blake2::{Blake2b, Digest};
 use bulletproofs::{BulletproofGens, PedersenGens};
 pub use curve25519_dalek::scalar::Scalar;
@@ -33,9 +33,9 @@ lazy_static! {
 
     /// Generators (base points) for Bulletproofs.
     /// The `party_capacity` is the maximum number of values in one proof. It should
-    /// be at least 2 * MAX_INPUTS + MAX_OUTPUTS, which allows for inputs, pseudo outputs, and outputs.
+    /// be at least MAX_OUTPUTS to allow for all outputs in a transaction
     pub static ref BP_GENERATORS: BulletproofGens =
-        BulletproofGens::new(64, 64);
+        BulletproofGens::new(64, MAX_OUTPUTS);
 }
 
 /// Applies a hash function and returns a RistrettoPoint.

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -63,7 +63,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 /// The transaction must have at least one input, and no more than the maximum allowed number of inputs.
 fn validate_number_of_inputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_inputs: u64,
+    maximum_allowed_inputs: usize,
 ) -> TransactionValidationResult<()> {
     let num_inputs = tx_prefix.inputs.len();
 
@@ -73,7 +73,7 @@ fn validate_number_of_inputs(
     }
 
     // Each transaction must have no more than the maximum allowed number of inputs.
-    if num_inputs > maximum_allowed_inputs as usize {
+    if num_inputs > maximum_allowed_inputs {
         return Err(TransactionValidationError::TooManyInputs);
     }
 
@@ -83,7 +83,7 @@ fn validate_number_of_inputs(
 /// The transaction must have at least one output.
 fn validate_number_of_outputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_outputs: u64,
+    maximum_allowed_outputs: usize,
 ) -> TransactionValidationResult<()> {
     let num_outputs = tx_prefix.outputs.len();
 
@@ -93,7 +93,7 @@ fn validate_number_of_outputs(
     }
 
     // Each transaction must have no more than the maximum allowed number of outputs.
-    if num_outputs > maximum_allowed_outputs as usize {
+    if num_outputs > maximum_allowed_outputs {
         return Err(TransactionValidationError::TooManyOutputs);
     }
 


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://youtu.be/Q5Yd2Io-g5c)

### Motivation

Currently, the pseudo_output commitments are included in the range proof, which increases the size of the range proof from "num_outputs" to "num_inputs + num_outputs". I originally included the pseudo_output commitments in the range proof out of caution, but since then we've concluded that it isn't necessary.

### In this PR
* Omits pseudo_output commitments from range proof.
* Simplifies the balance check in sign_with_balance_check.
* Various cleanup