### PR TITLE
Run Homebrew update on every macOS CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,18 +188,15 @@ commands:
       - restore_cache:
           name: Restore Homebrew cache
           key: v0-homebrew-{{ arch }}
-      - when:
-          condition: { equal: [ << pipeline.git.branch >>, master ] }
-          steps:
-            - run:
-                name: Update Homebrew
-                command: |
-                  brew --version
-                  brew update --preinstall
+      - run:
+          name: Update Homebrew
+          command: |
+            brew --version
+            brew update --preinstall
+            brew --version
       - run:
           name: Install Homebrew dependencies
           command: |
-            brew --version
             brew bundle --no-upgrade
 
   save-homebrew-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,7 @@ executors:
 
   macos:
     parameters:
-      xcode-version:
-        type: string
-        default: *default-xcode-version
+      xcode-version: { type: string, default: *default-xcode-version }
     macos:
       xcode: << parameters.xcode-version >>
     environment:
@@ -253,10 +251,7 @@ commands:
 
   prepare-for-build:
     parameters:
-      os:
-        type: enum
-        enum: ["linux", "macos", "windows"]
-        default: linux
+      os: { type: enum, enum: [ "linux", "macos", "windows" ], default: linux }
     steps:
       - checkout
       - when:
@@ -498,9 +493,7 @@ jobs:
   # Build using macOS
   build-macos:
     parameters:
-      xcode-version:
-        type: string
-        default: *default-xcode-version
+      xcode-version: { type: string, default: *default-xcode-version }
     executor:
       name: macos
       xcode-version: << parameters.xcode-version >>
@@ -510,8 +503,7 @@ jobs:
       RUSTFLAGS: -D warnings -C target-cpu=penryn
       CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/sgx/css/src/valid.css
     steps:
-      - prepare-for-build:
-          os: macos
+      - prepare-for-build: { os: macos }
       - run:
           name: Cargo check
           command: |


### PR DESCRIPTION
### Motivation

Our CI recently started failing on macOS CI runs (as seen [here](https://app.circleci.com/pipelines/github/mobilecoinfoundation/mobilecoin/2873/workflows/17d734ca-0734-4860-9413-4523e3d9e14e/jobs/7010/parallel-runs/0/steps/0-103)) because of an outdated Homebrew version. Previously we ran Homebrew update only when running CI from master, in order to cut down on CI run times for PRs. However, recently it has come to my attention that Homebrew doesn't support running without first updating (See https://github.com/Homebrew/homebrew-bundle/issues/840).

In order to resolve this issue while still minimizing CI times for PRs, this PR changes the CircleCI config to runs `brew update --preinstall` on every run of CI rather than just on master, while continuing to keep auto-update disabled otherwise. In the timespan of a single CI run, it should be perfectly acceptable to only run brew update once and still remain in line with Homebrew's guidance regarding keeping their tool up-to-date.

### In this PR
* Run Homebrew update on every CI run