### PR TITLE
MCC-1825 Fix ioactive MC-03

### DIFF
--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -99,7 +99,7 @@ impl FromBase64 for EpidPseudonym {
             let output = b64decode(src.as_bytes(), &mut buffer[..])?;
             output.len()
         };
-        if buflen < EPID_PSEUDONYM_LEN {
+        if buflen != EPID_PSEUDONYM_LEN {
             return Err(EncodingError::InvalidInputLength);
         }
         let (left, right) = buffer.split_at(buflen / 2);

--- a/watcher/README.md
+++ b/watcher/README.md
@@ -6,7 +6,7 @@ Watcher nodes perform an essential role in the MobileCoin network by verifying t
 Basic run command to sync block signatures from two nodes on the test network:
 
 Create a `sources.toml` file, for example:
-```
+```toml
 [[sources]]
 tx_source_url = "https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/"
 consensus_client_url = "mc://node1.test.mobilecoin.com/"


### PR DESCRIPTION
### Motivation
This resolves ioactive audit #MC-03, which constraints the length of EpidPseudonym to exactly the size expected (128B). This size has been verified using a recent IAS report.

### In this PR
* not-equals instead of less-than.
* Fix doctest in watcher
