### PR TITLE
FOG-372 Add test-vector path-printing binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2699,6 +2699,7 @@ dependencies = [
  "mc-crypto-keys",
  "mc-util-build-script",
  "pem",
+ "structopt",
  "x509-signature",
 ]
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2018"
 description = "Utilities for generating certificates and chains for unit tests"
 readme = "README.md"
 
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "mc-crypto-x509-test-vectors"
+path = "src/main.rs"
+
 [build-dependencies]
 cargo-emit = "0.1.1"
 mc-util-build-script = { path = "../../../util/build/script" }
@@ -14,4 +21,5 @@ mc-util-build-script = { path = "../../../util/build/script" }
 mc-crypto-keys = { path = "../../keys" }
 
 pem = "0.8"
+structopt = "0.3"
 x509-signature = "0.5"

--- a/crypto/x509/test-vectors/src/lib.rs
+++ b/crypto/x509/test-vectors/src/lib.rs
@@ -12,26 +12,36 @@ fn base_path() -> PathBuf {
     path
 }
 
-fn get_chain(name: &str) -> String {
+fn get_path(name: &str, extension: &str) -> PathBuf {
     let mut path = base_path();
     path.push(name);
-    path.set_extension("pem");
+    path.set_extension(extension);
+    path
+}
+
+/// Retrieve the path to a generated X509 Certificate Chain
+pub fn chain_path(name: &str) -> PathBuf {
+    get_path(name, "pem")
+}
+
+/// Retrieve the path to a generate X509 key
+pub fn key_path(name: &str) -> PathBuf {
+    get_path(name, "key")
+}
+
+fn get_chain(name: &str) -> String {
+    let path = chain_path(name);
     fs::read_to_string(path).expect("Could not read certificate chain")
 }
 
 fn get_leaf_key(name: &str) -> Ed25519Pair {
-    let mut path = base_path();
-    path.push(name);
-    path.set_extension("key");
+    let path = key_path(name);
 
     let pem_string = fs::read_to_string(path).expect("Could not read certificate chain");
-    eprintln!("Parsing PEM key");
     let pem_data = pem::parse(pem_string).expect("Could not parse PEM string");
-    eprintln!("Done parsing PEM key");
     let privkey = Ed25519Private::try_from_der(&pem_data.contents)
         .expect("Could not construct private key from key DER bytes");
 
-    eprintln!("Returning pair");
     Ed25519Pair::from(privkey)
 }
 

--- a/crypto/x509/test-vectors/src/main.rs
+++ b/crypto/x509/test-vectors/src/main.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2018-2021 MobileCoin Inc.
+
+//! Retrieve the paths of previously generated test vectors
+
+use std::{
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    str::FromStr,
+};
+use structopt::StructOpt;
+
+#[derive(Debug)]
+struct PathKindParseError;
+
+impl Display for PathKindParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "Unknown type given")
+    }
+}
+
+#[derive(Debug, PartialEq, StructOpt)]
+enum PathKind {
+    /// Retrieve the path to the PEM chain
+    Chain,
+    /// Retrieve the path to the PEM private key
+    Key,
+}
+
+impl FromStr for PathKind {
+    type Err = PathKindParseError;
+
+    fn from_str(src: &str) -> Result<PathKind, PathKindParseError> {
+        match src.to_lowercase().as_str() {
+            "chain" => Ok(PathKind::Chain),
+            "key" => Ok(PathKind::Key),
+            _ => Err(PathKindParseError),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, StructOpt)]
+struct Config {
+    /// The name of the test to use
+    #[structopt(long = "test-name")]
+    pub test_name: String,
+    /// The type of path to retrieve
+    #[structopt(long = "type")]
+    pub kind: PathKind,
+}
+
+fn main() {
+    let config = Config::from_args();
+    let output = match config.kind {
+        PathKind::Chain => mc_crypto_x509_test_vectors::chain_path(&config.test_name),
+        PathKind::Key => mc_crypto_x509_test_vectors::key_path(&config.test_name),
+    };
+    println!("{}", output.display())
+}


### PR DESCRIPTION
### Motivation

Integration tests need certificate chain and private key PEM files to do their work, this provides a simple binary that will print the build-time paths for the chains and certificates generated by our x509 test vectors crate. 

### In this PR

Adds `mc-crypto-x509-test-vectors` utility. This utility takes a `--type` arg, which is either `chain` or `key`, and a `--test-name`, which is typically going to be `ok_rsa_chain_25519_leaf`.

### Future Work
* Updating integration and client tests to work with this.

