### PR TITLE
watcher-db: add remove_all_for_source_url

### DIFF
--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -910,7 +910,7 @@ impl WatcherDB {
     /// Remove all the data associated with a given source url.
     pub fn remove_all_for_source_url(&self, src_url: &Url) -> Result<(), WatcherDBError> {
         if !self.write_allowed {
-            //return Err(WatcherDBError::ReadOnly);
+            return Err(WatcherDBError::ReadOnly);
         }
 
         let mut db_txn = self.env.begin_rw_txn()?;


### PR DESCRIPTION
### Motivation

During some watcher work I ran into the need to clear all the watcher data for a given source URL. This might be useful again in the future in case the watcher is accidentally started with incorrect configuration and manual fixes are needed.

### In this PR
* Add a way to remove all watched data for a given source URL

### Future Work
* Expose this through some CLI.

