### PR TITLE
Clarify the printing of commands with the dry-run option.

### DIFF
--- a/mob
+++ b/mob
@@ -117,36 +117,45 @@ if args.dry_run or not sys.stdout.isatty():
 # Implement verbose, dry_run settings
 ###
 
-# When python is invoked from docker in CI, we won't see anything because of
-# buffered output unless we flush. It's hard to ensure PYTHONUNBUFFERED=0 or -u
-# is used consistently.
 def eprint(*argv, **kwargs):
+    """
+    When python is invoked from docker in CI, we won't see anything because of
+    buffered output unless we flush. It's hard to ensure PYTHONUNBUFFERED=0 or -u
+    is used consistently.
+    """
     print(*argv, file=sys.stderr, **kwargs)
     sys.stderr.flush()
 
-# vprint is eprint that only happens in verbose mode
 def vprint(*argv, **kwargs):
+    """ vprint is eprint that only happens in verbose mode """
     if args.verbose:
         eprint(*argv, **kwargs)
+
+def vprint_command(cmd):
+    """ Print a command, whether it is in shell style or list style. """
+    if isinstance(cmd, list):
+        cmd = ' '.join(cmd)
+    vprint('$ ' + cmd)
+
 
 # Run a command, unless we are in dry_run mode and should not do that
 # Print the command if in verbose mode
 def maybe_run(command):
-    vprint(command)
+    vprint_command(command)
     if not args.dry_run:
         subprocess.check_call(command)
 
 # Change directory.
 # Print the command if in verbose mode
 def verbose_chdir(path):
-    vprint("cd", path)
+    vprint_command(['cd', path])
     os.chdir(path)
 
 # Check if we have a given docker tag
 def have_tag(arg):
     try:
         cmd = ["docker", "images", "-q", arg]
-        vprint(cmd)
+        vprint_command(cmd)
         return len(subprocess.check_output(cmd)) > 0
     except subprocess.CalledProcessError:
         eprint("Error searching for image: " + arg)
@@ -161,7 +170,7 @@ def get_git_commit():
     else:
         try:
             cmd = ["git", "describe", "--always", "--dirty=-modified"]
-            vprint(cmd)
+            vprint_command(cmd)
             return subprocess.check_output(cmd)[:-1].decode()
         except subprocess.CalledProcessError:
             eprint("Couldn't get git revision")
@@ -174,7 +183,7 @@ def get_git_commit():
 # Check if docker is available and bail out early with a message if appropriate
 if not args.dry_run:
     cmd = "command -v docker > /dev/null 2>&1"
-    vprint(cmd)
+    vprint_command(cmd)
     try:
         retcode = subprocess.call(cmd, shell=True)
     except:


### PR DESCRIPTION
Printing of commands in the mob script shows formatted lists, which don't copy and paste into the prompt. Quick fix to display dry-run commands better.

```
sudo ./mob --dry-run prompt                                                                                                                                 
Mapping SSH_AUTH_SOCKET into container                                                                                                                        
$ cd /home/christian/Tresor/work/mobilecoin_inc/mobilecoin                                                                                                    
$ docker image pull gcr.io/mobilenode-211420/builder-install:1_15                                                                                             
$ docker images -q gcr.io/mobilenode-211420/builder-install:1_15                                                                                              
$ cd docker                                                                                                                                                   
$ docker build . --target builder-install --tag gcr.io/mobilenode-211420/builder-install:1_15 --cache-from gcr.io/mobilenode-211420/builder-install:1_15 --cache-from gcr.io/mobilenode-211420/builder-install:1_15 --cache-from gcr.io/mobilenode-211420/builder-install:1_14                                              
$ cd /home/christian/Tresor/work/mobilecoin_inc/mobilecoin                                                                                                    
$ git describe --always --dirty=-modified                                                                                                                     
$ docker run --env CARGO_HOME=/tmp/mobilenode/cargo --volume /home/christian/Tresor/work/mobilecoin_inc/mobilecoin:/tmp/mobilenode --workdir /tmp/mobilenode --env RUST_BACKTRACE=full --env SGX_MODE=SW --env IAS_MODE=DEV --env GIT_COMMIT=0546cdf -t -i --expose 8080 --expose 8081 --expose 8443 --expose 3223 --expose 3225 --expose 3226 --expose 3228 --expose 4444 --env SSH_AUTH_SOCK=/tmp/ssh_auth_sock --volume /run/user/1000/keyring/ssh:/tmp/ssh_auth_sock --cap-add SYS_PTRACE gcr.io/mobilenode-211420/builder-install:1_15 /bin/bash 
```