### PR TITLE
MCC-2204 Some dependency Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "adler32"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
-
-[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,16 +155,16 @@ dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.3",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "base-x"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -199,9 +193,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -593,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -1160,14 +1154,14 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.14"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide 0.3.6",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2524,7 +2518,7 @@ dependencies = [
 name = "mc-consensus-service"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "chrono",
  "curve25519-dalek",
  "displaydoc",
@@ -3158,7 +3152,7 @@ dependencies = [
 name = "mc-sgx-core-types"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "bincode",
  "bitflags",
  "displaydoc",
@@ -3226,7 +3220,7 @@ dependencies = [
 name = "mc-sgx-epid-types"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "bincode",
  "bytes 0.5.4",
  "hex 0.4.2",
@@ -3260,7 +3254,7 @@ dependencies = [
 name = "mc-sgx-ias-types"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "bitflags",
  "chrono",
  "displaydoc",
@@ -3521,7 +3515,7 @@ dependencies = [
 name = "mc-util-encodings"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "binascii",
  "displaydoc",
  "hex 0.4.2",
@@ -3561,7 +3555,7 @@ dependencies = [
 name = "mc-util-grpc"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "cookie 0.14.3",
  "displaydoc",
  "futures 0.3.8",
@@ -3715,7 +3709,7 @@ dependencies = [
 name = "mc-util-uri"
 version = "1.0.0"
 dependencies = [
- "base64 0.12.1",
+ "base64 0.12.3",
  "displaydoc",
  "ed25519",
  "hex 0.4.2",
@@ -3821,15 +3815,6 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime 0.3.16",
  "unicase 2.6.0",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
-dependencies = [
- "adler32",
 ]
 
 [[package]]
@@ -4838,7 +4823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
  "async-compression",
- "base64 0.12.1",
+ "base64 0.12.3",
  "bytes 0.5.4",
  "encoding_rs",
  "futures-core",
@@ -4905,7 +4890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc7e5d6aaa32ace6893ae8a1875688ca7b07d6c2428ae88e704c3623c8866e9"
 dependencies = [
  "atty",
- "base64 0.12.1",
+ "base64 0.12.3",
  "log 0.4.11",
  "memchr",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
  "rand_core 0.5.1",
  "serde",
  "subtle 2.2.3",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "sha2 0.9.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2099,7 +2099,7 @@ dependencies = [
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
  "tempdir",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2702,7 +2702,7 @@ dependencies = [
  "signature",
  "tempdir",
  "x25519-dalek",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2737,7 +2737,7 @@ dependencies = [
  "serde",
  "sha2 0.9.2",
  "subtle 2.2.3",
- "zeroize 0.10.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3412,7 +3412,7 @@ dependencies = [
  "subtle 2.2.3",
  "tempdir",
  "time 0.1.43",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3451,7 +3451,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "yaml-rust",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3575,7 +3575,7 @@ dependencies = [
  "rand 0.6.5",
  "sha2 0.9.2",
  "subtle 2.2.3",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -3789,7 +3789,7 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5150,7 +5150,7 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2 0.9.2",
  "subtle 2.2.3",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -5181,7 +5181,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
 dependencies = [
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -6652,7 +6652,7 @@ checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -6702,12 +6702,6 @@ name = "yasna"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
-
-[[package]]
-name = "zeroize"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4090487fa66630f7b166fba2bbb525e247a5449f41c468cc1d98f8ae6ac03120"
 
 [[package]]
 name = "zeroize"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
  "serde 1.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1641,11 +1641,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1802,6 +1797,5 @@ dependencies = [
 "checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum x25519-dalek 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
-"checksum zeroize 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4090487fa66630f7b166fba2bbb525e247a5449f41c468cc1d98f8ae6ac03120"
 "checksum zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 "checksum zeroize_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -19,7 +19,7 @@ secrecy = "0.4"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 sha2 = { version = "0.9", default-features = false }
 subtle = { version = "2.2", default-features = false, features = ["i128"] }
-zeroize = "0.10"
+zeroize = "1.1.0"
 
 [dev-dependencies]
 rand_hc = "0.2"


### PR DESCRIPTION
### Motivation

This updates some dependencies and removes unnecessary duplicate versions where possible, as half of an effort to reduce version hysteresis among different repos. There is quite a bit more future work than work in this PR, as things are blocked on large updates (e.g. rusoto going full async, rocket not having a newer version, and sentry having some API breakage that needs accounting for).

### In this PR
* `mc-crypto-noise` now uses `zeroize = "1.1"` (removes last use of 0.10)
* Update `flate2` (removes old versions of other crates)
* Update `base-x`, `base64`, `const_fn` to versions used elsewhere.

### Future Work
* Upgrade rocket 0.4 -> ?, will fix stale deps:
    - hyper 0.10
    - base64 0.12
    - cookie 0.11
    - url 1.7.2
    - idna 0.1.5
    - log 0.3.9
    - mime 0.2.6
    - percent-encoding 1.0.1
    - toml 0.4.10

* rusoto -> 0.46, will rev stale deps:
    - dirs 1.0.5 
    - hyper 0.12.35
    - h2 0.1.26
    - bytes 0.4
    - hyper-rustls 0.17
    - rustls 0.16
    - base64 0.10
    - hmac 0.7.1
    - crypto-mac 0.7
    - sha2 0.8
    - block-buffer 0.7
    - block-padding 0.1
    - futures 0.1.29
    - futures-cpupool
    - digest 0.8
    - generic-array 0.12.3
    - parking_lot 0.9
    - lock_api 0.3.4
    - smallvec 0.6.3
    - subtle 1.0.0
    - tokio 0.1
    - tokio-rustls 0.10
* Remove failure from:
    - mc-attest-core
    - mc-attest-net
    - mc-attest-trusted
    - mc-common
    - mc-consensus-enclave-api
    - mc-crypto-box
    - mc-crypto-keys
    - mc-crypto-message-cipher
    - mc-crypto-noise
    - mc-ledger-db
    - mc-ledger-distribution
    - mc-ledger-sync
    - mc-mobilecoind
    - mc-peers
    - mc-transaction-std
    - mc-util-build-script
    - mc-watcher
    - protoc-grpcio
    - sentry
    - sentry-types
    - synstructure
* Patch serial_test (no update available), will fix:
 - parking_lot 0.10
* Update sentry to 0.22, reqwest to 0.11
