### PR TITLE
remove unnecessary cq_count

### DIFF
--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -356,7 +356,6 @@ impl<
         // Start GRPC server.
         let env = Arc::new(
             EnvBuilder::new()
-                .cq_count(1)
                 .name_prefix("User-RPC".to_string())
                 .build(),
         );


### PR DESCRIPTION
### Motivation

* consensus service should support processing client requests in parallel. For whatever reason, it is currently configured to have a worker pool of size 1.

### In this PR
* Remove the worker thread pool limitation

This passed deployment: https://deploybot.canadacentral.mobilecoin.com/blue/organizations/jenkins/mobilecoin-internal/detail/deploy%2Feran/184/pipeline