### PR TITLE
watcher: fetch from multiple sources in parallel

### DIFF
--- a/ledger/sync/src/lib.rs
+++ b/ledger/sync/src/lib.rs
@@ -9,7 +9,9 @@ pub use ledger_sync::{
     LedgerSync, LedgerSyncError, LedgerSyncService, LedgerSyncServiceThread, MockLedgerSync,
 };
 pub use network_state::{NetworkState, PollingNetworkState, SCPNetworkState};
-pub use reqwest_transactions_fetcher::ReqwestTransactionsFetcher;
+pub use reqwest_transactions_fetcher::{
+    ReqwestTransactionsFetcher, ReqwestTransactionsFetcherError,
+};
 pub use transactions_fetcher_trait::{TransactionFetcherError, TransactionsFetcher};
 
 #[cfg(any(test, feature = "test_utils"))]

--- a/watcher/src/error.rs
+++ b/watcher/src/error.rs
@@ -5,6 +5,7 @@
 use displaydoc::Display;
 use mc_connection::Error as ConnectionError;
 use mc_crypto_keys::KeyError;
+use mc_ledger_sync::ReqwestTransactionsFetcherError;
 use mc_util_lmdb::MetadataStoreError;
 use std::string::FromUtf8Error;
 
@@ -17,8 +18,8 @@ pub enum WatcherError {
     /// DB: {0}
     DB(WatcherDBError),
 
-    /// Sync failed
-    SyncFailed,
+    /// Block fetching failed
+    BlockFetch(ReqwestTransactionsFetcherError),
 
     /// Connection: {0}
     Connection(ConnectionError),
@@ -33,6 +34,12 @@ impl From<url::ParseError> for WatcherError {
 impl From<WatcherDBError> for WatcherError {
     fn from(src: WatcherDBError) -> Self {
         Self::DB(src)
+    }
+}
+
+impl From<ReqwestTransactionsFetcherError> for WatcherError {
+    fn from(src: ReqwestTransactionsFetcherError) -> Self {
+        Self::BlockFetch(src)
     }
 }
 

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -277,6 +277,7 @@ impl WatcherDB {
         // Sanity test - the URL needs to be configured.
         let urls = self.get_config_urls_with_txn(&db_txn)?;
         if !urls.contains(&src_url) {
+            log::trace!(self.logger, "{} not in {:?}", src_url, urls);
             return Err(WatcherDBError::NotFound);
         }
 


### PR DESCRIPTION
### Motivation

It's desirable to reduce the time in takes the watcher to sync blocks. Before the change proposed in this PR, the per-block fetching time would decrease linearly as a function of how many sources are configured.

### In this PR
Change fetching such that for each iteration all sources are polled in parallel.

Here are timings before and after for two consecutive runs of the watcher, with a limit of 100 blocks:
```
BEFORE:
real	1m23.908s
user	0m17.555s
sys	0m0.929s

real	1m10.915s
user	0m17.217s
sys	0m1.052s

AFTER:
real	0m20.911s
user	0m17.008s
sys	0m1.092s

real	0m21.182s
user	0m17.435s
sys	0m1.018s
```

### Future Work
* Poll each source in parallel but independently of others. Right now the fetching time is dictated by the slowest source URL, but a more elaborate change could work around that.

