### PR TITLE
Update continuous deployment to use intel.com/sgx resource requests

### DIFF
--- a/deploy/03-node1.yaml
+++ b/deploy/03-node1.yaml
@@ -236,8 +236,6 @@ spec:
             - name: "SEALED_BLOCK_SIGNING_KEY"
               value: "/keys/sealed-block-signing-key"
           volumeMounts:
-            - name: dev-isgx
-              mountPath: /dev/isgx
             - name: aesm-socket-dir
               mountPath: /var/run/aesmd
             - name: config-dir
@@ -252,15 +250,13 @@ spec:
             - name: supervisor-conf
               mountPath: /etc/supervisor/conf.d
               readOnly: true
-          securityContext:
-            privileged: true
+          resources:
+            limits:
+              intel.com/sgx: 5000
+            requests:
+              intel.com/sgx: 5000
 
       volumes:
-        # Volume-mapped SGX device
-        - name: dev-isgx
-          hostPath:
-            path: /dev/isgx
-            type: CharDevice
         - name: ledger-db-dir
           emptyDir: {}
         - name: config-dir

--- a/deploy/03-node2.yaml
+++ b/deploy/03-node2.yaml
@@ -236,8 +236,6 @@ spec:
             - name: "SEALED_BLOCK_SIGNING_KEY"
               value: "/keys/sealed-block-signing-key"
           volumeMounts:
-            - name: dev-isgx
-              mountPath: /dev/isgx
             - name: aesm-socket-dir
               mountPath: /var/run/aesmd
             - name: config-dir
@@ -252,15 +250,13 @@ spec:
             - name: supervisor-conf
               mountPath: /etc/supervisor/conf.d
               readOnly: true
-          securityContext:
-            privileged: true
+          resources:
+            limits:
+              intel.com/sgx: 5000
+            requests:
+              intel.com/sgx: 5000
 
       volumes:
-        # Volume-mapped SGX device
-        - name: dev-isgx
-          hostPath:
-            path: /dev/isgx
-            type: CharDevice
         - name: ledger-db-dir
           emptyDir: {}
         - name: config-dir

--- a/deploy/03-node3.yaml
+++ b/deploy/03-node3.yaml
@@ -236,8 +236,6 @@ spec:
             - name: "SEALED_BLOCK_SIGNING_KEY"
               value: "/keys/sealed-block-signing-key"
           volumeMounts:
-            - name: dev-isgx
-              mountPath: /dev/isgx
             - name: aesm-socket-dir
               mountPath: /var/run/aesmd
             - name: config-dir
@@ -252,15 +250,13 @@ spec:
             - name: supervisor-conf
               mountPath: /etc/supervisor/conf.d
               readOnly: true
-          securityContext:
-            privileged: true
+          resources:
+            limits:
+              intel.com/sgx: 5000
+            requests:
+              intel.com/sgx: 5000
 
       volumes:
-        # Volume-mapped SGX device
-        - name: dev-isgx
-          hostPath:
-            path: /dev/isgx
-            type: CharDevice
         - name: ledger-db-dir
           emptyDir: {}
         - name: config-dir

--- a/deploy/03-node4.yaml
+++ b/deploy/03-node4.yaml
@@ -236,8 +236,6 @@ spec:
             - name: "SEALED_BLOCK_SIGNING_KEY"
               value: "/keys/sealed-block-signing-key"
           volumeMounts:
-            - name: dev-isgx
-              mountPath: /dev/isgx
             - name: aesm-socket-dir
               mountPath: /var/run/aesmd
             - name: config-dir
@@ -252,15 +250,13 @@ spec:
             - name: supervisor-conf
               mountPath: /etc/supervisor/conf.d
               readOnly: true
-          securityContext:
-            privileged: true
+          resources:
+            limits:
+              intel.com/sgx: 5000
+            requests:
+              intel.com/sgx: 5000
 
       volumes:
-        # Volume-mapped SGX device
-        - name: dev-isgx
-          hostPath:
-            path: /dev/isgx
-            type: CharDevice
         - name: ledger-db-dir
           emptyDir: {}
         - name: account-db-dir

--- a/deploy/03-node5.yaml
+++ b/deploy/03-node5.yaml
@@ -236,8 +236,6 @@ spec:
             - name: "SEALED_BLOCK_SIGNING_KEY"
               value: "/keys/sealed-block-signing-key"
           volumeMounts:
-            - name: dev-isgx
-              mountPath: /dev/isgx
             - name: aesm-socket-dir
               mountPath: /var/run/aesmd
             - name: config-dir
@@ -252,15 +250,13 @@ spec:
             - name: supervisor-conf
               mountPath: /etc/supervisor/conf.d
               readOnly: true
-          securityContext:
-            privileged: true
+          resources:
+            limits:
+              intel.com/sgx: 5000
+            requests:
+              intel.com/sgx: 5000
 
       volumes:
-        # Volume-mapped SGX device
-        - name: dev-isgx
-          hostPath:
-            path: /dev/isgx
-            type: CharDevice
         - name: ledger-db-dir
           emptyDir: {}
         - name: config-dir


### PR DESCRIPTION
Soundtrack of this PR: [My Favorite Things](https://www.youtube.com/watch?v=8d9cD_Es9k4)

### Motivation

The consensus node deployments previously used `spec.template.spec.containers[].securityContext.privileged: "true"` as a way of getting access to the underlying host SGX character device `/dev/isgx`.  Running in `privileged: "true"` mode is an unnecessary  security exposure, especially if an alternative type of access is available.

Using an sgx device plugin, we can let the `kubelet` map the SGX device into the container, without giving full privileged access to the container itself.

### In this PR
* remove privileged mode
* remove manual /dev/isgx character device volume mount
* Add intel.com/sgx resource requests.

### Future Work
* Explore running the processes within the containers as a non-root/non-privileged user

