### PR TITLE
Fix deprecation warning (protobuf)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,15 +4491,15 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.14.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
+checksum = "86473d5f16580f10b131a0bf0afb68f8e029d1835d33a00f37281b05694e5312"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.14.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de113bba758ccf2c1ef816b127c958001b7831136c9bc3f8e9ec695ac4e82b0c"
+checksum = "c8b6ba4581fcd9c3ce3576f25e528467b0d3516e332884c0da6f2084fe59045f"
 dependencies = [
  "protobuf",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,7 +17,7 @@ mc-watcher-api = { path = "../watcher/api" }
 bs58 = "0.3.0"
 crc = "1.8.1"
 displaydoc = { version = "0.1.7", default-features = false }
-protobuf = "2.12"
+protobuf = "2.20"
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
 curve25519-dalek = { version = "3.0", default-features = false, features = ["simd_backend", "nightly"] }

--- a/api/src/convert/block.rs
+++ b/api/src/convert/block.rs
@@ -150,8 +150,8 @@ mod tests {
         // Encode using `prost`, decode using `protobuf`.
         {
             let prost_block_bytes = mc_util_serial::encode(&source_block);
-            let blockchain_block: blockchain::Block =
-                protobuf::parse_from_bytes(&prost_block_bytes).expect("failed decoding");
+            let blockchain_block =
+                blockchain::Block::parse_from_bytes(&prost_block_bytes).expect("failed decoding");
 
             assert_eq!(blockchain_block, blockchain::Block::from(&source_block));
         }

--- a/api/src/convert/block_signature.rs
+++ b/api/src/convert/block_signature.rs
@@ -119,8 +119,9 @@ mod tests {
         // Encode using `prost`, decode using `protobuf`.
         {
             let prost_block_signature_bytes = mc_util_serial::encode(&source_block_signature);
-            let blockchain_block_signature: blockchain::BlockSignature =
-                protobuf::parse_from_bytes(&prost_block_signature_bytes).expect("failed decoding");
+            let blockchain_block_signature =
+                blockchain::BlockSignature::parse_from_bytes(&prost_block_signature_bytes)
+                    .expect("failed decoding");
 
             assert_eq!(
                 blockchain_block_signature,

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -114,7 +114,7 @@ mod tests {
         // Encoding with prost, decoding with protobuf should be the identity function.
         {
             let bytes = mc_util_serial::encode(&tx);
-            let recovered_tx: external::Tx = protobuf::parse_from_bytes(&bytes).unwrap();
+            let recovered_tx = external::Tx::parse_from_bytes(&bytes).unwrap();
             assert_eq!(recovered_tx, external::Tx::from(&tx));
         }
 

--- a/api/src/display.rs
+++ b/api/src/display.rs
@@ -6,7 +6,7 @@
 use crate::printable;
 use crc::crc32;
 use displaydoc::Display;
-use protobuf::{parse_from_bytes, Message};
+use protobuf::Message;
 
 /// Decoding / encoding errors
 #[derive(Clone, Debug, Eq, PartialEq, Display)]
@@ -61,7 +61,7 @@ impl printable::PrintableWrapper {
         if expected_checksum.to_vec() != decoded_bytes {
             return Err(Error::ChecksumMismatch);
         }
-        let wrapper = parse_from_bytes(&wrapper_bytes)
+        let wrapper = PrintableWrapper::parse_from_bytes(&wrapper_bytes)
             .map_err(|err| Error::Deserialization(err.to_string()))?;
         Ok(wrapper)
     }

--- a/api/src/display.rs
+++ b/api/src/display.rs
@@ -61,7 +61,7 @@ impl printable::PrintableWrapper {
         if expected_checksum.to_vec() != decoded_bytes {
             return Err(Error::ChecksumMismatch);
         }
-        let wrapper = PrintableWrapper::parse_from_bytes(&wrapper_bytes)
+        let wrapper = Self::parse_from_bytes(&wrapper_bytes)
             .map_err(|err| Error::Deserialization(err.to_string()))?;
         Ok(wrapper)
     }

--- a/api/tests/prost.rs
+++ b/api/tests/prost.rs
@@ -12,8 +12,8 @@ use protobuf::Message as ProtobufMessage;
 fn round_trip_message<SRC: ProstMessage + Eq + Default, DEST: ProtobufMessage>(prost_val: &SRC) {
     let prost_bytes = mc_util_serial::encode(prost_val);
 
-    let dest_val: DEST =
-        protobuf::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
+    let dest_val =
+        DEST::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
 
     let protobuf_bytes = dest_val
         .write_to_bytes()

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -8,7 +8,7 @@ links = "mc-fog-api"
 [dependencies]
 futures = "0.3"
 grpcio = "0.6.0"
-protobuf = "2.12"
+protobuf = "2.20"
 
 mc-api = { path = "../../api" }
 mc-attest-api = { path = "../../attest/api" }

--- a/fog/api/test-utils/src/lib.rs
+++ b/fog/api/test-utils/src/lib.rs
@@ -17,8 +17,8 @@ pub fn round_trip_message<SRC: ProstMessage + Eq + Default, DEST: ProtobufMessag
 ) {
     let prost_bytes = mc_util_serial::encode(prost_val);
 
-    let dest_val: DEST =
-        protobuf::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
+    let dest_val =
+        DEST::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
 
     let protobuf_bytes = dest_val
         .write_to_bytes()
@@ -42,8 +42,8 @@ pub fn round_trip_protobuf_object<SRC: ProtobufMessage + Eq, DEST: ProstMessage 
 
     let prost_bytes = mc_util_serial::encode(&prost_val);
 
-    let final_val: SRC =
-        protobuf::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
+    let final_val =
+        SRC::parse_from_bytes(&prost_bytes).expect("Parsing protobuf from prost bytes failed");
 
     assert_eq!(*protobuf_val, final_val);
 }

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -25,7 +25,7 @@ crossbeam-channel = "0.5"
 failure = "0.1.8"
 grpcio = "0.6.0"
 mockall = "0.8.3"
-protobuf = "2.12"
+protobuf = "2.20"
 rand = "0.7"
 reqwest = { version = "0.10" , features = ["rustls-tls"], default_features = false }
 retry = "1.2"

--- a/ledger/sync/src/reqwest_transactions_fetcher.rs
+++ b/ledger/sync/src/reqwest_transactions_fetcher.rs
@@ -195,7 +195,7 @@ impl ReqwestTransactionsFetcher {
             bytes
         };
 
-        let obj: M = protobuf::parse_from_bytes(&bytes).map_err(|err| {
+        let obj = M::parse_from_bytes(&bytes).map_err(|err| {
             ReqwestTransactionsFetcherError::InvalidBlockReceived(
                 url.to_string(),
                 format!("protobuf parse failed: {:?}", err),


### PR DESCRIPTION
When trying to move android-bindings and libmobilecoin into their
own workspace (to allow configuration for smaller binaries), I got
errors in mc-api due to deprecation warnings added by protobuf 2.20.

This uprevs protobuf to 2.20 and fixes all deprecation warnings in
the public repo.