### PR TITLE
Fix exec call to mobilecoind-json binary in start-testnet-client.sh.

### DIFF
--- a/start-testnet-client.sh
+++ b/start-testnet-client.sh
@@ -48,8 +48,8 @@ if ps -p $pid > /dev/null; then
     echo "Sleeping 5s to allow mobilecoind to sync the ledger"
     sleep 5
 
-    echo "Starting local mc-mobilecoind-json."
-    ${TARGETDIR}/mc-mobilecoind-json
+    echo "Starting local mobilecoind-json."
+    ${TARGETDIR}/mobilecoind-json
 else
     echo "Starting mobilecoind failed. Please check logs at $(pwd)/mobilecoind.log."
 fi


### PR DESCRIPTION
The output binary from that package was renamed from mc-mobilecoind-json
to mobilecoind-json in commit b709b734.

