### PR TITLE
Add GetMixins to mobilecoind API

### DIFF
--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -687,7 +687,7 @@ fn get_proof_of_membership(
     let outputs: Vec<mc_api::external::TxOut> = request
         .outputs
         .iter()
-        .map(|json_tx_out| mc_api::external::TxOut::try_from(json_tx_out))
+        .map(mc_api::external::TxOut::try_from)
         .collect::<Result<Vec<_>, _>>()?;
 
     // Make gRPC request.
@@ -732,7 +732,7 @@ fn get_mixins(
     let excluded: Vec<mc_api::external::TxOut> = request
         .excluded
         .iter()
-        .map(|json_tx_out| mc_api::external::TxOut::try_from(json_tx_out))
+        .map(mc_api::external::TxOut::try_from)
         .collect::<Result<Vec<_>, _>>()?;
 
     // Make gRPC request

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -657,6 +657,39 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
+/// A request for randomly sampled TxOuts for use as mixins.
+pub struct JsonMixinRequest {
+    /// Number of mixins requested.
+    pub num_mixins: u64,
+    /// Outputs that should be excluded from the result.
+    pub excluded: Vec<JsonTxOut>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Randomly sampled TxOuts for use as mixins, with membership proofs.
+pub struct JsonMixinResponse {
+    /// TxOuts to use as mixins.
+    pub mixins: Vec<JsonTxOut>,
+    /// Corresponding membership proofs.
+    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Requests Merkle proof-of-membership for each queried TxOut
+pub struct JsonMembershipProofRequest {
+    pub outputs: Vec<JsonTxOut>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Outputs and their corresponding proofs of membership.
+pub struct JsonMembershipProofResponse {
+    /// Queried outputs.
+    pub outputs: Vec<JsonTxOut>,
+    /// Corresponding membership proofs.
+    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
 pub struct JsonTxIn {
     pub ring: Vec<JsonTxOut>,
     pub proofs: Vec<JsonTxOutMembershipProof>,

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -36,6 +36,7 @@ service MobilecoindAPI {
     rpc CreateAddressCode (CreateAddressCodeRequest) returns (CreateAddressCodeResponse) {}
 
     // Txs
+    rpc GetMixins( GetMixinsRequest) returns (GetMixinsResponse) {}
     rpc GetMembershipProofs (GetMembershipProofsRequest) returns (GetMembershipProofsResponse) {}
     rpc GenerateTx (GenerateTxRequest) returns (GenerateTxResponse) {}
     rpc GenerateOptimizationTx (GenerateOptimizationTxRequest) returns (GenerateOptimizationTxResponse) {}
@@ -394,6 +395,15 @@ message CreateAddressCodeResponse {
 message TxOutWithProof {
     external.TxOut output = 1;
     external.TxOutMembershipProof proof = 2;
+}
+
+message GetMixinsRequest {
+    uint64 num_mixins = 1;
+    repeated external.TxOut excluded = 2;
+}
+
+message GetMixinsResponse {
+    repeated TxOutWithProof mixins = 1;
 }
 
 message GetMembershipProofsRequest {

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -392,12 +392,12 @@ message CreateAddressCodeResponse {
 //
 
 message TxOutWithProof {
-    UnspentTxOut utxo = 1;
+    external.TxOut output = 1;
     external.TxOutMembershipProof proof = 2;
 }
 
 message GetMembershipProofsRequest {
-    repeated UnspentTxOut input_list = 1;
+    repeated external.TxOut outputs = 1;
 }
 
 message GetMembershipProofsResponse {

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -599,7 +599,7 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
     }
 
     /// Get `num_rings` rings of mixins.
-    fn get_rings(
+    pub fn get_rings(
         &self,
         ring_size: usize,
         num_rings: usize,

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -180,11 +180,11 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
 
         // The selected_utxos with corresponding proofs of membership.
         let selected_utxos_with_proofs: Vec<(UnspentTxOut, TxOutMembershipProof)> = {
-            let outputs = selected_utxos
+            let outputs: Vec<TxOut> = selected_utxos
                 .iter()
                 .map(|utxo| utxo.tx_out.clone())
                 .collect();
-            let proofs = self.get_membership_proofs(outputs)?;
+            let proofs = self.get_membership_proofs(&outputs)?;
 
             selected_utxos.into_iter().zip(proofs.into_iter()).collect()
         };
@@ -275,11 +275,11 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
 
         // The selected_utxos with corresponding proofs of membership.
         let selected_utxos_with_proofs: Vec<(UnspentTxOut, TxOutMembershipProof)> = {
-            let outputs = selected_utxos
+            let outputs: Vec<TxOut> = selected_utxos
                 .iter()
                 .map(|utxo| utxo.tx_out.clone())
                 .collect();
-            let proofs = self.get_membership_proofs(outputs)?;
+            let proofs = self.get_membership_proofs(&outputs)?;
 
             selected_utxos.into_iter().zip(proofs.into_iter()).collect()
         };
@@ -360,8 +360,8 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
 
         // The inputs with corresponding proofs of membership.
         let inputs_with_proofs: Vec<(UnspentTxOut, TxOutMembershipProof)> = {
-            let proofs = self
-                .get_membership_proofs(inputs.iter().map(|utxo| utxo.tx_out.clone()).collect())?;
+            let tx_outs: Vec<TxOut> = inputs.iter().map(|utxo| utxo.tx_out.clone()).collect();
+            let proofs = self.get_membership_proofs(&tx_outs)?;
             inputs.iter().cloned().zip(proofs.into_iter()).collect()
         };
         log::trace!(logger, "Got membership proofs");
@@ -371,15 +371,6 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
             .iter()
             .map(|(_, membership_proof)| membership_proof.index)
             .collect();
-
-        // let excluded_tx_out_indices: Vec<u64> = inputs
-        //     .iter()
-        //     .map(|utxo| {
-        //         self.ledger_db
-        //             .get_tx_out_index_by_hash(&utxo.tx_out.hash())
-        //             .map_err(Error::LedgerDB)
-        //     })
-        //     .collect::<Result<Vec<u64>, Error>>()?;
 
         let rings = self.get_rings(DEFAULT_RING_SIZE, inputs.len(), &input_indices)?;
         log::trace!(logger, "Got {} rings", rings.len());
@@ -579,7 +570,7 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
     /// Get membership proofs for a list of transaction outputs.
     pub fn get_membership_proofs(
         &self,
-        outputs: Vec<TxOut>,
+        outputs: &[TxOut],
     ) -> Result<Vec<TxOutMembershipProof>, Error> {
         let indexes = outputs
             .iter()

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -135,6 +135,15 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         }
     }
 
+    /// Create a TxProposal.
+    ///
+    /// # Arguments
+    /// * `send_monitor_id` - ???
+    /// * `change_subaddress` - Recipient of any change.
+    /// * `inputs` - UTXOs that will be spent by the transaction.
+    /// * `outlays` - Output amounts and recipients.
+    /// * `opt_fee` - Transaction fee in picoMOB. If zero, defaults to MIN_FEE.
+    /// * `opt_tombstone` - Tombstone block. If zero, sets to default.
     pub fn build_transaction(
         &self,
         sender_monitor_id: &MonitorId,
@@ -233,6 +242,11 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         Ok(tx_proposal)
     }
 
+    /// Create a TxProposal that attempts to merge multiple UTXOs into a single larger UTXO.
+    ///
+    /// # Arguments
+    /// * `monitor_id` - ???
+    /// * `subaddress_index` - ???
     pub fn generate_optimization_tx(
         &self,
         monitor_id: &MonitorId,
@@ -246,17 +260,15 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         // Get monitor data.
         let monitor_data = self.mobilecoind_db.get_monitor_data(monitor_id)?;
 
-        // Select UTXOs.
         let num_blocks_in_ledger = self.ledger_db.num_blocks()?;
 
-        let inputs = self
-            .mobilecoind_db
-            .get_utxos_for_subaddress(monitor_id, subaddress_index)?;
-        let (selected_utxos, fee) = Self::select_utxos_for_optimization(
-            num_blocks_in_ledger,
-            &inputs,
-            MAX_INPUTS as usize,
-        )?;
+        // Select UTXOs that will be spent by this transaction.
+        let (selected_utxos, fee) = {
+            let inputs = self
+                .mobilecoind_db
+                .get_utxos_for_subaddress(monitor_id, subaddress_index)?;
+            Self::select_utxos_for_optimization(num_blocks_in_ledger, &inputs, MAX_INPUTS as usize)?
+        };
 
         log::trace!(
             logger,
@@ -285,7 +297,7 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         };
         log::trace!(logger, "Got membership proofs");
 
-        // A ring of mixins for each selected utxo.
+        // A ring of mixins for each selected UTXO.
         let rings = {
             let excluded_tx_out_indices: Vec<u64> = selected_utxos_with_proofs
                 .iter()
@@ -333,6 +345,13 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
         Ok(tx_proposal)
     }
 
+    /// Create a TxProposal that sends the total value of all inputs minus the fee to a single receiver.
+    ///
+    /// # Arguments
+    /// * `account_key` -
+    /// * `inputs` - UTXOs that will be spent by the transaction.
+    /// * `receiver` - The single receiver of the transaction's outputs.
+    /// * `fee` - Transaction fee in picoMOB. If zero, defaults to MIN_FEE.
     pub fn generate_tx_from_tx_list(
         &self,
         account_key: &AccountKey,
@@ -577,11 +596,9 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
             .map(|tx_out| self.ledger_db.get_tx_out_index_by_hash(&tx_out.hash()))
             .collect::<Result<Vec<u64>, LedgerError>>()?;
         Ok(self.ledger_db.get_tx_out_proof_of_memberships(&indexes)?)
-
-        // Ok(outputs.into_iter().zip(proofs.into_iter()).collect())
     }
 
-    /// Get rings.
+    /// Get `num_rings` rings of mixins.
     fn get_rings(
         &self,
         ring_size: usize,
@@ -603,45 +620,57 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
             return Err(Error::InsufficientTxOuts);
         }
 
-        // Randomly sample `num_requested` TxOuts, without replacement and convert into a Vec<u64>
-        let mut rng = rand::thread_rng();
-        let mut sampled_indices: HashSet<u64> = HashSet::default();
-        while sampled_indices.len() < num_requested {
-            let index = rng.gen_range(0, num_txos);
-            if excluded_tx_out_indices.contains(&index) {
-                continue;
+        // Randomly sample `num_requested` indices of TxOuts to use as mixins.
+        let mixin_indices: Vec<u64> = {
+            let mut rng = rand::thread_rng();
+            let mut samples: HashSet<u64> = HashSet::default();
+            while samples.len() < num_requested {
+                let index = rng.gen_range(0, num_txos);
+                if excluded_tx_out_indices.contains(&index) {
+                    continue;
+                }
+                samples.insert(index);
             }
-            sampled_indices.insert(index);
-        }
-        let sampled_indices_vec: Vec<u64> = sampled_indices.into_iter().collect();
+            samples.into_iter().collect()
+        };
 
-        // Get proofs for all of those indexes.
-        let proofs = self
+        let mixins_result: Result<Vec<TxOut>, _> = mixin_indices
+            .iter()
+            .map(|&index| self.ledger_db.get_tx_out_by_index(index))
+            .collect();
+        let mixins: Vec<TxOut> = mixins_result?;
+
+        let membership_proofs = self
             .ledger_db
-            .get_tx_out_proof_of_memberships(&sampled_indices_vec)?;
+            .get_tx_out_proof_of_memberships(&mixin_indices)?;
 
-        // Create an iterator that returns (index, proof) elements.
-        let mut indexes_and_proofs_iterator =
-            sampled_indices_vec.into_iter().zip(proofs.into_iter());
+        let mixins_with_proofs: Vec<(TxOut, TxOutMembershipProof)> = mixins
+            .into_iter()
+            .zip(membership_proofs.into_iter())
+            .collect();
 
-        // Convert that into a Vec<Vec<TxOut, TxOutMembershipProof>>
-        let mut rings_with_proofs = Vec::new();
+        // Group mixins and proofs into individual rings.
+        let result: Vec<Vec<(_, _)>> = mixins_with_proofs
+            .chunks(ring_size)
+            .map(|chunk| chunk.to_vec())
+            .collect();
 
-        for _ in 0..num_rings {
-            let mut ring = Vec::new();
-            for _ in 0..ring_size {
-                let (index, proof) = indexes_and_proofs_iterator.next().unwrap();
-                let tx_out = self.ledger_db.get_tx_out_by_index(index)?;
-
-                ring.push((tx_out, proof));
-            }
-            rings_with_proofs.push(ring);
-        }
-
-        Ok(rings_with_proofs)
+        Ok(result)
     }
 
-    /// Build a TxProposal object.
+    /// Create a TxProposal.
+    ///
+    /// # Arguments
+    /// * `inputs` - UTXOs to spend, with membership proofs.
+    /// * `rings` - A set of mixins for each input, with membership proofs.
+    /// * `fee` - Transaction fee, in picoMOB.
+    /// * `from_account_key` - ???
+    /// * `change_subaddress` - ???
+    /// * `destinations` - ???
+    /// * `tombstone_block` - ???
+    /// * `fog_pubkey_resolver` - ???
+    /// * `rng` -
+    /// * `logger` - Logger
     fn build_tx_proposal(
         inputs: &[(UnspentTxOut, TxOutMembershipProof)],
         rings: Vec<Vec<(TxOut, TxOutMembershipProof)>>,

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -245,8 +245,8 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
     /// Create a TxProposal that attempts to merge multiple UTXOs into a single larger UTXO.
     ///
     /// # Arguments
-    /// * `monitor_id` - ???
-    /// * `subaddress_index` - ???
+    /// * `monitor_id` - Monitor ID of the inputs to spend.
+    /// * `subaddress_index` - Subaddress of the inputs to spend.
     pub fn generate_optimization_tx(
         &self,
         monitor_id: &MonitorId,
@@ -348,7 +348,7 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
     /// Create a TxProposal that sends the total value of all inputs minus the fee to a single receiver.
     ///
     /// # Arguments
-    /// * `account_key` -
+    /// * `account_key` -Account key that owns the inputs.
     /// * `inputs` - UTXOs that will be spent by the transaction.
     /// * `receiver` - The single receiver of the transaction's outputs.
     /// * `fee` - Transaction fee in picoMOB. If zero, defaults to MIN_FEE.
@@ -664,11 +664,11 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver + Send + Sync + 'stat
     /// * `inputs` - UTXOs to spend, with membership proofs.
     /// * `rings` - A set of mixins for each input, with membership proofs.
     /// * `fee` - Transaction fee, in picoMOB.
-    /// * `from_account_key` - ???
-    /// * `change_subaddress` - ???
-    /// * `destinations` - ???
-    /// * `tombstone_block` - ???
-    /// * `fog_pubkey_resolver` - ???
+    /// * `from_account_key` - Owns the inputs. Also the recipient of any change.
+    /// * `change_subaddress` - Subaddress for change recipient.
+    /// * `destinations` - Outputs of the transaction.
+    /// * `tombstone_block` - Tombstone block of the transaciton.
+    /// * `fog_pubkey_resolver` - Provides Fog key report, when Fog is enabled.
     /// * `rng` -
     /// * `logger` - Logger
     fn build_tx_proposal(

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -655,7 +655,7 @@ impl<
 
         let proofs: Vec<TxOutMembershipProof> = self
             .transactions_manager
-            .get_membership_proofs(outputs.clone())
+            .get_membership_proofs(&outputs)
             .map_err(|err| rpc_internal_error("get_membership_proofs", err, &self.logger))?;
 
         let mut response = mc_mobilecoind_api::GetMembershipProofsResponse::new();

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2760,7 +2760,7 @@ mod test {
     #[test_with_logger]
     /// Get mixins should not return an "excluded" TxOut.
     fn test_get_mixins_excluded(logger: Logger) {
-        let mut rng: StdRng = SeedableRng::from_seed([44u8; 32]);
+        let mut rng: StdRng = SeedableRng::from_seed([74u8; 32]);
 
         let sender = AccountKey::random(&mut rng);
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1664,26 +1664,35 @@ macro_rules! build_api {
 }
 
 build_api! {
+    // Monitors
     add_monitor AddMonitorRequest AddMonitorResponse add_monitor_impl,
     remove_monitor RemoveMonitorRequest Empty remove_monitor_impl,
     get_monitor_list Empty GetMonitorListResponse get_monitor_list_impl,
     get_monitor_status GetMonitorStatusRequest GetMonitorStatusResponse get_monitor_status_impl,
     get_unspent_tx_out_list GetUnspentTxOutListRequest GetUnspentTxOutListResponse get_unspent_tx_out_list_impl,
+
+    // Utilities
     generate_entropy Empty GenerateEntropyResponse generate_entropy_impl,
     get_account_key GetAccountKeyRequest GetAccountKeyResponse get_account_key_impl,
     get_public_address GetPublicAddressRequest GetPublicAddressResponse get_public_address_impl,
+
+    // b58 codes
     parse_request_code ParseRequestCodeRequest ParseRequestCodeResponse parse_request_code_impl,
     create_request_code CreateRequestCodeRequest CreateRequestCodeResponse create_request_code_impl,
     parse_transfer_code ParseTransferCodeRequest ParseTransferCodeResponse parse_transfer_code_impl,
     create_transfer_code CreateTransferCodeRequest CreateTransferCodeResponse create_transfer_code_impl,
     parse_address_code ParseAddressCodeRequest ParseAddressCodeResponse parse_address_code_impl,
     create_address_code CreateAddressCodeRequest CreateAddressCodeResponse create_address_code_impl,
+
+    // Transactions
     get_membership_proofs GetMembershipProofsRequest GetMembershipProofsResponse get_membership_proofs_impl,
     generate_tx GenerateTxRequest GenerateTxResponse generate_tx_impl,
     generate_optimization_tx GenerateOptimizationTxRequest GenerateOptimizationTxResponse generate_optimization_tx_impl,
     generate_transfer_code_tx GenerateTransferCodeTxRequest GenerateTransferCodeTxResponse generate_transfer_code_tx_impl,
     generate_tx_from_tx_out_list GenerateTxFromTxOutListRequest GenerateTxFromTxOutListResponse generate_tx_from_tx_out_list_impl,
     submit_tx SubmitTxRequest SubmitTxResponse submit_tx_impl,
+
+    // Databases
     get_ledger_info Empty GetLedgerInfoResponse get_ledger_info_impl,
     get_block_info GetBlockInfoRequest GetBlockInfoResponse get_block_info_impl,
     get_block GetBlockRequest GetBlockResponse get_block_impl,
@@ -1691,10 +1700,16 @@ build_api! {
     get_tx_status_as_receiver GetTxStatusAsReceiverRequest GetTxStatusAsReceiverResponse get_tx_status_as_receiver_impl,
     get_processed_block GetProcessedBlockRequest GetProcessedBlockResponse get_processed_block_impl,
     get_block_index_by_tx_pub_key GetBlockIndexByTxPubKeyRequest GetBlockIndexByTxPubKeyResponse get_block_index_by_tx_pub_key_impl,
+
+    // Convenience calls
     get_balance GetBalanceRequest GetBalanceResponse get_balance_impl,
     send_payment SendPaymentRequest SendPaymentResponse send_payment_impl,
     pay_address_code PayAddressCodeRequest SendPaymentResponse pay_address_code_impl,
+
+    // Network status
     get_network_status Empty GetNetworkStatusResponse get_network_status_impl,
+
+    // Database encryption
     set_db_password SetDbPasswordRequest Empty set_db_password_impl,
     unlock_db UnlockDbRequest Empty unlock_db_impl
 }


### PR DESCRIPTION
### Motivation

Adds API endpoint for getting TxOuts for use as mixins.

### In this PR
* GetMembershipProofRequest and GetMembershipProofResponse use TxOut instead of UnspentTxOut.
* Add GetMixins endpoint 
* Update mobilecoind-json
* TODO: Add unit tests to mobilecoind-json