### PR TITLE
Increment block version for next scheduled hardfork (v0 -> v1)

### DIFF
--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -559,12 +559,8 @@ impl LedgerDB {
             let last_block = self.get_block(num_blocks - 1)?;
 
             // The block's version should be bounded by
-            // [prev block version, min(prev block version + 1, max block version)]
-            if block.version >= last_block.version && block.version <= BLOCK_VERSION {
-                if block.version > last_block.version + 1 {
-                    return Err(Error::InvalidBlock);
-                }
-            } else {
+            // [prev block version, max block version]
+            if block.version < last_block.version || block.version > BLOCK_VERSION {
                 return Err(Error::InvalidBlock);
             }
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -550,7 +550,8 @@ impl LedgerDB {
                 return Err(Error::InvalidBlock);
             }
 
-            // The origin block is index '0' with default-initialized parent ID, by convention
+            // The origin block is index '0' with default-initialized parent ID, by
+            // convention
             if block.index != 0 || block.parent_id != BlockID::default() {
                 return Err(Error::InvalidBlock);
             }
@@ -563,8 +564,7 @@ impl LedgerDB {
                 if block.version > last_block.version + 1 {
                     return Err(Error::InvalidBlock);
                 }
-            }
-            else {
+            } else {
                 return Err(Error::InvalidBlock);
             }
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -55,7 +55,7 @@ impl Block {
     /// # Arguments
     /// * `outputs` - Outputs "minted" by the origin block.
     pub fn new_origin_block(outputs: &[TxOut]) -> Self {
-        let version = BLOCK_VERSION;
+        let version = 0; // The origin block is always 0
         let parent_id = BlockID::default();
         let index: BlockIndex = 0;
         let cumulative_txo_count = outputs.len() as u64;

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -10,7 +10,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 
 /// Version identifier.
-pub const BLOCK_VERSION: u32 = 0;
+pub const BLOCK_VERSION: u32 = 1;
 
 /// The index of a block in the blockchain.
 pub type BlockIndex = u64;

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -10,6 +10,8 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 
 /// Version identifier.
+/// This is the current version, which also implies it is the max version that
+/// could be considered valid.
 pub const BLOCK_VERSION: u32 = 1;
 
 /// The index of a block in the blockchain.

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -189,7 +189,7 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                 let block_contents = BlockContents::new(key_images, outputs);
 
                 let block = Block::new(
-                    BLOCK_VERSION,
+                    0,
                     &parent.as_ref().unwrap().id,
                     block_index,
                     parent.as_ref().unwrap().cumulative_txo_count,


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Scheduled hardforks should be tracked on-chain (note: any change to validator enclaves requires a scheduled hardfork). Currently the only version number available is the block header version. Originally this was intended to represent the block header format version, however block header format version changes can be subsumed under the overall hardfork version (i.e. the protocol version). Since the current header version is `0`, repurposing the version number to represent the hardfork version is semantically harmless.

This PR prepares a new block version for whenever the hardfork that goes v0 to v1 occurs. Note that this PR is a breaking change (will alter the validator enclave MRENCLAVE).

#### Block validation rule

This PR also adds a block validation rule. A block version must be no less than the previous block version, and may not exceed the maximum block version. [EDIT: Skipping block versions is allowed. It may be useful if block versions are consensed on but a certain version fails for one reason or another (e.g. a bug is found, or a large contingent of nodes reject it). In that case the only safe way to consense on a different hardfork (different validator code) is to use a different hardfork version.]

### In this PR
* Increments block header version (see MC-2258).
* Updates block validation to support version changes.

### Future Work
* Future scheduled hardforks may make use of `RFC - MobileCoin Scheduled Hardforks with SCP and Dual-Enclave Blocks` (unpublished draft at this time), which specifies a new block header format for tracking hardfork versions.
* Refactor semantics so instead of tracking 'hardfork versions' we track 'number of hardforks'.

