### PR TITLE
Rename ProposeTxResponse.num_blocks to block_count 

### DIFF
--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -367,7 +367,7 @@ impl UserTxConnection for ThickClient {
         })?;
 
         if resp.get_result() == ProposeTxResult::Ok {
-            Ok(resp.get_num_blocks())
+            Ok(resp.get_block_count())
         } else {
             Err(resp.get_result().into())
         }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -75,5 +75,5 @@ message ProposeTxResponse {
     ProposeTxResult result = 1;
 
     /// The number of blocks in the ledger at the time the request was received.
-    uint64 num_blocks = 2;
+    uint64 block_count = 2;
 }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -127,7 +127,7 @@ impl ConsensusClientApi for ClientApiService {
 
         result = result.and_then(|mut response| {
             let num_blocks = self.ledger.num_blocks().map_err(ConsensusGrpcError::from)?;
-            response.set_num_blocks(num_blocks);
+            response.set_block_count(num_blocks);
             Ok(response)
         });
 
@@ -240,7 +240,7 @@ mod client_api_tests {
         match client.client_tx_propose(&message) {
             Ok(propose_tx_response) => {
                 assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
-                assert_eq!(propose_tx_response.get_num_blocks(), num_blocks);
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
@@ -311,7 +311,7 @@ mod client_api_tests {
                     propose_tx_response.get_result(),
                     ProposeTxResult::ContainsSpentKeyImage
                 );
-                assert_eq!(propose_tx_response.get_num_blocks(), num_blocks);
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
@@ -373,7 +373,7 @@ mod client_api_tests {
                     propose_tx_response.get_result(),
                     ProposeTxResult::InvalidRangeProof
                 );
-                assert_eq!(propose_tx_response.get_num_blocks(), num_blocks);
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
             Err(e) => panic!("Unexpected error: {:?}", e),
         }

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -240,7 +240,7 @@ impl ConsensusPeerApi for PeerApiService {
                 match self.handle_tx_propose(enclave_msg, logger) {
                     Ok(num_blocks) => {
                         let mut response = ProposeTxResponse::new();
-                        response.set_num_blocks(num_blocks);
+                        response.set_block_count(num_blocks);
                         Ok(response)
                     }
 


### PR DESCRIPTION
### Motivation

We switched to using `block_count` to indicate the number of blocks in the ledger (as opposed to block index which is the zero-based  number of the block).


### In this PR
* Rename ProposeTxResponse.num_blocks to block_count 

### Future Work
* At some point we might want to change `LedgerDB num_blocks` to `block_count` as well.
