### PR TITLE
correctly gate time measurement and panic handlers

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -40,18 +40,13 @@ pub fn fast_hash(data: &[u8]) -> Hash {
 
 pub mod logger;
 
-// Logging related functionality
-cfg_if::cfg_if! {
-    if #[cfg(feature = "log")] {
-        mod panic_handler;
-
-        pub use panic_handler::setup_panic_handler;
-    }
-}
-
 // Loggers
 cfg_if::cfg_if! {
     if #[cfg(feature = "loggers")] {
+        mod panic_handler;
+
         pub mod sentry;
+
+        pub use panic_handler::setup_panic_handler;
     }
 }

--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -98,8 +98,6 @@ cfg_if::cfg_if! {
         /// Expose slog_scope
         pub use slog_scope;
 
-        use std::time::Instant;
-
         /// Get the global Logger instance, managed by `slog_scope`.
         #[cfg(feature = "log")]
         pub fn global_logger() -> Logger {
@@ -114,6 +112,13 @@ cfg_if::cfg_if! {
         {
             slog_scope::scope(&logger, || f(&logger))
         }
+    }
+}
+
+cfg_if::cfg_if! {
+    // Time tracing - only available when std is enable, since no_std has no concept of time.
+    if #[cfg(all(feature = "log", feature="std"))] {
+        use std::time::Instant;
 
         /// Simple time measurement utility, based on the [measure_time](https://docs.rs/measure_time/) crate.
         /// Note that even though the macro lives inside the `logger` module, it needs to be imported by


### PR DESCRIPTION
### Motivation

`mc-common` incorrectly allowed compilation of custom panic handler code based on the `log` feature (which enables the logging infrastructure but not highlevel application logger implementations). It also allowed compilation of time-tracing utilities that depend on `std::time`.

This caused the issue in https://github.com/mobilecoinfoundation/mobilecoin/issues/548

### In this PR
* Change the feature gates so that std usage is being properly respected.
