### PR TITLE
Fix typos

### DIFF
--- a/crypto/box/src/traits.rs
+++ b/crypto/box/src/traits.rs
@@ -114,7 +114,7 @@ pub trait CryptoBox<KexAlgo: Kex>: Default {
     /// Meant to mirror aead::decrypt_in_place
     ///
     /// Decryption can fail if:
-    /// - The buffer is too short to be interpretted
+    /// - The buffer is too short to be interpreted
     /// - The curvepoint cannot be deserialized
     /// - The mac check fails
     ///

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -43,7 +43,7 @@ use rand_core::{CryptoRng, RngCore};
 
 pub type RistrettoHkdfBlake2bAes128Gcm = HkdfBox<Ristretto, Blake2b, Aes128Gcm>;
 
-/// A "magic byte" value checked during this process, but not interpretted.
+/// A "magic byte" value checked during this process, but not interpreted.
 const MAJOR_VERSION: u8 = 1;
 /// The "default" version that we would use for encryption lacking any version negotiation.
 const LATEST_MINOR_VERSION: u8 = 0;
@@ -82,7 +82,7 @@ impl VersionedCryptoBox {
     pub fn acceptable_minor_versions() -> Vec<u8> {
         ACCEPTABLE_MINOR_VERSIONS.to_vec()
     }
-    /// Called by a client to select an acceptable version based on what a server adverstised
+    /// Called by a client to select an acceptable version based on what a server advertised
     pub fn select_version(others_acceptable_versions: &[u8]) -> Result<Self, VersionError> {
         Self::acceptable_minor_versions()
             .iter()

--- a/crypto/digestible/README.md
+++ b/crypto/digestible/README.md
@@ -426,7 +426,7 @@ to an enumerator. In this case, we follow the rules for an aggregate when append
 the anonymous struct to the transcript, and use the empty string for its name.
 
 In rust, an enum where every variant has no associated data can be tagged with e.g. `repr(u32)`
-and interpretted directly as a `u32`, as in C enums. An implementor may reasonably decide
+and interpreted directly as a `u32`, as in C enums. An implementor may reasonably decide
 to implement `digestible` for such an enum by converting to a `u32` and then appending that
 as a primitive. In this case `derive(Digestible)` should not be used, and this choice should be documented
 to allow cross-language implementations to do the same.


### PR DESCRIPTION
### Motivation

This PR performs minor cleanup by fixing several typos in the comments of various files of the `crypto` folder.