### PR TITLE
Add black for python linting

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update -q -q && \
 # prometheus = helps with running slam scripts locally
 
 # For use in CI
-RUN pip3 install awscli
+RUN pip3 install awscli black
 
 # filebeat is used for logs when running slam scripts locally
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.4.2-amd64.deb && \


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation
https://github.com/mobilecoinfoundation/mobilecoin/issues/592
https://github.com/mobilecoinfoundation/mobilecoin/pull/589 is going to require linter tools to be installed before we can lint 

### In this PR
We install the newest black. This will mean that we will have to relint as new black updates come out

### Future Work
* Verify we only want to use the newest black
* https://github.com/mobilecoinfoundation/mobilecoin/pull/589
