### PR TITLE
FOG-373 Make sample-keys take a fog authority certificate PEM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,12 +3595,14 @@ dependencies = [
  "mc-crypto-rand",
  "mc-util-from-random",
  "mc-util-serial",
+ "pem",
  "rand 0.7.3",
  "rand_hc 0.2.0",
  "serde",
  "serde_json",
  "structopt",
  "tempdir",
+ "x509-signature",
 ]
 
 [[package]]

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -566,13 +566,13 @@ mod account_key_tests {
 
     #[test]
     // Subaddress fog authority signature should verify
-    fn test_fog_authority_fingerprint_signature() {
+    fn test_fog_authority_signature() {
         let mut rng: StdRng = SeedableRng::from_seed([42u8; 32]);
         let view_private = RistrettoPrivate::from_random(&mut rng);
         let spend_private = RistrettoPrivate::from_random(&mut rng);
         let fog_url = "fog://example.com";
-        let mut fog_authority_fingerprint = [0u8; 32];
-        rng.fill_bytes(&mut fog_authority_fingerprint);
+        let mut fog_authority_spki = [0u8; 32];
+        rng.fill_bytes(&mut fog_authority_spki);
         let fog_report_key = String::from("");
 
         let account_key = AccountKey::new_with_fog(
@@ -580,13 +580,13 @@ mod account_key_tests {
             &view_private,
             fog_url,
             fog_report_key,
-            fog_authority_fingerprint,
+            fog_authority_spki,
         );
 
         let index = rng.next_u64();
         let subaddress = account_key.subaddress(index);
 
         // Note: The fog_authority_fingerprint is published, so it is known by the verifier.
-        verify_signature(&subaddress, &fog_authority_fingerprint);
+        verify_signature(&subaddress, &fog_authority_spki);
     }
 }

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -150,13 +150,6 @@ impl PublicAddress {
     }
 
     /// Get the optional fog authority sig (if it exists / is not empty).
-    #[deprecated]
-    #[inline]
-    pub fn fog_authority_fingerprint_sig(&self) -> Option<&[u8]> {
-        self.fog_authority_sig()
-    }
-
-    /// Get the optional fog authority sig (if it exists / is not empty).
     pub fn fog_authority_sig(&self) -> Option<&[u8]> {
         if self.fog_authority_sig.is_empty() {
             None

--- a/fog/report/validation/src/traits.rs
+++ b/fog/report/validation/src/traits.rs
@@ -23,8 +23,8 @@ pub trait FogPubkeyResolver {
 /// Represents a fog public key validated to use for creating encrypted fog hints.
 /// This object should be constructed only when the IAS report has been validated,
 /// and the chain of trust from the connection has been validated, and the
-/// the fog user's fog_authority_fingerprint_sig over the fingerprints in the signature chain
-/// has been validated for at least one fingerprint.
+/// the fog user's fog_authority_sig over the root subjectPublicKeyInfo in the
+/// signature chain has been validated.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FullyValidatedFogPubkey {
     /// The ristretto curve point which was extracted from the IAS report additional data

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -32,9 +32,11 @@ mc-util-serial = { path = "../../util/serial", features = ["std"] }
 hex = "0.4"
 rand = "0.7"
 rand_hc = "0.2.0"
+pem = "0.8"
 serde = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
+x509-signature = "0.5"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -18,8 +18,8 @@ struct Config {
     pub fog_report_id: Option<String>,
 
     /// Fog Authority Fingerprint, hex encoded
-    #[structopt(long, parse(try_from_str=parse_hex_to_vec))]
-    pub fog_authority_fingerprint: Option<VecBytes>,
+    #[structopt(long, parse(try_from_str=load_spki_from_file))]
+    pub fog_authority_spki: Option<VecBytes>,
 
     /// Number of user keys to generate.
     #[structopt(short, long, default_value = "10")]
@@ -33,6 +33,8 @@ struct Config {
     #[structopt(short, long, parse(try_from_str=hex::FromHex::from_hex))]
     pub seed: Option<[u8; 32]>,
 }
+
+fn load_spki_from_file(src: &str) -> Result<VecBytes, String> {}
 
 fn parse_hex_to_vec(src: &str) -> Result<VecBytes, String> {
     let v: Vec<u8> = Vec::from_hex(src)

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use hex::FromHex;
-use std::{path::PathBuf, vec::Vec};
+use std::{fs, path::PathBuf, string::ToString, vec::Vec};
 use structopt::StructOpt;
 
 // Hack to work around Vec special handling in structopt
@@ -17,8 +17,8 @@ struct Config {
     #[structopt(long)]
     pub fog_report_id: Option<String>,
 
-    /// Fog Authority Fingerprint, hex encoded
-    #[structopt(long, parse(try_from_str=load_spki_from_file))]
+    /// Fog Authority subjectPublicKeyInfo, loaded from a PEM root certificate
+    #[structopt(long = "fog-authority-root", parse(try_from_str=load_spki_from_pemfile))]
     pub fog_authority_spki: Option<VecBytes>,
 
     /// Number of user keys to generate.
@@ -30,20 +30,20 @@ struct Config {
     pub output_dir: Option<PathBuf>,
 
     // Seed to use when generating keys (e.g. 1234567812345678123456781234567812345678123456781234567812345678).
-    #[structopt(short, long, parse(try_from_str=hex::FromHex::from_hex))]
+    #[structopt(short, long, parse(try_from_str=FromHex::from_hex))]
     pub seed: Option<[u8; 32]>,
 }
 
-fn load_spki_from_file(src: &str) -> Result<VecBytes, String> {}
-
-fn parse_hex_to_vec(src: &str) -> Result<VecBytes, String> {
-    let v: Vec<u8> = Vec::from_hex(src)
-        .map_err(|e| format!("Could not get Vec from hex {}: {:?}", src, e))
-        .into_iter()
-        .flatten()
-        .collect();
-
-    Ok(v)
+/// Given a path as a string, read the file, parse it as PEM into DER, parse the
+/// DER into x509, and extract the subjectPublicKeyInfo as bytes.
+fn load_spki_from_pemfile(src: &str) -> Result<VecBytes, String> {
+    x509_signature::parse_certificate(
+        &pem::parse(fs::read(src).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?
+            .contents,
+    )
+    .map_err(|e| format!("{:?}", e))
+    .map(|cert| cert.subject_public_key_info().spki().to_vec())
 }
 
 fn main() {
@@ -61,7 +61,7 @@ fn main() {
         config.num,
         config.fog_report_url.as_deref(),
         config.fog_report_id.as_deref(),
-        config.fog_authority_fingerprint.as_deref(),
+        config.fog_authority_spki.as_deref(),
         config.seed.unwrap_or(mc_util_keyfile::keygen::DEFAULT_SEED),
     )
     .unwrap();

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -48,7 +48,7 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
     num_accounts: usize,
     fog_url: Option<&str>,
     fog_report_id: Option<&str>,
-    fog_authority_fingerprint: Option<&[u8]>,
+    fog_authority_spki: Option<&[u8]>,
     seed: [u8; 32],
 ) -> Result<(), std::io::Error> {
     let mut keys_rng: FixedRng = SeedableRng::from_seed(seed);
@@ -59,7 +59,7 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
             &mut keys_rng,
             fog_url.unwrap_or(&""),
             fog_report_id.unwrap_or_default(),
-            fog_authority_fingerprint.unwrap_or_default(),
+            fog_authority_spki.unwrap_or_default(),
         );
 
         write_keyfiles(path.as_ref(), &keyfile_name(i), &root_id)?;
@@ -144,13 +144,13 @@ mod testing {
 
         let fqdn = "example.com".to_string();
         let fog_report_id = "1";
-        let fog_authority_fingerprint = [18, 52, 18, 52];
+        let fog_authority_spki = [18, 52, 18, 52];
         write_default_keyfiles(
             &dir1,
             10,
             Some(&fqdn),
             Some(fog_report_id),
-            Some(&fog_authority_fingerprint),
+            Some(&fog_authority_spki),
             DEFAULT_SEED,
         )
         .unwrap();
@@ -159,7 +159,7 @@ mod testing {
             10,
             Some(&fqdn),
             Some(fog_report_id),
-            Some(&fog_authority_fingerprint),
+            Some(&fog_authority_spki),
             DEFAULT_SEED,
         )
         .unwrap();

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-pub mod config;
 mod json_format;
+
+pub mod config;
 pub mod keygen;
 
 use json_format::RootIdentityJson;


### PR DESCRIPTION
### Motivation

In order to perform integration testing of fog authority signatures, keys generated with keyfile need to include the proper bytes from the chain to be used.

### In this PR
* Removes the `--fog-authority-fingerprint` and adds `--fog-authority-root` which will take a pem certificate and extract the relevant bytes necessary for the fog authority signatures.

