### PR TITLE
MCC-710 Final changes regarded FullyValidatedFogPubkey and TransactionBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,7 +2829,9 @@ dependencies = [
  "mc-account-keys",
  "mc-attest-core",
  "mc-crypto-keys",
+ "mc-fog-api",
  "mc-util-encodings",
+ "mc-util-serial",
  "mockall",
 ]
 
@@ -3383,6 +3385,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-crypto-rand",
+ "mc-fog-report-validation",
  "mc-ledger-db",
  "mc-transaction-core",
  "mc-transaction-std",
@@ -3398,6 +3401,7 @@ dependencies = [
  "blake2",
  "curve25519-dalek",
  "failure",
+ "maplit",
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-fog-report-validation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2836,6 +2836,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-fog-report-validation-test-utils"
+version = "1.0.0"
+dependencies = [
+ "mc-account-keys",
+ "mc-fog-report-validation",
+]
+
+[[package]]
 name = "mc-ledger-db"
 version = "1.0.0"
 dependencies = [
@@ -2961,6 +2969,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-fog-report-connection",
  "mc-fog-report-validation",
+ "mc-fog-report-validation-test-utils",
  "mc-ledger-db",
  "mc-ledger-sync",
  "mc-mobilecoind-api",
@@ -3385,7 +3394,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-crypto-rand",
- "mc-fog-report-validation",
+ "mc-fog-report-validation-test-utils",
  "mc-ledger-db",
  "mc-transaction-core",
  "mc-transaction-std",
@@ -3405,6 +3414,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-fog-report-validation",
+ "mc-fog-report-validation-test-utils",
  "mc-transaction-core",
  "mc-util-from-random",
  "mc-util-serial",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,7 @@ dependencies = [
  "failure",
  "mc-account-keys",
  "mc-crypto-keys",
+ "mc-fog-report-validation",
  "mc-transaction-core",
  "mc-util-from-random",
  "mc-util-serial",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "fog/api",
     "fog/report/connection",
     "fog/report/validation",
+    "fog/report/validation/test-utils",
     "ledger/db",
     "ledger/distribution",
     "ledger/from-archive",

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -60,7 +60,7 @@ mod tests {
             mc_transaction_core_test_utils::get_outputs(&recipient_and_amounts, &mut rng)
         };
 
-        let mut transaction_builder = TransactionBuilder::new();
+        let mut transaction_builder = TransactionBuilder::new(Default::default());
 
         let ring: Vec<TxOut> = minted_outputs.clone();
         let public_key = RistrettoPublic::try_from(&minted_outputs[0].public_key).unwrap();
@@ -91,7 +91,7 @@ mod tests {
         transaction_builder.add_input(input_credentials);
         transaction_builder.set_fee(0);
         transaction_builder
-            .add_output(65536, &bob.default_subaddress(), None, &mut rng)
+            .add_output(65536, &bob.default_subaddress(), &mut rng)
             .unwrap();
 
         let tx = transaction_builder.build(&mut rng).unwrap();

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -34,6 +34,7 @@ mod tests {
         onetime_keys::recover_onetime_private_key,
         tx::{Tx, TxOut, TxOutMembershipProof},
     };
+    use mc_transaction_core_test_utils::MockFogResolver;
     use mc_transaction_std::{InputCredentials, TransactionBuilder};
     use protobuf::Message;
     use rand::{rngs::StdRng, SeedableRng};
@@ -60,7 +61,7 @@ mod tests {
             mc_transaction_core_test_utils::get_outputs(&recipient_and_amounts, &mut rng)
         };
 
-        let mut transaction_builder = TransactionBuilder::new(Default::default());
+        let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
 
         let ring: Vec<TxOut> = minted_outputs.clone();
         let public_key = RistrettoPublic::try_from(&minted_outputs[0].public_key).unwrap();

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -475,7 +475,7 @@ mod combine_tests {
         onetime_keys::recover_onetime_private_key,
         tx::{TxOut, TxOutMembershipProof},
     };
-    use mc_transaction_core_test_utils::AccountKey;
+    use mc_transaction_core_test_utils::{AccountKey, MockFogResolver};
     use mc_transaction_std::{InputCredentials, TransactionBuilder};
     use mc_util_from_random::FromRandom;
     use rand::SeedableRng;
@@ -548,7 +548,7 @@ mod combine_tests {
         )
         .unwrap();
 
-        let mut transaction_builder = TransactionBuilder::new(Default::default());
+        let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
         transaction_builder.add_input(input_credentials);
         transaction_builder.set_fee(0);
         transaction_builder
@@ -592,7 +592,7 @@ mod combine_tests {
 
                 // Step 2: Create a transaction that sends the full value of `tx_out` to `recipient_account`.
 
-                let mut transaction_builder = TransactionBuilder::new(Default::default());
+                let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
 
                 // Create InputCredentials to spend the TxOut.
                 let onetime_private_key = recover_onetime_private_key(
@@ -682,7 +682,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
@@ -714,7 +714,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
@@ -767,7 +767,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
@@ -845,7 +845,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
@@ -878,7 +878,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
@@ -932,7 +932,7 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new(Default::default());
+            let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -548,11 +548,11 @@ mod combine_tests {
         )
         .unwrap();
 
-        let mut transaction_builder = TransactionBuilder::new();
+        let mut transaction_builder = TransactionBuilder::new(Default::default());
         transaction_builder.add_input(input_credentials);
         transaction_builder.set_fee(0);
         transaction_builder
-            .add_output(123, &bob.default_subaddress(), None, &mut rng)
+            .add_output(123, &bob.default_subaddress(), &mut rng)
             .unwrap();
 
         let tx = transaction_builder.build(&mut rng).unwrap();
@@ -592,7 +592,7 @@ mod combine_tests {
 
                 // Step 2: Create a transaction that sends the full value of `tx_out` to `recipient_account`.
 
-                let mut transaction_builder = TransactionBuilder::new();
+                let mut transaction_builder = TransactionBuilder::new(Default::default());
 
                 // Create InputCredentials to spend the TxOut.
                 let onetime_private_key = recover_onetime_private_key(
@@ -622,7 +622,7 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0);
                 transaction_builder
-                    .add_output(88, &bob.default_subaddress(), None, &mut rng)
+                    .add_output(88, &bob.default_subaddress(), &mut rng)
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
@@ -682,11 +682,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &bob.default_subaddress(), None, &mut rng)
+                .add_output(123, &bob.default_subaddress(), &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -714,11 +714,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &recipient_account.default_subaddress(), None, &mut rng)
+                .add_output(123, &recipient_account.default_subaddress(), &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -767,11 +767,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &recipient_account.default_subaddress(), None, &mut rng)
+                .add_output(123, &recipient_account.default_subaddress(), &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -845,11 +845,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &bob.default_subaddress(), None, &mut rng)
+                .add_output(123, &bob.default_subaddress(), &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -878,11 +878,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &recipient_account.default_subaddress(), None, &mut rng)
+                .add_output(123, &recipient_account.default_subaddress(), &mut rng)
                 .unwrap();
 
             let mut tx = transaction_builder.build(&mut rng).unwrap();
@@ -932,11 +932,11 @@ mod combine_tests {
             )
             .unwrap();
 
-            let mut transaction_builder = TransactionBuilder::new();
+            let mut transaction_builder = TransactionBuilder::new(Default::default());
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0);
             transaction_builder
-                .add_output(123, &recipient_account.default_subaddress(), None, &mut rng)
+                .add_output(123, &recipient_account.default_subaddress(), &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();

--- a/fog/report/connection/src/lib.rs
+++ b/fog/report/connection/src/lib.rs
@@ -1,172 +1,104 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
-//! Fog Report Connection handles resolving the public key from the report service
-//! on making grpc to the reports endpoint
+#![deny(missing_docs)]
 
-use core::str::FromStr;
+//! Fog Report Connection handles connecting to the fog report service and
+//! building up a FogReportResponses object needed to create a transaction
+//! with fog recipients.
+
 use displaydoc::Display;
 use grpcio::{ChannelBuilder, Environment};
-use mc_account_keys::PublicAddress;
-use mc_attest_core::{VerificationReport, Verifier};
 use mc_common::logger::{log, o, Logger};
 use mc_fog_api::report_grpc;
-use mc_fog_report_validation::ingest_report::{Error as IngestReportError, IngestReportVerifier};
-use mc_util_grpc::{BasicCredentials, ConnectionUriGrpcioChannel};
-use mc_util_uri::{ConnectionUri, FogUri, UriParseError};
+use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_util_uri::FogUri;
 use std::sync::Arc;
 
-pub use mc_fog_report_validation::{FogPubkeyResolver, FullyValidatedFogPubkey};
+pub use mc_fog_report_validation::FogReportResponses;
 
-#[derive(Debug, Display)]
-pub enum Error {
-    /// Recipient doesn't have fog
-    RecipientHasNoFog,
-    /// Invalid fog url: {0}
-    InvalidFogUrl(UriParseError),
-    /// grpc failure: {0}
-    Rpc(grpcio::Error),
-    /// deserialization failed: {0}
-    DeserializationFailed(mc_util_serial::decode::Error),
-    /// report rejected: {0}
-    Rejected(IngestReportError),
-    /// Fog Report Server has no available reports
-    NoReports,
-    /// Matching report not found
-    NotFound,
+/// Fog report server connection based on grpcio
+///
+/// TODO: As an optimization, it might be good to make this like a connection
+/// pool that holds onto its grpc connections, so that they can be reused
+/// if a client is constructing transactions frequently.
+/// The user of this API would tear down this object when they want these
+/// connections to be closed.
+#[derive(Clone)]
+pub struct GrpcFogReportConnection {
+    /// grpc environment
+    env: Arc<Environment>,
+    /// The logging instance
+    logger: Logger,
 }
 
-impl From<UriParseError> for Error {
-    fn from(src: UriParseError) -> Self {
-        Self::InvalidFogUrl(src)
+impl GrpcFogReportConnection {
+    /// Create a new GrpcFogReportConnection object
+    pub fn new(env: Arc<Environment>, logger: Logger) -> Self {
+        Self { env, logger }
     }
+
+    /// Fetch fog reports corresponding to a series of FogUris.
+    /// This attempts to be efficient, not contacting a server twice if a FogUri appears twice.
+    pub fn fetch_fog_reports(
+        &self,
+        uris: impl Iterator<Item = FogUri>,
+    ) -> Result<FogReportResponses, Error> {
+        let mut responses = FogReportResponses::default();
+        for uri in uris {
+            self.fetch_fog_report(&mut responses, &uri)?;
+        }
+        Ok(responses)
+    }
+
+    /// Given a set of previously collected FogReportResponse's, and another Uri, make a corresponding
+    /// request and add it to the collection, if such a response is not already present.
+    pub fn fetch_fog_report(
+        &self,
+        responses: &mut FogReportResponses,
+        uri: &FogUri,
+    ) -> Result<(), Error> {
+        match responses.entry(uri.to_string()) {
+            std::collections::btree_map::Entry::Occupied(_) => Ok(()),
+            std::collections::btree_map::Entry::Vacant(ent) => {
+                let logger = self.logger.new(o!("mc.fog.cxn" => uri.to_string()));
+
+                // Build channel to this URI
+                let ch = ChannelBuilder::default_channel_builder(self.env.clone())
+                    .connect_to_uri(uri, &logger);
+                let report_grpc_client = report_grpc::ReportApiClient::new(ch);
+
+                // Request reports
+                let req = mc_fog_api::report::ReportRequest::new();
+                let resp = report_grpc_client.get_reports(&req)?;
+
+                if resp.reports.len() == 0 {
+                    log::warn!(
+                        self.logger,
+                        "Report server at {} has no available reports",
+                        uri
+                    );
+                    return Err(Error::NoReports);
+                }
+
+                // Store entire response, for later validation against measurement and public addresses
+                ent.insert(resp);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Errors that can occur during GrpcFogReportConnection operation
+#[derive(Debug, Display)]
+pub enum Error {
+    /// grpc failure: {0}
+    Rpc(grpcio::Error),
+    /// Fog Report Server has no available reports
+    NoReports,
 }
 
 impl From<grpcio::Error> for Error {
     fn from(src: grpcio::Error) -> Self {
         Self::Rpc(src)
-    }
-}
-
-impl From<mc_util_serial::decode::Error> for Error {
-    fn from(src: mc_util_serial::decode::Error) -> Self {
-        Self::DeserializationFailed(src)
-    }
-}
-
-impl From<IngestReportError> for Error {
-    fn from(src: IngestReportError) -> Self {
-        Self::Rejected(src)
-    }
-}
-
-/// Fog Pubkey resolver based on grpcio
-pub struct GrpcFogPubkeyResolver {
-    /// Ingest report verifier
-    verifier: IngestReportVerifier,
-    /// The logging instance
-    logger: Logger,
-    /// grpc environment
-    env: Arc<Environment>,
-}
-
-impl GrpcFogPubkeyResolver {
-    pub fn new(verifier: &Verifier, env: Arc<Environment>, logger: Logger) -> Self {
-        Self {
-            verifier: IngestReportVerifier::from(verifier),
-            env,
-            logger,
-        }
-    }
-}
-
-impl FogPubkeyResolver for GrpcFogPubkeyResolver {
-    type Error = Error;
-
-    fn get_fog_pubkey(&self, recipient: &PublicAddress) -> Result<FullyValidatedFogPubkey, Error> {
-        let fog_report_url_str = recipient.fog_report_url().ok_or(Error::RecipientHasNoFog)?;
-        let fog_report_url = FogUri::from_str(fog_report_url_str)?;
-        let fog_report_id_str = recipient.fog_report_id().unwrap_or("");
-
-        let logger = self
-            .logger
-            .new(o!("mc.fog.cxn" => fog_report_url.to_string()));
-
-        let creds = BasicCredentials::new(&fog_report_url.username(), &fog_report_url.password());
-
-        // Build channel to this URI
-        // FIXME: We must get the TLS fingerprints and do fingerprint checking with sig
-        let ch = ChannelBuilder::default_channel_builder(self.env.clone())
-            .connect_to_uri(&fog_report_url, &logger);
-        let report_grpc_client = report_grpc::ReportApiClient::new(ch);
-
-        // Request reports
-        let req = mc_fog_api::report::ReportRequest::new();
-        let resp = report_grpc_client.get_reports_opt(&req, creds.call_option()?)?;
-
-        if resp.reports.len() == 0 {
-            log::warn!(
-                self.logger,
-                "Report server at {} has no available reports",
-                fog_report_url_str
-            );
-            return Err(Error::NoReports);
-        }
-
-        for rep in resp.reports.iter() {
-            // Make sure the fog_url, which came from ingest --fqdn config param,
-            // matches Alice's fog_url in her public identity
-            // Note: Neither of these strings is expected to have scheme or port
-            // So we should possibly load them as url's and normalize them by
-            // removing those things before doing the test.
-            log::debug!(
-                logger,
-                "Comparing found fog_report_id: '{}', with recipient fog_report_id: '{}'",
-                rep.fog_report_id,
-                fog_report_id_str,
-            );
-            if rep.fog_report_id == fog_report_id_str {
-                // Get the pubkey from the attestation evidence
-                // NOTE: We are not doing a key exchange, so we do not care about Ingest's ResponderId
-                let remote_report: VerificationReport = mc_util_serial::deserialize(&rep.report)
-                    .map_err(|err| {
-                        log::error!(
-                            logger,
-                            "Failed deserializing fog ingest VerificationReport: report_id: '{}', err = {}",
-                            fog_report_id_str,
-                            err
-                        );
-                        err
-                    })?;
-
-                // Validate report
-                let pubkey = self.verifier.validate_ingest_ias_report(remote_report).map_err(|err| {
-                        log::error!(
-                            logger,
-                            "Failed validating fog ingest VerificationReport: report_id: '{}', err = {}",
-                            fog_report_id_str,
-                            err
-                        );
-                        err
-                    })?;
-                return Ok(FullyValidatedFogPubkey {
-                    pubkey,
-                    pubkey_expiry: rep.pubkey_expiry,
-                    fog_report_id: rep.fog_report_id.clone(),
-                });
-            }
-        }
-
-        let found_urls: Vec<String> = resp
-            .reports
-            .iter()
-            .map(|rep| format!("'{}'", rep.fog_report_id))
-            .collect();
-        log::error!(
-            logger,
-            "Could not find needed fog report among the returned reports: wanted id: '{}', found ids: [{}].",
-            fog_report_id_str,
-            found_urls.join(", ")
-        );
-        Err(Error::NotFound)
     }
 }

--- a/fog/report/connection/src/lib.rs
+++ b/fog/report/connection/src/lib.rs
@@ -21,11 +21,9 @@ pub use mc_fog_report_validation::FogReportResponses;
 
 /// Fog report server connection based on grpcio
 ///
-/// TODO: As an optimization, it might be good to make this like a connection
-/// pool that holds onto its grpc connections, so that they can be reused
-/// if a client is constructing transactions frequently.
-/// The user of this API would tear down this object when they want these
-/// connections to be closed.
+/// TODO: As an optimization, it might be good to make this object hold onto its
+/// grpc channels, so that they can be reused across calls, instead of establishing
+/// new connections each time.
 #[derive(Clone)]
 pub struct GrpcFogReportConnection {
     /// grpc environment
@@ -89,7 +87,7 @@ impl GrpcFogReportConnection {
                 "Report server at {} has no available reports",
                 uri
             );
-            return Err(Error::NoReports);
+            return Err(Error::NoReports(uri.clone()));
         }
 
         // Return entire response
@@ -102,8 +100,8 @@ impl GrpcFogReportConnection {
 pub enum Error {
     /// grpc failure: {0}
     Rpc(grpcio::Error),
-    /// Fog Report Server has no available reports
-    NoReports,
+    /// Fog Report Server has no available reports: {0}
+    NoReports(FogUri),
 }
 
 impl From<grpcio::Error> for Error {

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -12,7 +12,9 @@ automock = ["mockall"]
 mc-account-keys = { path = "../../../account-keys" }
 mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-crypto-keys = { path = "../../../crypto/keys" }
+mc-fog-api = { path = "../../../fog/api" }
 mc-util-encodings = { path = "../../../util/encodings" }
+mc-util-serial = { path = "../../../util/serial" }
 
 displaydoc = { version = "0.1", default-features = false }
 mockall = { version = "0.8.3", optional = true }

--- a/fog/report/validation/README.md
+++ b/fog/report/validation/README.md
@@ -1,6 +1,6 @@
 mc-fog-report-validation
 ========================
 
-This contains the logic for validating a report created by an ingest node
+This contains the logic for validating results from the fog report server
 and extracting the validated pubkey. This crate must not depend on grpcio and
 must be libmobilecoin-friendly.

--- a/fog/report/validation/src/ingest_report.rs
+++ b/fog/report/validation/src/ingest_report.rs
@@ -12,7 +12,7 @@ use mc_util_encodings::Error as EncodingError;
 /// A structure that can validate ingest enclave reports and measurements at runtime.
 ///
 /// This is expected to take the verification report and produce the ias-validated and decompressed RistrettoPublic key.
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct IngestReportVerifier {
     verifier: Verifier,
 }

--- a/fog/report/validation/src/lib.rs
+++ b/fog/report/validation/src/lib.rs
@@ -1,147 +1,121 @@
 //! Logic for representing fog public keys from the fog-report server
 //! that have been fully validated, and the associated metadata.
+//!
+//! Note: Ideally this crate would be no_std compatible, but that is aspirational.
+//! The ReportResponse object is not no_std right now, and neither is x509 stuff.
+//! This is tracked in FOG-334.
+//! The main reason to make it no_std compatible is to support constructing
+//! mobilecoin transactions with fog recipients on an embedded device like a
+//! tiny hardware wallet, that doesn't have threads and won't have rust std.
 
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 #![deny(missing_docs)]
-#![cfg_attr(not(any(test, feature = "automock")), no_std)]
 
 extern crate alloc;
 
 use alloc::{
-    collections::{btree_map::Entry, BTreeMap},
+    collections::BTreeMap,
     string::{String, ToString},
 };
-use core::fmt::{Debug, Display};
-use displaydoc::Display;
 use mc_account_keys::PublicAddress;
-use mc_crypto_keys::RistrettoPublic;
-
-#[cfg(any(test, feature = "automock"))]
-use mockall::*;
+use mc_attest_core::{VerificationReport, Verifier};
+use mc_fog_api::report::ReportResponse;
 
 /// Data structure for fog-ingest report validation
 pub mod ingest_report;
+use ingest_report::IngestReportVerifier;
 
-/// Represents a fog public key validated to use for creating encrypted fog hints.
-/// This object should be constructed only when the IAS report has been validated.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct IasValidatedFogPubkey(pub RistrettoPublic);
+/// Interface for a class that can take public addresses and produce validated
+/// fog pubkeys suitable for the transaction builder.
+/// This is the FogResolver object.
+mod traits;
+pub use traits::{FogPubkeyError, FogPubkeyResolver, FullyValidatedFogPubkey};
 
-impl AsRef<RistrettoPublic> for IasValidatedFogPubkey {
-    fn as_ref(&self) -> &RistrettoPublic {
-        &self.0
-    }
-}
+#[cfg(any(test, feature = "automock"))]
+pub use traits::MockFogPubkeyResolver;
 
-/// Fully resolves a public address to a fully validated fog public key structure,
-/// including all the data from the report server.
-/// This interface may include grpc and so likely cannot be implemented in a way
-/// that is safe for libmobilecoin / asynchronous java requirements.
-#[cfg_attr(any(test, feature = "automock"), automock(type Error = String;))]
-pub trait FogPubkeyResolver {
-    /// Error type returned by the fog pubkey resolver
-    type Error: Display + Debug;
-    /// Fetch and validate a fog public key, given a recipient's public address
-    fn get_fog_pubkey(
-        &self,
-        recipient: &PublicAddress,
-    ) -> Result<FullyValidatedFogPubkey, Self::Error>;
-}
-
-/// Represents a fog public key validated to use for creating encrypted fog hints.
-/// This object should be constructed only when the IAS report has been validated,
-/// and the chain of trust from the connection has been validated, and the
-/// the fog user's fog_authority_fingerprint_sig over the fingerprints in the signature chain
-/// has been validated for at least one fingerprint.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct FullyValidatedFogPubkey {
-    /// The fog_report_id value from the fog report.Report proto structure
-    pub fog_report_id: String,
-    /// The ristretto curve point which was extracted from the IAS report additional data
-    /// after validation. This is the encryption key used to create encrypted fog hints.
-    /// The corresponding private key lives only in SGX ingest nodes.
-    pub pubkey: RistrettoPublic,
-    /// The pubkey_expiry value is the latest block that fog-service promises
-    /// that is valid to encrypt fog hints using this key for.
-    /// The client should obey this limit by not setting tombstone block for a
-    /// transaction larger than this limit if the fog pubkey is used.
-    pub pubkey_expiry: u64,
-}
-
-/// Represents a set of fully validated fog public keys
+/// Represents a set of unvalidated responses from Fog report servers
+/// Key = Fog-url that was contacted, must match the string in user's public address
+/// Value = The complete response from the fog report server
 ///
-/// These can be fetched before building a transaction, then the rest of the
-/// transaction building process can happen offline.
-#[derive(Default, Debug)]
-pub struct FullyValidatedFogPubkeys {
-    /// Map from fog_url, fog_report_id strings to fully validated pubkeys
-    keys: BTreeMap<(String, String), FullyValidatedFogPubkey>,
+/// When constructing a transaction, the fog-url for each recipient should be
+/// extracted from their public address, then a request to that report server should
+/// be made. The responses should be collected in a map-structure (like this).
+/// This should be done for each recipient.
+///
+/// This map structure is ultimately consumed by the TransactionBuilder object,
+/// which validates the responses against the fog data in the public addresses when
+/// building the transaction.
+///
+/// This map structure should not be cached, because the fog pubkeys have an
+/// expiry date and don't live that long. They can be cached for a short time,
+/// but the transaction builder enforces that the tombstone block for the transaction
+/// is limited by the pubkey expiry value of any fog pubkey that is used,
+/// so if these are cached too long, the transaction will be rejected by consensus.
+///
+/// In the case of constructing off-line transactions with Fog recipients, the flow is:
+/// (1) Take fog-urls from (offline) public addresses to the online machine
+/// (2) Hit the fog report servers (online machine), producing FogReportResponses
+/// (3) Take FogReportResponses to the offline machine, and use with transaction builder,
+///     to create the transaction offline.
+/// (4) Take the constructed transaction to the online machine and submit to consensus.
+///
+/// Note: there is no particular reason for this to be BTreeMap instead of HashMap,
+/// except that it is slightly more portable, only requiring the alloc crate.
+pub type FogReportResponses = BTreeMap<String, ReportResponse>;
+
+/// A collection of unvalidated fog reports, together with an IAS verifier.
+/// This object is passed to the TransactionBuilder object.
+/// When fog is not involved, it can simply be defaulted.
+///
+/// Once constructed, this object can get validated fog pubkeys to build fog hints
+/// for transactions, without talking to the internet, and so is compatible with
+/// offline transactions to fog recipients. Only getting the FogReportResponses
+/// requires an online connection.
+#[derive(Default, Clone, Debug)]
+pub struct FogResolver {
+    responses: FogReportResponses,
+    verifier: IngestReportVerifier,
 }
 
-impl FullyValidatedFogPubkeys {
-    /// Check if we have a fog pubkey needed for a given recipient.
-    /// If so, do nothing.
-    /// If not, try to fetch one using the resolver.
-    pub fn add_key_for_recipient<R: FogPubkeyResolver>(
-        &mut self,
-        resolver: &R,
-        recipient: &PublicAddress,
-    ) -> Result<(), R::Error> {
-        if let Some(table_key) = self.table_key(recipient) {
-            match self.keys.entry(table_key) {
-                Entry::Occupied(_) => {}
-                Entry::Vacant(ent) => {
-                    ent.insert(resolver.get_fog_pubkey(recipient)?);
-                }
-            }
+impl FogResolver {
+    /// Create a new FogResolver object, given serialized (unverified)
+    /// fog report server responses,
+    /// and an attestation verifier for fog ingest measurements.
+    pub fn new(responses: FogReportResponses, verifier: &Verifier) -> Self {
+        Self {
+            responses,
+            verifier: IngestReportVerifier::from(verifier),
         }
-        Ok(())
-    }
-
-    /// Alternative to add_key_for_recipient, this may be helpful for SDK code which doesn't want to make blocking calls into rust.
-    pub fn add_key(&mut self, report_url: String, validated_key: FullyValidatedFogPubkey) {
-        self.keys.insert(
-            (report_url, validated_key.fog_report_id.clone()),
-            validated_key,
-        );
-    }
-
-    /// Construct the key to use in the table for given public address
-    /// Returns None if the public address doesn't have a fog report url.
-    fn table_key(&self, addr: &PublicAddress) -> Option<(String, String)> {
-        addr.fog_report_url().map(|url| {
-            (
-                url.to_string(),
-                addr.fog_report_id().unwrap_or("").to_string(),
-            )
-        })
-    }
-
-    /// Get the smallest pubkey_expiry value of any of these fog pubkeys.
-    /// Returns u64::MAX if there are no fog pubkeys present.
-    pub fn smallest_pubkey_expiry_value(&self) -> u64 {
-        self.keys.values().fold(u64::MAX, |cur_min, key| {
-            core::cmp::min(cur_min, key.pubkey_expiry)
-        })
     }
 }
 
-impl FogPubkeyResolver for FullyValidatedFogPubkeys {
-    type Error = FogPubkeyError;
-
+impl FogPubkeyResolver for FogResolver {
     fn get_fog_pubkey(
         &self,
         recipient: &PublicAddress,
-    ) -> Result<FullyValidatedFogPubkey, Self::Error> {
-        if let Some(table_key) = self.table_key(recipient) {
-            if let Some(result) = self.keys.get(&table_key) {
-                Ok(result.clone())
+    ) -> Result<FullyValidatedFogPubkey, FogPubkeyError> {
+        if let Some(url) = recipient.fog_report_url() {
+            let url = url.to_string();
+            if let Some(result) = self.responses.get(&url) {
+                let report_id = recipient.fog_report_id().unwrap_or("").to_string();
+                for report in result.reports.iter() {
+                    if report_id == report.fog_report_id {
+                        // TODO validate x509 chain and recipient.fog_authority_sig here,
+                        // Howeve, probably skip that if uri scheme is "insecure-fog"?
+                        let remote_report: VerificationReport =
+                            mc_util_serial::deserialize(&report.report)?;
+                        let pubkey = self.verifier.validate_ingest_ias_report(remote_report)?;
+                        return Ok(FullyValidatedFogPubkey {
+                            pubkey,
+                            pubkey_expiry: report.pubkey_expiry,
+                        });
+                    }
+                }
+                Err(FogPubkeyError::NoMatchingReportId(url, report_id))
             } else {
-                Err(FogPubkeyError::FogPubkeyNotPrefetched(
-                    table_key.0,
-                    table_key.1,
-                ))
+                Err(FogPubkeyError::NoMatchingReportResponse(url))
             }
         } else {
             Err(FogPubkeyError::NoFogReportUrl)
@@ -149,11 +123,28 @@ impl FogPubkeyResolver for FullyValidatedFogPubkeys {
     }
 }
 
-/// An error that can occur when trying to get a fog pubkey from the FullyValidatedFogPubkeys set
-#[derive(Display, Debug)]
-pub enum FogPubkeyError {
-    /// FogPubkey was not prefetched for url = {0}, report_id = {1}
-    FogPubkeyNotPrefetched(String, String),
-    /// Address has no fog_report_url, cannot fetch fog pubkey
-    NoFogReportUrl,
+/// A mock fog resolver for tests, which skips all IAS, x509, and grpc
+/// It maps Fog-urls (Strings) to FullyValidatedFogPubkey
+///
+/// DO NOT use this except in test code!
+#[derive(Default, Debug)]
+pub struct MockFogResolver(pub BTreeMap<String, FullyValidatedFogPubkey>);
+
+impl FogPubkeyResolver for MockFogResolver {
+    fn get_fog_pubkey(
+        &self,
+        addr: &PublicAddress,
+    ) -> Result<FullyValidatedFogPubkey, FogPubkeyError> {
+        if let Some(fog_url) = addr.fog_report_url() {
+            if let Some(result) = self.0.get(fog_url) {
+                Ok(result.clone())
+            } else {
+                Err(FogPubkeyError::NoMatchingReportResponse(
+                    fog_url.to_string(),
+                ))
+            }
+        } else {
+            Err(FogPubkeyError::NoFogReportUrl)
+        }
+    }
 }

--- a/fog/report/validation/src/lib.rs
+++ b/fog/report/validation/src/lib.rs
@@ -1,17 +1,26 @@
+//! Logic for representing fog public keys from the fog-report server
+//! that have been fully validated, and the associated metadata.
+
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
+#![deny(missing_docs)]
 #![cfg_attr(not(any(test, feature = "automock")), no_std)]
 
 extern crate alloc;
 
-use alloc::string::String;
+use alloc::{
+    collections::{btree_map::Entry, BTreeMap},
+    string::{String, ToString},
+};
 use core::fmt::{Debug, Display};
+use displaydoc::Display;
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::RistrettoPublic;
 
 #[cfg(any(test, feature = "automock"))]
 use mockall::*;
 
+/// Data structure for fog-ingest report validation
 pub mod ingest_report;
 
 /// Represents a fog public key validated to use for creating encrypted fog hints.
@@ -31,7 +40,9 @@ impl AsRef<RistrettoPublic> for IasValidatedFogPubkey {
 /// that is safe for libmobilecoin / asynchronous java requirements.
 #[cfg_attr(any(test, feature = "automock"), automock(type Error = String;))]
 pub trait FogPubkeyResolver {
+    /// Error type returned by the fog pubkey resolver
     type Error: Display + Debug;
+    /// Fetch and validate a fog public key, given a recipient's public address
     fn get_fog_pubkey(
         &self,
         recipient: &PublicAddress,
@@ -56,4 +67,93 @@ pub struct FullyValidatedFogPubkey {
     /// The client should obey this limit by not setting tombstone block for a
     /// transaction larger than this limit if the fog pubkey is used.
     pub pubkey_expiry: u64,
+}
+
+/// Represents a set of fully validated fog public keys
+///
+/// These can be fetched before building a transaction, then the rest of the
+/// transaction building process can happen offline.
+#[derive(Default, Debug)]
+pub struct FullyValidatedFogPubkeys {
+    /// Map from fog_url, fog_report_id strings to fully validated pubkeys
+    keys: BTreeMap<(String, String), FullyValidatedFogPubkey>,
+}
+
+impl FullyValidatedFogPubkeys {
+    /// Check if we have a fog pubkey needed for a given recipient.
+    /// If so, do nothing.
+    /// If not, try to fetch one using the resolver.
+    pub fn add_key_for_recipient<R: FogPubkeyResolver>(
+        &mut self,
+        resolver: &R,
+        recipient: &PublicAddress,
+    ) -> Result<(), R::Error> {
+        if let Some(table_key) = self.table_key(recipient) {
+            match self.keys.entry(table_key) {
+                Entry::Occupied(_) => {}
+                Entry::Vacant(ent) => {
+                    ent.insert(resolver.get_fog_pubkey(recipient)?);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Alternative to add_key_for_recipient, this may be helpful for SDK code which doesn't want to make blocking calls into rust.
+    pub fn add_key(&mut self, report_url: String, validated_key: FullyValidatedFogPubkey) {
+        self.keys.insert(
+            (report_url, validated_key.fog_report_id.clone()),
+            validated_key,
+        );
+    }
+
+    /// Construct the key to use in the table for given public address
+    /// Returns None if the public address doesn't have a fog report url.
+    fn table_key(&self, addr: &PublicAddress) -> Option<(String, String)> {
+        addr.fog_report_url().map(|url| {
+            (
+                url.to_string(),
+                addr.fog_report_id().unwrap_or("").to_string(),
+            )
+        })
+    }
+
+    /// Get the smallest pubkey_expiry value of any of these fog pubkeys.
+    /// Returns u64::MAX if there are no fog pubkeys present.
+    pub fn smallest_pubkey_expiry_value(&self) -> u64 {
+        self.keys.values().fold(u64::MAX, |cur_min, key| {
+            core::cmp::min(cur_min, key.pubkey_expiry)
+        })
+    }
+}
+
+impl FogPubkeyResolver for FullyValidatedFogPubkeys {
+    type Error = FogPubkeyError;
+
+    fn get_fog_pubkey(
+        &self,
+        recipient: &PublicAddress,
+    ) -> Result<FullyValidatedFogPubkey, Self::Error> {
+        if let Some(table_key) = self.table_key(recipient) {
+            if let Some(result) = self.keys.get(&table_key) {
+                Ok(result.clone())
+            } else {
+                Err(FogPubkeyError::FogPubkeyNotPrefetched(
+                    table_key.0,
+                    table_key.1,
+                ))
+            }
+        } else {
+            Err(FogPubkeyError::NoFogReportUrl)
+        }
+    }
+}
+
+/// An error that can occur when trying to get a fog pubkey from the FullyValidatedFogPubkeys set
+#[derive(Display, Debug)]
+pub enum FogPubkeyError {
+    /// FogPubkey was not prefetched for url = {0}, report_id = {1}
+    FogPubkeyNotPrefetched(String, String),
+    /// Address has no fog_report_url, cannot fetch fog pubkey
+    NoFogReportUrl,
 }

--- a/fog/report/validation/src/lib.rs
+++ b/fog/report/validation/src/lib.rs
@@ -103,7 +103,7 @@ impl FogPubkeyResolver for FogResolver {
                 for report in result.reports.iter() {
                     if report_id == report.fog_report_id {
                         // TODO validate x509 chain and recipient.fog_authority_sig here,
-                        // Howeve, probably skip that if uri scheme is "insecure-fog"?
+                        // However, probably skip that if uri scheme is "insecure-fog"?
                         let remote_report: VerificationReport =
                             mc_util_serial::deserialize(&report.report)?;
                         let pubkey = self.verifier.validate_ingest_ias_report(remote_report)?;

--- a/fog/report/validation/src/traits.rs
+++ b/fog/report/validation/src/traits.rs
@@ -1,0 +1,66 @@
+use crate::ingest_report::Error as IngestReportError;
+use core::fmt::Debug;
+use displaydoc::Display;
+use mc_account_keys::PublicAddress;
+use mc_crypto_keys::RistrettoPublic;
+
+#[cfg(any(test, feature = "automock"))]
+use mockall::*;
+
+/// Class that can resolve a public address to a fully-validated fog public key structure,
+/// including the pubkey expiry data from the report server.
+#[cfg_attr(any(test, feature = "automock"), automock)]
+pub trait FogPubkeyResolver {
+    /// Fetch and validate a fog public key, given a recipient's public address
+    fn get_fog_pubkey(
+        &self,
+        recipient: &PublicAddress,
+    ) -> Result<FullyValidatedFogPubkey, FogPubkeyError>;
+}
+
+/// Represents a fog public key validated to use for creating encrypted fog hints.
+/// This object should be constructed only when the IAS report has been validated,
+/// and the chain of trust from the connection has been validated, and the
+/// the fog user's fog_authority_fingerprint_sig over the fingerprints in the signature chain
+/// has been validated for at least one fingerprint.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct FullyValidatedFogPubkey {
+    /// The ristretto curve point which was extracted from the IAS report additional data
+    /// after validation. This is the encryption key used to create encrypted fog hints.
+    /// The corresponding private key lives only in SGX ingest nodes.
+    pub pubkey: RistrettoPublic,
+    /// The pubkey_expiry value is the latest block that fog-service promises
+    /// that is valid to encrypt fog hints using this key for.
+    /// The client should obey this limit by not setting tombstone block for a
+    /// transaction larger than this limit if the fog pubkey is used.
+    pub pubkey_expiry: u64,
+}
+
+/// An error that can occur when trying to get a validated fog pubkey from the
+/// FogResolver object
+/// TODO: Add x509 errors, user-sig check errors, etc. here
+#[derive(Display, Debug)]
+pub enum FogPubkeyError {
+    /// No matching reports response for url = {0}
+    NoMatchingReportResponse(String),
+    /// No matching report id for url = {0}, report_id = {1}
+    NoMatchingReportId(String, String),
+    /// Address has no fog_report_url, cannot fetch fog pubkey
+    NoFogReportUrl,
+    /// Ingest report deserialization error: {0},
+    Deserialization(mc_util_serial::decode::Error),
+    /// Ingest report verification error: {0}
+    IngestReport(IngestReportError),
+}
+
+impl From<IngestReportError> for FogPubkeyError {
+    fn from(src: IngestReportError) -> Self {
+        Self::IngestReport(src)
+    }
+}
+
+impl From<mc_util_serial::decode::Error> for FogPubkeyError {
+    fn from(src: mc_util_serial::decode::Error) -> Self {
+        Self::Deserialization(src)
+    }
+}

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mc-fog-report-validation-test-utils"
+version = "1.0.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+mc-account-keys = { path = "../../../../account-keys" }
+mc-fog-report-validation = { path = ".." }

--- a/fog/report/validation/test-utils/README.md
+++ b/fog/report/validation/test-utils/README.md
@@ -1,0 +1,5 @@
+mc-fog-report-validation-test-utils
+===================================
+
+This crate contains a mock fog resolver object for use with the transaction
+builder in unit tests. It bypasses IAS, x509, and grpc, and must not be used in production.

--- a/fog/report/validation/test-utils/src/lib.rs
+++ b/fog/report/validation/test-utils/src/lib.rs
@@ -1,0 +1,29 @@
+pub use mc_account_keys::PublicAddress;
+pub use mc_fog_report_validation::{FogPubkeyError, FogPubkeyResolver, FullyValidatedFogPubkey};
+use std::collections::BTreeMap;
+
+/// A mock fog resolver for tests, which skips all IAS, x509, and grpc
+/// It maps Fog-urls (Strings) to FullyValidatedFogPubkey
+///
+/// DO NOT use this except in test code!
+#[derive(Default, Debug)]
+pub struct MockFogResolver(pub BTreeMap<String, FullyValidatedFogPubkey>);
+
+impl FogPubkeyResolver for MockFogResolver {
+    fn get_fog_pubkey(
+        &self,
+        addr: &PublicAddress,
+    ) -> Result<FullyValidatedFogPubkey, FogPubkeyError> {
+        if let Some(fog_url) = addr.fog_report_url() {
+            if let Some(result) = self.0.get(fog_url) {
+                Ok(result.clone())
+            } else {
+                Err(FogPubkeyError::NoMatchingReportResponse(
+                    fog_url.to_string(),
+                ))
+            }
+        } else {
+            Err(FogPubkeyError::NoFogReportUrl)
+        }
+    }
+}

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -62,6 +62,7 @@ tempdir = "0.3"
 mc-common = { path = "../common", features = ["loggers"] }
 mc-connection-test-utils = { path = "../connection/test-utils" }
 mc-fog-report-validation = { path = "../fog/report/validation", features = ["automock"] }
+mc-fog-report-validation-test-utils = { path = "../fog/report/validation/test-utils" }
 mc-transaction-core-test-utils = { path = "../transaction/core/test-utils" }
 mc-util-from-random = { path = "../util/from-random" }
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -25,6 +25,7 @@ mc-crypto-digestible = { path = "../crypto/digestible", features = ["derive"] }
 mc-crypto-keys = { path = "../crypto/keys" }
 mc-crypto-rand = { path = "../crypto/rand" }
 mc-fog-report-connection = { path = "../fog/report/connection" }
+mc-fog-report-validation = { path = "../fog/report/validation" }
 mc-ledger-db = { path = "../ledger/db" }
 mc-ledger-sync = { path = "../ledger/sync" }
 mc-mobilecoind-api = { path = "../mobilecoind/api" }

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -113,7 +113,7 @@ fn main() {
                 ledger_db.clone(),
                 mobilecoind_db.clone(),
                 peer_manager,
-                config.get_fog_pubkey_resolver(logger.clone()).map(Arc::new),
+                config.get_fog_resolver_factory(logger.clone()),
                 logger.clone(),
             );
 

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -7,10 +7,11 @@ use mc_attest_core::{MrSignerVerifier, Verifier, DEBUG_ENCLAVE};
 use mc_common::{logger::Logger, ResponderId};
 use mc_connection::{ConnectionManager, ThickClient};
 use mc_consensus_scp::QuorumSet;
-use mc_fog_report_connection::GrpcFogPubkeyResolver;
+use mc_fog_report_connection::GrpcFogReportConnection;
+use mc_fog_report_validation::FogResolver;
 use mc_mobilecoind_api::MobilecoindUri;
 use mc_sgx_css::Signature;
-use mc_util_uri::{ConnectionUri, ConsensusClientUri};
+use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
 #[cfg(feature = "ip-check")]
 use reqwest::{
     blocking::Client,
@@ -155,7 +156,8 @@ impl Config {
         QuorumSet::new_with_node_ids(node_ids.len() as u32, node_ids)
     }
 
-    pub fn get_fog_pubkey_resolver(&self, logger: Logger) -> Option<GrpcFogPubkeyResolver> {
+    /// Get the attestation verifier used to verify fog reports when sending to fog recipients
+    pub fn get_fog_ingest_verifier(&self) -> Option<Verifier> {
         self.fog_ingest_enclave_css.as_ref().map(|signature| {
             let mr_signer_verifier = {
                 let mut mr_signer_verifier = MrSignerVerifier::new(
@@ -167,19 +169,41 @@ impl Config {
                 mr_signer_verifier
             };
 
-            let report_verifier = {
-                let mut verifier = Verifier::default();
-                verifier.debug(DEBUG_ENCLAVE).mr_signer(mr_signer_verifier);
-                verifier
-            };
+            let mut verifier = Verifier::default();
+            verifier.debug(DEBUG_ENCLAVE).mr_signer(mr_signer_verifier);
+            verifier
+        })
+    }
 
-            let env = Arc::new(
-                grpcio::EnvBuilder::new()
-                    .name_prefix("FogPubkeyResolver-RPC".to_string())
-                    .build(),
-            );
+    /// Get the function which creates FogResolver given a list of recipient addresses
+    /// The string error should be mapped by invoker of this factory to Error::FogError
+    pub fn get_fog_resolver_factory(
+        &self,
+        logger: Logger,
+    ) -> Arc<dyn Fn(&[FogUri]) -> Result<FogResolver, String> + Send + Sync> {
+        let env = Arc::new(
+            grpcio::EnvBuilder::new()
+                .name_prefix("FogPubkeyResolver-RPC".to_string())
+                .build(),
+        );
 
-            GrpcFogPubkeyResolver::new(&report_verifier, env, logger)
+        let conn = GrpcFogReportConnection::new(env, logger);
+
+        let verifier = self.get_fog_ingest_verifier();
+
+        Arc::new(move |fog_uris| -> Result<FogResolver, String> {
+            if fog_uris.is_empty() {
+                Ok(Default::default())
+            } else {
+                if let Some(verifier) = verifier.as_ref() {
+                    let report_responses = conn
+                        .fetch_fog_reports(fog_uris.iter().cloned())
+                        .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
+                    Ok(FogResolver::new(report_responses, verifier))
+                } else {
+                    Err("Some recipients have fog, but no fog ingest report verifier was configured".to_string())
+                }
+            }
         })
     }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1847,9 +1847,8 @@ mod test {
     use mc_common::{logger::test_with_logger, HashSet};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_crypto_rand::RngCore;
-    use mc_fog_report_validation::{
-        FullyValidatedFogPubkey, MockFogPubkeyResolver, MockFogResolver,
-    };
+    use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogPubkeyResolver};
+    use mc_fog_report_validation_test_utils::MockFogResolver;
     use mc_transaction_core::{
         constants::{MAX_INPUTS, MINIMUM_FEE, RING_SIZE},
         fog_hint::FogHint,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2664,9 +2664,9 @@ mod test {
 
         // Insert into database.
         let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
-        let mut transaction_builder = TransactionBuilder::new();
+        let mut transaction_builder = TransactionBuilder::new(Default::default());
         let (tx_out, tx_confirmation) = transaction_builder
-            .add_output(10, &receiver.subaddress(0), None, &mut rng)
+            .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
 
         add_txos_to_ledger_db(&mut ledger_db, &vec![tx_out.clone()], &mut rng);
@@ -4736,12 +4736,11 @@ mod test {
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
-        let mut transaction_builder = TransactionBuilder::new();
+        let mut transaction_builder = TransactionBuilder::new(Default::default());
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
-                None,
                 &mut rng,
             )
             .unwrap();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -22,7 +22,7 @@ use mc_common::{
 };
 use mc_connection::{BlockchainConnection, UserTxConnection};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
-use mc_fog_report_connection::FogPubkeyResolver;
+use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Error as LedgerError, Ledger, LedgerDB};
 use mc_ledger_sync::{NetworkState, PollingNetworkState};
 use mc_mobilecoind_api::{
@@ -58,7 +58,7 @@ pub struct Service {
 impl Service {
     pub fn new<
         T: BlockchainConnection + UserTxConnection + 'static,
-        FPR: FogPubkeyResolver + Send + Sync + 'static,
+        FPR: FogPubkeyResolver + 'static,
     >(
         ledger_db: LedgerDB,
         mobilecoind_db: Database,
@@ -156,7 +156,7 @@ impl Service {
 
 pub struct ServiceApi<
     T: BlockchainConnection + UserTxConnection + 'static,
-    FPR: FogPubkeyResolver + Send + Sync + 'static,
+    FPR: FogPubkeyResolver + 'static,
 > {
     transactions_manager: TransactionsManager<T, FPR>,
     ledger_db: LedgerDB,
@@ -167,10 +167,8 @@ pub struct ServiceApi<
     logger: Logger,
 }
 
-impl<
-        T: BlockchainConnection + UserTxConnection + 'static,
-        FPR: FogPubkeyResolver + Send + Sync + 'static,
-    > Clone for ServiceApi<T, FPR>
+impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolver + 'static> Clone
+    for ServiceApi<T, FPR>
 {
     fn clone(&self) -> Self {
         Self {
@@ -185,10 +183,8 @@ impl<
     }
 }
 
-impl<
-        T: BlockchainConnection + UserTxConnection + 'static,
-        FPR: FogPubkeyResolver + Send + Sync + 'static,
-    > ServiceApi<T, FPR>
+impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolver + 'static>
+    ServiceApi<T, FPR>
 {
     pub fn new(
         transactions_manager: TransactionsManager<T, FPR>,
@@ -1761,7 +1757,7 @@ macro_rules! build_api {
     ($( $service_function_name:ident $service_request_type:ident $service_response_type:ident $service_function_impl:ident ),+)
     =>
     (
-        impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'static> MobilecoindApi for ServiceApi<T, FPR> {
+        impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolver> MobilecoindApi for ServiceApi<T, FPR> {
             $(
                 fn $service_function_name(
                     &mut self,
@@ -1851,7 +1847,9 @@ mod test {
     use mc_common::{logger::test_with_logger, HashSet};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_crypto_rand::RngCore;
-    use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogPubkeyResolver};
+    use mc_fog_report_validation::{
+        FullyValidatedFogPubkey, MockFogPubkeyResolver, MockFogResolver,
+    };
     use mc_transaction_core::{
         constants::{MAX_INPUTS, MINIMUM_FEE, RING_SIZE},
         fog_hint::FogHint,
@@ -1862,6 +1860,7 @@ mod test {
     };
     use mc_transaction_std::TransactionBuilder;
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
+    use mc_util_uri::FogUri;
     use rand::{rngs::StdRng, SeedableRng};
     use std::{
         convert::{TryFrom, TryInto},
@@ -2664,7 +2663,7 @@ mod test {
 
         // Insert into database.
         let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
-        let mut transaction_builder = TransactionBuilder::new(Default::default());
+        let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
         let (tx_out, tx_confirmation) = transaction_builder
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
@@ -4219,19 +4218,20 @@ mod test {
 
         // Fog resolver
         let fog_private_key = RistrettoPrivate::from_random(&mut rng);
-        let fog_pubkey_resolver = Arc::new({
+        let fog_pubkey_resolver_factory: Arc<
+            dyn Fn(&[FogUri]) -> Result<MockFogPubkeyResolver, String> + Send + Sync,
+        > = Arc::new(move |_| -> Result<MockFogPubkeyResolver, String> {
             let mut fog_pubkey_resolver = MockFogPubkeyResolver::new();
             let pubkey = RistrettoPublic::from(&fog_private_key);
             fog_pubkey_resolver
                 .expect_get_fog_pubkey()
                 .return_once(move |_recipient| {
                     Ok(FullyValidatedFogPubkey {
-                        fog_report_id: "".to_owned(),
                         pubkey,
                         pubkey_expiry: 10000,
                     })
                 });
-            fog_pubkey_resolver
+            Ok(fog_pubkey_resolver)
         });
 
         let sender = AccountKey::random(&mut rng);
@@ -4258,12 +4258,12 @@ mod test {
             .unwrap();
 
         log::debug!(logger, "Setting up server {:?}", port);
-        let (_server, server_conn_manager) = test_utils::setup_server(
+        let (_server, server_conn_manager) = test_utils::setup_server::<MockFogPubkeyResolver>(
             logger.clone(),
             ledger_db.clone(),
             mobilecoind_db.clone(),
             None,
-            Some(fog_pubkey_resolver),
+            Some(fog_pubkey_resolver_factory),
             &uri,
         );
         log::debug!(logger, "Setting up client {:?}", port);
@@ -4736,7 +4736,7 @@ mod test {
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
-        let mut transaction_builder = TransactionBuilder::new(Default::default());
+        let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -19,7 +19,7 @@ use mc_connection_test_utils::{test_client_uri, MockBlockchainConnection};
 use mc_consensus_scp::QuorumSet;
 use mc_crypto_keys::RistrettoPrivate;
 use mc_crypto_rand::{CryptoRng, RngCore};
-use mc_fog_report_validation::{FogPubkeyResolver, MockFogPubkeyResolver};
+use mc_fog_report_validation::{FogPubkeyResolver, MockFogResolver};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_ledger_sync::PollingNetworkState;
 use mc_mobilecoind_api::{mobilecoind_api_grpc::MobilecoindApiClient, MobilecoindUri};
@@ -28,7 +28,7 @@ use mc_transaction_core::{
 };
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
-use mc_util_uri::ConnectionUri;
+use mc_util_uri::{ConnectionUri, FogUri};
 use mc_watcher::watcher_db::WatcherDB;
 use std::{
     path::PathBuf,
@@ -225,12 +225,12 @@ pub fn get_free_port() -> u16 {
     PORT_NR.fetch_add(1, SeqCst) as u16 + 30100
 }
 
-pub fn setup_server<FPR: FogPubkeyResolver + Send + Sync + 'static>(
+pub fn setup_server<FPR: FogPubkeyResolver + Default + Send + Sync + 'static>(
     logger: Logger,
     ledger_db: LedgerDB,
     mobilecoind_db: Database,
     watcher_db: Option<WatcherDB>,
-    fog_pubkey_resolver: Option<Arc<FPR>>,
+    fog_resolver_factory: Option<Arc<dyn Fn(&[FogUri]) -> Result<FPR, String> + Send + Sync>>,
     uri: &MobilecoindUri,
 ) -> (
     Service,
@@ -264,7 +264,7 @@ pub fn setup_server<FPR: FogPubkeyResolver + Send + Sync + 'static>(
         ledger_db.clone(),
         mobilecoind_db.clone(),
         conn_manager.clone(),
-        fog_pubkey_resolver,
+        fog_resolver_factory.unwrap_or(Arc::new(|_| Ok(FPR::default()))),
         logger.clone(),
     );
 
@@ -331,12 +331,12 @@ pub fn get_testing_environment(
         MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{}/", port)).unwrap();
 
     log::debug!(logger, "Setting up server {:?}", port);
-    let (server, server_conn_manager) = setup_server(
+    let (server, server_conn_manager) = setup_server::<MockFogResolver>(
         logger.clone(),
         ledger_db.clone(),
         mobilecoind_db.clone(),
         None,
-        Option::<Arc<MockFogPubkeyResolver>>::None,
+        None,
         &uri,
     );
     log::debug!(logger, "Setting up client {:?}", port);

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -19,7 +19,7 @@ use mc_connection_test_utils::{test_client_uri, MockBlockchainConnection};
 use mc_consensus_scp::QuorumSet;
 use mc_crypto_keys::RistrettoPrivate;
 use mc_crypto_rand::{CryptoRng, RngCore};
-use mc_fog_report_validation::{FogPubkeyResolver, MockFogResolver};
+use mc_fog_report_validation_test_utils::{FogPubkeyResolver, MockFogResolver};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_ledger_sync::PollingNetworkState;
 use mc_mobilecoind_api::{mobilecoind_api_grpc::MobilecoindApiClient, MobilecoindUri};

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -49,11 +49,11 @@ rand_hc = "0.2"
 tempdir = "0.3"
 time = "0.1"
 
+mc-crypto-digestible-test-utils = { path = "../../crypto/digestible/test-utils" }
 mc-ledger-db = { path = "../../ledger/db" }
+mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 mc-util-test-helper = { path = "../../util/test-helper" }
-mc-crypto-digestible-test-utils = { path = "../../crypto/digestible/test-utils" }
-mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
 
 [dev-dependencies.proptest]
 version = "0.10" # Only works for 0.9.1 or newer

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -12,7 +12,7 @@ tempdir = "0.3"
 mc-account-keys = { path = "../../../account-keys" }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../crypto/rand" }
-mc-fog-report-validation = { path = "../../../fog/report/validation" }
+mc-fog-report-validation-test-utils = { path = "../../../fog/report/validation/test-utils" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core = { path = "../../../transaction/core" }
 mc-transaction-std = { path = "../../../transaction/std" }

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -12,6 +12,7 @@ tempdir = "0.3"
 mc-account-keys = { path = "../../../account-keys" }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../crypto/rand" }
+mc-fog-report-validation = { path = "../../../fog/report/validation" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core = { path = "../../../transaction/core" }
 mc-transaction-std = { path = "../../../transaction/std" }

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -85,7 +85,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
-    let mut transaction_builder = TransactionBuilder::new();
+    let mut transaction_builder = TransactionBuilder::new(Default::default());
 
     // The first transaction in the origin block should contain enough outputs to use as mixins.
     let origin_block_contents = ledger.get_block_contents(0).unwrap();
@@ -125,7 +125,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
 
     // Output
     transaction_builder
-        .add_output(amount, recipient, None, rng)
+        .add_output(amount, recipient, rng)
         .unwrap();
 
     // Tombstone block

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -4,6 +4,7 @@ use core::convert::TryFrom;
 pub use mc_account_keys::{AccountKey, PublicAddress, ViewKey, DEFAULT_SUBADDRESS_INDEX};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_crypto_rand::{CryptoRng, RngCore};
+pub use mc_fog_report_validation::MockFogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 pub use mc_transaction_core::{
     constants::MINIMUM_FEE,
@@ -85,7 +86,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
-    let mut transaction_builder = TransactionBuilder::new(Default::default());
+    let mut transaction_builder = TransactionBuilder::new(MockFogResolver::default());
 
     // The first transaction in the origin block should contain enough outputs to use as mixins.
     let origin_block_contents = ledger.get_block_contents(0).unwrap();

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -4,7 +4,7 @@ use core::convert::TryFrom;
 pub use mc_account_keys::{AccountKey, PublicAddress, ViewKey, DEFAULT_SUBADDRESS_INDEX};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_crypto_rand::{CryptoRng, RngCore};
-pub use mc_fog_report_validation::MockFogResolver;
+pub use mc_fog_report_validation_test_utils::MockFogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 pub use mc_transaction_core::{
     constants::MINIMUM_FEE,

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -29,6 +29,7 @@ curve25519-dalek = { version = "3.0", default-features = false, features = ["nig
 blake2 = { version = "0.9", default-features = false }
 
 [dev-dependencies]
+maplit = "1.0"
 yaml-rust = "0.4"
 
 mc-util-test-helper = { path = "../../util/test-helper" }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -18,6 +18,7 @@ mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-util-serial = { path = "../../util/serial" }
 mc-transaction-core = { path = "../../transaction/core"}
 mc-util-from-random = { path = "../../util/from-random" }
+mc-fog-report-validation = { path = "../../fog/report/validation" }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -32,4 +32,5 @@ blake2 = { version = "0.9", default-features = false }
 maplit = "1.0"
 yaml-rust = "0.4"
 
+mc-fog-report-validation-test-utils = { path = "../../fog/report/validation/test-utils" }
 mc-util-test-helper = { path = "../../util/test-helper" }

--- a/transaction/std/src/error.rs
+++ b/transaction/std/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-2020 MobileCoin Inc.
 
 use failure::Fail;
+use mc_fog_report_validation::FogPubkeyError;
 use mc_transaction_core::{ring_signature, ring_signature::Error, AmountError};
 
 #[derive(Debug, Fail)]
@@ -29,15 +30,8 @@ pub enum TxBuilderError {
     #[fail(display = "No inputs")]
     NoInputs,
 
-    #[fail(
-        display = "When building a transaction, a public key was provided for the recipient's fog server, but their public address does not have a Fog server"
-    )]
-    IngestPubkeyUnexpectedlyProvided,
-
-    #[fail(
-        display = "When building a transaction, a public key was not provided for the recipient's fog server, but their public address does have a Fog server"
-    )]
-    IngestPubkeyNotProvided,
+    #[fail(display = "Fog public key error: {}", _0)]
+    FogPublicKey(FogPubkeyError),
 
     #[fail(display = "Key error: {}", _0)]
     KeyError(mc_crypto_keys::KeyError),
@@ -70,5 +64,11 @@ impl From<mc_crypto_keys::KeyError> for TxBuilderError {
 impl From<ring_signature::Error> for TxBuilderError {
     fn from(_: Error) -> Self {
         TxBuilderError::RingSignatureFailed
+    }
+}
+
+impl From<FogPubkeyError> for TxBuilderError {
+    fn from(src: FogPubkeyError) -> Self {
+        TxBuilderError::FogPublicKey(src)
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -243,29 +243,6 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     }
 }
 
-/// Creates a TxOut that sends `value` to `recipient`.
-///
-/// Note: This is only used in test code
-///
-/// # Arguments
-/// * `value` - Value of the output, in picoMOB.
-/// * `recipient` - Recipient's address.
-/// * `fog_resolver` - Set of prefetched fog public keys to choose from
-/// * `rng` - Entropy for the encryption.
-///
-/// # Returns
-/// * A transaction output, and the shared secret for this TxOut.
-#[allow(unused)]
-fn create_output<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
-    value: u64,
-    recipient: &PublicAddress,
-    fog_resolver: &FPR,
-    rng: &mut RNG,
-) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
-    let (hint, _pubkey_expiry) = create_fog_hint(recipient, fog_resolver, rng)?;
-    create_output_with_fog_hint(value, recipient, hint, rng)
-}
-
 /// Creates a TxOut that sends `value` to `recipient` using the provided `fog_hint`.
 ///
 /// # Arguments
@@ -319,7 +296,7 @@ pub mod transaction_builder_tests {
     use super::*;
     use maplit::btreemap;
     use mc_account_keys::{AccountKey, DEFAULT_SUBADDRESS_INDEX};
-    use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogResolver};
+    use mc_fog_report_validation_test_utils::{FullyValidatedFogPubkey, MockFogResolver};
     use mc_transaction_core::{
         constants::{MAX_INPUTS, MAX_OUTPUTS, MILLIMOB_TO_PICOMOB},
         onetime_keys::*,
@@ -329,6 +306,28 @@ pub mod transaction_builder_tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
     use std::convert::TryFrom;
+
+    /// Creates a TxOut that sends `value` to `recipient`.
+    ///
+    /// Note: This is only used in test code
+    ///
+    /// # Arguments
+    /// * `value` - Value of the output, in picoMOB.
+    /// * `recipient` - Recipient's address.
+    /// * `fog_resolver` - Set of prefetched fog public keys to choose from
+    /// * `rng` - Entropy for the encryption.
+    ///
+    /// # Returns
+    /// * A transaction output, and the shared secret for this TxOut.
+    fn create_output<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
+        value: u64,
+        recipient: &PublicAddress,
+        fog_resolver: &FPR,
+        rng: &mut RNG,
+    ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
+        let (hint, _pubkey_expiry) = create_fog_hint(recipient, fog_resolver, rng)?;
+        create_output_with_fog_hint(value, recipient, hint, rng)
+    }
 
     /// Creates a ring of of TxOuts.
     ///


### PR DESCRIPTION
There are a few problems with the TransactionBuilder API in regards
to fog ingest public keys.

(1) It makes the API user match public addresses with ingest public keys.
If they do this wrong, the money will not be found by the recipient.
(2) It doesn't enforce that the ingest public keys that are used are
fully validated using the type system.
(3) It doesn't enforce the rule that the tombstone block of the transaction
may not exceed the pubkey_expiry of any of the fog public keys that used.

This change makes the TransactionBuilder take a set of FullyValidatedPublicKeys
object when building transactions. This object can be populated by taking
a FogPubkeyResolver and passing that, with each recipient PublicAddress,
to the object, which caches them for a short period of time.
The cache is consumed by the TransactionBuilder, reflecting the idea
that these should be fetched again with each transaction.

This caching also automatically minimizes network traffic since we
skip the second request to fog report server if two recipients have
the same fog url and report id.

This is a good idea because it turns out that in testnet block 42,
we have all zeroes for fog hints, which suggests that some client
in the past was doing fog hints wrong.

The present change was proposed months ago to try to make it harder
to use the transaction builder wrongly with respect to fog, and
hopefully reduce the number of bugs that lead to lost/missing transactions
or bad fog hints, that are hard debug due to use of encryption.

An advantage of the proposed API is that it is compatible with a device that
wants to creates off-line transactions:
- They would fetch the FullyValidatedFogPubkeys first, online, and serialize that
- Then move that data offline and use the transaction builder, fully offline.
- Then move the resulting Tx to online machine to submit the transaction.