### PR TITLE
use official bulletproofs repo that has merged the version bump change we need

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 [[package]]
 name = "bulletproofs"
 version = "2.0.0"
-source = "git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780#e8e8ef45ecc6d31f1a9525140edc977351d0f780"
+source = "git+https://github.com/dalek-cryptography/bulletproofs?rev=464acb72432ccc6c5131397fd811a5f01ec2454b#464acb72432ccc6c5131397fd811a5f01ec2454b"
 dependencies = [
  "byteorder",
  "clear_on_drop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
 #   See: https://github.com/pyfisch/cbor/pull/198
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
-# Patched to depend on crates that depend on digest 0.9
-bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
+# Not-yet-released version that depends on newer crates.
+bulletproofs = { git = "https://github.com/dalek-cryptography/bulletproofs", rev = "464acb72432ccc6c5131397fd811a5f01ec2454b" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -172,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bulletproofs"
 version = "2.0.0"
-source = "git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780#e8e8ef45ecc6d31f1a9525140edc977351d0f780"
+source = "git+https://github.com/dalek-cryptography/bulletproofs?rev=464acb72432ccc6c5131397fd811a5f01ec2454b#464acb72432ccc6c5131397fd811a5f01ec2454b"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1042,7 +1042,7 @@ name = "mc-transaction-core"
 version = "1.0.0"
 dependencies = [
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)",
+ "bulletproofs 2.0.0 (git+https://github.com/dalek-cryptography/bulletproofs?rev=464acb72432ccc6c5131397fd811a5f01ec2454b)",
  "curve25519-dalek 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "displaydoc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1680,7 +1680,7 @@ dependencies = [
 "checksum block-buffer 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 "checksum block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 "checksum block-padding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-"checksum bulletproofs 2.0.0 (git+https://github.com/eranrund/bulletproofs?rev=e8e8ef45ecc6d31f1a9525140edc977351d0f780)" = "<none>"
+"checksum bulletproofs 2.0.0 (git+https://github.com/dalek-cryptography/bulletproofs?rev=464acb72432ccc6c5131397fd811a5f01ec2454b)" = "<none>"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -70,8 +70,8 @@ prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b
 #   See: https://github.com/pyfisch/cbor/pull/198
 serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a7c1d523aae1ec4aa7386f402cb2f4341b5" }
 
-# Patched to depend on crates that depend on digest 0.9
-bulletproofs = { git = "https://github.com/eranrund/bulletproofs", rev = "e8e8ef45ecc6d31f1a9525140edc977351d0f780" }
+# Not-yet-released version that depends on newer crates.
+bulletproofs = { git = "https://github.com/dalek-cryptography/bulletproofs", rev = "464acb72432ccc6c5131397fd811a5f01ec2454b" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }


### PR DESCRIPTION
### Motivation

* We'd like to maintain as few forks as possible.

### In this PR
* Switch to a commit from the official bulletproofs repository

