### PR TITLE
default to ensuring our URLs have have a trailing slash

### DIFF
--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -194,4 +194,7 @@ pub trait UriScheme:
     const SCHEME_INSECURE: &'static str;
     const DEFAULT_SECURE_PORT: u16;
     const DEFAULT_INSECURE_PORT: u16;
+
+    /// When true, ensure the path components of a URI ends with a slash.
+    const NORMALIZE_PATH_TRAILING_SLASH: bool = true;
 }

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -196,5 +196,8 @@ pub trait UriScheme:
     const DEFAULT_INSECURE_PORT: u16;
 
     /// When true, ensure the path components of a URI ends with a slash.
+    /// This is genenerally the desired behavior for our URIs since we currently do not use any of
+    /// them to point at a specific file. Having a consistent trailing slash ensures that parsing
+    /// `scheme://host` and `scheme://host/` results in equal objects.
     const NORMALIZE_PATH_TRAILING_SLASH: bool = true;
 }

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -95,9 +95,7 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
             Url::parse(src).map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
 
         if Scheme::NORMALIZE_PATH_TRAILING_SLASH && !url.path().ends_with('/') {
-            url = url
-                .join("/")
-                .map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
+            url.set_path(&format!("{}/", url.path()));
         }
 
         let host = url

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -91,7 +91,14 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
     type Err = UriParseError;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(src).map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
+        let mut url =
+            Url::parse(src).map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
+
+        if Scheme::NORMALIZE_PATH_TRAILING_SLASH && !url.path().ends_with('/') {
+            url = url
+                .join("/")
+                .map_err(|err| UriParseError::UrlParse(src.to_string(), err))?;
+        }
 
         let host = url
             .host_str()


### PR DESCRIPTION
### Motivation

I ran into a bug that printed the following error message:
`Tried to send our peer list to peer insecure-igp://localhost:4301/, but despite successful status the peer list is still wrong! Expected: [insecure-igp://localhost:4300/, insecure-igp://localhost:4301/], Found: [insecure-igp://localhost:4300/, insecure-igp://localhost:4301/]`

While the URLs appear to be identical, they were in fact not. The [Display implementation](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/util/uri/src/uri.rs#L86) makes them appear as if they always have a trailing slash, but the underlying [url](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/util/uri/src/uri.rs#L28) might be different (`scheme://host` vs `scheme://host/`). Since the only time a trailing slash is not desirable is when pointing at a specific file (as opposed to a a path), it would be nice if by default we always ensured our URLs are slash-terminated. 

### In this PR
* Default all of our URI schemes to appending a terminating slash if one is missing, while still allowing to disable this behavior if the need ever comes up.

