### PR TITLE
FOG-137 Add mc-crypto-digestible-signature crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-crypto-digestible-signature"
+version = "1.0.0"
+dependencies = [
+ "mc-crypto-digestible",
+ "schnorrkel",
+ "signature",
+]
+
+[[package]]
 name = "mc-crypto-digestible-test-utils"
 version = "1.0.0"
 dependencies = [
@@ -2722,6 +2731,7 @@ dependencies = [
  "failure",
  "hex_fmt",
  "mc-crypto-digestible",
+ "mc-crypto-digestible-signature",
  "mc-crypto-hashes",
  "mc-util-from-random",
  "mc-util-repr-bytes",
@@ -2731,6 +2741,7 @@ dependencies = [
  "prost",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "schnorrkel",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crypto/digestible",
     "crypto/digestible/derive/test",
     "crypto/digestible/test-utils",
+    "crypto/digestible/signature",
     "crypto/keys",
     "crypto/message-cipher",
     "crypto/noise",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -845,6 +845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-crypto-digestible-signature"
+version = "1.0.0"
+dependencies = [
+ "mc-crypto-digestible 1.0.0",
+ "schnorrkel 0.9.1 (git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028)",
+ "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mc-crypto-hashes"
 version = "1.0.0"
 dependencies = [
@@ -866,11 +875,14 @@ dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-crypto-digestible 1.0.0",
+ "mc-crypto-digestible-signature 1.0.0",
  "mc-util-from-random 1.0.0",
  "mc-util-repr-bytes 1.0.0",
  "mc-util-serial 1.0.0",
  "prost 0.6.1 (git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schnorrkel 0.9.1 (git+https://github.com/w3f/schnorrkel?rev=cfdbe9ae865a4d3ffa2566d896d4dbedf5107028)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mc-crypto-digestible-signature"
+version = "1.0.0"
+authors = ["MobileCoin"]
+edition = "2018"
+description = "Semantic Signatures by MobileCoin"
+readme = "README.md"
+
+[dependencies]
+mc-crypto-digestible = { path = ".." }
+
+signature = { version = "1.2", default-features = false }
+
+# Overridden since we need a not-yet-released commit that uprevs a bunch of dependencies.
+schnorrkel = { git = "https://github.com/w3f/schnorrkel", rev = "cfdbe9ae865a4d3ffa2566d896d4dbedf5107028", default-features = false }

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -3,7 +3,7 @@ name = "mc-crypto-digestible-signature"
 version = "1.0.0"
 authors = ["MobileCoin"]
 edition = "2018"
-description = "Semantic Signatures by MobileCoin"
+description = "Digestible Signatures"
 readme = "README.md"
 
 [dependencies]

--- a/crypto/digestible/signature/README.md
+++ b/crypto/digestible/signature/README.md
@@ -1,0 +1,3 @@
+# Signatures for Digestibles
+
+This crate provides a trait which is designed to allow signatures over semantic structures using the `Digestible` method of semantic hashing.

--- a/crypto/digestible/signature/README.md
+++ b/crypto/digestible/signature/README.md
@@ -1,3 +1,3 @@
-# Signatures for Digestibles
+# Digestible Signatures
 
 This crate provides a trait which is designed to allow signatures over semantic structures using the `Digestible` method of semantic hashing.

--- a/crypto/digestible/signature/src/lib.rs
+++ b/crypto/digestible/signature/src/lib.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2018-2020 MobileCoin Inc.
+
+#![no_std]
+
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
+use signature::{Signature, Signer, Verifier};
+
+pub use signature::Error;
+
+/// Construct a deterministic semantic signature over a given object.
+pub trait DigestibleSigner<S: Signature, T: Digestible> {
+    fn sign_semantic(&self, context: &'static [u8], message: &T) -> S;
+
+    /// Sign the digestible hash of the given object
+    fn try_sign_semantic(&self, context: &'static [u8], message: &T) -> Result<S, Error>;
+}
+
+/// Verify a deterministic semantic signature over a given object
+pub trait DigestibleVerifier<S: Signature, T: Digestible> {
+    /// Verify a signature made over a digestible hash of a given object
+    fn verify_semantic(&self, context: &'static [u8], message: &T, sig: &S) -> Result<(), Error>;
+}
+
+/// A blanket implementation of [DigestibleSigner] for [signature::Signer] implementations.
+///
+/// This operates akin to a deterministic pre-hashed signature, in that we create a 512-bit hash
+/// of the message object, and then sign that hash.
+impl<T: Digestible, S: Signature, K: Signer<S>> DigestibleSigner<S, T> for K {
+    fn sign_semantic(&self, context: &'static [u8], message: &T) -> S {
+        let transcript = message.digest32::<MerlinTranscript>(context);
+        self.sign(&transcript)
+    }
+
+    fn try_sign_semantic(&self, context: &'static [u8], message: &T) -> Result<S, Error> {
+        let transcript = message.digest32::<MerlinTranscript>(context);
+        self.try_sign(&transcript)
+    }
+}
+
+/// A blanket implementation of [DigestibleVerifier] for [signature::Verifier] implementations.
+///
+/// This operates akin to a deterministic pre-hashed signature, in that we create a 512-bit hash
+/// of the message object, and then sign that hash.
+impl<T: Digestible, S: Signature, V: Verifier<S>> DigestibleVerifier<S, T> for V {
+    fn verify_semantic(
+        &self,
+        context: &'static [u8],
+        message: &T,
+        signature: &S,
+    ) -> Result<(), Error> {
+        let transcript = message.digest32::<MerlinTranscript>(context);
+        self.verify(&transcript, signature)
+    }
+}

--- a/crypto/digestible/signature/src/lib.rs
+++ b/crypto/digestible/signature/src/lib.rs
@@ -9,16 +9,16 @@ pub use signature::Error;
 
 /// Construct a deterministic semantic signature over a given object.
 pub trait DigestibleSigner<S: Signature, T: Digestible> {
-    fn sign_semantic(&self, context: &'static [u8], message: &T) -> S;
+    fn sign_digestible(&self, context: &'static [u8], message: &T) -> S;
 
     /// Sign the digestible hash of the given object
-    fn try_sign_semantic(&self, context: &'static [u8], message: &T) -> Result<S, Error>;
+    fn try_sign_digestible(&self, context: &'static [u8], message: &T) -> Result<S, Error>;
 }
 
 /// Verify a deterministic semantic signature over a given object
 pub trait DigestibleVerifier<S: Signature, T: Digestible> {
     /// Verify a signature made over a digestible hash of a given object
-    fn verify_semantic(&self, context: &'static [u8], message: &T, sig: &S) -> Result<(), Error>;
+    fn verify_digestible(&self, context: &'static [u8], message: &T, sig: &S) -> Result<(), Error>;
 }
 
 /// A blanket implementation of [DigestibleSigner] for [signature::Signer] implementations.
@@ -26,12 +26,12 @@ pub trait DigestibleVerifier<S: Signature, T: Digestible> {
 /// This operates akin to a deterministic pre-hashed signature, in that we create a 512-bit hash
 /// of the message object, and then sign that hash.
 impl<T: Digestible, S: Signature, K: Signer<S>> DigestibleSigner<S, T> for K {
-    fn sign_semantic(&self, context: &'static [u8], message: &T) -> S {
+    fn sign_digestible(&self, context: &'static [u8], message: &T) -> S {
         let transcript = message.digest32::<MerlinTranscript>(context);
         self.sign(&transcript)
     }
 
-    fn try_sign_semantic(&self, context: &'static [u8], message: &T) -> Result<S, Error> {
+    fn try_sign_digestible(&self, context: &'static [u8], message: &T) -> Result<S, Error> {
         let transcript = message.digest32::<MerlinTranscript>(context);
         self.try_sign(&transcript)
     }
@@ -42,7 +42,7 @@ impl<T: Digestible, S: Signature, K: Signer<S>> DigestibleSigner<S, T> for K {
 /// This operates akin to a deterministic pre-hashed signature, in that we create a 512-bit hash
 /// of the message object, and then sign that hash.
 impl<T: Digestible, S: Signature, V: Verifier<S>> DigestibleVerifier<S, T> for V {
-    fn verify_semantic(
+    fn verify_digestible(
         &self,
         context: &'static [u8],
         message: &T,

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -2,9 +2,10 @@
 
 #![no_std]
 
+pub use merlin::Transcript as MerlinTranscript;
+
 use cfg_if::cfg_if;
 use generic_array::{ArrayLength, GenericArray};
-pub use merlin::Transcript as MerlinTranscript;
 
 /// A trait for creating non-malleable digests of objects using merlin transcripts.
 ///

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -3,6 +3,8 @@ name = "mc-crypto-keys"
 version = "1.0.0"
 authors = ["MobileCoin"]
 edition = "2018"
+description = "MobileCoin DH Key Exchange and Digital Signatures"
+readme = "README.md"
 
 [dependencies]
 binascii = "0.1.2"
@@ -10,6 +12,7 @@ cfg-if = "0.1"
 digest = { version = "0.9", default-features = false }
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
+mc-crypto-digestible-signature = { path = "../../crypto/digestible/signature" }
 failure = { version = "0.1.8", default-features = false, features = ["derive"] }
 hex_fmt = "0.3"
 mc-util-from-random = { path = "../../util/from-random" }
@@ -17,11 +20,15 @@ mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 mc-util-serial = { path = "../../util/serial", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.5", default-features = false }
+rand_hc = "0.2"
 signature = { version = "1.2", default-features = false, features = ["digest-preview"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 sha2 = { version = "0.9", default-features = false }
 x25519-dalek = { version = "1.1.0", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
+
+# Overridden since we need a not-yet-released commit that uprevs a bunch of dependencies.
+schnorrkel = { git = "https://github.com/w3f/schnorrkel", rev = "cfdbe9ae865a4d3ffa2566d896d4dbedf5107028", default-features = false }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }
@@ -35,7 +42,6 @@ ed25519-dalek = { version = "1.0.0", default-features = false, features = ["allo
 mc-crypto-hashes = { path = "../hashes" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 pem = "0.6"
-rand_hc = "0.2"
 serde_json = "1.0"
 mc-util-test-helper = { path = "../../util/test-helper" }
 tempdir = "0.3"

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -101,6 +101,7 @@ impl DistinguishedEncoding for Ed25519Signature {
     }
 }
 
+/// An Ed25519 public key.
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, Serialize, Digestible)]
 pub struct Ed25519Public(DalekPublicKey);
 

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -108,7 +108,7 @@ impl RistrettoPrivate {
         let mut t = MerlinTranscript::new(b"SigningContext");
         t.append_message(b"", context);
         t.append_message(b"sign-bytes", &message);
-        // NOTE: The fog_authority_fingerprint_sig is deterministic due to using the above nonce as the rng seed
+        // NOTE: This signature is deterministic due to using the above nonce as the rng seed
         let csprng = Hc128Rng::from_seed(nonce);
         let transcript = attach_rng(t, csprng);
         keypair.sign(transcript)
@@ -138,17 +138,17 @@ impl Debug for RistrettoPrivate {
 }
 
 impl<T: Digestible> DigestibleSigner<RistrettoSignature, T> for RistrettoPrivate {
-    fn sign_semantic(&self, context: &'static [u8], message: &T) -> RistrettoSignature {
+    fn sign_digestible(&self, context: &'static [u8], message: &T) -> RistrettoSignature {
         let message = message.digest32::<MerlinTranscript>(context);
         RistrettoSignature::from(self.sign_schnorrkel(context, &message))
     }
 
-    fn try_sign_semantic(
+    fn try_sign_digestible(
         &self,
         context: &'static [u8],
         message: &T,
     ) -> Result<RistrettoSignature, Error> {
-        Ok(self.sign_semantic(context, message))
+        Ok(self.sign_digestible(context, message))
     }
 }
 
@@ -352,7 +352,7 @@ impl Debug for RistrettoPublic {
 }
 
 impl<T: Digestible> DigestibleVerifier<RistrettoSignature, T> for RistrettoPublic {
-    fn verify_semantic(
+    fn verify_digestible(
         &self,
         context: &'static [u8],
         message: &T,

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -15,17 +15,24 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
-use digest::generic_array::typenum::U32;
+use digest::generic_array::typenum::{U32, U64};
 use hex_fmt::HexFmt;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
+use mc_crypto_digestible_signature::{DigestibleSigner, DigestibleVerifier};
 use mc_util_from_random::FromRandom;
 use mc_util_repr_bytes::{
     derive_core_cmp_from_as_ref, derive_into_vec_from_repr_bytes,
     derive_prost_message_from_repr_bytes, derive_repr_bytes_from_as_ref_and_try_from,
     derive_serde_from_repr_bytes, derive_try_from_slice_from_repr_bytes, ReprBytes,
 };
-use rand_core::{CryptoRng, RngCore};
+use rand_core::{CryptoRng, RngCore, SeedableRng};
+use rand_hc::Hc128Rng;
+use schnorrkel::{
+    context::attach_rng, PublicKey as SchnorrkelPublic, SecretKey as SchnorrkelPrivate,
+    Signature as SchnorrkelSignature, SignatureError as SchnorrkelError, SIGNATURE_LENGTH,
+};
 use serde::{Deserialize, Serialize};
+use signature::{Error as SignatureError, Error};
 use zeroize::Zeroize;
 
 /// A Ristretto-format private scalar
@@ -75,6 +82,37 @@ impl RistrettoPrivate {
     pub fn to_bytes(&self) -> [u8; 32] {
         *self.0.as_bytes()
     }
+
+    /// Sign the given bytes using a deterministic scheme based on Schnorrkel.
+    pub fn sign_schnorrkel(&self, context: &[u8], message: &[u8]) -> SchnorrkelSignature {
+        // Create a deterministic nonce using a merlin transcript. See this crate's README
+        // for a security statement.
+        let nonce = {
+            let mut transcript = MerlinTranscript::new(b"SigningNonce");
+            transcript.append_message(b"context", &context);
+            transcript.append_message(b"private", &self.to_bytes());
+            transcript.append_message(b"message", &message);
+            let mut nonce = [0u8; 32];
+            transcript.challenge_bytes(b"nonce", &mut nonce);
+            nonce
+        };
+
+        // Construct a Schnorrkel SecretKey object from ourselves, and our nonce value
+        let mut secret_bytes = [0u8; 64];
+        secret_bytes[0..32].copy_from_slice(&self.to_bytes());
+        secret_bytes[32..64].copy_from_slice(&nonce);
+        let secret_key = SchnorrkelPrivate::from_bytes(&secret_bytes).unwrap();
+        let keypair = secret_key.to_keypair();
+
+        // SigningContext provides domain separation for signature
+        let mut t = MerlinTranscript::new(b"SigningContext");
+        t.append_message(b"", context);
+        t.append_message(b"sign-bytes", &message);
+        // NOTE: The fog_authority_fingerprint_sig is deterministic due to using the above nonce as the rng seed
+        let csprng = Hc128Rng::from_seed(nonce);
+        let transcript = attach_rng(t, csprng);
+        keypair.sign(transcript)
+    }
 }
 
 impl AsRef<Scalar> for RistrettoPrivate {
@@ -99,8 +137,19 @@ impl Debug for RistrettoPrivate {
     }
 }
 
-impl PrivateKey for RistrettoPrivate {
-    type Public = RistrettoPublic;
+impl<T: Digestible> DigestibleSigner<RistrettoSignature, T> for RistrettoPrivate {
+    fn sign_semantic(&self, context: &'static [u8], message: &T) -> RistrettoSignature {
+        let message = message.digest32::<MerlinTranscript>(context);
+        RistrettoSignature::from(self.sign_schnorrkel(context, &message))
+    }
+
+    fn try_sign_semantic(
+        &self,
+        context: &'static [u8],
+        message: &T,
+    ) -> Result<RistrettoSignature, Error> {
+        Ok(self.sign_semantic(context, message))
+    }
 }
 
 impl FromRandom for RistrettoPrivate {
@@ -129,6 +178,10 @@ impl KexReusablePrivate for RistrettoPrivate {
 
 impl KexPrivate for RistrettoPrivate {
     type Secret = RistrettoSecret;
+}
+
+impl PrivateKey for RistrettoPrivate {
+    type Public = RistrettoPublic;
 }
 
 /// A private ristretto key which is ephemeral, should never be copied,
@@ -197,16 +250,16 @@ impl ReprBytes for RistrettoPublic {
     type Size = U32;
     type Error = KeyError;
 
-    fn to_bytes(&self) -> GenericArray<u8, U32> {
-        self.0.compress().to_bytes().into()
-    }
-
     fn from_bytes(src: &GenericArray<u8, U32>) -> Result<Self, KeyError> {
         Ok(Self(
             CompressedRistretto::from_slice(src.as_slice())
                 .decompress()
                 .ok_or(KeyError::InvalidPublicKey)?,
         ))
+    }
+
+    fn to_bytes(&self) -> GenericArray<u8, U32> {
+        self.0.compress().to_bytes().into()
     }
 }
 
@@ -229,6 +282,18 @@ impl RistrettoPublic {
     // This is okay in non-generic code
     pub fn to_bytes(&self) -> [u8; 32] {
         self.0.compress().to_bytes()
+    }
+
+    /// Verify a deterministic Schnorrkel signature created with the corresponding [`RistrettoPrivate::sign_schnorrkel()`] method.
+    pub fn verify_schnorrkel(
+        &self,
+        context: &'static [u8],
+        message: &[u8],
+        signature: &SchnorrkelSignature,
+    ) -> Result<(), SchnorrkelError> {
+        let ctx = schnorrkel::signing_context(context);
+        let pubkey = SchnorrkelPublic::from_point(*self.as_ref());
+        pubkey.verify(ctx.bytes(&message), &signature)
     }
 }
 
@@ -283,6 +348,21 @@ impl From<&RistrettoEphemeralPrivate> for RistrettoPublic {
 impl Debug for RistrettoPublic {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(f, "RistrettoPublic({})", HexFmt(self.to_bytes()))
+    }
+}
+
+impl<T: Digestible> DigestibleVerifier<RistrettoSignature, T> for RistrettoPublic {
+    fn verify_semantic(
+        &self,
+        context: &'static [u8],
+        message: &T,
+        signature: &RistrettoSignature,
+    ) -> Result<(), SignatureError> {
+        let message = message.digest32::<MerlinTranscript>(context);
+        let signature = signature.try_into().map_err(|_e| SignatureError::new())?;
+        Ok(self
+            .verify_schnorrkel(context, &message, &signature)
+            .map_err(|_e| SignatureError::new())?)
     }
 }
 
@@ -439,7 +519,7 @@ impl From<CompressedRistretto> for CompressedRistrettoPublic {
 impl PublicKey for CompressedRistrettoPublic {}
 
 /// A zero-width type used to identify the Ristretto key exchange system.
-pub struct Ristretto {}
+pub struct Ristretto;
 
 /// The implementation of the Ristretto key exchange system.
 impl Kex for Ristretto {
@@ -448,6 +528,81 @@ impl Kex for Ristretto {
     type EphemeralPrivate = RistrettoEphemeralPrivate;
     type Secret = RistrettoSecret;
 }
+
+#[repr(transparent)]
+pub struct RistrettoSignature([u8; SIGNATURE_LENGTH]);
+
+impl AsRef<[u8]> for RistrettoSignature {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8; SIGNATURE_LENGTH]> for RistrettoSignature {
+    fn as_ref(&self) -> &[u8; SIGNATURE_LENGTH] {
+        &self.0
+    }
+}
+
+impl Debug for RistrettoSignature {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{:?}", &self.0[..])
+    }
+}
+
+impl Default for RistrettoSignature {
+    fn default() -> RistrettoSignature {
+        Self([0u8; 64])
+    }
+}
+
+impl Display for RistrettoSignature {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", HexFmt(&self))
+    }
+}
+
+impl Eq for RistrettoSignature {}
+
+impl From<SchnorrkelSignature> for RistrettoSignature {
+    fn from(src: SchnorrkelSignature) -> RistrettoSignature {
+        Self(src.to_bytes())
+    }
+}
+
+impl Signature for RistrettoSignature {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, SignatureError> {
+        Self::try_from(bytes)
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+impl TryFrom<&[u8]> for RistrettoSignature {
+    type Error = SignatureError;
+
+    fn try_from(src: &[u8]) -> Result<RistrettoSignature, SignatureError> {
+        SchnorrkelSignature::from_bytes(src)
+            .map(|sig| Self(sig.to_bytes()))
+            .map_err(|_| SignatureError::new())
+    }
+}
+
+impl TryFrom<&RistrettoSignature> for SchnorrkelSignature {
+    type Error = SchnorrkelError;
+
+    fn try_from(src: &RistrettoSignature) -> Result<SchnorrkelSignature, SchnorrkelError> {
+        SchnorrkelSignature::from_bytes(&src.0)
+    }
+}
+
+derive_core_cmp_from_as_ref!(RistrettoSignature, [u8]);
+derive_into_vec_from_repr_bytes!(RistrettoSignature);
+derive_repr_bytes_from_as_ref_and_try_from!(RistrettoSignature, U64);
+derive_serde_from_repr_bytes!(RistrettoSignature);
+derive_prost_message_from_repr_bytes!(RistrettoSignature);
 
 #[cfg(test)]
 mod test {
@@ -474,9 +629,9 @@ mod test {
         mc_util_test_helper::run_with_several_seeds(|mut rng| {
             let privkey = RistrettoPrivate::from_random(&mut rng);
             let serialized =
-                mc_util_serial::serialize(&privkey).expect("Could not serialize privkey.");
-            let deserialized: RistrettoPrivate =
-                mc_util_serial::deserialize(&serialized).expect("Could not deserialize privkey");
+                mc_util_serial::serialize(&privkey).expect("Could not serialize private key.");
+            let deserialized: RistrettoPrivate = mc_util_serial::deserialize(&serialized)
+                .expect("Could not deserialize private key");
             let pubkey = RistrettoPublic::from(&privkey);
             let deserialized_pubkey = RistrettoPublic::from(&deserialized);
             assert_eq!(deserialized_pubkey, pubkey);


### PR DESCRIPTION
### Motivation

Currently, we perform construction of signatures over `Digestible` structures by first creating a digest hash of them, then signing that hash. This pulls all that functionality into the keys crate, to sit alongside a new pair of digestible-related helper traits, which unify transcript construction over digestible objects for use in schnorrkel and ed25519 signatures.

This is to ease the ergonomics of signing a structure to be `privkey.sign_semantic(b"context", &structure)`, and `pubkey.verify_semantic(b"context", &structure)`, and ensure we're constructing these transcripts uniformly for each key type.

### In this PR
 * Provides a `DigestibleSigner`/`DigestibleVerifier` trait pair.
 * Provides a blanket implementation for stuff with `Signer`/`Verifier` implementations.
 - Move `mc-crypto-sig` functionality into methods on `RistrettoPublic`, `RistrettoPrivate`.

### Future Work
* Move unit tests of `mc-crypto-sig` into keys.
* Unit tests of ed25519 blanket implementation.