### PR TITLE
expose the full attestation report (that also includes the signature and certificate chain)

### DIFF
--- a/attest/ake/src/event.rs
+++ b/attest/ake/src/event.rs
@@ -313,7 +313,7 @@ impl Into<Vec<u8>> for AuthResponseInput {
 /// An authentication response input to a responder
 impl MealyInput for AuthResponseInput {}
 
-/// The IAS report us the final output when authentication succeeds.
+/// The IAS report is the final output when authentication succeeds.
 impl MealyOutput for VerificationReport {}
 
 /// A type similar to aead::Payload used to distinguish writer inputs from

--- a/attest/ake/src/event.rs
+++ b/attest/ake/src/event.rs
@@ -7,7 +7,7 @@ use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 use digest::{BlockInput, FixedOutput, Reset, Update};
-use mc_attest_core::{VerificationReport, VerificationReportData, Verifier};
+use mc_attest_core::{VerificationReport, Verifier};
 use mc_crypto_keys::Kex;
 use mc_crypto_noise::{HandshakeIX, HandshakeNX, HandshakePattern, NoiseCipher, ProtocolName};
 
@@ -313,8 +313,8 @@ impl Into<Vec<u8>> for AuthResponseInput {
 /// An authentication response input to a responder
 impl MealyInput for AuthResponseInput {}
 
-/// The IAS report contents are the final output when authentication succeeds.
-impl MealyOutput for VerificationReportData {}
+/// The IAS report us the final output when authentication succeeds.
+impl MealyOutput for VerificationReport {}
 
 /// A type similar to aead::Payload used to distinguish writer inputs from
 /// outputs.

--- a/attest/ake/src/initiator.rs
+++ b/attest/ake/src/initiator.rs
@@ -174,7 +174,7 @@ where
                 // However, we still make sure the report contains valid data
                 // before we continue by calling `.verify`. Callers can then
                 // safely construct a VerificationReportData object out of the
-                // VeriVerificationReport returned.
+                // VerificationReport returned.
                 let _report_data = verifier
                     .report_data(
                         &result

--- a/attest/ake/src/initiator.rs
+++ b/attest/ake/src/initiator.rs
@@ -12,7 +12,7 @@ use aead::{AeadMut, NewAead};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
-use mc_attest_core::{ReportDataMask, VerificationReport, VerificationReportData};
+use mc_attest_core::{ReportDataMask, VerificationReport};
 use mc_crypto_keys::{Kex, ReprBytes};
 use mc_crypto_noise::{
     HandshakeIX, HandshakeNX, HandshakeOutput, HandshakePattern, HandshakeState, HandshakeStatus,
@@ -142,9 +142,8 @@ where
     }
 }
 
-/// AuthPending + AuthResponseInput => Ready + VerificationReportData
-impl<KexAlgo, Cipher, DigestType>
-    Transition<Ready<Cipher>, AuthResponseInput, VerificationReportData>
+/// AuthPending + AuthResponseInput => Ready + VerificationReport
+impl<KexAlgo, Cipher, DigestType> Transition<Ready<Cipher>, AuthResponseInput, VerificationReport>
     for AuthPending<KexAlgo, Cipher, DigestType>
 where
     KexAlgo: Kex,
@@ -157,7 +156,7 @@ where
         self,
         _csprng: &mut R,
         input: AuthResponseInput,
-    ) -> Result<(Ready<Cipher>, VerificationReportData), Self::Error> {
+    ) -> Result<(Ready<Cipher>, VerificationReport), Self::Error> {
         let output = self
             .state
             .read_message(input.as_ref())
@@ -169,7 +168,14 @@ where
                     .map_err(|_e| Error::ReportDeserialization)?;
 
                 let mut verifier = input.verifier;
-                let report_data = verifier
+
+                // We are not returning the report data and instead returning the raw report
+                // since that also includes the signature and certificate chain.
+                // However, we still make sure the report contains valid data
+                // before we continue by calling `.verify`. Callers can then
+                // safely construct a VerificationReportData object out of the
+                // VeriVerificationReport returned.
+                let _report_data = verifier
                     .report_data(
                         &result
                             .remote_identity
@@ -186,7 +192,7 @@ where
                         reader: result.responder_cipher,
                         binding: result.channel_binding,
                     },
-                    report_data,
+                    remote_report,
                 ))
             }
         }

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -756,7 +756,7 @@ impl VerificationReport {
         // Parse the JSON
         let report_data: VerificationReportData = self.try_into()?;
 
-        // Check the report contains
+        // Check the report contents
         report_data.verify(
             IAS_VERSION,
             expected_ias_nonce,


### PR DESCRIPTION
### Motivation

For upcoming `mc-watcher` improvements we want to be able to store the complete attestation verification report. For that, we the AKE state machine to expose the raw report + the signature over it + the certificate chain, in addition to the parsed report data.

### In this PR
* Change the AKE state machine to expose the full `VerificationReport` and not just `VerificationReportData` (which can be constructed from `VerificationReport`).

### Future Work
* I don't think this affects SDK or `internal` but due to other pending uprev issues am not currently able to verify that.

