### PR TITLE
Fixes to cryptobox API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
-source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
+source = "git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
 dependencies = [
  "aead",
  "aes",
@@ -2594,7 +2594,6 @@ dependencies = [
 name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
- "aead",
  "aes-gcm",
  "blake2",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,5 +146,5 @@ bulletproofs = { git = "https://github.com/dalek-cryptography/bulletproofs", rev
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }
 
 # We need to patch aes-gcm so we can make some fields/functions/structs pub in order to have a constant time decrypt
-aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
+aes-gcm = { git = "https://github.com/mobilecoinofficial/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm"
 version = "0.6.0"
-source = "git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
+source = "git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa#d1a8517d3dd867ed9c5794002add67992a42f6aa"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -761,7 +761,7 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
+ "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-attest-ake 1.0.0",
  "mc-attest-core 1.0.0",
@@ -780,7 +780,7 @@ dependencies = [
 name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
+ "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,7 +795,7 @@ name = "mc-crypto-ct-aead"
 version = "0.5.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
+ "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "block-cipher 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -869,7 +869,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "1.0.0"
 dependencies = [
- "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
+ "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mc-util-serial 1.0.0",
@@ -883,7 +883,7 @@ name = "mc-crypto-noise"
 version = "1.0.0"
 dependencies = [
  "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
+ "aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1660,7 +1660,7 @@ dependencies = [
 [metadata]
 "checksum aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 "checksum aes 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
-"checksum aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)" = "<none>"
+"checksum aes-gcm 0.6.0 (git+https://github.com/mobilecoinofficial/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)" = "<none>"
 "checksum aes-soft 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 "checksum aesni 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 "checksum aho-corasick 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)" = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -780,7 +780,6 @@ dependencies = [
 name = "mc-crypto-box"
 version = "1.0.0"
 dependencies = [
- "aead 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes-gcm 0.6.0 (git+https://github.com/xoloki/AEADs?rev=d1a8517d3dd867ed9c5794002add67992a42f6aa)",
  "blake2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -77,7 +77,6 @@ bulletproofs = { git = "https://github.com/dalek-cryptography/bulletproofs", rev
 cpuid-bool = { git = "https://github.com/eranrund/RustCrypto-utils", rev = "74f8e04e9d18d93fc6d05c72756c236dc88daa19" }
 
 # We need to patch aes-gcm so we can make some fields/functions/structs pub in order to have a constant time decrypt
-aes-gcm = { git = "https://github.com/xoloki/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
-
+aes-gcm = { git = "https://github.com/mobilecoinofficial/AEADs", rev = "d1a8517d3dd867ed9c5794002add67992a42f6aa" }
 
 [workspace]

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -5,15 +5,16 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-aead = "0.3"
 aes-gcm = { version = "0.6.0" }
 blake2 = { version = "0.9", default-features = false }
 digest = { version = "0.9" }
 failure = { version = "0.1.8", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
+rand_core = { version = "0.5", default-features = false }
+
 mc-crypto-ct-aead = { path = "../ct-aead" }
 mc-crypto-keys = { path = "../keys", default-features = false }
-rand_core = { version = "0.5", default-features = false }
+
 
 [dev_dependencies]
 mc-util-from-random = { path = "../../util/from-random" }

--- a/crypto/box/src/fixed_buffer.rs
+++ b/crypto/box/src/fixed_buffer.rs
@@ -1,3 +1,4 @@
+use crate::aead;
 use aead::{Buffer, Error};
 
 /// The rust aead crate is organized around a Buffer trait which abstracts

--- a/crypto/box/src/hkdf_box.rs
+++ b/crypto/box/src/hkdf_box.rs
@@ -1,13 +1,15 @@
-use crate::traits::{CryptoBox, Error};
-
-use aead::{
-    generic_array::{
-        sequence::{Concat, Split},
-        typenum::{Sum, Unsigned},
-        ArrayLength, GenericArray,
+use crate::{
+    aead::{
+        generic_array::{
+            sequence::{Concat, Split},
+            typenum::{Sum, Unsigned},
+            ArrayLength, GenericArray,
+        },
+        AeadInPlace, Error as AeadError, NewAead,
     },
-    AeadInPlace, Error as AeadError, NewAead,
+    traits::{CryptoBox, Error},
 };
+
 use core::{
     convert::TryFrom,
     marker::PhantomData,
@@ -15,7 +17,7 @@ use core::{
 };
 use digest::{BlockInput, Digest, FixedOutput, Reset, Update};
 use hkdf::Hkdf;
-use mc_crypto_ct_aead::CtAeadDecrypt;
+use mc_crypto_ct_aead::{CtAeadDecrypt, CtDecryptResult};
 use mc_crypto_keys::{Kex, ReprBytes};
 use rand_core::{CryptoRng, RngCore};
 
@@ -93,7 +95,7 @@ where
         key: &KexAlgo::Private,
         tag: &GenericArray<u8, Self::FooterSize>,
         buffer: &mut [u8],
-    ) -> Result<bool, Error> {
+    ) -> Result<CtDecryptResult, Error> {
         // ECDH
         use mc_crypto_keys::KexReusablePrivate;
         // TODO: In generic_array 0.14 the tag can be split without copying it

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate alloc;
 
 pub use aead::generic_array;
+pub use mc_crypto_ct_aead::aead;
 
 mod hkdf_box;
 mod traits;
@@ -55,7 +56,7 @@ mod test {
                         algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
-                    assert_eq!(success, true);
+                    assert_eq!(bool::from(success), true);
                 }
             }
         });
@@ -76,12 +77,8 @@ mod test {
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
-                    let decrypted = algo.decrypt(&not_a, &ciphertext);
-                    if decrypted.is_err() {
-                        assert_eq!(decrypted, Err(Error::MacFailed));
-                    } else {
-                        assert_eq!(decrypted.unwrap().0, false);
-                    }
+                    let (success, _decrypted) = algo.decrypt(&not_a, &ciphertext).unwrap();
+                    assert_eq!(bool::from(success), false);
                 }
             }
         });
@@ -106,7 +103,7 @@ mod test {
                         .decrypt_fixed_length(&a, &ciphertext)
                         .expect("decryption failed!");
                     assert_eq!(plaintext, &decrypted);
-                    assert_eq!(success, true);
+                    assert_eq!(bool::from(success), true);
                 }
             }
         });

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -213,7 +213,7 @@ mod test {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
                     let (success, _decrypted) = algo.decrypt(&not_a, &ciphertext).unwrap();
-                    assert_eq!(bool::from(success), false);
+                    assert!(!bool::from(success));
                 }
             }
         });

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -17,23 +17,24 @@
 //! 0 = hkdf_blake2b_aes_128_gcm
 
 use crate::{
+    aead::{
+        generic_array::{
+            arr,
+            sequence::Concat,
+            typenum::{Unsigned, U50},
+            GenericArray,
+        },
+        Error as AeadError,
+    },
     hkdf_box::HkdfBox,
     traits::{CryptoBox, Error},
 };
 
-use aead::{
-    generic_array::{
-        arr,
-        sequence::Concat,
-        typenum::{Unsigned, U50},
-        GenericArray,
-    },
-    Error as AeadError,
-};
 use aes_gcm::Aes128Gcm;
 use alloc::vec::Vec;
 use blake2::Blake2b;
 use failure::Fail;
+use mc_crypto_ct_aead::CtDecryptResult;
 use mc_crypto_keys::{Kex, Ristretto};
 use rand_core::{CryptoRng, RngCore};
 
@@ -141,7 +142,7 @@ impl CryptoBox<Ristretto> for VersionedCryptoBox {
         key: &<Ristretto as Kex>::Private,
         footer: &GenericArray<u8, Self::FooterSize>,
         buffer: &mut [u8],
-    ) -> Result<bool, Error> {
+    ) -> Result<CtDecryptResult, Error> {
         // Note: When generic_array is upreved, this can be tidier using this:
         // https://docs.rs/generic-array/0.14.1/src/generic_array/sequence.rs.html#302-320
         // For now we have to split as a slice, then convert back to Generic Array.
@@ -190,7 +191,7 @@ mod test {
                         algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
-                    assert_eq!(success, true);
+                    assert_eq!(bool::from(success), true);
                 }
             }
         });
@@ -211,12 +212,8 @@ mod test {
             for plaintext in &[&plaintext1[..], &plaintext2[..]] {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
-                    let decrypted = algo.decrypt(&not_a, &ciphertext);
-                    if decrypted.is_err() {
-                        assert_eq!(decrypted, Err(Error::MacFailed));
-                    } else {
-                        assert_eq!(decrypted.unwrap().0, false);
-                    }
+                    let (success, _decrypted) = algo.decrypt(&not_a, &ciphertext).unwrap();
+                    assert_eq!(bool::from(success), false);
                 }
             }
         });

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -191,7 +191,7 @@ mod test {
                         algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
-                    assert_eq!(bool::from(success), true);
+                    assert!(bool::from(success));
                 }
             }
         });

--- a/crypto/ct-aead/src/lib.rs
+++ b/crypto/ct-aead/src/lib.rs
@@ -5,9 +5,11 @@
 extern crate alloc;
 
 // Re-export the versions of traits and objects from our dependencies
+pub use aead;
 pub use aes_gcm;
+pub use subtle;
 
 mod aes_impl;
 
 mod traits;
-pub use traits::CtAeadDecrypt;
+pub use traits::{CtAeadDecrypt, CtDecryptResult};

--- a/crypto/ct-aead/src/traits.rs
+++ b/crypto/ct-aead/src/traits.rs
@@ -1,8 +1,12 @@
 use aead::AeadInPlace;
 use block_cipher::generic_array::GenericArray;
+use subtle::Choice;
 
 /// API for Aead in-place decryption which is constant-time with respect to
 /// the mac check failing
+///
+/// This is meant to extend the AeadInPlace trait and be implemented by those
+/// AEAD's which have a constant-time decrypt operation.
 pub trait CtAeadDecrypt: AeadInPlace {
     /// Decrypt a buffer using given aead nonce, validating associated data
     /// under the mac (tag).
@@ -11,14 +15,44 @@ pub trait CtAeadDecrypt: AeadInPlace {
     /// not branching on whether or not the mac check succeeded.
     ///
     /// Returns:
-    /// true: The mac check succeeded and the buffer contains the plaintext
-    /// false: The mac check failed, and the buffer contains failed decryption.
-    ///        The caller should zeroize buffer before it is discarded.
+    /// Choice::from(true): The mac check succeeded and the buffer contains the plaintext
+    /// Choice::from(false): Decryption failed, and the buffer contains failed decryption.
+    ///        The caller SHOULD zeroize buffer before it is discarded.
     fn ct_decrypt_in_place_detached(
         &self,
         nonce: &GenericArray<u8, Self::NonceSize>,
         associated_data: &[u8],
         buffer: &mut [u8],
         tag: &GenericArray<u8, Self::TagSize>,
-    ) -> bool;
+    ) -> CtDecryptResult;
+}
+
+/// A new-type wrapper around choice with the #[must_use] annotation that Result has.
+/// This wraps the value Choice::from(true) when decryption succeeded, and Choice::from(false) otherwise.
+#[must_use = "The result of constant time decryption should not be discarded"]
+#[derive(Copy, Clone, Debug)]
+pub struct CtDecryptResult(pub Choice);
+
+impl AsRef<Choice> for CtDecryptResult {
+    fn as_ref(&self) -> &Choice {
+        &self.0
+    }
+}
+
+impl From<Choice> for CtDecryptResult {
+    fn from(src: Choice) -> Self {
+        CtDecryptResult(src)
+    }
+}
+
+impl From<CtDecryptResult> for Choice {
+    fn from(src: CtDecryptResult) -> Choice {
+        src.0
+    }
+}
+
+impl From<CtDecryptResult> for bool {
+    fn from(src: CtDecryptResult) -> bool {
+        bool::from(Choice::from(src))
+    }
 }

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -15,52 +15,16 @@ use mc_crypto_box::{
 use mc_crypto_keys::{
     CompressedRistrettoPublic, ReprBytes, Ristretto, RistrettoPrivate, RistrettoPublic,
 };
-use mc_crypto_rand::McRng;
-use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
-use subtle::{Choice, ConditionallySelectable};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+use zeroize::Zeroize;
 
-pub type PlaintextArray = GenericArray<
+// The size of the plaintext (with magic numbers) in a fog hint.
+// This is slightly larger than ristretto public.
+type PlaintextArray = GenericArray<
     u8,
     Diff<EncryptedFogHintSize, <VersionedCryptoBox as CryptoBox<Ristretto>>::FooterSize>,
 >;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Plaintext(PlaintextArray);
-
-impl Default for Plaintext {
-    fn default() -> Self {
-        Self(PlaintextArray::default())
-    }
-}
-
-impl ConditionallySelectable for Plaintext {
-    fn conditional_select(a: &Self, b: &Self, c: subtle::Choice) -> Self {
-        let mut ret: Self = *a;
-
-        Plaintext::conditional_assign_array(&mut ret.0, &b.0, c);
-
-        ret
-    }
-}
-
-impl Plaintext {
-    fn as_mut(&mut self) -> &mut PlaintextArray {
-        &mut self.0
-    }
-
-    fn as_ref(&self) -> &PlaintextArray {
-        &self.0
-    }
-
-    fn conditional_assign_array(target: &mut PlaintextArray, src: &PlaintextArray, cond: Choice) {
-        assert_eq!(target.len(), src.len());
-
-        for idx in 0..target.len() {
-            target[idx].conditional_assign(&src[idx], cond);
-        }
-    }
-}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FogHint {
@@ -123,15 +87,16 @@ impl FogHint {
         ingest_server_pubkey: &RistrettoPublic,
         rng: &mut T,
     ) -> EncryptedFogHint {
-        let mut plaintext = Plaintext::default();
+        let mut plaintext = PlaintextArray::default();
 
-        plaintext.as_mut()[..RISTRETTO_PUBLIC_LEN].copy_from_slice(&self.view_pubkey.to_bytes());
-        for byte in &mut plaintext.as_mut()[RISTRETTO_PUBLIC_LEN..] {
+        plaintext[..RISTRETTO_PUBLIC_LEN].copy_from_slice(&self.view_pubkey.to_bytes());
+        for byte in &mut plaintext[RISTRETTO_PUBLIC_LEN..] {
             *byte = MAGIC_NUMBER;
         }
         let bytes = VersionedCryptoBox::default()
-            .encrypt_fixed_length(rng, ingest_server_pubkey, &plaintext.0)
+            .encrypt_fixed_length(rng, ingest_server_pubkey, &plaintext)
             .expect("cryptobox encryption failed unexpectedly");
+        plaintext.zeroize();
         EncryptedFogHint::from(bytes)
     }
 
@@ -148,46 +113,40 @@ impl FogHint {
     ///
     /// # Returns
     /// * Choice(1) on success Choice(0) otherwise
+    /// * self is only modified in the operation is successful
     #[inline(never)]
     pub fn ct_decrypt(
         ingest_server_private_key: &RistrettoPrivate,
         ciphertext: &EncryptedFogHint,
         output: &mut Self,
     ) -> Choice {
-        let mut rng = McRng::default();
-        let mut plaintext = Plaintext::default();
-        let default_pubkey = RistrettoPublic::from_random(&mut rng);
-
-        plaintext.as_mut()[..RISTRETTO_PUBLIC_LEN].copy_from_slice(&default_pubkey.to_bytes());
-
-        let (real_plaintext, mut success) = match VersionedCryptoBox::default()
-            .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())
-        {
-            Ok((result, real_plaintext)) => (Plaintext(real_plaintext), result),
-            Err(_) => (plaintext, false),
-        };
-
-        let choice = Choice::from(success as u8);
-        plaintext.conditional_assign(&real_plaintext, choice);
+        let (mut success, mut plaintext): (Choice, PlaintextArray) =
+            match VersionedCryptoBox::default()
+                .decrypt_fixed_length(ingest_server_private_key, ciphertext.as_ref())
+            {
+                Ok((success, plaintext)) => (Choice::from(success), plaintext),
+                Err(_) => {
+                    // An error that we don't have to be constant time with respect to, since rust Result was used
+                    return Choice::from(0);
+                }
+            };
 
         // Check magic numbers
-        for byte in &plaintext.as_ref()[RISTRETTO_PUBLIC_LEN..] {
-            if *byte != MAGIC_NUMBER {
-                success = false;
-            }
+        for byte in &plaintext[RISTRETTO_PUBLIC_LEN..] {
+            success &= byte.ct_eq(&MAGIC_NUMBER);
         }
 
-        let bytes = &plaintext.as_ref()[0..RISTRETTO_PUBLIC_LEN];
-        match CompressedRistrettoPublic::try_from(bytes) {
-            Ok(key) => {
-                output.view_pubkey = key;
-                Choice::from(success as u8)
-            }
-            Err(_) => {
-                output.view_pubkey = CompressedRistrettoPublic::from(default_pubkey);
-                Choice::from(0)
-            }
+        // Write pubkey bytes to output if success is true, otherwise don't change output
+        let mut output_bytes = output.view_pubkey.to_bytes();
+        for idx in 0..output_bytes.len() {
+            output_bytes[idx].conditional_assign(&plaintext[idx], success);
         }
+        output.view_pubkey = CompressedRistrettoPublic::try_from(output_bytes.as_slice()).expect("Converting from bytes to compressed ristretto doesn't fail if they have the right size");
+
+        // Zeroize temporary buffers
+        plaintext.zeroize();
+        output_bytes.zeroize();
+        success
     }
 }
 

--- a/transaction/core/src/fog_hint.rs
+++ b/transaction/core/src/fog_hint.rs
@@ -19,9 +19,11 @@ use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroize;
 
-// The size of the plaintext (with magic numbers) in a fog hint.
-// This is slightly larger than ristretto public.
-type PlaintextArray = GenericArray<
+/// The size of the plaintext (with magic numbers) in a fog hint.
+/// This is slightly larger than CompressedRistrettoPublic.
+///
+/// This type is pub because it is used in some tests in other crates
+pub type PlaintextArray = GenericArray<
     u8,
     Diff<EncryptedFogHintSize, <VersionedCryptoBox as CryptoBox<Ristretto>>::FooterSize>,
 >;


### PR DESCRIPTION
Recent testing has shown that sometimes, errors are mishandled
when using the cryptobox API. The problem is:

(1) Mac check failure is returned using a `bool`, but this doesn't
    have the `#[must_use]` annotation that `core::Result` does.
(2) Cryptobox itself was still using the `Error::MacFailed` which
    was supposed to go away.
(3) Cryptobox itself was not using xoloki's CtAead trait, it was
    still using the variable time thing, and only the return codes
    were changing.

The solution proposed is:
(1) Introduce CtDecryptResult type which is a new-type wrapper around
    `subtle::Choice` which has the must-use annotation. Put this
    in `mc-crypto-ct-aead` crate and use it.
    Previously I was worried to use `subtle::Choice` as an API type,
    but now we have doen that elsewhere and it hasn't caused churn
    or problems.
(2) Make cryptobox return CtDecryptResult instead of bool as it had
    been doing, and nuke the `MacFailed` error variant which should
    be gone now. Make cryptobox also use the same version of `aead`
    crate that `mc-crypto-ct-aead` crate is exporting.
(3) Make cryptobox actually use the constant-time aes-gcm.

Besides these issues, while updating the fog hint code that uses this,
we noticed:
(4) The fog hint decryption code which used cryptobox is needlessly
    complicated, uses an RNG for no real reason, and introduces
    unnecessary types with special implementations of subtle trait.

Proposed change:
(4)  We have now made it completely determinsitic, which is better
    for testability, and documented that it doesn't make changes
    if decryption fails, which is all that is needed. Then the
    caller can decide what value the output parameter should have
    in that case. We deleted the unnecessary types and functions.
    We also made the fog hint code zeroize the temporary buffers,
    per cryptobox documentation.