### PR TITLE
Simplify Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,8 +570,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.11.2"
-source = "git+https://github.com/mitsuhiko/console?rev=1307823#13078231718e5a328dc9aba27117ec0a9674ae3f"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
 dependencies = [
  "encode_unicode",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,6 @@ prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b
 # https://github.com/slog-rs/slog/pull/268
 slog = { git = "https://github.com/mobilecoinofficial/slog", rev = "cc1562258b81353426d17a55b7447256fa6eabbf" }
 dialoguer = { git = "https://github.com/mitsuhiko/dialoguer", rev = "a0c6c1e" }
-console = { git = "https://github.com/mitsuhiko/console", rev = "1307823" }
 
 # Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
 lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation
Currently, we hard code the console library. The relevant blame hints this was needed for patches at the time. This is needed to clean up the build and help reduce technical debt.

### In this PR
Removes the relevant duplicate console library.

### TODO
- [x]  Bump the Cargo.lock

### Future Work
I will probably continue to simplify the Cargo.toml
