### PR TITLE
Don’t install Cargo deps from project dir in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,10 +131,10 @@ commands:
           command: |
             set -x
 
-            command -v cargo-install-update >/dev/null || cargo install cargo-update
-            command -v cargo-trim >/dev/null || cargo install cargo-trim
+            command -v cargo-install-update >/dev/null || (cd .. && cargo install cargo-update)
+            command -v cargo-trim >/dev/null || (cd .. && cargo install cargo-trim)
 
-            cargo install-update --all
+            (cd .. && cargo install-update --all)
 
             # Configure cargo-trim with the project's Cargo.lock files
             mkdir -p ~/.config
@@ -233,9 +233,9 @@ commands:
       - run:
           name: Install CI dependencies
           command: |
-            command -v sccache >/dev/null || cargo install sccache
-            command -v cargo-cache >/dev/null || cargo install cargo-cache
-            command -v cargo2junit >/dev/null || cargo install cargo2junit
+            command -v sccache >/dev/null || (cd .. && cargo install sccache)
+            command -v cargo-cache >/dev/null || (cd .. && cargo install cargo-cache)
+            command -v cargo2junit >/dev/null || (cd .. && cargo install cargo2junit)
 
   prefetch-cargo-deps:
     steps:


### PR DESCRIPTION
### Motivation

One of our CI dependencies (`tokio`, on which `sccache` depends) recently updated and is no longer compatible with the version of Rust that our project is pinned to ([Failing CI log](https://app.circleci.com/pipelines/github/mobilecoinfoundation/mobilecoin/3143/workflows/380fc8d6-9fd3-42c4-8938-20d81aca333f/jobs/8100)). This is only a problem because we install our CI Cargo dependencies from our project dir, which in turn installs these dependencies using our project's pinned Rust version, rather than using stable.

This PR fixes that issue by `cd`'ing up 1 level whenever `cargo install` is invoked so that Cargo no longer detects the presence of the `rust-toolchain` file.