### PR TITLE
fix: url from public address was not normalized before lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ dependencies = [
  "mc-fog-api",
  "mc-util-encodings",
  "mc-util-serial",
+ "mc-util-uri",
  "mockall",
 ]
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -15,6 +15,7 @@ mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-fog-api = { path = "../../../fog/api" }
 mc-util-encodings = { path = "../../../util/encodings" }
 mc-util-serial = { path = "../../../util/serial" }
+mc-util-uri = { path = "../../../util/uri" }
 
 displaydoc = { version = "0.1", default-features = false }
 mockall = { version = "0.8.3", optional = true }

--- a/fog/report/validation/src/lib.rs
+++ b/fog/report/validation/src/lib.rs
@@ -18,9 +18,11 @@ use alloc::{
     collections::BTreeMap,
     string::{String, ToString},
 };
+use core::str::FromStr;
 use mc_account_keys::PublicAddress;
 use mc_attest_core::{VerificationReport, Verifier};
 use mc_fog_api::report::ReportResponse;
+use mc_util_uri::FogUri;
 
 /// Data structure for fog-ingest report validation
 pub mod ingest_report;
@@ -97,6 +99,8 @@ impl FogPubkeyResolver for FogResolver {
         recipient: &PublicAddress,
     ) -> Result<FullyValidatedFogPubkey, FogPubkeyError> {
         if let Some(url) = recipient.fog_report_url() {
+            // Normalize the string to URL before lookup
+            let url = FogUri::from_str(url)?;
             let url = url.to_string();
             if let Some(result) = self.responses.get(&url) {
                 let report_id = recipient.fog_report_id().unwrap_or("").to_string();

--- a/fog/report/validation/src/traits.rs
+++ b/fog/report/validation/src/traits.rs
@@ -3,6 +3,7 @@ use core::fmt::Debug;
 use displaydoc::Display;
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::RistrettoPublic;
+use mc_util_uri::UriParseError;
 
 #[cfg(any(test, feature = "automock"))]
 use mockall::*;
@@ -47,6 +48,8 @@ pub enum FogPubkeyError {
     NoMatchingReportId(String, String),
     /// Address has no fog_report_url, cannot fetch fog pubkey
     NoFogReportUrl,
+    /// Failed to parse fog url: {0}
+    Url(UriParseError),
     /// Ingest report deserialization error: {0},
     Deserialization(mc_util_serial::decode::Error),
     /// Ingest report verification error: {0}
@@ -62,5 +65,11 @@ impl From<IngestReportError> for FogPubkeyError {
 impl From<mc_util_serial::decode::Error> for FogPubkeyError {
     fn from(src: mc_util_serial::decode::Error) -> Self {
         Self::Deserialization(src)
+    }
+}
+
+impl From<UriParseError> for FogPubkeyError {
+    fn from(src: UriParseError) -> Self {
+        Self::Url(src)
     }
 }


### PR DESCRIPTION
this causes lookup to fail during fog conformance tests

this fixes up mcc-710 #581 