### PR TITLE
MCC-2204 Redux Update arc-swap to non-yanked version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayref"


### PR DESCRIPTION
### Motivation

While updating the `arc-swap` crate in a different repo, it became evident that the version pinned in `Cargo.lock` has been yanked. This updates that crate to the latest version in the series.

### In this PR
* Update arc-swap to non-yanked version 

### Future Work
* See if there are any other yanked crates, integrate that test into CI.