### PR TITLE
FOG-361: Fog resolver should normalize URIs on both sides

### DIFF
--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -198,7 +198,8 @@ impl Config {
                 let report_responses = conn
                     .fetch_fog_reports(fog_uris.iter().cloned())
                     .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
-                Ok(FogResolver::new(report_responses, verifier))
+                Ok(FogResolver::new(report_responses, verifier)
+                    .map_err(|err| format!("Invalid fog url: {}", err))?)
             } else {
                 Err(
                     "Some recipients have fog, but no fog ingest report verifier was configured"


### PR DESCRIPTION
Currently, Fog resolver normalizes uris when looking up queries,
but not when taking the set of report responses. After this commit,
it normalizes the strings to URIs on both sides.

Arguably, we should just change the `BTreeMap<String, ReportResponse>`  to `BTreeMap<FogUri, ReportResponse>`, but I think that is a more disruptive change so i was reluctant to do it that way