### PR TITLE
[MCC-447] Set default author to MobileCoin for new crates

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -18,3 +18,7 @@ rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
 
 [target.x86_64-apple-darwin]
 rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
+
+[cargo-new]
+name = "MobileCoin"
+email = ""


### PR DESCRIPTION
### Motivation

All crate in the `mobilecoin` repo should have their `authors` field set to `["MobileCoin"]`. This PR ensures that this value is prefilled automatically for any new crates created using `cargo new` .

### In this PR
* Sets the `name` and `email` properties within the `cargo-new` section of the repo's cargo config to `"MobileCoin"` and `""`, respectively.

Fixes MCC-447
