### PR TITLE
Fix test_client usage of GetTxStatusAsSender

### DIFF
--- a/mobilecoind/strategies/accounts.py
+++ b/mobilecoind/strategies/accounts.py
@@ -130,14 +130,16 @@ def poll_mitosis(starting_balance, account_data, tx_stats, stub):
 
 def poll(monitor_id, tx_stats, stub):
     complete = {t: False for t in tx_stats.keys()}
-    receipts = {t: tx_stats[t]['receipt'] for t in tx_stats.keys()}
+    receipts = {t: tx_stats[t] for t in tx_stats.keys()}
     pending = complete.keys()
     while not all(complete.values()):
         for tx_id in pending:
             try:
                 resp = stub.GetTxStatusAsSender(
-                    mobilecoind_api_pb2.GetTxStatusAsSenderRequest(
-                        receipt=receipts[tx_id]))
+                    mobilecoind_api_pb2.SubmitTxResponse(
+                        sender_tx_receipt=receipts[tx_id]["receipt"].sender_tx_receipt,
+                        receiver_tx_receipt_list=receipts[tx_id]["receipt"].receiver_tx_receipt_list
+                    ))
                 if resp.status == mobilecoind_api_pb2.TxStatus.TombstoneBlockExceeded:
                     print("Transfer did not complete in time", tx_id)
                     complete[tx_id] = True

--- a/mobilecoind/strategies/test_client.py
+++ b/mobilecoind/strategies/test_client.py
@@ -64,14 +64,13 @@ def run_test(stub, amount, monitor_id, dest, max_seconds):
             tombstone=0,
         ))
 
-    tx_receipt = tx_resp.sender_tx_receipt
     tx_stats[0] = {
         'start': time.time(),
         'time_delta': None,
-        'tombstone': tx_receipt.tombstone,
+        'tombstone': tx_resp.sender_tx_receipt.tombstone,
         'block_delta': None,
         'status': TransferStatus.pending,
-        'receipt': tx_receipt,
+        'receipt': tx_resp,
     }
     stats = poll(monitor_id, tx_stats, stub)
     # FIXME: Move max seconds check inside polling


### PR DESCRIPTION
### Motivation

In #674 we fixed status as sender, but the test_client also needed to incorporate the fix for continuous deployment

### In this PR
* Fixes up GetTxStatusAsSender in the test_client

[MCC-2183](https://mobilecoin.atlassian.net/browse/MCC-2183)

