### PR TITLE
Add password hash to mobilecoind-json

### DIFF
--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -19,6 +19,15 @@ Options are:
 
 ### Usage with cURL
 
+#### Set password for DB
+
+To ensure that the DB stores the account keys at rest, you should make sure that you run mobilecoind with `--encrypted-db` and then call "set-password" via mobilecoind-json on startup. This will set the password hash for the mobilecoinid-db backend. The password hash should be derived according to your security needs, for example, with argon2.
+
+```
+curl -s localhost:9090/set-password -d '{"password_hash": "c7f04fcd40d093ca6578b13d790df0790c96e94a77815e5052993af1b9d12923"}' -X POST -H 'Content-type: application/json'
+{"success":true}
+```
+
 #### Generate a new master key
 ```
 $ curl localhost:9090/entropy -X POST

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -39,6 +39,24 @@ struct State {
     pub mobilecoind_api_client: MobilecoindApiClient,
 }
 
+/// Set the password for the mobilecoind-db
+#[post("/set-password", format = "json", data = "<password>")]
+fn set_password(
+    state: rocket::State<State>,
+    password: Json<JsonPasswordRequest>,
+) -> Result<Json<JsonPasswordResponse>, String> {
+    let mut req = mc_mobilecoind_api::SetDbPasswordRequest::new();
+    req.set_password(
+        hex::decode(password.password_hash.clone())
+            .map_err(|err| format!("Failed decoding password hex: {}", err))?,
+    );
+    let _resp = state
+        .mobilecoind_api_client
+        .set_db_password(&req)
+        .map_err(|err| format!("Failed setting password: {}", err))?;
+    Ok(Json(JsonPasswordResponse { success: true }))
+}
+
 /// Requests a new root entropy from mobilecoind
 #[post("/entropy")]
 fn entropy(state: rocket::State<State>) -> Result<Json<JsonEntropyResponse>, String> {
@@ -674,6 +692,7 @@ fn main() {
         .mount(
             "/",
             routes![
+                set_password,
                 entropy,
                 account_key,
                 add_monitor,

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -11,6 +11,16 @@ use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom, iter::FromIterator};
 
+#[derive(Deserialize, Default)]
+pub struct JsonPasswordRequest {
+    pub password_hash: String,
+}
+
+#[derive(Serialize, Default)]
+pub struct JsonPasswordResponse {
+    pub success: bool,
+}
+
 #[derive(Serialize, Default)]
 pub struct JsonEntropyResponse {
     pub entropy: String,


### PR DESCRIPTION
### Motivation

mobilecoind offers the option to encrypt the account_keys at rest in the DB on the backend. This PR exposes an endpoint in mobilecoind-json to pass the password_hash to mobilecoind.

### In this PR
* adds set-password endpoint and updates README

[MCC-2150](https://mobilecoin.atlassian.net/browse/MCC-2150)
