### PR TITLE
build mobilecoind with --no-default-features to allow running local network

### DIFF
--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -410,10 +410,16 @@ class Network:
             )
 
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-mobilecoind -p mc-util-grpc-admin-tool {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool {CARGO_FLAGS}',
             shell=True,
             check=True,
         )
+        subprocess.run(
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build --no-default-features -p mc-mobilecoind {CARGO_FLAGS}',
+            shell=True,
+            check=True,
+        )
+
 
     def add_node(self, name, peers, quorum_set):
         node_num = len(self.nodes)


### PR DESCRIPTION
### Motivation

We need to be able to run a mobilecoind in release mode when running a local network.

### In this PR
* Ensuring the local network script builds it in a way that allows us to do so.
