### PR TITLE
Speed up watcher syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,7 @@ dependencies = [
  "prost",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rayon",
  "serde",
  "serial_test",
  "serial_test_derive",

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -82,18 +82,20 @@ fn main() {
             .expect("Could not create or open WatcherDB");
 
             // Start watcher db sync thread, unless running in offline mode.
-            log::info!(logger, "Starting watcher sync thread from mobilecoind.");
             let watcher_sync_thread = if config.offline {
-                None
+                panic!("Attempted to start watcher but we are configured in offline mode");
             } else {
-                Some(WatcherSyncThread::new(
-                    watcher_db.clone(),
-                    transactions_fetcher,
-                    ledger_db.clone(),
-                    config.poll_interval,
-                    false,
-                    logger.clone(),
-                ))
+                log::info!(logger, "Starting watcher sync thread from mobilecoind.");
+                Some(
+                    WatcherSyncThread::new(
+                        watcher_db.clone(),
+                        ledger_db.clone(),
+                        config.poll_interval,
+                        false,
+                        logger.clone(),
+                    )
+                    .expect("Failed starting watcher thread"),
+                )
             };
             (Some(watcher_db), watcher_sync_thread)
         }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -36,6 +36,7 @@ grpcio = "0.6.0"
 hex = "0.4"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+rayon = "1.2"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 structopt = "0.3"
 toml = "0.5"

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -116,10 +116,10 @@ pub struct SourcesConfig {
 
 impl SourcesConfig {
     /// Returns a list of URLs that can be used to fetch block contents from.
-    pub fn tx_source_urls(&self) -> Vec<String> {
+    pub fn tx_source_urls(&self) -> Vec<Url> {
         self.sources
             .iter()
-            .map(|source_config| source_config.tx_source_url().as_str().to_owned())
+            .map(|source_config| source_config.tx_source_url())
             .collect()
     }
 

--- a/watcher/src/error.rs
+++ b/watcher/src/error.rs
@@ -23,6 +23,9 @@ pub enum WatcherError {
 
     /// Connection: {0}
     Connection(ConnectionError),
+
+    /// Unknown tx source url: {0}
+    UnknownTxSourceUrl(String),
 }
 
 impl From<url::ParseError> for WatcherError {

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -17,7 +17,10 @@ use mc_util_repr_bytes::ReprBytes;
 use mc_util_serial::{decode, encode, Message};
 use mc_watcher_api::TimestampResultCode;
 
-use lmdb::{Cursor, Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
+use lmdb::{
+    Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, RwTransaction, Transaction,
+    WriteFlags,
+};
 use mc_util_repr_bytes::typenum::Unsigned;
 use std::{
     convert::{TryFrom, TryInto},
@@ -147,6 +150,8 @@ impl WatcherDB {
             Environment::new()
                 .set_max_dbs(10)
                 .set_map_size(MAX_LMDB_FILE_SIZE)
+                // TODO - needed because currently our test cloud machines have slow disks.
+                .set_flags(EnvironmentFlags::NO_SYNC)
                 .open(path.as_ref())?,
         );
 


### PR DESCRIPTION
Make ReqwestTransactionsFetcher support caching of merged blocks when fetching by block index.
Use rayon to parallel fetch transactions.

Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation

Watcher performance is suboptimal and there are some low hanging fruits for speeding it up. Following this PR it takes `mobilecoind` with watcher enabled about 3.5 minutes to fully sync the ~155k blocks of test net.

### In this PR
* Make `ReqwestTransactionsFetcher` support using merged-blocks/caching when fetching blocks identified only by their block index (as opposed to the entire `Block` object). This substantially reduces the amount of S3 requests needed (in favor or fewer, larger object fetches)
* Switch to using `rayon` for parallel fetching instead of using a home-made solution.
* Turn of `fsync` after every `lmdb` write (similarly to what we do for `LedgerDB`)
