### PR TITLE
MCC-2284 Enforce proper BIP-44 path for slip10 derivation

### DIFF
--- a/account-keys/slip10/src/lib.rs
+++ b/account-keys/slip10/src/lib.rs
@@ -40,7 +40,8 @@ impl AsRef<[u8]> for Slip10Key {
 }
 
 /// Create the view and spend private keys, and return them in reverse order,
-/// e.g. `(spend, view)`, to match `AccountKey::new()`
+/// e.g. `(spend, view)`, to match
+/// [`AccountKey::new()`](mc_account_key::AccountKey::new)
 impl Into<(RistrettoPrivate, RistrettoPrivate)> for Slip10Key {
     fn into(self) -> (RistrettoPrivate, RistrettoPrivate) {
         let mut okm = [0u8; 64];
@@ -69,7 +70,8 @@ impl From<[u8; 32]> for Slip10Key {
     }
 }
 
-/// A default derivation of the Slip10Key from a Mnemonic.
+/// A default derivation of the [`Slip10Key`] from a
+/// [`Mnemonic`](tiny_bip39::Mnemonic).
 ///
 /// This is equivalent to calling `mnemonic.derive_slip10_key(0)`.
 impl From<Mnemonic> for Slip10Key {
@@ -78,7 +80,7 @@ impl From<Mnemonic> for Slip10Key {
     }
 }
 
-/// A common interface for constructing a Slip10Key for MobileCoin given an
+/// A common interface for constructing a [`Slip10Key`] for MobileCoin given an
 /// account index.
 pub trait Slip10KeyGenerator {
     /// Derive a MobileCoin SLIP10 key for the given account from the current
@@ -86,7 +88,13 @@ pub trait Slip10KeyGenerator {
     fn derive_slip10_key(self, account_index: u32) -> Slip10Key;
 }
 
+/// The BIP44 "usage" component of a BIP32 path.
+///
+/// See https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki for more details.
 const USAGE_BIP44: u32 = 44;
+/// The MobileCoin "coin type" component of a BIP32 path.
+///
+/// See https://github.com/satoshilabs/slips/blob/master/slip-0044.md for reference.
 const COINTYPE_MOBILECOIN: u32 = 866;
 
 // This lets us get to
@@ -94,11 +102,14 @@ const COINTYPE_MOBILECOIN: u32 = 866;
 // try_into_account_key(...)
 impl Slip10KeyGenerator for Mnemonic {
     fn derive_slip10_key(self, account_index: u32) -> Slip10Key {
-        let path = [USAGE_BIP44, COINTYPE_MOBILECOIN, account_index];
         // We explicitly do not support passphrases for BIP-39 mnemonics, please
         // see the Mobilecoin Key Derivation design specification, v1.0.0, for
         // design rationale.
         let seed = Seed::new(&self, "");
+
+        // This is constructing an `m/44/866/<idx>` BIP32 path for use by SLIP-0010.
+        let path = [USAGE_BIP44, COINTYPE_MOBILECOIN, account_index];
+
         // We're taking what the SLIP-0010 spec calls the "Ed25519 private key"
         // here as our `SLip10Key`. That said, we're not actually using this as
         // an Ed25519 key, just IKM for a pair of HKDF-SHA512 instances whose
@@ -114,7 +125,8 @@ impl Slip10KeyGenerator for Mnemonic {
 }
 
 impl Slip10Key {
-    /// Try to construct a new AccountKey from an existing Slip10Key.
+    /// Try to construct a new [`AccountKey`](mc_account_keys::AccountKey) from
+    /// an existing [`Slip10Key`].
     // In the future, AccountKey::new_with_fog will be fallible.
     pub fn try_into_account_key(
         self,
@@ -274,6 +286,7 @@ mod test {
     /// A test vector using
     struct MnemonicToRistretto {
         phrase: &'static str,
+        account_index: u32,
         view_hex: &'static str,
         spend_hex: &'static str,
     }
@@ -311,136 +324,355 @@ mod test {
     ///     "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump" \
     ///     "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold"
     /// ```
-    const EN_MNEMONIC_STRINGS: [MnemonicToRistretto; 24] = [
+    const EN_MNEMONIC_STRINGS: [MnemonicToRistretto; 48] = [// Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            account_index: 0,
             view_hex: "e60abdbb6b46bcb34c24c232e4461ee3de964b3f460cccd9fa2ac75ae2b28a19f71389015d1c67a7dc8d84e15eaf8245d2c413b6f6b5069c5d93f49baa410f62",
             spend_hex: "290383347788fd93c878a3f35cdfab30033276ef34a6df99cc8bf6a963ed74128e34f6c6e1022813236c6b22ef851d5403fbbed7c06b5df547e5e1e64c4bb022",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            account_index: 1,
+            view_hex: "fc463f5e0339f64a33e4e1109b823e3c455778d6aaeb22350099901ec09f4be54f5f064a55ab70ed530ddb1bc6109748ef32f86d350c4f3a2b24dc789417e2a5",
+            spend_hex: "f357477b6ee7917ac3fc0415969ae8654f2eda17d604064970b6ac13dba860306f964c41388f8271af50729e227d0dbf0420551a4958ce40efcb146db2f3fbe0",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            account_index: 0,
             view_hex: "f91c5068f6bd8f63c3c2c30621ed87621ddede8f131a76432cee816dbd84a7d2f83669366c5e51e83779168a856c5cc926164bea24bc0fa69d43c16b7bdc9dea",
             spend_hex: "18b66268ad126db62a45d6bf782811c29af1e44ff4402da87eea04e2b33c51aa4907f66a39c9039bdd58d89f26b987afd7f7aad7ae6b46bc1c6bd6cf0f22227d",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "legal winner thank year wave sausage worth useful legal winner thank yellow",
+            account_index: 1,
+            view_hex: "c7d52b4f744a31dd1ec4408c08aa13bb179018494ff0c636db40ca0a60172cfa0ef3788ee35255acd59013460cbab263ff4d48aed80f960dc6b661da150098b2",
+            spend_hex: "b02777704984bb7b340e1e11b354742aef65e44c057b4142de145d17befb8b7467ed2e2ac28746d2188fa2b111f68ecf30d89cd682e803884b997eb01b6d0acb",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+            account_index: 0,
             view_hex: "202e4561ad8ffb0267581d26d922b4d2701fa78a5c22042c51f18a376a22c0c3365921c3a61c995b541cdf36ed2ced36b21a4a8ce9ce133cf8c0d82449dff004",
             spend_hex: "2c13c547ba47c674400aca8218bd1c41605df9aa3747c70b5eb98118b255bfbbd67cde8d8ff6a153c0c9ed927e9a849331481781a500512b4cf7fe731e2d3706",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+            account_index: 1,
+            view_hex: "eb0e103760ae6cc266c0e8480ad36607dfa41713ce03ed224316dfc7e9678c19df28edc0f566eb59623b79c51f971a0460ba36938b1be0582bf0a9f5a53e6759",
+            spend_hex: "a0ff94aa07f55fc55206c42a2f392cb0799b6651581506810e7ddf910f60200b285542a30ea8d7199dcaf6d1ad13c6d1912ce669735f116b30332a0507a7b105",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            account_index: 0,
             view_hex: "ade167a8ea0d1ed54ea4fcb8ffd98123e606adf34d2796f3a4f759939c11132053478d2055ef62260c9f4557c3962a1cf7c1e42a442effcee40d5f61133b32a9",
             spend_hex: "212ccaef63bb3a7591991b75e30f5c5017ee4c1cd7c2e3d1e90bb3a32485d7dcd1d10c7321604a68620a160872230b29e07b5ac9bb1c6ca5cc902fb5e3836fac",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+            account_index: 1,
+            view_hex: "ff27df80555896e8a967c47dab77e9a05756602cfd933e0ba3f350558de9f734f9ae713dd87eee704fc55ba074577cb192b59ded38c14fcc435f9bf51d025370",
+            spend_hex: "a5cd5d3d0504646b2a8a82a28708522987230088ffb733f10c7b39ff08a65def8ee37705f3e54671d4b481f9129e391537f000d0753a2504bc3ccbb6a38ebe0e",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+            account_index: 0,
             view_hex: "70c48e2377c2ed6d358ec0aebaa340852d23f15e8a75781b0c1210dd8705df1d52a2823833b59ad3af058756fc9d185864085878b083f2ea742336ad9714ac2a",
             spend_hex: "0729302d6037105e8ca7464336511caa7d4c73e60e0d82046bb35606a36835764a62332a5c7f0c857067ca521d20e01486cf14cc694f261d3f849408da43f516",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+            account_index: 1,
+            view_hex: "a4d8e53b4ed6fea1d990c8767fb01231dd223b92d35bad30c098f3fda698e6b2d7f7b81b0eb59ce9160bfbb0ec666876ce86df75f552d1d58a34a23971e00698",
+            spend_hex: "05372c5bebbc09a219a35d7af39a348faf7bea10a3cdea850d291fda7166d02e1dc207827fd90151b83b278f959992f58b550029963c6c0584bd9dbae0d74e48",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+            account_index: 0,
             view_hex: "da3ae36fbc4d251d2d2e095c0d94c537ccc7b330486b8ef05c14c0149c40c5e4789643680d05034e14abfca8ba44e4a81be7a3143b6320a7845940e9cfe9b979",
             spend_hex: "cd185d503a84ea857404c2fa4ad74816d764029e758fd5f08b3e2dfb51467baef29c8ccd3aa2055d19e1bd4701bdafc802ab41f99e3d06b905b789b6061f4013",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+            account_index: 1,
+            view_hex: "53a68f40fecec62dca274b12e17a311e39d58a943bb0ca85db92fe509acb7e605f0d6d45dc38e6e9247a0dbf316cf5c3d88ba6426f7ce3ad03c3562400972bee",
+            spend_hex: "954f7a3833b730bc7bb819a3a6fd6079cd7a6e6a05a41b7f4bfc7ebcf416e3ce6184b3af00b5babb748563d87da7b8db219de001bef2a74bdd0952a09ad5b616",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+            account_index: 0,
             view_hex: "c7514e29687e73b26f4ac95aa1cff820c06583c942a949dcf8c7f89c37dc6311b82e73e5002ce4b48f5f025f49dc87fe5d091a7b1038b234526d159f883c422b",
             spend_hex: "e1e46ad482ebfe38b8dfad21c71bfae4d9ee261c7e9aedd044686424176a16f0e9ad418a8cc59461ee31e9f850b778e06961fce04076a75c3e5aae091377cab7",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+            account_index: 1,
+            view_hex: "a41d701487a470ed1f9d182d7fcd67d9d98e659d59e55bc07074498a91cdc384821b647b735102c7dbb6cafdd7012505e2215d72cc3a599165fbeeaf9056df65",
+            spend_hex: "402a264656fdc0c8fa830ca588b003f24cc42437ed1800ea1ccde100363bbbb2f9cc2b5f1a14455edc356eaf0f221ed0acf9fab26a99dba12758fa7ba8729540",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+            account_index: 0,
             view_hex: "412340d6b94f6b3e3823386d2ce037885ee1430dd286aaa94107389165f4f13c0077e0100b4bf09bf3fcb81f97e22609950a1aa3107ebb891d79dad1ccf9eea5",
             spend_hex: "9e5cec675ad02ebede6ed891cf824024dcb61718415d4e761fff571d786313447155bd084b09cc7b88c7b70c43ab5d1990515f15c98e61e6d1d792c50a555ef3",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+            account_index: 1,
+            view_hex: "d58ffa7697831c5dd44c40865ee6f00d12cb731f57c2d4b2b8dfc4ce8d5a1916b9ee083b9d36d3124e67d71cdb88f2724e525e1d244732c35faba9ac1c1d596f",
+            spend_hex: "153f195291dbbf0a82bbd35544a0647ea88150a802c31f2dde723b5926422a522f50f140f28e1e0ec5c92ef624ac394c8ec913c1617cde6542616b357bf9800f",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+            account_index: 0,
             view_hex: "4ab6041974d9f32a49d8f8e9c96c958c80cdb2261b1d964d588704f32d1bc7e4f139fb0f20d33e4a329b2e0de63a5e09a7b333a32b8df69ec7a0946b001f2785",
             spend_hex: "ada65765f7f8d13e9e6600e9cb49d5fbec586f7455f16c7741621b8bb9c411101ae9f83be2077b9f7f7ff6eb344ffb99837b84acf688b723f24951727fe14a25",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+            account_index: 1,
+            view_hex: "1ec6e3ce98fead794d5c2f5852ff1404e920d0fbb9cf3a457861e7127642fc5644cc38b8c6d2f1e5bc35cf65be3a97d2306b309d7c84b5400419b77c1a97b804",
+            spend_hex: "3044415f0235e7e9704dd439e47ceba8c3323fff2eb3273bffa776d1c7651dae4aa0a3de2c9e3b70005aff745df48abeea6a6df8dd94f87ee1d0cccd775850bc",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+            account_index: 0,
             view_hex: "92366562217464fefac36a914acb483a48cd50d9ac0fde6067d5bd7e3f796d516c9c7a87a7d0f7807369e2fadc3f7ea4c0bed93161d1113e3b763a66fad8a643",
             spend_hex: "86f44eeae04c323c7977d5d32399b7dc4b51596651d00508eec822242b041ccb42a75f122db2a3a9bec8aeb707079b89f4098bbab798e7e4e98baa5966f94169",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+            account_index: 1,
+            view_hex: "9026d71c7742870ef51c5525ea94f08791ff175e7d4b4bdcfb5e8176e27b543f420b17ba5d02a2a2fff16d1449589ab4f35323695899dce932e538302985a207",
+            spend_hex: "3e183b105843a0a7709333600c1d6233ff64d24ced366ec3ffe49d22d8b8e7aa9895819e784df50e3037b754ab2f3df112caee85cd22c1796cc94937eb35c4ea",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+            account_index: 0,
             view_hex: "534dcd3768040f8e8c22ab06291a4a6e1054f7963e40171a6848b9eea4e78e89d09af928c26e3fcfa154fcf0916c7ba6159b0a5e304e19bc78387a6f34eabac4",
             spend_hex: "40f96d1fb392a04c2ed59531d12c12e0fdc8f0ae2f30cdc5e7cb1e269769dd8a24f6c785bc77c11e69329e50e847f6a3426e12048f23ba15b59cd09d8e191386",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+            account_index: 1,
+            view_hex: "b4416bbba159dc1bc1c7aa689faed2bf3c24116badd4e0e0d5231c77167e158b708bec6d71458e105c161702a6d3d51c7ea5a799b09bab838c86879efcf76af1",
+            spend_hex: "a31c371c61385e09814d4291dda24901c355b3992ae84382df2c8e4f2ff82c38ae6f963d77120ac032085e9b6ffd0d3895ae78d97d282099759493c64b246087",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+            account_index: 0,
             view_hex: "41b4efb4a40a87f9cdbdc3b58334a0e973b87f3a74b2f06a523696d1ce7e046bff96c8faf34aa1aa11c27f74d0d87d885fd1bab8187baaa1b63b9ef89c106ebb",
             spend_hex: "c0461cae6d6ee6095ae9388fe2516c5cd6b5a8571551f9b49f83dc23bd8b2c7289ac72367cb014a9e7c297a860ee54b5c1b79b24c1c29da9848b35d50e613ea3",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+            account_index: 1,
+            view_hex: "5bddef43fbbfdd094069a35b8906c01ae0269291f72745d2c9b8ed1ebb719313e7f753681ea623e259a2e2986f5c6123a07b3bb944b09721c6b14e27095aa976",
+            spend_hex: "7918a94df5ee675f9d7a91c1bda23348f4ca9dac8bc7f0cdbacac40d42db90db14ef454c80c8f41a6adc70ff3fd2cb5457c4988547b3cbd13dca09a97a9eb2a5",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+            account_index: 0,
             view_hex: "58dcf1bbe93b2691d79a449e2c6e08cadffb3c0a28ad58d964b97bc6525dd739c04feb4d685ec5c1af923528bf3b122d4f0df99174632037fd7a9876d95ecb14",
             spend_hex: "0a4960b57be1d6e0c4c431595862364f4a5d9f33d32525175d76fe60c74e6b261c67073bcf43ac7d4890c1b2a5d54f42439e84322f1372acf58909205d3198e5",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+            account_index: 1,
+            view_hex: "889387d17970851eee2263ff69323ad59991d304629afa0c34afb2ce88c7303780d497a5d66252e090101235ad894495bd53d7694e2091da7886f95b6f7e769d",
+            spend_hex: "a86fefee3a0023fe62ff3552a3ce67663387efa4aa99518b2ea3a5ce5c51b3be7024fcbd4565870ae6f79fca627a53c96a91edfe43e48608002fc0cc8b9d35f0",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+            account_index: 0,
             view_hex: "1cd3dd23f5ce851a1d83e4471be473edf76557d138f5ba5f6079ff71ede01c7069cd958b61a1305e38eb14975c80ae82ccb4c5eccd7f18a1c81a3f8b2a939c39",
             spend_hex: "65bc69ef2e84e663648b5940d2b49e7d65d0fee989b3ba09c285eb64abd45b56c7eeee08146764ae82ec9e56a8b3647cec05e754deecc0e6af5ee67ada90b7f4",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+            account_index: 1,
+            view_hex: "fd29bb5845d1254bfb96cda30318972a0b3e1e3b420cdd284f406a06ecce5210474a595de883a52b71e6b2bdfea00de51b297a381cdffe83461ab5d0214706fb",
+            spend_hex: "e77379827aaf40ff76e13e40b4f1b40fd261fdbf3a42ac606d915e9989aab37d497d54fa96a4ec5e1a7f5c53721e84b9528027ca72d7156cd9855897891851b8",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+            account_index: 0,
             view_hex: "2a25f8379e510a9f98dd8c83ba1b20dcd6a1ec8b7fd11ac42a115c4c2bfcac6f0d8b09fc6a6ebaae27ea69ab5a3d1da7df6f0c313c82307538240be235493e89",
             spend_hex: "9d231d98f64b8e51aa1f75c980096f32940c0cf69a53868f9bf552b509b73b919745c686d60ac11b64bbe73eec9e024a468422c3f712519407314d763b52843d",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+            account_index: 1,
+            view_hex: "340400ea3c47ee8286afdb8cb5a39010f27ed614e4ab3ce91e3f2f363818c95f3e8f4e9d97274f847c8d50505520ea822d365bb5c569f62e8cc44151d75592d5",
+            spend_hex: "d879552e9570202ebda58990a75f18270849c89dd8ec40e73983ed64d6428fd4369f71e44714ed5acb31d17f08a7fc8fd81be300eebe05ba5913d187b8e23552",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "scheme spot photo card baby mountain device kick cradle pact join borrow",
+            account_index: 0,
             view_hex: "c1a2b43c716fccc639b1a6246e905762cbee358b436387cc613a79c45849c28facdf6e4aaf9b7f50e4e9bf7f4e58bff98dccc663f28e4a28f60b915837407db2",
             spend_hex: "70ea0fd06293564a76a58de7cd6039b3fc924204d5878f2fe6814c237ac7fbbc419eb70dc7837c968854509fb6234ccf9116cd7ffb27bdd9df32ba01c9fe02b0",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "scheme spot photo card baby mountain device kick cradle pact join borrow",
+            account_index: 1,
+            view_hex: "bc6c24c30b9060e01950fac1a5d5c491090f643dfe8be2a6ec301e1cb08458a18f0ed331722b445621b5666dca5c1359563d67b9cd289aa27ff7b09ec12fcb48",
+            spend_hex: "2950c8ced3e50c171bfa40317f38a52d15a908b9713b08fa36175947c433d9ae0aa4108e7a8199572fa0810056dd4cd05c9586c4defe0afaca598cb35d2d5f57",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+            account_index: 0,
             view_hex: "e667b4b7029e9c9c06786d8fa2b709d6a48fd4cff738355716ff469a243fdc40764c07cd764be259e006fb22097c8c65a7d3e1b71bdf51f266b8945ece7b6ea6",
             spend_hex: "ec531d4bde1c7cad6eb904dde7b15bbc94642cbbb551f928296ff3a388e04a24cb55b13d5c17e1716994a6338bb46ec4b0ef2acbfe76b3b3cf23ccbe17d5bdbc",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+            account_index: 1,
+            view_hex: "05c65be4f1e735eba32ecab9833cd395acb35a3b1e64fe4569f25bd56fd53048a3e308d3417116aad264fc1d51c0c45518753ecaf0fdf5f0f07bef6c2eaa18c3",
+            spend_hex: "8eddba4a8d0eb6dc8af5b57f96900b94a1afcb88821c8e25b6528d52944ab47bce2b4cb0caeb7d44d4c8ea19bb5c737e601c04225cad31ac6199bf6622d89c9b",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+            account_index: 0,
             view_hex: "be265d3f1ecce2830e682a4d2ed754f98487fcb32b8e3461f344092f0bb089303f5c5b2a939face114f5b261a04ae345d684bca0ef114a94dd83383d7828c707",
             spend_hex: "75d2518ef07fd34bde19166ebf9af89bba20bf39761bc16fabf5837177ea5d7a7ebf4f40c77af3d4dd9042d80bb94a60d243cdaff88e7236d4feb57582c4ff4d",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+            account_index: 1,
+            view_hex: "94905bfb581ee3a050724ef1c413cbe65512a86be38352977cf0f5d65c19b15ea1d13688ff76bf27915bd4b2cf9379cae2af10ab9dbe20be78640c01fbd9a9da",
+            spend_hex: "5342cc3d661314319e7220a9d34fddf61cb4ff9ba80f5dd68aeace28caad704eb4e4815dd375d4195966acf00115ab52b0a4fb67b1b81e79ad82b343a07f65a1",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "cat swing flag economy stadium alone churn speed unique patch report train",
+            account_index: 0,
             view_hex: "42f9e9eeab40301854c14440920bcd7c5f8dbee70fa0c7eebf102e3a5e367ff975621dc0363bf9e55c7645936d5c7146a907d96286bc70662042d567ccbe386a",
             spend_hex: "4af25d4f760ddec7fbfbe0b7852666aa0a1b87abbc361e64ebdfae26cc9d82c3ce4bc396db87786337e02299d47a0b2c305b4c2dcb44e11ab87609119e54ef1d",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "cat swing flag economy stadium alone churn speed unique patch report train",
+            account_index: 1,
+            view_hex: "56c1318fdb93b434475f12737e8b94a0502d774f751b5e02ad5afa88e8f25bb4fb6b415eedf9927333be6c01f96fe9a6623bd1d44a358f80d8508ea7aa54dc4e",
+            spend_hex: "484794591314b9ccdcea4aac7655b8f98418de82830642e76d972b3695849e72183978274e29de7773cd03e6957730f45601a7a1e9d7eefee604d78f40822278",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+            account_index: 0,
             view_hex: "23eb58dd532e80cef0772b0415b9b3b8d3da4c0427c295865f839febb0ce5ed8aca584afc2d097983eb49e08897d78c37878d5d4e00f069ffa2331571db2b956",
             spend_hex: "1e1ff479932b2723eec5b24e5f8a58b43a599867778dacf933117cdc87947b72f93e5a3eab6cb3d70a080ed497e1abf9af452ef4784ea71f298cdc5e64dce314",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+            account_index: 1,
+            view_hex: "4e190e25dd12f0c6ba3319f1ad7fa868622b4ba5cf7785dc98cc09a7ca5dfafc5f3d27f5b56b2dbf688354cf6aa8b4a615e2e953ace6278d14dc59ee27caefc0",
+            spend_hex: "ac0d884be61c54b76e9c49d9c068141bd3a1b003f509b274b91ca8c4fc80a7c49d1825964adcf4d1976c6031a972b2b02deb4880022befb4789f39540cfb7270",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+            account_index: 0,
             view_hex: "3471ad1cae238b02e8fee729d04fd45c8ca8c91c141c75dbe89c47e78dcccd430aed8f78cceeedd7c7ba548b8ae32501951679f025a15bf6ddcc14cafd2836db",
             spend_hex: "37ec88f0bc514d13e2c795f57a980461990d11a66a1255fd3b432d1d5367982ea7d1396ea7a53c96cb200d473dc196cddd1065c5814f2cb6d6ad4cefc252092e",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+            account_index: 1,
+            view_hex: "40aa28ae6022141535dbf2703619fb6a56dc7994218e143287ca6343401effa33e969c2c24e13c34c0de978249ae191b8caefed5f3258967c68c023ad584fb73",
+            spend_hex: "71a02f9e9217a5928ff6b46202648f4f18575bbb27e08560b83e483060da80ccdf56bf19edec4cdc4915157f2cd5f9c2712bd69ba23202ca3dff025bb54a4144",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+            account_index: 0,
             view_hex: "38cc9bb5994553120ef065eabe9d094b7bcef00fc4fcbead4c7b8d01f18b92cad0b0027e5277a751e46c89452272debbd8f818f7011a7be493e3c4bfac5da71a",
             spend_hex: "fc935be921e75c85bc7e168a0ab861b19529cd24a56e9c5d10d677ffcee55eae383f1a1bf7ae4d82d97b2036ba848e470a6b1f9f8fc72deab0bc169f8e2c893f",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+            account_index: 1,
+            view_hex: "53ff60800bd8479ef5fc1f3699404029423a99ccc5e6c4c45513d51a6a2b59a168becb43fad6c5223e700893e441d734005e0c24850234217b06b87aea6301f8",
+            spend_hex: "d960234ec22cad5d8e355f16e7e5fa09d1676189a0246c2ad815e8c7be59416bf222b2f96f4e9912236c9894c9aa6d9704fbef0be0cb3eec0155150de06b6ad1",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+            account_index: 0,
             view_hex: "f09e2c5efcf7e5482e6afa4d0bd80a2dfc3fb2650c1da030f764b6118fbba2dc4b8b98cf0c6abb72f02afe669231e7839e175b9ebfd3dc6e97fba9ee5a46d9ba",
             spend_hex: "c80947469d4d694779f49a010633628100804454fcc78f0aaa7e4fac1253ab6dc93816153805ddc9ea8c74538e71a7d25534e17b374b244a96cb38610d1b48e9",
         },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+            account_index: 1,
+            view_hex: "df344386e61e46c13b3aab3b3044c172c878aaaa050d57fe7969b6ecee4a34d4c84b7782f0da1860053e8bf9ec1f198865470d70836b376d7708172b924268b5",
+            spend_hex: "a0e74e73f90a6dda13dd5aed01a16ef1cf3356eb06f88362bf0dab55dac08fc094cc92e916b8148b1c4c2ed4d91ee2cb4eb9dd9154775939c70e375c6acc9baa",
+        },
+        // Path: m/44'/866'/0'
         MnemonicToRistretto {
             phrase: "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+            account_index: 0,
             view_hex: "a93f976cdce8c2a975c7bb50fa05095c28a8ba735a555e08051a5c38fb835a4e664593a9f2a8a77a72b985fbcb68570d299fa36888899336a5f08125edc53295",
             spend_hex: "cfe38b011230806ff090e938b669535df087d8475cd280f089d7e554593e08ecff710c13a73aba3659255c9d08a33cc24fed9947b7af2a212bce2454faf6be02",
+        },
+        // Path: m/44'/866'/1'
+        MnemonicToRistretto {
+            phrase: "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+            account_index: 1,
+            view_hex: "a2715afec916ee62d4b117397f7c1868877f56cd6bce82cc28e8278ebfb1bf3eacc79953629e06961370401c66d0335ef881d5dc43f393f8d0835811e3de5108",
+            spend_hex: "2285d224077b99af07e49a85083cc65109f2401697784e6f959da668b248b34f174673a54fbe91bfe6ef5f2e38d8674962d91134637f04a69897d93b0c5dff24",
         },
     ];
 
     #[test]
     fn mnemonic_into_account_key() {
         for data in EN_MNEMONIC_STRINGS.iter() {
-            std::eprintln!("Generating for phrase {}", data.phrase);
+            std::eprintln!(
+                "Generating for phrase {} at path m/44'/866'/{}'",
+                data.phrase,
+                data.account_index
+            );
             let mnemonic = Mnemonic::from_phrase(data.phrase, Language::English)
                 .expect("Could not read test phrase into mnemonic");
-            let key = mnemonic.derive_slip10_key(0);
+            let key = mnemonic.derive_slip10_key(data.account_index);
             let account_key = AccountKey::from(key);
 
             let mut expected_view_bytes = [0u8; 64];

--- a/account-keys/slip10/src/lib.rs
+++ b/account-keys/slip10/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 
 use alloc::borrow::ToOwned;
 use bip39::{Mnemonic, Seed};
-use core::{fmt::Display, result::Result as CoreResult};
+use core::result::Result as CoreResult;
 use curve25519_dalek::scalar::Scalar;
 use displaydoc::Display;
 use hkdf::Hkdf;
@@ -21,10 +21,6 @@ use zeroize::Zeroize;
 /// derivation
 #[derive(Debug, Display, Eq, PartialEq)]
 pub enum Error {
-    /// The path provided contained a member that was not "hardened".
-    // FIXME: this is currently unused, and the slip10_ed25519 crate clamps to the appropriate
-    //        range.
-    UnhardenedPath,
     /// There was an error creating the account key: {0}
     AccountKey(AccountKeyError),
 }
@@ -73,22 +69,32 @@ impl From<[u8; 32]> for Slip10Key {
     }
 }
 
-/// A common interface for constructing a Slip10Key at a particular path from
-/// existing entropy
-pub trait Slip10KeyGenerator {
-    /// The type of error, if any, to be returned if it occurs
-    type Error: Display;
-
-    /// Derive a slip10 key for the given path from the current object
-    fn derive_slip10_key(self, path: &[u32]) -> CoreResult<Slip10Key, Self::Error>;
+/// A default derivation of the Slip10Key from a Mnemonic.
+///
+/// This is equivalent to calling `mnemonic.derive_slip10_key(0)`.
+impl From<Mnemonic> for Slip10Key {
+    fn from(src: Mnemonic) -> Slip10Key {
+        src.derive_slip10_key(0)
+    }
 }
 
-// This lets us get to
-// Mnemonic::from_phrases().derive_slip10_key(path).try_into_account_key(...)
-impl Slip10KeyGenerator for Mnemonic {
-    type Error = Error;
+/// A common interface for constructing a Slip10Key for MobileCoin given an
+/// account index.
+pub trait Slip10KeyGenerator {
+    /// Derive a MobileCoin SLIP10 key for the given account from the current
+    /// object
+    fn derive_slip10_key(self, account_index: u32) -> Slip10Key;
+}
 
-    fn derive_slip10_key(self, path: &[u32]) -> Result<Slip10Key> {
+const USAGE_BIP44: u32 = 44;
+const COINTYPE_MOBILECOIN: u32 = 866;
+
+// This lets us get to
+// Mnemonic::from_phrases().derive_slip10_key(account_index).
+// try_into_account_key(...)
+impl Slip10KeyGenerator for Mnemonic {
+    fn derive_slip10_key(self, account_index: u32) -> Slip10Key {
+        let path = [USAGE_BIP44, COINTYPE_MOBILECOIN, account_index];
         // We explicitly do not support passphrases for BIP-39 mnemonics, please
         // see the Mobilecoin Key Derivation design specification, v1.0.0, for
         // design rationale.
@@ -98,17 +104,14 @@ impl Slip10KeyGenerator for Mnemonic {
         // an Ed25519 key, just IKM for a pair of HKDF-SHA512 instances whose
         // output will be correctly transformed into the Ristretto255 keypair we
         // need.
-        let key = slip10_ed25519::derive_ed25519_private_key(seed.as_bytes(), path);
+        //
+        // This will also transform any "unhardened" path components into their
+        // "hardened" version.
+        let key = slip10_ed25519::derive_ed25519_private_key(seed.as_bytes(), &path);
 
-        Ok(Slip10Key(key))
+        Slip10Key(key)
     }
 }
-
-// TODO: Slip10KeyGenerator for Seed
-//
-// This is a tougher call, since there doesn't appear to be any way to ensure
-// the password is blank for this---and From<[u8; 32]> may be all we need for HW
-// wallets...
 
 impl Slip10Key {
     /// Try to construct a new AccountKey from an existing Slip10Key.
@@ -139,6 +142,8 @@ impl From<Slip10Key> for AccountKey {
 
 #[cfg(test)]
 mod test {
+    extern crate std;
+
     use super::*;
     use bip39::Language;
 
@@ -277,138 +282,165 @@ mod test {
     ///
     /// In those tests it's assumed the password is "TREZOR", but it's safe to
     /// assume these wordlists are all burned. This particular structure was
-    /// generated using the `mnemonic2slip.py` script.
+    /// generated using this command:
+    ///
+    /// ```bash
+    /// ./mnemonic2slip.py \
+    ///     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" \
+    ///     "legal winner thank year wave sausage worth useful legal winner thank yellow" \
+    ///     "letter advice cage absurd amount doctor acoustic avoid letter advice cage above" \
+    ///     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong" \
+    ///     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent" \
+    ///     "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will" \
+    ///     "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always" \
+    ///     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when" \
+    ///     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art" \
+    ///     "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title" \
+    ///     "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless" \
+    ///     "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote" \
+    ///     "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic" \
+    ///     "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog" \
+    ///     "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length" \
+    ///     "scheme spot photo card baby mountain device kick cradle pact join borrow" \
+    ///     "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave" \
+    ///     "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside" \
+    ///     "cat swing flag economy stadium alone churn speed unique patch report train" \
+    ///     "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access" \
+    ///     "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform" \
+    ///     "vessel ladder alter error federal sibling chat ability sun glass valve picture" \
+    ///     "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump" \
+    ///     "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold"
+    /// ```
     const EN_MNEMONIC_STRINGS: [MnemonicToRistretto; 24] = [
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-            view_hex: "8bd04a61f03bb35a3ce59120089e6cc1a7887fa127f904725ade32474e43550a996eb3732b671ae2e4e1914aafde9afc11c7d353bda1c55505c173c6705b57f3",
-            spend_hex: "815b3648210dc2f25a54bb0c19b721ebe170564446a7a3794c540ba6d9b7b5f58a19dfc3d15f283de210d913d31cbb142fa4f49ec5377494e76d059fa71664d5",
+            view_hex: "e60abdbb6b46bcb34c24c232e4461ee3de964b3f460cccd9fa2ac75ae2b28a19f71389015d1c67a7dc8d84e15eaf8245d2c413b6f6b5069c5d93f49baa410f62",
+            spend_hex: "290383347788fd93c878a3f35cdfab30033276ef34a6df99cc8bf6a963ed74128e34f6c6e1022813236c6b22ef851d5403fbbed7c06b5df547e5e1e64c4bb022",
         },
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank yellow",
-            view_hex: "378a7738a8798e7584b3fbdb776c515a8fcd3c2cd73bf46a0fbf9f49ac6f04cfcc3529673ca4383456bc6125e44440ae1ae4cad4507d45d70fae2de123c9913b",
-            spend_hex: "08dd28ef8d2727c2f8e7dcc21f5f39f89d9ec2b41144fccd00e1cc1953515f4c82c9e7b66c8882baad6cfb7e95030c9dd65d0389a46718ea92549bf47bc9b34b",
+            view_hex: "f91c5068f6bd8f63c3c2c30621ed87621ddede8f131a76432cee816dbd84a7d2f83669366c5e51e83779168a856c5cc926164bea24bc0fa69d43c16b7bdc9dea",
+            spend_hex: "18b66268ad126db62a45d6bf782811c29af1e44ff4402da87eea04e2b33c51aa4907f66a39c9039bdd58d89f26b987afd7f7aad7ae6b46bc1c6bd6cf0f22227d",
         },
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-            view_hex: "c66be3d420665d3299f7e59f5c1f79aa22c9706010cd3a4428d7c7f624d684ac161e47ae8bc7091c53dcc19d3d342d8352a9a499c18c59bc89518ea73159290d",
-            spend_hex: "9c40fe0b1d19be68b64c878673a537eedeb8d40483fcc5a553d59961a0c6f341cba36f920eab22aa543e83780d0a336398ac0663fb8db00d3ebe51ef3c55eec4",
+            view_hex: "202e4561ad8ffb0267581d26d922b4d2701fa78a5c22042c51f18a376a22c0c3365921c3a61c995b541cdf36ed2ced36b21a4a8ce9ce133cf8c0d82449dff004",
+            spend_hex: "2c13c547ba47c674400aca8218bd1c41605df9aa3747c70b5eb98118b255bfbbd67cde8d8ff6a153c0c9ed927e9a849331481781a500512b4cf7fe731e2d3706",
         },
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-            view_hex: "f148170960ce77008f3899660dc61868d2de595e7508e4e2d224d356529ac4705b7560a12d2516193f402e7024dcf178a53a700d28e863683fb7c671a487484c",
-            spend_hex: "2bda81c4cb985ea1394d879ebf43d15dae5d7df699b0275e52b7984ff0c28378c0c3970c9aaaee0efec9c23606deec2d0e72f5b4f97d68a2990c078e50c6e5fb",
+            view_hex: "ade167a8ea0d1ed54ea4fcb8ffd98123e606adf34d2796f3a4f759939c11132053478d2055ef62260c9f4557c3962a1cf7c1e42a442effcee40d5f61133b32a9",
+            spend_hex: "212ccaef63bb3a7591991b75e30f5c5017ee4c1cd7c2e3d1e90bb3a32485d7dcd1d10c7321604a68620a160872230b29e07b5ac9bb1c6ca5cc902fb5e3836fac",
         },
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
-            view_hex: "4e60a45f45ab52cac11c35a333326491d784b91960d666212f316b713d9c7310421b0605bfd3884cc79f342ea1ab1b8bbb097407feb08aae0e91bc5e0576e3c1",
-            spend_hex: "2d80efd9584e5aa0e2323fe97b50d2e597a6fa6bbb01da11cab583c5dc7b166f8eb6d9d39b5dec120bbef2da794ad48aaec86e44af6528fec4856f8ae9322fb2",
+            view_hex: "70c48e2377c2ed6d358ec0aebaa340852d23f15e8a75781b0c1210dd8705df1d52a2823833b59ad3af058756fc9d185864085878b083f2ea742336ad9714ac2a",
+            spend_hex: "0729302d6037105e8ca7464336511caa7d4c73e60e0d82046bb35606a36835764a62332a5c7f0c857067ca521d20e01486cf14cc694f261d3f849408da43f516",
         },
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-            view_hex: "fd679b5eafefa5d391eb2fb7ccef3b5afbf6dda598451f1a04cc2f5ddd5536c387f398ba67efc6d9af693aefda620437bc792718d21790c592dafadc5ef3629c",
-            spend_hex: "e84e4f9d3fba03d1c6c76691e778ed92edce2a4c3526df057ec9451218d000cf5194be9916154e6d092f6bad532e6ca719ca0eaa50ad7781f93ac20fd37e14b8",
+            view_hex: "da3ae36fbc4d251d2d2e095c0d94c537ccc7b330486b8ef05c14c0149c40c5e4789643680d05034e14abfca8ba44e4a81be7a3143b6320a7845940e9cfe9b979",
+            spend_hex: "cd185d503a84ea857404c2fa4ad74816d764029e758fd5f08b3e2dfb51467baef29c8ccd3aa2055d19e1bd4701bdafc802ab41f99e3d06b905b789b6061f4013",
         },
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
-            view_hex: "1ba2004b0c19341e73acc24fc1a4308bb38b40da220721caeb3bff8496ffa7f6970d2de5da7bae93eadc0a47b8ee05cfce69b96e18384859ee7bab8342fcd37a",
-            spend_hex: "4ec968404233f1667d4a7599c3678817edba281472277b881e46a0df677df46d04acc59fb23a347d711517dc887c4e8fd9a22300537941c9521c9c83ee93567b",
+            view_hex: "c7514e29687e73b26f4ac95aa1cff820c06583c942a949dcf8c7f89c37dc6311b82e73e5002ce4b48f5f025f49dc87fe5d091a7b1038b234526d159f883c422b",
+            spend_hex: "e1e46ad482ebfe38b8dfad21c71bfae4d9ee261c7e9aedd044686424176a16f0e9ad418a8cc59461ee31e9f850b778e06961fce04076a75c3e5aae091377cab7",
         },
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
-            view_hex: "d01e1224470a1f1eb21a4170b75c2c60afbd42db1925693f553c733f446fb061d3edacf82d82d24bc6c7f961c695ba6664edf58cbc19a621ef84ee03525793aa",
-            spend_hex: "4828d56b3ebdaa030562fa9d2729ad2f08ef830b72513b012ce2afcb8a96f0d443af88cdf4937a3be6ba54ffcde7279955e99831870c5db6d2d510b49df0c2eb",
+            view_hex: "412340d6b94f6b3e3823386d2ce037885ee1430dd286aaa94107389165f4f13c0077e0100b4bf09bf3fcb81f97e22609950a1aa3107ebb891d79dad1ccf9eea5",
+            spend_hex: "9e5cec675ad02ebede6ed891cf824024dcb61718415d4e761fff571d786313447155bd084b09cc7b88c7b70c43ab5d1990515f15c98e61e6d1d792c50a555ef3",
         },
         MnemonicToRistretto {
             phrase: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-            view_hex: "9e66e10c06f193bea050531f3efcf2beeced7ecaddbc517bafea06d063e202589abbdaf75ad4f5ea0c13c8ba3dbadce06a8907fc5d9d6f46d58b8b92f4de160e",
-            spend_hex: "56a4352d24b73484901e8875e4945eb2435d8530e5fccfdb7c2c536d02d05cae462689973c7bdc88910c0c5ac64494826d27d944a7a7064c436f99f9262cf859",
+            view_hex: "4ab6041974d9f32a49d8f8e9c96c958c80cdb2261b1d964d588704f32d1bc7e4f139fb0f20d33e4a329b2e0de63a5e09a7b333a32b8df69ec7a0946b001f2785",
+            spend_hex: "ada65765f7f8d13e9e6600e9cb49d5fbec586f7455f16c7741621b8bb9c411101ae9f83be2077b9f7f7ff6eb344ffb99837b84acf688b723f24951727fe14a25",
         },
         MnemonicToRistretto {
             phrase: "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
-            view_hex: "696a398414350f7ded40d67aa0cd276635b05f8c4b98735457433195bfca465d8b4a294bc76b310643e92a648de1d5a46a7c21fbe8fd1fb8eb0e0182887984c4",
-            spend_hex: "efab7c8c87c95e5225b5e6f716b18d8b23c9fed2605ff8e3aeceddd7335448910886e8447587018b732087c47ef82508978c6a572f46c43d1bfa9a0d57dcf96d",
+            view_hex: "92366562217464fefac36a914acb483a48cd50d9ac0fde6067d5bd7e3f796d516c9c7a87a7d0f7807369e2fadc3f7ea4c0bed93161d1113e3b763a66fad8a643",
+            spend_hex: "86f44eeae04c323c7977d5d32399b7dc4b51596651d00508eec822242b041ccb42a75f122db2a3a9bec8aeb707079b89f4098bbab798e7e4e98baa5966f94169",
         },
         MnemonicToRistretto {
             phrase: "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
-            view_hex: "04f44228aec47f77ed64498979ac544843ec4231eea1ce9608d49c481394a3f302d0df228adb7354a2b65d9edd9481023e4197f165521dad1ba38f450d45407c",
-            spend_hex: "8babcba4a096292f4d471232d90b9a75ff0f6cdce718e11d8026baff84cb2c871d5d1257bfe12ab83223ab3f6845455fe464c032a4a8e135abb52287787b4182",
+            view_hex: "534dcd3768040f8e8c22ab06291a4a6e1054f7963e40171a6848b9eea4e78e89d09af928c26e3fcfa154fcf0916c7ba6159b0a5e304e19bc78387a6f34eabac4",
+            spend_hex: "40f96d1fb392a04c2ed59531d12c12e0fdc8f0ae2f30cdc5e7cb1e269769dd8a24f6c785bc77c11e69329e50e847f6a3426e12048f23ba15b59cd09d8e191386",
         },
         MnemonicToRistretto {
             phrase: "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
-            view_hex: "7ebba2e3fc3e6bd6104c6c88e8055ce354f3f440861a4e2e6d668337e552648f30f8c062d50865accff92e4e1e3800052b4086bf8830e493144ba4520191af93",
-            spend_hex: "9c806b3234fc81352ce80f5f71dfc764a9018b6bfb8ad9692ac86ef1fe1c7031dd086e22911b6ae052d564a752762de1d69d9546fcad941c0b2a87ba2d8dd467",
+            view_hex: "41b4efb4a40a87f9cdbdc3b58334a0e973b87f3a74b2f06a523696d1ce7e046bff96c8faf34aa1aa11c27f74d0d87d885fd1bab8187baaa1b63b9ef89c106ebb",
+            spend_hex: "c0461cae6d6ee6095ae9388fe2516c5cd6b5a8571551f9b49f83dc23bd8b2c7289ac72367cb014a9e7c297a860ee54b5c1b79b24c1c29da9848b35d50e613ea3",
         },
         MnemonicToRistretto {
             phrase: "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
-            view_hex: "55492f2c512e6fe19de9b819d8cacf15d56f19685a87725ab7d00ccd112dd9af6baefbff6b842f260157d3c5a59412e17214005eedd45aa6f516557edacbfa2d",
-            spend_hex: "5bb705e5d7a923ef48dfe369e1453f27934f484b9ccc56f67610102cff3c2c16aac0392bce1d4ed41ce7c5c42ad6141e397114581db56dfaaa47455893f155db",
+            view_hex: "58dcf1bbe93b2691d79a449e2c6e08cadffb3c0a28ad58d964b97bc6525dd739c04feb4d685ec5c1af923528bf3b122d4f0df99174632037fd7a9876d95ecb14",
+            spend_hex: "0a4960b57be1d6e0c4c431595862364f4a5d9f33d32525175d76fe60c74e6b261c67073bcf43ac7d4890c1b2a5d54f42439e84322f1372acf58909205d3198e5",
         },
         MnemonicToRistretto {
             phrase: "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
-            view_hex: "68eeea32075781760ac7eb0fe97efc9d8a18f3932ae61462c3f50d7e01982061304d1e629b484e42e38c79a8acc9f8d49bde51aeef4d2d87b83990ae6907dd71",
-            spend_hex: "577db5cb77e28e50fb793bca4e665723d81c8781145bac9c377a60cf2797d81861000778bba327ac655f75444d45fb3a2d0e4bcad3c2f4dfb790ecb518fb8d7f",
+            view_hex: "1cd3dd23f5ce851a1d83e4471be473edf76557d138f5ba5f6079ff71ede01c7069cd958b61a1305e38eb14975c80ae82ccb4c5eccd7f18a1c81a3f8b2a939c39",
+            spend_hex: "65bc69ef2e84e663648b5940d2b49e7d65d0fee989b3ba09c285eb64abd45b56c7eeee08146764ae82ec9e56a8b3647cec05e754deecc0e6af5ee67ada90b7f4",
         },
         MnemonicToRistretto {
             phrase: "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
-            view_hex: "e230711aa9e2ef8d662f38bab22242a271dcbed98ee1ac3195fba7bd7fd1cde567a744c3fb6d6f9049fabb1ef83598ccb3ce3165b5bae741b63f9109161b5225",
-            spend_hex: "11dee61157dc185c3eabe4e2ceb31058cdc82c10ecf58542e67c06bc50b98d93757d1c8139867c9ba68ef9bc8b5b141183fd072636b84e45603f180d53dc43b5",
+            view_hex: "2a25f8379e510a9f98dd8c83ba1b20dcd6a1ec8b7fd11ac42a115c4c2bfcac6f0d8b09fc6a6ebaae27ea69ab5a3d1da7df6f0c313c82307538240be235493e89",
+            spend_hex: "9d231d98f64b8e51aa1f75c980096f32940c0cf69a53868f9bf552b509b73b919745c686d60ac11b64bbe73eec9e024a468422c3f712519407314d763b52843d",
         },
         MnemonicToRistretto {
             phrase: "scheme spot photo card baby mountain device kick cradle pact join borrow",
-            view_hex: "e697f302dfab59beed28509bd63b3b0a8205a5edfe389dfed1d35863f3ed8037498f4d506c88bec92d436e134a89ec301e0da90f73ff14fe00c759548945701e",
-            spend_hex: "8d5e53a200f1fe85f2817aa51e81979d57e50ffcf1891f3865bdc5be2d2b770123dbb1a81844b26a3104173f1fe462c7fec1282a562007adf353f930ea2c3ca4",
+            view_hex: "c1a2b43c716fccc639b1a6246e905762cbee358b436387cc613a79c45849c28facdf6e4aaf9b7f50e4e9bf7f4e58bff98dccc663f28e4a28f60b915837407db2",
+            spend_hex: "70ea0fd06293564a76a58de7cd6039b3fc924204d5878f2fe6814c237ac7fbbc419eb70dc7837c968854509fb6234ccf9116cd7ffb27bdd9df32ba01c9fe02b0",
         },
         MnemonicToRistretto {
             phrase: "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
-            view_hex: "d5b5eff3d6b32736c68dbb282b2db6eac35d4a91a0c588cf54b56883d72ec7156b5cf946ad9e4f47f0c54320c80e9c189072c91c4c8a0f780b3ab85350b26f5e",
-            spend_hex: "b2dd6490b3a44a1b064807e4352fe46ea6934d3100c3aafc1dbd9877bcb0069b495d8403c61472da83d1018fd7dda4e9b370a5cd34ff95769e715d5d1b8a58a4",
+            view_hex: "e667b4b7029e9c9c06786d8fa2b709d6a48fd4cff738355716ff469a243fdc40764c07cd764be259e006fb22097c8c65a7d3e1b71bdf51f266b8945ece7b6ea6",
+            spend_hex: "ec531d4bde1c7cad6eb904dde7b15bbc94642cbbb551f928296ff3a388e04a24cb55b13d5c17e1716994a6338bb46ec4b0ef2acbfe76b3b3cf23ccbe17d5bdbc",
         },
         MnemonicToRistretto {
             phrase: "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
-            view_hex: "ecd6f35a8107a1efedf2f783a3c7c84e48d8c13d407812ce2a13892d9bcafeda9538188c2608cb67abf1566d76b60d7a511a1c12fb65fc11a3856c19129ee732",
-            spend_hex: "a014d8ffdd98ec1c2475bebc2263516363458225563b99b5e0a7ea9538fe463337838452fc9c17ed1d6a89a03c3e823186ff11087d869df0cd8ccbc55f5ae410",
+            view_hex: "be265d3f1ecce2830e682a4d2ed754f98487fcb32b8e3461f344092f0bb089303f5c5b2a939face114f5b261a04ae345d684bca0ef114a94dd83383d7828c707",
+            spend_hex: "75d2518ef07fd34bde19166ebf9af89bba20bf39761bc16fabf5837177ea5d7a7ebf4f40c77af3d4dd9042d80bb94a60d243cdaff88e7236d4feb57582c4ff4d",
         },
         MnemonicToRistretto {
             phrase: "cat swing flag economy stadium alone churn speed unique patch report train",
-            view_hex: "bbdac4f43a2279249fc51717e5fef6af266ef1dc7179c3b2ca35e00dd4bcef5d29ad61486c2f221871d97e7df5c58b435caaac27fff3e84c492c2fcdbdd7f2d9",
-            spend_hex: "1eacb453ce8b25235b1dd541b0e8308cfa4e52cd1ee0f57d3f951b885acf4be24657f2f6eb54325d6aa6b206cec4155ad8e2c614999ce9f3c662f6b8c0488e7e",
+            view_hex: "42f9e9eeab40301854c14440920bcd7c5f8dbee70fa0c7eebf102e3a5e367ff975621dc0363bf9e55c7645936d5c7146a907d96286bc70662042d567ccbe386a",
+            spend_hex: "4af25d4f760ddec7fbfbe0b7852666aa0a1b87abbc361e64ebdfae26cc9d82c3ce4bc396db87786337e02299d47a0b2c305b4c2dcb44e11ab87609119e54ef1d",
         },
         MnemonicToRistretto {
             phrase: "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
-            view_hex: "3b88e1b554ec9adbcfc63bfcfd3722e22cc07836fdbbffd36082f678f851efc6f61971903e64f00b6feb5e7b51c72eec5badbc6b0feedd4bd5f94d291875501d",
-            spend_hex: "d14a61deac228aadccc2b07bc43ae773c65199b8eb9ae49cd74002406059decdbb6f6ebcbdb1e0e698732c6f610a83527ce83f00dbcbf085b281502a5245cee9",
+            view_hex: "23eb58dd532e80cef0772b0415b9b3b8d3da4c0427c295865f839febb0ce5ed8aca584afc2d097983eb49e08897d78c37878d5d4e00f069ffa2331571db2b956",
+            spend_hex: "1e1ff479932b2723eec5b24e5f8a58b43a599867778dacf933117cdc87947b72f93e5a3eab6cb3d70a080ed497e1abf9af452ef4784ea71f298cdc5e64dce314",
         },
         MnemonicToRistretto {
             phrase: "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
-            view_hex: "6a198583006bd3af8fa37f81678d934048f4bbd6cb04221781851b69293419a459c2f8f6caf1abd4f997f3d28f6aebc8fae8942ec809a248e1901c86c94687ff",
-            spend_hex: "44a0cc673efc7512edb076a7c253c08523e6ab9b2e38d105e812ae908524484e134b40ef074f276706fda2b4386d2e721525f8bdb263f91db5fd05b828426514",
+            view_hex: "3471ad1cae238b02e8fee729d04fd45c8ca8c91c141c75dbe89c47e78dcccd430aed8f78cceeedd7c7ba548b8ae32501951679f025a15bf6ddcc14cafd2836db",
+            spend_hex: "37ec88f0bc514d13e2c795f57a980461990d11a66a1255fd3b432d1d5367982ea7d1396ea7a53c96cb200d473dc196cddd1065c5814f2cb6d6ad4cefc252092e",
         },
         MnemonicToRistretto {
             phrase: "vessel ladder alter error federal sibling chat ability sun glass valve picture",
-            view_hex: "4da2769c4014e242935edcec09cb218630ec902983e114de4dded2103c9e014b2ca1a8998ebd37dee388647f2f637d6181a7abb871649610f44efe3054257810",
-            spend_hex: "a3b6c66456686ec326cb099cd3ee1b00ee7b71b4ca93b31a18a5553e75d4d8b7027430908592576cf25145e9a7c8b1af98383b334e40fad1031b5d217fb46ee1",
+            view_hex: "38cc9bb5994553120ef065eabe9d094b7bcef00fc4fcbead4c7b8d01f18b92cad0b0027e5277a751e46c89452272debbd8f818f7011a7be493e3c4bfac5da71a",
+            spend_hex: "fc935be921e75c85bc7e168a0ab861b19529cd24a56e9c5d10d677ffcee55eae383f1a1bf7ae4d82d97b2036ba848e470a6b1f9f8fc72deab0bc169f8e2c893f",
         },
         MnemonicToRistretto {
             phrase: "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
-            view_hex: "4c6a8bbfe8c74ca2c6b9a896606b9e1656169b8dcad42ee74cf3d21f924a3600cf333ce153a9370e2327d909b2c382f57bf18e6747dd21b626b167467feee1ac",
-            spend_hex: "d598faeb6f5d373544e204fa7006c880459eaa485ae09603f6201212c5f749c6f4bb59a2c025ca219b14905be3c291900ff65922975b95df1c8cf28a0ea03a92",
+            view_hex: "f09e2c5efcf7e5482e6afa4d0bd80a2dfc3fb2650c1da030f764b6118fbba2dc4b8b98cf0c6abb72f02afe669231e7839e175b9ebfd3dc6e97fba9ee5a46d9ba",
+            spend_hex: "c80947469d4d694779f49a010633628100804454fcc78f0aaa7e4fac1253ab6dc93816153805ddc9ea8c74538e71a7d25534e17b374b244a96cb38610d1b48e9",
         },
         MnemonicToRistretto {
             phrase: "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
-            view_hex: "bb668a4f525442a87f14451afa0fd823fe8e1dd46c0fbd3169db65098b17b0f4a07bac6036a8765d2ad33c3629d207f704b7441408d71019e3115c4c767888be",
-            spend_hex: "1d62e1f31d69b00f57e5d1ac5abcbc0cf77f719262dbe9a065d3dfa7c3fc60e85cc6d053f536cba7a23aa65d506e6dce4468bc9be25266ce772fa7bda8f11978",
+            view_hex: "a93f976cdce8c2a975c7bb50fa05095c28a8ba735a555e08051a5c38fb835a4e664593a9f2a8a77a72b985fbcb68570d299fa36888899336a5f08125edc53295",
+            spend_hex: "cfe38b011230806ff090e938b669535df087d8475cd280f089d7e554593e08ecff710c13a73aba3659255c9d08a33cc24fed9947b7af2a212bce2454faf6be02",
         },
     ];
 
     #[test]
     fn mnemonic_into_account_key() {
         for data in EN_MNEMONIC_STRINGS.iter() {
+            std::eprintln!("Generating for phrase {}", data.phrase);
             let mnemonic = Mnemonic::from_phrase(data.phrase, Language::English)
                 .expect("Could not read test phrase into mnemonic");
-            let key = mnemonic
-                .derive_slip10_key(&[])
-                .expect("Could not derive slip key from mnemonic for the 'm' path");
+            let key = mnemonic.derive_slip10_key(0);
             let account_key = AccountKey::from(key);
 
             let mut expected_view_bytes = [0u8; 64];

--- a/account-keys/slip10/src/mnemonic2slip.py
+++ b/account-keys/slip10/src/mnemonic2slip.py
@@ -96,12 +96,16 @@ def derive(parent_key, parent_chaincode, i, curve):
 def main():
     args = sys.argv[1:]
     for arg in args:
+        print("// Path: m/44'/866'/0'")
         print("MnemonicToRistretto {")
         print(f"    phrase: \"{arg}\",")
+        print("    account_index: 0,")
 
         mnemo = mnemonic.Mnemonic("english")
         master_seed = mnemo.to_seed(arg, "")
 
+        # manually build the path to m/usage/cointype/acctidx
+        # for us, usage is BIP-44, cointype is MobileCoin
         # m
         k, c = seed2hdnode(master_seed, b"ed25519 seed", 'ed25519')
         # m/44
@@ -109,18 +113,36 @@ def main():
         # m/44/866
         k, c = derive(k, c, 866 + privdev, 'ed25519')
         # m/44/866/0
-        k, _c = derive(k, c, 0 + privdev, 'ed25519')
+        acct0, _c = derive(k, c, 0 + privdev, 'ed25519')
 
-        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-view", k, hashlib.sha512)
+        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-view", acct0, hashlib.sha512)
         key = kdf.expand(length=64)
 
         print(f"    view_hex: \"{key.hex()}\",")
 
-        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-spend", k, hashlib.sha512)
+        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-spend", acct0, hashlib.sha512)
         key = kdf.expand(length=64)
 
         print(f"    spend_hex: \"{key.hex()}\",")
         print("},")
 
+        print("// Path: m/44'/866'/1'")
+        print("MnemonicToRistretto {")
+        print(f"    phrase: \"{arg}\",")
+        print("    account_index: 1,")
+
+        # m/44/866/1
+        acct1, _c = derive(k, c, 1 + privdev, 'ed25519')
+
+        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-view", acct1, hashlib.sha512)
+        key = kdf.expand(length=64)
+
+        print(f"    view_hex: \"{key.hex()}\",")
+
+        kdf = hkdf.Hkdf(b"mobilecoin-ristretto255-spend", acct1, hashlib.sha512)
+        key = kdf.expand(length=64)
+
+        print(f"    spend_hex: \"{key.hex()}\",")
+        print("},")
 
 main()

--- a/account-keys/slip10/src/testvectors.py
+++ b/account-keys/slip10/src/testvectors.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+import binascii
+import hashlib
+import hmac
+import struct
+import ecdsa
+import ed25519
+from base58 import b58encode_check
+
+privdev = 0x80000000
+
+def int_to_string(x, pad):
+    result = ['\x00'] * pad
+    while x > 0:
+        pad -= 1
+        ordinal = x & 0xFF
+        result[pad] = (chr(ordinal))
+        x >>= 8
+    return ''.join(result)
+
+def string_to_int(s):
+    result = 0
+    for c in s:
+        if not isinstance(c, int):
+            c = ord(c)
+        result = (result << 8) + c
+    return result
+
+# mode 0 - compatible with BIP32 private derivation
+def seed2hdnode(seed, modifier, curve):
+    k = seed
+    while True:
+        h = hmac.new(modifier, seed, hashlib.sha512).digest()
+        key, chaincode = h[:32], h[32:]
+        a = string_to_int(key)
+        if (curve == 'ed25519'):
+            break
+        if (a < curve.order and a != 0):
+            break
+        seed = h
+    return (key, chaincode)
+
+def fingerprint(publickey):
+    h = hashlib.new('ripemd160', hashlib.sha256(publickey).digest()).digest()
+    return h[:4]
+
+def b58xprv(parent_fingerprint, private_key, chain, depth, childnr):
+    raw = ('\x04\x88\xad\xe4' +
+              chr(depth) + parent_fingerprint + int_to_string(childnr, 4) +
+              chain + '\x00' + private_key)
+    return b58encode_check(raw)
+
+def b58xpub(parent_fingerprint, public_key, chain, depth, childnr):
+    raw = ('\x04\x88\xb2\x1e' +
+              chr(depth) + parent_fingerprint + int_to_string(childnr, 4) +
+              chain + public_key)
+    return b58encode_check(raw)
+
+def publickey(private_key, curve):
+    if curve == 'ed25519':
+        sk = ed25519.SigningKey(private_key)
+        return b'\x00' + sk.get_verifying_key().to_bytes()
+    else:
+        Q = string_to_int(private_key) * curve.generator
+        xstr = int_to_string(Q.x(), 32)
+        parity = Q.y() & 1
+        return chr(2 + parity) + xstr
+
+def derive(parent_key, parent_chaincode, i, curve):
+    assert len(parent_key) == 32
+    assert len(parent_chaincode) == 32
+    k = parent_chaincode
+    if ((i & privdev) != 0):
+        key = b'\x00' + parent_key
+    else:
+        key = publickey(parent_key, curve)
+    d = key + struct.pack('>L', i)
+    while True:
+        h = hmac.new(k, d, hashlib.sha512).digest()
+        key, chaincode = h[:32], h[32:]
+        if curve == 'ed25519':
+            break
+        a = string_to_int(key)
+        key = (a + string_to_int(parent_key)) % curve.order
+        if (a < curve.order and key != 0):
+            key = int_to_string(key, 32)
+            break
+        d = '\x01' + h[32:] + struct.pack('>L', i)
+                        
+    return (key, chaincode)
+
+def get_curve_info(curvename):
+    if curvename == 'secp256k1':
+        return (ecdsa.curves.SECP256k1, b'Bitcoin seed') 
+    if curvename == 'nist256p1':
+        return (ecdsa.curves.NIST256p, b'Nist256p1 seed') 
+    if curvename == 'ed25519':
+        return ('ed25519', b'ed25519 seed')
+    raise BaseException('unsupported curve: '+curvename)
+
+def show_testvector(name, curvename, seedhex, derivationpath):
+    curve, seedmodifier = get_curve_info(curvename)
+    master_seed = binascii.unhexlify(seedhex)
+    k,c = seed2hdnode(master_seed, seedmodifier, curve)
+    p = publickey(k, curve)
+    fpr = b'\x00\x00\x00\x00'
+    path = 'm'
+    print("### "+name+" for "+curvename)
+    print('')
+    print("Seed (hex): " + seedhex)
+    print('')
+    print('* Chain ' + path)
+    print('  * fingerprint: ' + fpr.hex())
+    print('  * chain code: ' + c.hex())
+    print('  * private: ' + k.hex())
+    print('  * public: ' + p.hex())
+    depth = 0
+    for i in derivationpath:
+        if curve == 'ed25519':
+            # no public derivation for ed25519
+            i = i | privdev
+        fpr = fingerprint(p)
+        depth = depth + 1
+        path = path + "/" + str(i & (privdev-1))
+        if ((i & privdev) != 0):
+            path = path + "<sub>H</sub>"
+        k,c = derive(k, c, i, curve)
+        p = publickey(k, curve) 
+        print('* Chain ' + path)
+        print('  * fingerprint: ' + fpr.hex())
+        print('  * chain code: ' + c.hex())
+        print('  * private: ' + k.hex())
+        print('  * public: ' + p.hex())
+        #print b58xprv(fpr, kc, cc, depth, i)
+        #print b58xpub(fpr, pc, cc, depth, i)
+    print
+
+def show_testvectors(name, curvenames, seedhex, derivationpath):
+    for curvename in curvenames:
+        show_testvector(name, curvename, seedhex, derivationpath)
+
+
+show_testvectors("Real", ['ed25519'],
+                 '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4',
+                 [privdev + 44, privdev + 866, privdev + 0])
+


### PR DESCRIPTION
### Motivation

We currently allow the caller to use any BIP-32 path when deriving a SLIP-0010 ed25519 "private key" from a mnemonic seed. We should enforce proper BIP-44 with an account index, akin to how Stellar is doing this for their currencies (and seemingly how monero also does this stuff).

### In this PR
* Make `Slip10KeyGenerator::derive_slip10_key()` only take an account index.
* Make `Slip10KeyGenerator::derive_slip10_key()` infallible
* `impl From<Mnemonic> for Slip10Key` using a zero account-index.
* Update test-vector generation
* Add slip10's testvectors.py for reference.

### Future Work
* Spec integration
