### PR TITLE
remove unused patch entry for grpcio

### DIFF
--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1680,11 +1680,6 @@ dependencies = [
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
-[[patch.unused]]
-name = "grpcio"
-version = "0.6.0"
-source = "git+https://github.com/jcape/grpc-rs?rev=74797d973f0e81555c3c01857ccdbb8092f21f67#74797d973f0e81555c3c01857ccdbb8092f21f67"
-
 [metadata]
 "checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 "checksum aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -59,9 +59,6 @@ debug-assertions = false
 overflow-checks = false
 
 [patch.crates-io]
-# grpcio patched with metadata
-grpcio = { git = "https://github.com/jcape/grpc-rs", rev = "74797d973f0e81555c3c01857ccdbb8092f21f67" }
-
 # prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
 # current revision is from jun 13 2020, waiting for a new prost release
 # https://github.com/danburkert/prost/issues/329


### PR DESCRIPTION
The enclave does not care about grpcio.