### PR TITLE
Add rpc_precondition_error, and make these use Display instead of Debug

### DIFF
--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -352,7 +352,7 @@ impl ConsensusPeerApi for PeerApiService {
                 match TxHash::try_from(&tx_hash_bytes[..]) {
                     Ok(tx_hash) => tx_hashes.push(tx_hash),
                     Err(_) => {
-                        let result = Err(rpc_invalid_arg_error("tx_hash", (), &logger));
+                        let result = Err(rpc_invalid_arg_error("tx_hash", "", &logger));
                         send_result(ctx, sink, result, &logger);
                         return;
                     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -4186,7 +4186,7 @@ mod test {
             Err(GrpcError::RpcFailure(RpcStatus { details, .. })) => {
                 assert_eq!(
                     details,
-                    Some("transactions_manager.build_transaction: InsufficientFunds".to_owned())
+                    Some("transactions_manager.build_transaction: Insufficient funds".to_owned())
                 );
             }
             Err(err) => panic!("Unexpected error: {:?}", err),


### PR DESCRIPTION
In another PR we found use for the `FAILED_PRECONDITION` status code
of grpc.

While touching this code, we thought it would be a good idea to make
these conversion functions (which convert Error objects to appropriate
RpcStatus objects from grpcio crate), report the Error objects
using `Display` instead of `Debug`, because all of our Error objects
implement `Display` and it's usually more readable to a human than
the `Debug` formatting. This also makes the "context" thing use `Display`
as well instead of `ToString`, since in reality almost all `ToString`
implementations come from `Display` because of the blanket implementation.