### PR TITLE
[MCC-1994] Adds validate_outputs_are_sorted

### DIFF
--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -77,6 +77,7 @@ enum ProposeTxResult {
     UnsortedInputs = 39;
     MissingMemo = 40;
     MemosNotAllowed = 41;
+    UnsortedOutputs = 42;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -46,6 +46,7 @@ impl From<Error> for ProposeTxResult {
             Error::TxFeeError => Self::TxFeeError,
             Error::KeyError => Self::KeyError,
             Error::UnsortedInputs => Self::UnsortedInputs,
+            Error::UnsortedOutputs => Self::UnsortedOutputs,
             Error::MissingMemo => Self::MissingMemo,
             Error::MemosNotAllowed => Self::MemosNotAllowed,
         }
@@ -91,6 +92,7 @@ impl TryInto<Error> for ProposeTxResult {
             Self::TxFeeError => Ok(Error::TxFeeError),
             Self::KeyError => Ok(Error::KeyError),
             Self::UnsortedInputs => Ok(Error::UnsortedInputs),
+            Self::UnsortedOutputs => Ok(Error::UnsortedOutputs),
             Self::MissingMemo => Ok(Error::MissingMemo),
             Self::MemosNotAllowed => Ok(Error::MemosNotAllowed),
         }

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -78,6 +78,9 @@ pub enum TransactionValidationError {
      */
     UnsortedInputs,
 
+    /// Outputs must be sorted by public_key, ascending.
+    UnsortedOutputs,
+
     /// Key Images must be sorted.
     UnsortedKeyImages,
 


### PR DESCRIPTION
### Motivation

Transaction outputs should be deterministically ordered. A required ordering removes an unneeded "degree of freedom" in the transaction structure, and prevents a possible source of information leakage (e.g. client software that always orders transaction outputs from largest value to smallest value).

### In this PR
* Adds `validate_outputs_are_sorted` to transaction validation.