### PR TITLE
Use cmov to implement conditional_select for FogHint

### DIFF
--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -52,6 +52,14 @@ impl Plaintext {
     fn as_ref(&self) -> &PlaintextArray {
         &self.0
     }
+
+    fn conditional_assign_array(target: &mut PlaintextArray, src: &PlaintextArray, cond: Choice) {
+        assert_eq!(target.len(), src.len());
+
+        for idx in 0..target.len() {
+            target[idx].conditional_assign(&src[idx], cond);
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -36,11 +36,11 @@ impl Default for Plaintext {
 
 impl ConditionallySelectable for Plaintext {
     fn conditional_select(a: &Self, b: &Self, c: subtle::Choice) -> Self {
-        if bool::from(c) {
-            *b
-        } else {
-            *a
-        }
+        let ret: Self = a;
+
+        ret.cmov(c, b);
+
+        ret
     }
 }
 

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -36,9 +36,9 @@ impl Default for Plaintext {
 
 impl ConditionallySelectable for Plaintext {
     fn conditional_select(a: &Self, b: &Self, c: subtle::Choice) -> Self {
-        let ret: Self = a;
+        let mut ret: Self = *a;
 
-        ret.cmov(c, b);
+        Plaintext::conditional_assign_array(&mut ret.0, &b.0, c);
 
         ret
     }


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=CM3mB6WrhJ4](Aztec Camera - Oblivious)

### Motivation

My initial implementation of ```conditional_select``` for FogHint wasn't oblivious enough.  Now I use cmov to not only be constant time, but also memory access oblivious.

### In this PR
* Rewrite FogHint::conditional_select

Fixes FOG-299

### Future Work
This should fix this with no need for future work.
