### PR TITLE
Revert "[MCC-1969] Removes pseudo_outputs from range proof"

### DIFF
--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -11,10 +11,10 @@ pub const MAX_TRANSACTIONS_PER_BLOCK: usize = 5000;
 pub const RING_SIZE: usize = 11;
 
 /// Each transaction must contain no more than this many inputs (rings).
-pub const MAX_INPUTS: usize = 16;
+pub const MAX_INPUTS: u64 = 16;
 
 /// Each transaction must contain no more than this many outputs.
-pub const MAX_OUTPUTS: usize = 16;
+pub const MAX_OUTPUTS: u64 = 16;
 
 /// Maximum number of blocks in the future a transaction's tombstone block can be set to.
 pub const MAX_TOMBSTONE_BLOCKS: u64 = 100;

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -4,7 +4,7 @@
 #![macro_use]
 extern crate alloc;
 
-use crate::{constants::MAX_OUTPUTS, domain_separators::HASH_TO_POINT_DOMAIN_TAG};
+use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
 use blake2::{Blake2b, Digest};
 use bulletproofs::{BulletproofGens, PedersenGens};
 pub use curve25519_dalek::scalar::Scalar;
@@ -33,9 +33,9 @@ lazy_static! {
 
     /// Generators (base points) for Bulletproofs.
     /// The `party_capacity` is the maximum number of values in one proof. It should
-    /// be at least MAX_OUTPUTS to allow for all outputs in a transaction
+    /// be at least 2 * MAX_INPUTS + MAX_OUTPUTS, which allows for inputs, pseudo outputs, and outputs.
     pub static ref BP_GENERATORS: BulletproofGens =
-        BulletproofGens::new(64, MAX_OUTPUTS);
+        BulletproofGens::new(64, 64);
 }
 
 /// Applies a hash function and returns a RistrettoPoint.

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -37,7 +37,7 @@ pub struct SignatureRctBulletproofs {
     #[prost(message, repeated, tag = "2")]
     pub pseudo_output_commitments: Vec<CompressedCommitment>,
 
-    /// Proof that all transaction outputs are in [0, 2^64).
+    /// Proof that all pseudo_outputs and transaction outputs are in [0, 2^64).
     /// This contains range_proof.to_bytes(). It is stored this way so that this struct may derive
     /// Default, which is a requirement for serializing with Prost.
     #[prost(bytes, tag = "3")]
@@ -134,10 +134,12 @@ impl SignatureRctBulletproofs {
             decompressed_pseudo_output_commitments.push(commitment);
         }
 
-        // Output commitments must be in [0, 2^64).
+        // pseudo_output_commitments and output commitments must be in [0, 2^64).
         {
-            let commitments: Vec<CompressedRistretto> = output_commitments
+            let commitments: Vec<CompressedRistretto> = self
+                .pseudo_output_commitments
                 .iter()
+                .chain(output_commitments.iter())
                 .map(|compressed_commitment| compressed_commitment.point)
                 .collect();
 
@@ -245,45 +247,68 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
         }
     }
 
-    let input_values: Vec<u64> = input_secrets.iter().map(|(_, value, _)| *value).collect();
-    let (output_values, output_blindings): (Vec<u64>, Vec<Scalar>) =
-        output_values_and_blindings.iter().cloned().unzip();
+    // Blindings for pseudo_outputs. All but the last are random.
+    // Constructing blindings in this way ensures that sum_of_outputs - sum_of_pseudo_outputs = 0
+    // if the sum of outputs and the sum of pseudo_outputs have equal value.
+    let mut pseudo_output_blindings: Vec<Scalar> = Vec::new();
+    for _i in 0..num_inputs - 1 {
+        pseudo_output_blindings.push(Scalar::random(rng));
+    }
+    // The implicit fee output is ommitted because its blinding is zero.
+    let sum_of_output_blindings: Scalar = output_values_and_blindings
+        .iter()
+        .map(|(_, blinding)| blinding)
+        .sum();
+
+    let sum_of_pseudo_output_blindings: Scalar = pseudo_output_blindings.iter().sum();
+    let last_blinding: Scalar = sum_of_output_blindings - sum_of_pseudo_output_blindings;
+    pseudo_output_blindings.push(last_blinding);
+
+    // Create Range proofs for outputs and pseudo-outputs.
+    let pseudo_output_values_and_blindings: Vec<(u64, Scalar)> = input_secrets
+        .iter()
+        .zip(pseudo_output_blindings.iter())
+        .map(|((_, value, _), blinding)| (*value, *blinding))
+        .collect();
+
+    let (range_proof, commitments) = {
+        let values_and_blindings: Vec<(u64, Scalar)> = pseudo_output_values_and_blindings
+            .iter()
+            .chain(output_values_and_blindings.iter())
+            .map(|(value, blinding)| (*value, *blinding))
+            .collect();
+
+        // The implicit fee output is omitted from the range proof because it is known.
+
+        let (values, blindings): (Vec<_>, Vec<_>) = values_and_blindings.into_iter().unzip();
+        generate_range_proofs(&values, &blindings, rng).map_err(|_e| Error::RangeProofError)?
+    };
 
     if check_value_is_preserved {
-        let input_sum: Scalar = input_values.iter().map(|&x| Scalar::from(x)).sum();
-        let output_sum: Scalar = output_values.iter().map(|&x| Scalar::from(x)).sum();
-        // The value of inputs should equal the value of outputs, including the implicit fee output.
-        if input_sum != output_sum + Scalar::from(fee) {
+        let sum_of_output_commitments: RistrettoPoint = output_values_and_blindings
+            .iter()
+            .map(|(value, blinding)| GENERATORS.commit(Scalar::from(*value), *blinding))
+            .sum();
+
+        let sum_of_pseudo_output_commitments: RistrettoPoint = pseudo_output_values_and_blindings
+            .iter()
+            .map(|(value, blinding)| GENERATORS.commit(Scalar::from(*value), *blinding))
+            .sum();
+
+        // The implicit fee output.
+        let fee_commitment = GENERATORS.commit(Scalar::from(fee), *FEE_BLINDING);
+
+        let difference =
+            sum_of_output_commitments + fee_commitment - sum_of_pseudo_output_commitments;
+        if difference != GENERATORS.commit(Scalar::zero(), Scalar::zero()) {
             return Err(Error::ValueNotConserved);
         }
     }
 
-    // Proof that output values are in [0, 2^64).
-    // The implicit fee output is omitted from the range proof because it is known.
-    let (range_proof, _commitments) = generate_range_proofs(&output_values, &output_blindings, rng)
-        .map_err(|_e| Error::RangeProofError)?;
-
-    // Blindings for pseudo_outputs. All but the last are random.
-    // Constructing blindings in this way ensures that sum_of_outputs - sum_of_pseudo_outputs = 0
-    // if the sum of outputs and the sum of pseudo_outputs have equal value.
-    let pseudo_output_blindings: Vec<Scalar> = {
-        let mut blindings = Vec::new();
-        for _i in 0..num_inputs - 1 {
-            blindings.push(Scalar::random(rng));
-        }
-        // The implicit fee output is omitted because its blinding is zero.
-        let last_blinding =
-            output_blindings.iter().sum::<Scalar>() - blindings.iter().sum::<Scalar>();
-        blindings.push(last_blinding);
-        blindings
-    };
-
-    // Each pseudo_output commits to the same value as an input, but uses a different blinding.
-    let pseudo_output_commitments: Vec<CompressedCommitment> = input_values
+    let pseudo_output_commitments: Vec<CompressedCommitment> = commitments
         .iter()
-        .zip(pseudo_output_blindings.iter())
-        .map(|(&value, &blinding)| GENERATORS.commit(Scalar::from(value), blinding))
-        .map(|point| CompressedCommitment::from(&point.compress()))
+        .take(num_inputs)
+        .map(CompressedCommitment::from)
         .collect();
 
     // Extend the message with the range proof and pseudo_output_commitments.
@@ -556,7 +581,7 @@ mod rct_bulletproofs_tests {
                 fee,
                 &mut rng,
             );
-            assert_eq!(result, Ok(()));
+            assert!(result.is_ok());
         }
 
         #[test]

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -63,7 +63,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 /// The transaction must have at least one input, and no more than the maximum allowed number of inputs.
 fn validate_number_of_inputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_inputs: usize,
+    maximum_allowed_inputs: u64,
 ) -> TransactionValidationResult<()> {
     let num_inputs = tx_prefix.inputs.len();
 
@@ -73,7 +73,7 @@ fn validate_number_of_inputs(
     }
 
     // Each transaction must have no more than the maximum allowed number of inputs.
-    if num_inputs > maximum_allowed_inputs {
+    if num_inputs > maximum_allowed_inputs as usize {
         return Err(TransactionValidationError::TooManyInputs);
     }
 
@@ -83,7 +83,7 @@ fn validate_number_of_inputs(
 /// The transaction must have at least one output.
 fn validate_number_of_outputs(
     tx_prefix: &TxPrefix,
-    maximum_allowed_outputs: usize,
+    maximum_allowed_outputs: u64,
 ) -> TransactionValidationResult<()> {
     let num_outputs = tx_prefix.outputs.len();
 
@@ -93,7 +93,7 @@ fn validate_number_of_outputs(
     }
 
     // Each transaction must have no more than the maximum allowed number of outputs.
-    if num_outputs > maximum_allowed_outputs {
+    if num_outputs > maximum_allowed_outputs as usize {
         return Err(TransactionValidationError::TooManyOutputs);
     }
 


### PR DESCRIPTION
Reverts mobilecoinfoundation/mobilecoin#542

This will be included in a later enclave upgrade.