### PR TITLE
MCC-2266 Utility to debug-print a signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,6 +3182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-sgx-css-dump"
+version = "1.0.1-pre1"
+dependencies = [
+ "hex_fmt",
+ "mc-sgx-css",
+ "structopt",
+]
+
+[[package]]
 name = "mc-sgx-debug-edl"
 version = "1.0.1-pre1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "sgx/core-types",
     "sgx/core-types-sys",
     "sgx/css",
+    "sgx/css-dump",
     "sgx/debug-edl",
     "sgx/epid",
     "sgx/epid-sys",

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mc-sgx-css-dump"
+version = "1.0.1-pre1"
+authors = ["MobileCoin"]
+edition = "2018"
+license = "GPL-3.0"
+
+[dependencies]
+mc-sgx-css = { path = "../css" }
+
+hex_fmt = "0.3"
+structopt = "0.3"

--- a/sgx/css-dump/README.md
+++ b/sgx/css-dump/README.md
@@ -1,0 +1,1 @@
+# SGX CSS Command-Line Utility

--- a/sgx/css-dump/rustfmt.toml
+++ b/sgx/css-dump/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2018"
+merge_imports = true
+wrap_comments = true

--- a/sgx/css-dump/src/main.rs
+++ b/sgx/css-dump/src/main.rs
@@ -1,0 +1,111 @@
+//! Intel SGX SIGSTRUCT Dump Utility
+//!
+//! This utility will read a SIGSTRUCT (css) file from standard input or the
+//! command-line, print it's contents (optionally as debug byte arrays) to
+//! standard output or an output file.
+
+use hex_fmt::HexFmt;
+use mc_sgx_css::Signature;
+use std::{
+    convert::TryFrom,
+    fmt::Write,
+    fs,
+    io::{self, Read, Write as IoWrite},
+    mem,
+    path::PathBuf,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Config {
+    /// The SIGSTRUCT file to read, or stdin
+    #[structopt(parse(from_os_str))]
+    pub input: Option<PathBuf>,
+    /// The output location, or stdout
+    #[structopt(parse(from_os_str))]
+    pub output: Option<PathBuf>,
+}
+
+fn main() {
+    let config = Config::from_args();
+
+    let input = if config.input.is_some() {
+        std::fs::read(config.input.unwrap()).expect("Could not read input file")
+    } else {
+        // sigstruct structures are 1 x86_64 page
+        let mut bytes = vec![0u8; mem::size_of::<Signature>()];
+        io::stdin()
+            .read_exact(&mut bytes)
+            .expect("Could not read SIGSTRUCT from standard input");
+        bytes
+    };
+
+    let sigstruct = Signature::try_from(input.as_slice()).expect("Could not parse input");
+
+    let mut output = String::with_capacity(8192);
+    writeln!(output, "Signature {{").expect("Could not write output");
+    writeln!(
+        output,
+        "    header: 0x{}, ",
+        HexFmt(&sigstruct.header()[..])
+    )
+    .expect("Could not write output");
+    writeln!(output, "    vendor: {:?}, ", sigstruct.vendor()).expect("Could not write output");
+    writeln!(output, "    date: 0x{:02x?}, ", sigstruct.date()).expect("Could not write output");
+    writeln!(
+        output,
+        "    header2: 0x{}, ",
+        HexFmt(&sigstruct.header2()[..])
+    )
+    .expect("Could not write output");
+    writeln!(
+        output,
+        "    swdefined: 0x{}, ",
+        HexFmt(&sigstruct.swdefined()[..])
+    )
+    .expect("Could not write output");
+    writeln!(
+        output,
+        "    MRSIGNER: 0x{}, ",
+        HexFmt(&sigstruct.mrsigner()[..])
+    )
+    .expect("Could not write output");
+    writeln!(
+        output,
+        "    signature: 0x{}, ",
+        HexFmt(&sigstruct.signature()[..])
+    )
+    .expect("Could not write output");
+    writeln!(output, "    miscselect: {}, ", sigstruct.misc_select())
+        .expect("Could not write output");
+    writeln!(output, "    miscmask: {}, ", sigstruct.misc_mask()).expect("Could not write output");
+    writeln!(output, "    attributes: {}, ", sigstruct.attributes())
+        .expect("Could not write output");
+    writeln!(
+        output,
+        "    attributemask: {}, ",
+        sigstruct.attribute_mask()
+    )
+    .expect("Could not write output");
+    writeln!(
+        output,
+        "    MRENCLAVE: 0x{}, ",
+        HexFmt(&sigstruct.mrenclave()[..])
+    )
+    .expect("Could not write output");
+    writeln!(output, "    isvprodid: {}, ", sigstruct.product_id())
+        .expect("Could not write output");
+    writeln!(output, "    isvsvn: {}, ", sigstruct.version()).expect("Could not write output");
+    writeln!(output, "    q1: 0x{}, ", HexFmt(&sigstruct.q1()[..]))
+        .expect("Could not write output");
+    writeln!(output, "    q2 0x{}, ", HexFmt(&sigstruct.q2()[..])).expect("Could not write output");
+    writeln!(output, "}}").expect("Could not write output");
+
+    if config.output.is_some() {
+        fs::write(config.output.unwrap(), output.as_bytes()).expect("Could not write output file");
+    } else {
+        io::stdout()
+            .write_all(output.as_bytes())
+            .expect("Could not write output to standard out")
+    }
+}

--- a/sgx/css/src/lib.rs
+++ b/sgx/css/src/lib.rs
@@ -63,6 +63,10 @@ pub enum Error {
     NonZeroReserved,
 }
 
+/// The length of the header1 field, in bytes
+pub const HEADER_LEN: usize = 16;
+/// The length of the header2 field, in bytes
+pub const HEADER2_LEN: usize = 16;
 /// The length of the SWDEFINED field, in bytes
 pub const SWDEFINED_LEN: usize = 4;
 /// The length of the MODULUS field, in bytes
@@ -132,6 +136,11 @@ pub struct Signature {
 }
 
 impl Signature {
+    /// Retrieve a reference to the header bytes
+    pub fn header(&self) -> &[u8; HEADER_LEN] {
+        &self.header
+    }
+
     /// Retrieve the enclave vendor type.
     pub fn vendor(&self) -> EnclaveVendor {
         u32::from_le_bytes(self.vendor)
@@ -146,6 +155,11 @@ impl Signature {
     /// It's a terrible way of encoding dates, but it's how SIGSTRUCT works internally.
     pub fn date(&self) -> u32 {
         u32::from_le_bytes(self.date)
+    }
+
+    /// Retrieve a reference to the secondary header bytes
+    pub fn header2(&self) -> &[u8; HEADER2_LEN] {
+        &self.header2
     }
 
     /// Retrieve the software-defined bytes


### PR DESCRIPTION
### Motivation

Tracking down attestation failures during debug sessions typically results in discovering a mismatch between the expected MRENCLAVE or MRSIGNER and the enclave that is actually running, and most folks are compiling with a SIGSTRUCT file, not the `.signed.so` enclave binary itself. Intel provides no utilities to read this SIGSTRUCT file, so this will read it and output it using our SGX code.

### In this PR
* Implements `mc-sgx-css-dump` binary.
* Adds some missing accessors to the `mc_sgx_css::Signature` type to replicate the debug printf of Signature.

### Future Work
* Figure out a nice way to support debug print options in custom implementations, e.g. pretty-printing with hash...

