### PR TITLE
Multiple sigstructs returned for testnet enclave; use first only.

### DIFF
--- a/start-testnet-client.sh
+++ b/start-testnet-client.sh
@@ -12,11 +12,18 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 source "$HOME/.cargo/env"
 
-pushd "$(dirname "$0")"
+pushd "$(dirname "$0")" >/dev/null
+
+if ! command -v jq >/dev/null 2>&1 ; then
+    ERRNO="$?"
+    printf "ERROR: This script requires jq, a commandline JSON parser and transformer.\n"
+    printf "       Please install jq in your distro's recommended manner.\n"
+    exit $ERRNO
+fi
 
 echo "Pulling down TestNet consensus validator signature material"
 
-SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | grep sigstruct | awk '{print $2}' | tr -d \" | head -n 1)
+SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | jq -r '.consensus | .sigstruct')
 curl -O https://enclave-distribution.test.mobilecoin.com/${SIGSTRUCT_URI}
 
 TARGETDIR=./target/release

--- a/start-testnet-client.sh
+++ b/start-testnet-client.sh
@@ -16,7 +16,7 @@ pushd "$(dirname "$0")"
 
 echo "Pulling down TestNet consensus validator signature material"
 
-SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | grep sigstruct | awk '{print $2}' | tr -d \")
+SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | grep sigstruct | awk '{print $2}' | tr -d \" | head -n 1)
 curl -O https://enclave-distribution.test.mobilecoin.com/${SIGSTRUCT_URI}
 
 TARGETDIR=./target/release


### PR DESCRIPTION
Multiple enclave distribution URIs are returned from the testnet server, causing
the ./start-testnet-client.sh script to attempt to curl a valid URL, followed by
three more invalid URIs, e.g.

    curl -O \
        https://enclave-distribution.test.mobilecoin.com/pool/aa60fcbc62fd7670584fb7649559cc1ba0f7d354/bf7fa957a6a94acb588851bc8767eca5776c79f4fc2aa6bcb99312c3c386c/consensus-enclave.css \
        pool/b81c9bef5b2572c2fe92b2698abc894c58cbeff7/bf7fa957a6a94acb588851bc8767eca5776c79f4fc2aa6bcb99312c3c386c/ingest-enclave.css

which results in a non-recoverable "curl: (6) Could not resolve host: pool"
error.

This fix causes us to only use the first consensus-enclave sigstruct.