### PR TITLE
Cloneable json types

### DIFF
--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -227,7 +227,7 @@ impl From<&mc_mobilecoind_api::CreateRequestCodeResponse> for JsonCreateRequestC
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonPublicAddress {
     /// Hex encoded compressed ristretto bytes
     pub view_public_key: String,
@@ -446,7 +446,7 @@ pub struct JsonPayAddressCodeRequest {
     pub change_subaddress: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonOutlay {
     pub value: String,
     pub receiver: JsonPublicAddress,
@@ -480,7 +480,7 @@ impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonAmount {
     pub commitment: String,
     pub masked_value: String,
@@ -495,7 +495,7 @@ impl From<&Amount> for JsonAmount {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxOut {
     pub amount: JsonAmount,
     pub target_key: String,
@@ -558,13 +558,13 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonRange {
     pub from: String,
     pub to: String,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxOutMembershipElement {
     pub range: JsonRange,
     pub hash: String,
@@ -582,7 +582,7 @@ impl From<&TxOutMembershipElement> for JsonTxOutMembershipElement {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxOutMembershipProof {
     pub index: String,
     pub highest_index: String,
@@ -654,40 +654,7 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
-/// A request for randomly sampled TxOuts for use as mixins.
-pub struct JsonMixinRequest {
-    /// Number of mixins requested.
-    pub num_mixins: u64,
-    /// Outputs that should be excluded from the result.
-    pub excluded: Vec<JsonTxOut>,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug)]
-/// Randomly sampled TxOuts for use as mixins, with membership proofs.
-pub struct JsonMixinResponse {
-    /// TxOuts to use as mixins.
-    pub mixins: Vec<JsonTxOut>,
-    /// Corresponding membership proofs.
-    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug)]
-/// Requests Merkle proof-of-membership for each queried TxOut
-pub struct JsonMembershipProofRequest {
-    pub outputs: Vec<JsonTxOut>,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug)]
-/// Outputs and their corresponding proofs of membership.
-pub struct JsonMembershipProofResponse {
-    /// Queried outputs.
-    pub outputs: Vec<JsonTxOut>,
-    /// Corresponding membership proofs.
-    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
-}
-
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxIn {
     pub ring: Vec<JsonTxOut>,
     pub proofs: Vec<JsonTxOutMembershipProof>,
@@ -732,7 +699,7 @@ impl TryFrom<&JsonTxIn> for TxIn {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxPrefix {
     pub inputs: Vec<JsonTxIn>,
     pub outputs: Vec<JsonTxOut>,
@@ -787,7 +754,7 @@ impl TryFrom<&JsonTxPrefix> for TxPrefix {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonRingMLSAG {
     pub c_zero: String,
     pub responses: Vec<String>,
@@ -808,7 +775,7 @@ impl From<&RingMLSAG> for JsonRingMLSAG {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonSignatureRctBulletproofs {
     pub ring_signatures: Vec<JsonRingMLSAG>,
     pub pseudo_output_commitments: Vec<String>,
@@ -889,7 +856,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
     }
 }
 
-#[derive(Deserialize, Serialize, Default, Debug)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTx {
     pub prefix: JsonTxPrefix,
     pub signature: JsonSignatureRctBulletproofs,

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -929,16 +929,16 @@ pub struct JsonTxProposal {
     pub outlay_list: Vec<JsonOutlay>,
     pub tx: JsonTx,
     pub fee: u64,
-    pub outlay_index_to_tx_out_index: Vec<(u64, u64)>,
+    pub outlay_index_to_tx_out_index: Vec<(usize, usize)>,
     pub outlay_confirmation_numbers: Vec<Vec<u8>>,
 }
 
 impl From<&mc_mobilecoind_api::TxProposal> for JsonTxProposal {
     fn from(src: &mc_mobilecoind_api::TxProposal) -> Self {
-        let outlay_map: Vec<(u64, u64)> = src
+        let outlay_map: Vec<(usize, usize)> = src
             .get_outlay_index_to_tx_out_index()
             .iter()
-            .map(|(key, val)| (*key, *val))
+            .map(|(key, val)| (*key as usize, *val as usize))
             .collect();
         Self {
             input_list: src
@@ -982,7 +982,7 @@ impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
             .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
         proposal.set_fee(src.fee);
         proposal.set_outlay_index_to_tx_out_index(HashMap::from_iter(
-            src.outlay_index_to_tx_out_index.clone(),
+            src.outlay_index_to_tx_out_index.iter().map(|(key, val)| (*key as u64, *val as u64)),
         ));
         proposal.set_outlay_confirmation_numbers(RepeatedField::from_vec(
             src.outlay_confirmation_numbers.clone(),

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -982,7 +982,9 @@ impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
             .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
         proposal.set_fee(src.fee);
         proposal.set_outlay_index_to_tx_out_index(HashMap::from_iter(
-            src.outlay_index_to_tx_out_index.iter().map(|(key, val)| (*key as u64, *val as u64)),
+            src.outlay_index_to_tx_out_index
+                .iter()
+                .map(|(key, val)| (*key as u64, *val as u64)),
         ));
         proposal.set_outlay_confirmation_numbers(RepeatedField::from_vec(
             src.outlay_confirmation_numbers.clone(),

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -654,6 +654,39 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
     }
 }
 
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// A request for randomly sampled TxOuts for use as mixins.
+pub struct JsonMixinRequest {
+    /// Number of mixins requested.
+    pub num_mixins: u64,
+    /// Outputs that should be excluded from the result.
+    pub excluded: Vec<JsonTxOut>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Randomly sampled TxOuts for use as mixins, with membership proofs.
+pub struct JsonMixinResponse {
+    /// TxOuts to use as mixins.
+    pub mixins: Vec<JsonTxOut>,
+    /// Corresponding membership proofs.
+    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Requests Merkle proof-of-membership for each queried TxOut
+pub struct JsonMembershipProofRequest {
+    pub outputs: Vec<JsonTxOut>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+/// Outputs and their corresponding proofs of membership.
+pub struct JsonMembershipProofResponse {
+    /// Queried outputs.
+    pub outputs: Vec<JsonTxOut>,
+    /// Corresponding membership proofs.
+    pub membership_proofs: Vec<JsonTxOutMembershipProof>,
+}
+
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxIn {
     pub ring: Vec<JsonTxOut>,


### PR DESCRIPTION
Soundtrack of this PR: [Clone Wars](https://www.youtube.com/watch?v=cNO3aNksUzg)

### Motivation

For conversions to and from various json types, cloning is useful for certain fields when passing in the src object as a reference.

### In this PR
* Adds derive clone to Json types
* Updates `u64` fields in a map to a `usize` where it is referring to indices

[WS-78](https://mobilecoin.atlassian.net/browse/WS-78)

