### PR TITLE
mobilecoind[-json]: use external.Receipt instead of ReceiverTxReceipt for consistency

### DIFF
--- a/mobilecoind-json/README.md
+++ b/mobilecoind-json/README.md
@@ -107,14 +107,15 @@ $ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/pay-addres
                       ["dc8a91dbacad97b59e9709379c279a28b3c35262f6744226d15ee87be6bbf132",
                       "7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],
                       "tombstone":2121},
- "receiver_tx_receipt_list":[
-    {"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
-                  "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
-                  "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
-    "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
-    "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
-    "tombstone":2329,
-    "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
+ "receiver_tx_receipt_list":[{
+    "public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+    "confirmation":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+    "tombstone_block":2329,
+    "amount":{
+        "commitment":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+        "masked_value":"8c109687365677f0c9/bf7fa957a6a94acb588851bc8767eca5776c79f4fc2bb"
+    }
+}]
 ```
 
 If you would like the change from a used TXO returned to a different subaddress, there is an optional field to do so:
@@ -145,13 +146,14 @@ the list can be send to the recipient over a separate channel (e.g. a secure cha
 verify that they were paid by the sender.
 ```
 $ curl localhost:9090/tx/status-as-receiver \
-  -d '{"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
-                    "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
-                    "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
-        "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
-        "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
-        "tombstone":2329,
-        "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}' \
+  -d '{"public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+       "confirmation":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+       "tombstone_block":2329,
+       "amount":{
+           "commitment":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+           "masked_value":"8c109687365677f0c9/bf7fa957a6a94acb588851bc8767eca5776c79f4fc2bb"
+       }
+  }' \
   -X POST -H 'Content-Type: application/json'
 
 {"status":"verified"}
@@ -200,13 +202,16 @@ $ curl localhost:9090/monitors/<monitor_id>/subaddresses/<subaddress>/build-and-
                       "7e22679d8e3c14ba9c6c45256902e7af8e82644618e65a4589bab268bfde4b61"],
                       "tombstone":2121},
  "receiver_tx_receipt_list":[
-    {"recipient":{"view_public_key":"f460626a6cefb0bdfc73bb0c3a9c1a303a858f0b1b4ea59b154a1aa8d927af71",
-                  "spend_public_key":"6a74da2dc6ff116d9278a30a4f8584e9edf165a22faf04a3ac210f219641a92d",
-                  "fog_report_url":"", "fog_authority_fingerprint_sig":"", "fog_report_id":""},
-    "tx_public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
-    "tx_out_hash":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
-    "tombstone":2329,
-    "confirmation_number":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112"}]}
+    {"recipient":{
+        "public_key":"7060ad50195686ebba591ccfed18ff9536b729d07a00022a21eb21db7e9a266b",
+        "confirmation":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+        "tombstone_block":2329,
+        "amount":{
+            "commitment":"190ec89253bf47a05385b24e5b289a3a31127462aad613da9484f77d03986112",
+            "masked_value":"8c109687365677f0c9/bf7fa957a6a94acb588851bc8767eca5776c79f4fc2bb"
+        }
+    }}]
+}
 ```
 
 This returns receipt information that can be used by the sender to verify their transaction went through and also receipts to give to the receivers

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -553,18 +553,19 @@ fn check_transfer_status(
 #[post("/tx/status-as-receiver", format = "json", data = "<receipt>")]
 fn check_receiver_transfer_status(
     state: rocket::State<State>,
-    receipt: Json<JsonReceiverTxReceipt>,
+    receipt: Json<JsonReceipt>,
 ) -> Result<Json<JsonStatusResponse>, String> {
-    let mut receiver_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+    let mut receiver_receipt = mc_api::external::Receipt::new();
+
     let mut tx_public_key = CompressedRistretto::new();
-    tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{}", err))?);
-    receiver_receipt.set_tx_public_key(tx_public_key);
-    receiver_receipt
-        .set_tx_out_hash(hex::decode(&receipt.tx_out_hash).map_err(|err| format!("{}", err))?);
-    receiver_receipt.set_tombstone(receipt.tombstone);
-    receiver_receipt.set_confirmation_number(
-        hex::decode(&receipt.confirmation_number).map_err(|err| format!("{}", err))?,
-    );
+    tx_public_key.set_data(hex::decode(&receipt.public_key).map_err(|err| format!("{}", err))?);
+    receiver_receipt.set_public_key(tx_public_key);
+
+    let mut confirmation_number = mc_api::external::TxOutConfirmationNumber::new();
+    confirmation_number
+        .set_hash(hex::decode(&receipt.confirmation).map_err(|err| format!("{}", err))?);
+
+    receiver_receipt.set_tombstone_block(receipt.tombstone_block);
 
     let mut req = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
     req.set_receipt(receiver_receipt);

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -506,7 +506,7 @@ message SubmitTxResponse {
     SenderTxReceipt sender_tx_receipt = 1;
 
     // Receiver tx receipt, used for checking the tx status as the receiver.
-    // Receits order match the outlay order in the TxProposal.
+    // Receipts order match the outlay order in the TxProposal.
     repeated external.Receipt receiver_tx_receipt_list = 2;
 }
 

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -162,27 +162,7 @@ message SenderTxReceipt {
     repeated external.KeyImage key_image_list = 1;
 
     // Tombstone block set in the transaction.
-    uint64 tombstone = 2;
-}
-
-// Structure used to check transaction status as a recipient.
-// There exists one receipt per output, so a transaction having multiple outputs would have
-// multiple ReceiverTxReceipts.
-message ReceiverTxReceipt {
-    // The recipient this receipt refers to
-    external.PublicAddress recipient = 1;
-
-    // The public key of the TxOut sent to this recipient.
-    external.CompressedRistretto tx_public_key = 2;
-
-    // The hash of the TxOut sent to this recipient.
-    bytes tx_out_hash = 3;
-
-    // Tombstone block set in the transaction.
-    uint64 tombstone = 4;
-
-    // Confirmation number for this TxOut
-    bytes confirmation_number = 5;
+    uint64 tombstone_block = 2;
 }
 
 // Structure used to report monitor status
@@ -522,8 +502,12 @@ message SubmitTxRequest {
     TxProposal tx_proposal = 1;
 }
 message SubmitTxResponse {
+    // Sender tx receipt, used for checking the tx status as the sender.
     SenderTxReceipt sender_tx_receipt = 1;
-    repeated ReceiverTxReceipt receiver_tx_receipt_list = 2;
+
+    // Receiver tx receipt, used for checking the tx status as the receiver.
+    // Receits order match the outlay order in the TxProposal.
+    repeated external.Receipt receiver_tx_receipt_list = 2;
 }
 
 //
@@ -588,7 +572,7 @@ message GetTxStatusAsSenderResponse {
 
 // Get the status of a submitted transaction as the Recipient (using the tx public key).
 message GetTxStatusAsReceiverRequest {
-    ReceiverTxReceipt receipt = 1;
+    external.Receipt receipt = 1;
 
     // Optionally pass in a monitor ID to validate confirmation number
     bytes monitor_id = 2;
@@ -669,7 +653,8 @@ message SendPaymentResponse {
     SenderTxReceipt sender_tx_receipt = 1;
 
     // Information receivers can use to check if the transaction landed in the ledger.
-    repeated ReceiverTxReceipt receiver_tx_receipt_list = 2;
+    // Receits are ordered based on the outlays in the payment request.
+    repeated external.Receipt receiver_tx_receipt_list = 2;
 
     // The TxProposal that was submitted to the network. The fee that was paid can be checked at
     // tx_proposal.tx.prefix.fee

--- a/start-testnet-client.sh
+++ b/start-testnet-client.sh
@@ -48,8 +48,8 @@ if ps -p $pid > /dev/null; then
     echo "Sleeping 5s to allow mobilecoind to sync the ledger"
     sleep 5
 
-    echo "Starting local mc-mobilecoind-json."
-    ${TARGETDIR}/mc-mobilecoind-json
+    echo "Starting local mobilecoind-json."
+    ${TARGETDIR}/mobilecoind-json
 else
     echo "Starting mobilecoind failed. Please check logs at $(pwd)/mobilecoind.log."
 fi

--- a/tools/release-tests/mirror-json-test.py
+++ b/tools/release-tests/mirror-json-test.py
@@ -219,7 +219,7 @@ else:
     shutdown(1)
 
 # Check the mirror to see the block height of the transaction
-tx_pubkey = receiver_tx_receipt['tx_public_key']
+tx_pubkey = receiver_tx_receipt['public_key']
 url = f"http://localhost:8001/tx-out/{tx_pubkey}/block-index"
 response = requests.get(url)
 if response.status_code == 200:
@@ -291,7 +291,7 @@ else:
     shutdown(1)
 
 # Check the mirror to see the block height of the transaction
-tx_pubkey = receiver_tx_receipt['tx_public_key']
+tx_pubkey = receiver_tx_receipt['public_key']
 url = f"http://localhost:8001/tx-out/{tx_pubkey}/block-index"
 response = requests.get(url)
 if response.status_code == 200:


### PR DESCRIPTION
### Motivation

We want the receipt format to be unified across our system. Currently there are two receipt protos, which is suboptimal.

### In this PR
* Remove the `mobilecoind`-specific one in favor of `external.Receipt`.
* Rename a few occurrences of `tombstone` to `tombstone_block` to match whats inside `external.Receipt`.

