### PR TITLE
mc-watcher keeps log of attestation verification reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,6 +3749,7 @@ dependencies = [
  "mc-transaction-core-test-utils",
  "mc-util-from-random",
  "mc-util-lmdb",
+ "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",
  "mc-util-uri",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,6 +3736,7 @@ version = "1.0.0"
 dependencies = [
  "failure",
  "grpcio",
+ "hex 0.4.2",
  "lmdb-rkv",
  "mc-account-keys",
  "mc-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,6 +3743,7 @@ dependencies = [
  "mc-attest-core",
  "mc-common",
  "mc-connection",
+ "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-ledger-db",
  "mc-ledger-sync",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,10 +3735,13 @@ name = "mc-watcher"
 version = "1.0.0"
 dependencies = [
  "failure",
+ "grpcio",
  "lmdb-rkv",
  "mc-account-keys",
  "mc-api",
+ "mc-attest-core",
  "mc-common",
+ "mc-connection",
  "mc-crypto-keys",
  "mc-ledger-db",
  "mc-ledger-sync",
@@ -3748,12 +3751,15 @@ dependencies = [
  "mc-util-lmdb",
  "mc-util-serial",
  "mc-util-test-helper",
+ "mc-util-uri",
  "mc-watcher-api",
  "prost",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "serde",
  "structopt",
  "tempdir",
+ "toml 0.5.7",
  "url 2.1.1",
 ]
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -20,6 +20,7 @@ mc-transaction-core = { path = "../transaction/core" }
 mc-transaction-core-test-utils = { path = "../transaction/core/test-utils" }
 mc-util-from-random = { path = "../util/from-random" }
 mc-util-lmdb = { path = "../util/lmdb" }
+mc-util-repr-bytes = { path = "../util/repr-bytes" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 mc-watcher-api = { path = "api" }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -19,12 +19,16 @@ mc-transaction-core-test-utils = { path = "../transaction/core/test-utils" }
 mc-util-from-random = { path = "../util/from-random" }
 mc-util-lmdb = { path = "../util/lmdb" }
 mc-util-serial = { path = "../util/serial" }
+mc-util-uri = { path = "../util/uri" }
 mc-watcher-api = { path = "api" }
 
 failure = "0.1.8"
+grpcio = "0.6.0"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 structopt = "0.3"
+toml = "0.5"
 url = "2.1"
 
 [dev-dependencies]

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -10,7 +10,9 @@ path = "src/bin/main.rs"
 
 [dependencies]
 mc-api = { path = "../api" }
+mc-attest-core = { path = "../attest/core" }
 mc-common = { path = "../common", features = ["log"] }
+mc-connection = { path = "../connection" }
 mc-crypto-keys = { path = "../crypto/keys" }
 mc-ledger-db = { path = "../ledger/db" }
 mc-ledger-sync = { path = "../ledger/sync" }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -27,6 +27,7 @@ mc-watcher-api = { path = "api" }
 
 failure = "0.1.8"
 grpcio = "0.6.0"
+hex = "0.4"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -13,6 +13,7 @@ mc-api = { path = "../api" }
 mc-attest-core = { path = "../attest/core" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }
+mc-crypto-digestible = { path = "../crypto/digestible" }
 mc-crypto-keys = { path = "../crypto/keys" }
 mc-ledger-db = { path = "../ledger/db" }
 mc-ledger-sync = { path = "../ledger/sync" }

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -7,7 +7,8 @@
 //! blocks are synced.
 
 use mc_watcher::{
-    config::WatcherConfig, watcher::Watcher, watcher_db::create_or_open_rw_watcher_db,
+    config::WatcherConfig, verification_reports_collector::VerificationReportsCollector,
+    watcher::Watcher, watcher_db::create_or_open_rw_watcher_db,
 };
 
 use mc_common::logger::{create_app_logger, log, o};
@@ -35,9 +36,16 @@ fn main() {
     )
     .expect("Could not create or open watcher db");
     let watcher = Watcher::new(
-        watcher_db,
+        watcher_db.clone(),
         transactions_fetcher,
         sources_config.tx_source_urls_to_consensus_client_urls(),
+        logger.clone(),
+    );
+
+    let _verification_reports_collector = VerificationReportsCollector::new(
+        watcher_db,
+        sources_config.tx_source_urls_to_consensus_client_urls(),
+        SYNC_RETRY_INTERVAL,
         logger.clone(),
     );
 

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -34,7 +34,12 @@ fn main() {
         logger.clone(),
     )
     .expect("Could not create or open watcher db");
-    let watcher = Watcher::new(watcher_db, transactions_fetcher, logger.clone());
+    let watcher = Watcher::new(
+        watcher_db,
+        transactions_fetcher,
+        sources_config.tx_source_urls_to_consensus_client_urls(),
+        logger.clone(),
+    );
 
     loop {
         // For now, ignore origin block, as it does not have a signature.

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -22,9 +22,11 @@ fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = WatcherConfig::from_args();
+    let sources_config = config.sources_config();
+
 
     let transactions_fetcher =
-        ReqwestTransactionsFetcher::new(config.tx_source_urls.clone(), logger.clone())
+        ReqwestTransactionsFetcher::new(sources_config.tx_source_urls(), logger.clone())
             .expect("Failed creating ReqwestTransactionsFetcher");
 
     let watcher_db = create_or_open_rw_watcher_db(

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -24,7 +24,6 @@ fn main() {
     let config = WatcherConfig::from_args();
     let sources_config = config.sources_config();
 
-
     let transactions_fetcher =
         ReqwestTransactionsFetcher::new(sources_config.tx_source_urls(), logger.clone())
             .expect("Failed creating ReqwestTransactionsFetcher");
@@ -35,9 +34,10 @@ fn main() {
         logger.clone(),
     )
     .expect("Could not create or open watcher db");
-    let watcher = Watcher::new(watcher_db, transactions_fetcher, logger);
-    // For now, ignore origin block, as it does not have a signature.
+    let watcher = Watcher::new(watcher_db, transactions_fetcher, logger.clone());
+
     loop {
+        // For now, ignore origin block, as it does not have a signature.
         let syncing_done = watcher
             .sync_signatures(1, config.max_block_height)
             .expect("Could not sync signatures");

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -35,12 +35,7 @@ fn main() {
         logger.clone(),
     )
     .expect("Could not create or open watcher db");
-    let watcher = Watcher::new(
-        watcher_db.clone(),
-        transactions_fetcher,
-        sources_config.tx_source_urls_to_consensus_client_urls(),
-        logger.clone(),
-    );
+    let watcher = Watcher::new(watcher_db.clone(), transactions_fetcher, logger.clone());
 
     let _verification_reports_collector = VerificationReportsCollector::new(
         watcher_db,

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -13,10 +13,8 @@ use mc_watcher::{
 
 use mc_common::logger::{create_app_logger, log, o};
 use mc_ledger_sync::ReqwestTransactionsFetcher;
-use std::{thread::sleep, time::Duration};
+use std::thread::sleep;
 use structopt::StructOpt;
-
-const SYNC_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 fn main() {
     mc_common::setup_panic_handler();
@@ -40,7 +38,7 @@ fn main() {
     let _verification_reports_collector = VerificationReportsCollector::new(
         watcher_db,
         sources_config.tx_source_urls_to_consensus_client_urls(),
-        SYNC_RETRY_INTERVAL,
+        config.poll_interval,
         logger.clone(),
     );
 
@@ -54,6 +52,6 @@ fn main() {
             break;
         }
 
-        sleep(SYNC_RETRY_INTERVAL);
+        sleep(config.poll_interval);
     }
 }

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -5,7 +5,7 @@
 use mc_common::HashMap;
 use mc_util_uri::ConsensusClientUri;
 use serde::{Deserialize, Serialize};
-use std::{fs, iter::FromIterator, path::PathBuf};
+use std::{fs, iter::FromIterator, path::PathBuf, str::FromStr, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -27,6 +27,10 @@ pub struct WatcherConfig {
     /// (Optional) Number of blocks to sync
     #[structopt(long)]
     pub max_block_height: Option<u64>,
+
+    /// How many seconds to wait between polling.
+    #[structopt(long, default_value = "1", parse(try_from_str=parse_duration_in_seconds))]
+    pub poll_interval: Duration,
 }
 
 impl WatcherConfig {
@@ -47,7 +51,7 @@ impl WatcherConfig {
 struct SourceConfig {
     /// URL to use for pulling blocks.
     ///
-    /// For example: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.master.mobilecoin.com/
+    /// For example: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
     tx_source_url: String,
 
     /// (Optional) Consensus node client URL to use for fetching the remote attestation report
@@ -94,6 +98,10 @@ impl SourcesConfig {
                 .map(|client_url| (source_config.tx_source_url(), client_url))
         }))
     }
+}
+
+fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
+    Ok(Duration::from_secs(u64::from_str(src)?))
 }
 
 #[cfg(test)]

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -2,9 +2,10 @@
 
 //! Configuration parameters for the watcher test utility.
 
+use mc_common::HashMap;
 use mc_util_uri::ConsensusClientUri;
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf};
+use std::{fs, iter::FromIterator, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -68,6 +69,17 @@ impl SourcesConfig {
             .iter()
             .map(|source_config| source_config.tx_source_url.clone())
             .collect()
+    }
+
+    /// Returns a map of tx source url -> consensus client url. This is used when we want to try
+    /// and connect to the consensus block that provided some block from a given URL.
+    pub fn tx_source_urls_to_consensus_client_urls(&self) -> HashMap<String, ConsensusClientUri> {
+        HashMap::from_iter(self.sources.iter().filter_map(|source_config| {
+            source_config
+                .consensus_client_url
+                .clone()
+                .map(|client_url| (source_config.tx_source_url.clone(), client_url))
+        }))
     }
 }
 

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -2,7 +2,9 @@
 
 //! Configuration parameters for the watcher test utility.
 
-use std::path::PathBuf;
+use mc_util_uri::ConsensusClientUri;
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -16,13 +18,88 @@ pub struct WatcherConfig {
     #[structopt(long, default_value = "/tmp/watcher-db", parse(from_os_str))]
     pub watcher_db: PathBuf,
 
-    /// URLs to use to pull blocks.
-    ///
-    /// For example: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.master.mobilecoin.com/
-    #[structopt(long = "tx-source-url", required = true, min_values = 1)]
-    pub tx_source_urls: Vec<String>,
+    /// The location of the sources.toml file. This file configures the list of block sources and
+    /// consensus nodes that are being watched.
+    #[structopt(long)]
+    pub sources_path: PathBuf,
 
     /// (Optional) Number of blocks to sync
     #[structopt(long)]
     pub max_block_height: Option<u64>,
+}
+
+impl WatcherConfig {
+    pub fn sources_config(&self) -> SourcesConfig {
+        // Read configuration file.
+        let data = fs::read_to_string(&self.sources_path)
+            .unwrap_or_else(|err| panic!("failed reading {:?}: {:?}", self.sources_path, err));
+
+        // Parse configuration file.
+        toml::from_str(&data)
+            .unwrap_or_else(|err| panic!("failed TOML parsing {:?}: {:?}", self.sources_path, err))
+    }
+}
+
+/// A single watched source configuration.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
+pub struct SourceConfig {
+    /// URL to use for pulling blocks.
+    ///
+    /// For example: https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.master.mobilecoin.com/
+    pub tx_source_url: String,
+
+    /// (Optional) Consensus node client URL to use for fetching the remote attestation report
+    /// whenever a block signer change is detected.
+    pub consensus_client_url: Option<ConsensusClientUri>,
+}
+
+/// Sources configuration - this configures which sources are being watched.
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
+pub struct SourcesConfig {
+    pub sources: Vec<SourceConfig>,
+}
+
+impl SourcesConfig {
+    pub fn tx_source_urls(&self) -> Vec<String> {
+        self.sources
+            .iter()
+            .map(|source_config| source_config.tx_source_url.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn sources_config_toml() {
+        let expected_config = SourcesConfig {
+            sources: vec![
+                SourceConfig {
+                    tx_source_url: "https://www.source.com/".to_owned(),
+                    consensus_client_url: None,
+                },
+                SourceConfig {
+                    tx_source_url: "https://www.2nd-source.com/".to_owned(),
+                    consensus_client_url: Some(
+                        ConsensusClientUri::from_str("mc://www.x.com:443/").unwrap(),
+                    ),
+                },
+            ],
+        };
+
+        let input_toml: &str = r#"
+            [[sources]]
+            tx_source_url = "https://www.source.com/"
+
+            [[sources]]
+            tx_source_url = "https://www.2nd-source.com/"
+            consensus_client_url = "mc://www.x.com:443/"
+        "#;
+        let config: SourcesConfig = toml::from_str(input_toml).expect("failed parsing toml");
+
+        assert_eq!(config, expected_config);
+    }
 }

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -29,6 +29,7 @@ pub struct WatcherConfig {
 }
 
 impl WatcherConfig {
+    /// Load the sources configuration file.
     pub fn sources_config(&self) -> SourcesConfig {
         // Read configuration file.
         let data = fs::read_to_string(&self.sources_path)
@@ -56,10 +57,12 @@ pub struct SourceConfig {
 /// Sources configuration - this configures which sources are being watched.
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct SourcesConfig {
+    /// List of sources being watched.
     pub sources: Vec<SourceConfig>,
 }
 
 impl SourcesConfig {
+    /// Returns a list of URLs that can be used to fetch block contents from.
     pub fn tx_source_urls(&self) -> Vec<String> {
         self.sources
             .iter()

--- a/watcher/src/error.rs
+++ b/watcher/src/error.rs
@@ -2,6 +2,7 @@
 
 use failure::Fail;
 use mc_util_lmdb::MetadataStoreError;
+use std::string::FromUtf8Error;
 
 /// Watcher Errors
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Fail)]
@@ -54,6 +55,9 @@ pub enum WatcherDBError {
 
     #[fail(display = "Metadata store error: {}", _0)]
     MetadataStore(MetadataStoreError),
+
+    #[fail(display = "Utf8 error")]
+    Utf8,
 }
 
 impl From<lmdb::Error> for WatcherDBError {
@@ -83,5 +87,11 @@ impl From<std::io::Error> for WatcherDBError {
 impl From<MetadataStoreError> for WatcherDBError {
     fn from(e: MetadataStoreError) -> Self {
         Self::MetadataStore(e)
+    }
+}
+
+impl From<FromUtf8Error> for WatcherDBError {
+    fn from(_src: FromUtf8Error) -> Self {
+        Self::Utf8
     }
 }

--- a/watcher/src/error.rs
+++ b/watcher/src/error.rs
@@ -1,11 +1,13 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use failure::Fail;
+use mc_connection::Error as ConnectionError;
+use mc_crypto_keys::KeyError;
 use mc_util_lmdb::MetadataStoreError;
 use std::string::FromUtf8Error;
 
 /// Watcher Errors
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Fail)]
+#[derive(Debug, Fail)]
 pub enum WatcherError {
     #[fail(display = "URL Parse Error: {}", _0)]
     URLParse(url::ParseError),
@@ -15,17 +17,26 @@ pub enum WatcherError {
 
     #[fail(display = "SyncFailed")]
     SyncFailed,
+
+    #[fail(display = "Node connection error: {}", _0)]
+    Connection(ConnectionError),
 }
 
 impl From<url::ParseError> for WatcherError {
     fn from(src: url::ParseError) -> Self {
-        WatcherError::URLParse(src)
+        Self::URLParse(src)
     }
 }
 
 impl From<WatcherDBError> for WatcherError {
     fn from(src: WatcherDBError) -> Self {
-        WatcherError::DB(src)
+        Self::DB(src)
+    }
+}
+
+impl From<ConnectionError> for WatcherError {
+    fn from(src: ConnectionError) -> Self {
+        Self::Connection(src)
     }
 }
 
@@ -58,6 +69,12 @@ pub enum WatcherDBError {
 
     #[fail(display = "Utf8 error")]
     Utf8,
+
+    #[fail(display = "URL Parse Error: {}", _0)]
+    URLParse(url::ParseError),
+
+    #[fail(display = "Crypto key error: {}", _0)]
+    CryptoKey(KeyError),
 }
 
 impl From<lmdb::Error> for WatcherDBError {
@@ -93,5 +110,17 @@ impl From<MetadataStoreError> for WatcherDBError {
 impl From<FromUtf8Error> for WatcherDBError {
     fn from(_src: FromUtf8Error) -> Self {
         Self::Utf8
+    }
+}
+
+impl From<url::ParseError> for WatcherDBError {
+    fn from(src: url::ParseError) -> Self {
+        Self::URLParse(src)
+    }
+}
+
+impl From<KeyError> for WatcherDBError {
+    fn from(src: KeyError) -> Self {
+        Self::CryptoKey(src)
     }
 }

--- a/watcher/src/lib.rs
+++ b/watcher/src/lib.rs
@@ -6,6 +6,7 @@
 #![forbid(unsafe_code)]
 
 pub mod config;
+pub mod verification_reports_collector;
 pub mod watcher;
 pub mod watcher_db;
 

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -67,7 +67,6 @@ impl VerificationReportsCollector {
 
     /// Stop the thread.
     pub fn stop(&mut self) {
-        // TODO an option to wait until the queue is empty.
         self.stop_requested.store(true, Ordering::SeqCst);
         if let Some(thread) = self.join_handle.take() {
             thread.join().expect("thread join failed");
@@ -236,6 +235,8 @@ impl VerificationReportsCollectorThread {
             hex::encode(verification_report_block_signer.to_bytes())
         );
 
+        // Store the VerificationReport in the database, and also remove
+        // verification_report_block_signer and potential_signers from the polling queue.
         match self.watcher_db.add_verification_report(
             tx_src_url,
             &verification_report_block_signer,

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -1,0 +1,251 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+//! Worker thread for collecting verification reports from nodes.
+
+use crate::watcher_db::WatcherDB;
+use grpcio::Environment;
+use mc_attest_core::{VerificationReport, VerificationReportData, Verifier, DEBUG_ENCLAVE};
+use mc_common::{
+    logger::{log, Logger},
+    HashMap,
+};
+use mc_connection::{AttestedConnection, ThickClient};
+use mc_crypto_keys::Ed25519Public;
+use mc_util_repr_bytes::ReprBytes;
+use mc_util_uri::ConsensusClientUri;
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+use url::Url;
+
+/// Periodically checks the verification report poll queue in the database and attempts to contact
+/// nodes and get their verification report.
+pub struct VerificationReportsCollector {
+    join_handle: Option<thread::JoinHandle<()>>,
+    stop_requested: Arc<AtomicBool>,
+}
+
+impl VerificationReportsCollector {
+    /// Create a new verification reports collector thread.
+    pub fn new(
+        watcher_db: WatcherDB,
+        tx_source_urls_to_consensus_client_urls: HashMap<String, ConsensusClientUri>,
+        poll_interval: Duration,
+        logger: Logger,
+    ) -> Self {
+        let stop_requested = Arc::new(AtomicBool::new(false));
+
+        let thread_stop_requested = stop_requested.clone();
+        let join_handle = Some(
+            thread::Builder::new()
+                .name("VerificationReportsCollector".into())
+                .spawn(move || {
+                    let thread = VerificationReportsCollectorThread::new(
+                        watcher_db,
+                        tx_source_urls_to_consensus_client_urls,
+                        poll_interval,
+                        logger,
+                        thread_stop_requested,
+                    );
+
+                    thread.entrypoint();
+                })
+                .expect("Failed spawning VerificationReportsCollector thread"),
+        );
+
+        Self {
+            join_handle,
+            stop_requested,
+        }
+    }
+
+    /// Stop the thread.
+    pub fn stop(&mut self) {
+        // TODO an option to wait until the queue is empty.
+        self.stop_requested.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.join_handle.take() {
+            thread.join().expect("thread join failed");
+        }
+    }
+}
+
+impl Drop for VerificationReportsCollector {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+struct VerificationReportsCollectorThread {
+    watcher_db: WatcherDB,
+    tx_source_urls_to_consensus_client_urls: HashMap<String, ConsensusClientUri>,
+    poll_interval: Duration,
+    logger: Logger,
+    stop_requested: Arc<AtomicBool>,
+    grpcio_env: Arc<Environment>,
+}
+
+impl VerificationReportsCollectorThread {
+    pub fn new(
+        watcher_db: WatcherDB,
+        tx_source_urls_to_consensus_client_urls: HashMap<String, ConsensusClientUri>,
+        poll_interval: Duration,
+        logger: Logger,
+        stop_requested: Arc<AtomicBool>,
+    ) -> Self {
+        let grpcio_env = Arc::new(
+            grpcio::EnvBuilder::new()
+                .name_prefix("WatcherNodeGrpc")
+                .build(),
+        );
+
+        Self {
+            watcher_db,
+            tx_source_urls_to_consensus_client_urls,
+            poll_interval,
+            logger,
+            stop_requested,
+            grpcio_env,
+        }
+    }
+
+    pub fn entrypoint(self) {
+        log::info!(self.logger, "VerificationReportsCollectorThread starting");
+        loop {
+            if self.stop_requested.load(Ordering::SeqCst) {
+                log::debug!(
+                    self.logger,
+                    "VerificationReportsCollectorThread stop requested."
+                );
+                break;
+            }
+
+            // See whats currently in the queue.
+            match self.watcher_db.get_verification_report_poll_queue() {
+                Ok(queue) => self.process_queue(queue),
+                Err(err) => {
+                    log::error!(
+                        self.logger,
+                        "Failed getting verification report queue: {}",
+                        err
+                    );
+                }
+            };
+
+            thread::sleep(self.poll_interval);
+        }
+    }
+
+    fn process_queue(&self, queue: HashMap<Url, Vec<Ed25519Public>>) {
+        for (tx_src_url, potential_signers) in queue {
+            let hex_potential_signers = potential_signers
+                .iter()
+                .map(|signer| hex::encode(signer.to_bytes()))
+                .collect::<Vec<_>>();
+            log::debug!(
+                self.logger,
+                "Queue entry: {} -> {:?}",
+                tx_src_url,
+                hex_potential_signers
+            );
+
+            // See if we can get a node url for this tx_src_url.
+            let node_url = self
+                .tx_source_urls_to_consensus_client_urls
+                .get(tx_src_url.as_str());
+            if node_url.is_none() {
+                log::debug!(
+                    self.logger,
+                    "Skipping {} - not in tx_source_urls_to_consensus_client_urls",
+                    tx_src_url,
+                );
+                continue;
+            }
+            let node_url = node_url.unwrap();
+
+            // Contact node and get a VerificationReport.
+            let mut verifier = Verifier::default();
+            verifier.debug(DEBUG_ENCLAVE);
+
+            let mut client = match ThickClient::new(
+                node_url.clone(),
+                verifier,
+                self.grpcio_env.clone(),
+                self.logger.clone(),
+            ) {
+                Ok(client) => client,
+                Err(err) => {
+                    log::error!(
+                        self.logger,
+                        "Failed constructing client to connect to {}: {}",
+                        node_url,
+                        err
+                    );
+                    return;
+                }
+            };
+
+            // Attest in order to get a VerificationReport
+            match client.attest() {
+                Ok(report) => {
+                    self.process_report(&node_url, &tx_src_url, &potential_signers, &report)
+                }
+                Err(err) => {
+                    log::error!(
+                        self.logger,
+                        "Failed attesting to {} (for {}): {}",
+                        node_url,
+                        tx_src_url,
+                        err
+                    );
+                }
+            }
+        }
+    }
+
+    fn process_report(
+        &self,
+        node_url: &ConsensusClientUri,
+        tx_src_url: &Url,
+        potential_signers: &[Ed25519Public],
+        verification_report: &VerificationReport,
+    ) {
+        let report_data = match VerificationReportData::try_from(verification_report) {
+            Ok(data) => data,
+            Err(err) => {
+                log::error!(
+                    self.logger,
+                    "Failed extracting report data from {}: {}",
+                    node_url,
+                    err
+                );
+                return;
+            }
+        };
+
+        let report_body = match report_data.quote.report_body() {
+            Ok(body) => body,
+            Err(err) => {
+                log::error!(
+                    self.logger,
+                    "Failed getting report body from {}: {}",
+                    node_url,
+                    err
+                );
+                return;
+            }
+        };
+
+        let custom_data = report_body.report_data();
+        let custom_data_bytes: &[u8] = custom_data.as_ref();
+
+        let signer_bytes = &custom_data_bytes[32..];
+
+        log::crit!(self.logger, "HEH {:?}", hex::encode(signer_bytes));
+    }
+}

--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -34,8 +34,8 @@ impl Watcher {
     ///
     /// # Arguments
     /// * `watcher_db` - The backing database to use for storing and retreiving data
-    /// * `transactions_fetcher` - The trnasaction fetcher used to fetch blocks from watched source
-    /// URLs
+    /// * `transactions_fetcher` - The transaction fetcher used to fetch blocks from watched source
+    ///   URLs
     pub fn new(
         watcher_db: WatcherDB,
         transactions_fetcher: ReqwestTransactionsFetcher,

--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -118,11 +118,14 @@ impl Watcher {
     ///
     /// * `start` - starting block to sync.
     /// * `max_block_height` - the max block height to sync per archive url. If None, continue polling.
+    ///
+    /// Returns true if syncing has reached max_block_height, false if more blocks still need to be
+    /// synced.
     pub fn sync_signatures(
         &self,
         start: u64,
         max_block_height: Option<u64>,
-    ) -> Result<(), WatcherError> {
+    ) -> Result<bool, WatcherError> {
         log::debug!(
             self.logger,
             "Now syncing signatures from {} to {:?}",
@@ -143,7 +146,7 @@ impl Watcher {
                 });
             }
             if last_synced.is_empty() {
-                return Ok(());
+                return Ok(true);
             }
 
             // Track whether sync failed - this catches cases where S3 is behind local ledger,
@@ -170,7 +173,7 @@ impl Watcher {
                 }
             }
             if sync_failed.values().all(|x| *x) {
-                return Ok(());
+                return Ok(false);
             }
         }
     }

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -53,7 +53,7 @@ impl MetadataStoreSettings for WatcherDbMetadataStoreSettings {
 pub const BLOCK_SIGNATURES_DB_NAME: &str = "watcher_db:block_signatures";
 
 /// VerificationReports database name.
-pub const VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NANE: &str =
+pub const VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NAME: &str =
     "watcher_db:verification_reports_by_block_signer";
 
 /// Verification reports poll queue database name.
@@ -156,7 +156,7 @@ impl WatcherDB {
 
         let block_signatures = env.open_db(Some(BLOCK_SIGNATURES_DB_NAME))?;
         let verification_reports_by_signer =
-            env.open_db(Some(VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NANE))?;
+            env.open_db(Some(VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NAME))?;
         let verification_reports_by_hash =
             env.open_db(Some(VERIFICATION_REPORTS_BY_HASH_DB_NAME))?;
         let verification_reports_poll_queue =
@@ -203,7 +203,7 @@ impl WatcherDB {
 
         env.create_db(Some(BLOCK_SIGNATURES_DB_NAME), DatabaseFlags::DUP_SORT)?;
         env.create_db(
-            Some(VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NANE),
+            Some(VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NAME),
             DatabaseFlags::DUP_SORT,
         )?;
         env.create_db(
@@ -702,7 +702,7 @@ impl WatcherDB {
     }
 
     /// Get verification reports seen for a specific block signer/URL pair.
-    /// In theory there should ever be a single report (or none) for a given block_signer+src_url
+    /// In theory there should only ever be a single report (or none) for a given block_signer+src_url
     /// pair but if something weird is going on we want to capture that, and as such multiple
     /// reports are supported. See more detailed explanation above
     /// `get_verification_reports_for_signer`.

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -28,7 +28,7 @@ impl MetadataStoreSettings for WatcherDbMetadataStoreSettings {
     // If this is properly maintained, we could check during ledger db opening for any
     // incompatibilities, and either refuse to open or perform a migration.
     #[allow(clippy::unreadable_literal)]
-    const LATEST_VERSION: u64 = 20200805;
+    const LATEST_VERSION: u64 = 20210121;
 
     /// The current crate version that manages the database.
     const CRATE_VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -39,6 +39,10 @@ impl MetadataStoreSettings for WatcherDbMetadataStoreSettings {
 
 /// Block signatures database name.
 pub const BLOCK_SIGNATURES_DB_NAME: &str = "watcher_db:block_signatures";
+
+/// VerificationReports database name.
+pub const VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NANE: &str =
+    "watcher_db:verification_reports_by_block_signer";
 
 /// Last synced archive blocks database name.
 pub const LAST_SYNCED_DB_NAME: &str = "watcher_db:last_synced";
@@ -73,6 +77,9 @@ pub struct WatcherDB {
 
     /// Signature store.
     block_signatures: Database,
+
+    /// Verification reports by block signer database.
+    verification_reports_by_signer: Database,
 
     /// Last synced archive block.
     last_synced: Database,
@@ -112,12 +119,15 @@ impl WatcherDB {
         version.is_compatible_with_latest()?;
 
         let block_signatures = env.open_db(Some(BLOCK_SIGNATURES_DB_NAME))?;
+        let verification_reports_by_signer =
+            env.open_db(Some(VERIFICATION_REPORTS_BY_BLOCK_SIGNER_DB_NANE))?;
         let last_synced = env.open_db(Some(LAST_SYNCED_DB_NAME))?;
         let config = env.open_db(Some(CONFIG_DB_NAME))?;
 
         Ok(WatcherDB {
             env,
             block_signatures,
+            verification_reports_by_signer,
             last_synced,
             config,
             write_allowed: false,

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -600,7 +600,13 @@ impl WatcherDB {
             WriteFlags::NO_OVERWRITE,
         ) {
             Ok(()) => Ok(()),
-            Err(lmdb::Error::KeyExist) => Ok(()),
+            Err(lmdb::Error::KeyExist) => {
+                log::trace!(
+                    self.logger,
+                    "write_verification_report: report hash already in db"
+                );
+                Ok(())
+            }
             Err(err) => Err(err),
         }?;
 
@@ -612,7 +618,13 @@ impl WatcherDB {
             WriteFlags::NO_DUP_DATA,
         ) {
             Ok(()) => Ok(()),
-            Err(lmdb::Error::KeyExist) => Ok(()),
+            Err(lmdb::Error::KeyExist) => {
+                log::trace!(
+                    self.logger,
+                    "write_verification_report: report already associated with signer+src_url"
+                );
+                Ok(())
+            }
             Err(err) => Err(err),
         }?;
 
@@ -710,7 +722,7 @@ impl WatcherDB {
         for (key_bytes2, value_bytes) in cursor.iter_dup_of(&key_bytes).filter_map(Result::ok) {
             assert_eq!(key_bytes, key_bytes2);
 
-            let report = self.get_verification_report_by_hash(db_txn, value_bytes)?;
+            let report = self.get_verification_report_by_hash(&db_txn, value_bytes)?;
             results.push(report);
         }
 


### PR DESCRIPTION
### Motivation

We'd like `mc-watcher` to support more thorough watching of the network. The first step in a series of upcoming improvements is to have it fetch the `VerificationReport` each time a new block signer is encountered, and store that in its database.

### In this PR
* `mc-watcher` sources are now configured via a `sources.toml` toml file. This change was necessary because we needed to introduce a map of tx source url -> consensus client url (so that when a new block is fetched from the tx source url, if a new block signer is detected, we can contact the node that created the block and get its `VerificationReport`). Passing this map via command line was gnarly, so this moved to a configuration file (similar to `network.toml` in `mc-consensus-service`)
* The `WatcherDB` now includes additional databases (inside the LMDB file) for storing `VerificationReport`s. The reports are indexed by (block signer public key, tx src url).

### Future Work
* ~~Unit tests for `VerificationReportsCollector`.~~ See https://github.com/eranrund/mobilecoin/pull/16
* Create a utility that prints which block signers were used for each range of blocks, and the matching verification report (if available).
* Make `mc-watcher` store all blocks fetched so that if the S3 sources ever goes away, the block data remains available locally.

