### PR TITLE
expose VerificationReport in AttestedConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "failure",
  "grpcio",
  "mc-attest-api",
+ "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",
  "mc-connection",

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -4,6 +4,7 @@
 
 use crate::error::{Result, RetryResult};
 use grpcio::Error as GrpcError;
+use mc_attest_core::VerificationReport;
 use mc_transaction_core::{tx::Tx, Block, BlockID, BlockIndex};
 use mc_util_uri::ConnectionUri;
 use std::{
@@ -29,7 +30,7 @@ pub trait AttestedConnection: Connection {
 
     fn is_attested(&self) -> bool;
 
-    fn attest(&mut self) -> StdResult<(), Self::Error>;
+    fn attest(&mut self) -> StdResult<VerificationReport, Self::Error>;
 
     fn deattest(&mut self);
 
@@ -38,7 +39,7 @@ pub trait AttestedConnection: Connection {
         func: impl FnOnce(&mut Self) -> StdResult<T, GrpcError>,
     ) -> StdResult<T, Self::Error> {
         if !self.is_attested() {
-            self.attest()?;
+            let _verification_report = self.attest()?;
         }
 
         let result = func(self);

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -13,6 +13,7 @@ pub use crate::{error::Error, messages::EnclaveCall};
 
 use alloc::{string::String, vec::Vec};
 use core::{cmp::Ordering, hash::Hash, result::Result as StdResult};
+use mc_attest_core::VerificationReport;
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, PeerAuthRequest,
     PeerAuthResponse, PeerSession,
@@ -238,7 +239,11 @@ pub trait ConsensusEnclave: ReportableEnclave {
     fn peer_accept(&self, req: PeerAuthRequest) -> Result<(PeerAuthResponse, PeerSession)>;
 
     /// Complete the connection
-    fn peer_connect(&self, peer_id: &ResponderId, res: PeerAuthResponse) -> Result<PeerSession>;
+    fn peer_connect(
+        &self,
+        peer_id: &ResponderId,
+        res: PeerAuthResponse,
+    ) -> Result<(PeerSession, VerificationReport)>;
 
     /// Destroy a peer association
     fn peer_close(&self, channel_id: &PeerSession) -> Result<()>;

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -240,7 +240,11 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         Ok(self.ake.peer_accept(req)?)
     }
 
-    fn peer_connect(&self, peer_id: &ResponderId, msg: PeerAuthResponse) -> Result<PeerSession> {
+    fn peer_connect(
+        &self,
+        peer_id: &ResponderId,
+        msg: PeerAuthResponse,
+    ) -> Result<(PeerSession, VerificationReport)> {
         Ok(self.ake.peer_connect(peer_id, msg)?)
     }
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -147,8 +147,12 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         Ok((PeerAuthResponse::default(), PeerSession::default()))
     }
 
-    fn peer_connect(&self, _node_id: &ResponderId, _msg: PeerAuthResponse) -> Result<PeerSession> {
-        Ok(vec![].into())
+    fn peer_connect(
+        &self,
+        _node_id: &ResponderId,
+        _msg: PeerAuthResponse,
+    ) -> Result<(PeerSession, VerificationReport)> {
+        Ok((vec![].into(), VerificationReport::default()))
     }
 
     fn peer_close(&self, _msg: &PeerSession) -> Result<()> {

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -46,7 +46,7 @@ mock! {
 
         fn peer_accept(&self, req: PeerAuthRequest) -> ConsensusEnclaveResult<(PeerAuthResponse, PeerSession)>;
 
-        fn peer_connect(&self, peer_id: &ResponderId, res: PeerAuthResponse) -> ConsensusEnclaveResult<PeerSession>;
+        fn peer_connect(&self, peer_id: &ResponderId, res: PeerAuthResponse) -> ConsensusEnclaveResult<(PeerSession, VerificationReport)>;
 
         fn peer_close(&self, channel_id: &PeerSession) -> ConsensusEnclaveResult<()>;
 

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -174,7 +174,11 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn peer_connect(&self, peer_id: &ResponderId, msg: PeerAuthResponse) -> Result<PeerSession> {
+    fn peer_connect(
+        &self,
+        peer_id: &ResponderId,
+        msg: PeerAuthResponse,
+    ) -> Result<(PeerSession, VerificationReport)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::PeerConnect(peer_id.clone(), msg))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -9,6 +9,7 @@ test_utils = []
 
 [dependencies]
 mc-attest-api = { path = "../attest/api" }
+mc-attest-core = { path = "../attest/core" }
 mc-attest-enclave-api = { path = "../attest/enclave-api" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }


### PR DESCRIPTION
### Motivation

For the upcoming `mc-watcher` changes we want to be able to expose the `VerificationReport` that is returned as part of the attestation process to the caller, so that they could store it, or look at the data it contains.

### In this PR
* Changing `AttestedConnection::attest` to return the `VerificationReport`.
* Changing `peer_connect` to return the `VerificationReport`.

### Future Work
* Upreving `internal`, I am working on that.
