### PR TITLE
Initial mnemonic support for mobilecoind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
  "libz-sys",
  "lmdb-rkv",
  "mc-account-keys",
+ "mc-account-keys-slip10",
  "mc-api",
  "mc-attest-core",
  "mc-common",
@@ -3047,6 +3048,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempdir",
+ "tiny-bip39",
 ]
 
 [[package]]

--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -27,7 +27,7 @@ message PaymentRequest {
 /// used for gift cards.
 message TransferPayload {
     /// The root entropy, allowing the recipient to spend the money
-    bytes entropy = 1;
+    bytes root_entropy = 1;
 
     /// The public key of the UTXO to spend. This is an optimization, meaning
     /// the recipient does not need to scan the entire ledger.

--- a/api/src/display.rs
+++ b/api/src/display.rs
@@ -195,7 +195,7 @@ mod display_tests {
     #[test]
     fn test_transfer_payload_roundtrip() {
         let mut transfer_payload = TransferPayload::new();
-        transfer_payload.set_entropy(vec![1u8; 32]);
+        transfer_payload.set_root_entropy(vec![1u8; 32]);
         transfer_payload
             .mut_tx_out_public_key()
             .set_data(vec![2u8; 32]);

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -32,14 +32,27 @@ pub struct JsonUnlockDbResponse {
 }
 
 #[derive(Serialize, Default, Debug)]
-pub struct JsonEntropyResponse {
+pub struct JsonRootEntropyResponse {
     pub entropy: String,
 }
 
-impl From<&mc_mobilecoind_api::GenerateEntropyResponse> for JsonEntropyResponse {
-    fn from(src: &mc_mobilecoind_api::GenerateEntropyResponse) -> Self {
+impl From<&mc_mobilecoind_api::GenerateRootEntropyResponse> for JsonRootEntropyResponse {
+    fn from(src: &mc_mobilecoind_api::GenerateRootEntropyResponse) -> Self {
         Self {
-            entropy: hex::encode(&src.entropy),
+            entropy: hex::encode(&src.root_entropy),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Default, Debug)]
+pub struct JsonMnemonicResponse {
+    pub mnemonic: String,
+}
+
+impl From<&mc_mobilecoind_api::GenerateMnemonicResponse> for JsonMnemonicResponse {
+    fn from(src: &mc_mobilecoind_api::GenerateMnemonicResponse) -> Self {
+        Self {
+            mnemonic: src.mnemonic.clone(),
         }
     }
 }

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -14,6 +14,7 @@ ip-check = []
 
 [dependencies]
 mc-account-keys = { path = "../account-keys" }
+mc-account-keys-slip10 = { path = "../account-keys/slip10" }
 mc-api = { path = "../api" }
 mc-attest-core = { path = "../attest/core" }
 mc-common = { path = "../common", features = ["log"] }
@@ -57,6 +58,7 @@ retry = "1.2"
 serde_json = "1.0"
 structopt = "0.3"
 tempdir = "0.3"
+tiny-bip39 = "0.8"
 
 [dev-dependencies]
 mc-common = { path = "../common", features = ["loggers"] }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -25,6 +25,7 @@ service MobilecoindAPI {
     // Utilities
     rpc GenerateEntropy (google.protobuf.Empty) returns (GenerateEntropyResponse) {}
     rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
+    rpc GetAccountKeyFromMnemonic (GetAccountKeyFromMnemonicRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 
     // b58 Codes
@@ -320,6 +321,11 @@ message GenerateEntropyResponse {
 // Generate an AccountKey from a 32 byte root entropy value.
 message GetAccountKeyFromRootEntropyRequest {
     bytes entropy = 1;
+}
+// Generate an AccountKey from a mnemonic.
+message GetAccountKeyFromMnemonicRequest {
+    string mnemonic = 1;
+    uint32 account_index = 2;
 }
 message GetAccountKeyResponse {
     external.AccountKey account_key = 1;

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -23,7 +23,7 @@ service MobilecoindAPI {
     rpc GetUnspentTxOutList (GetUnspentTxOutListRequest) returns (GetUnspentTxOutListResponse) {}
 
     // Utilities
-    rpc GenerateEntropy (google.protobuf.Empty) returns (GenerateEntropyResponse) {}
+    rpc GenerateRootEntropy (google.protobuf.Empty) returns (GenerateRootEntropyResponse) {}
     rpc GenerateMnemonic (google.protobuf.Empty) returns (GenerateMnemonicResponse) {}
     rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
     rpc GetAccountKeyFromMnemonic (GetAccountKeyFromMnemonicRequest) returns (GetAccountKeyResponse) {}
@@ -314,7 +314,7 @@ message GetUnspentTxOutListResponse {
 
 // Generate a new random root entropy value.
 // - empty request
-message GenerateEntropyResponse {
+message GenerateRootEntropyResponse {
 	  // 32 bytes generated using a cryptographically secure RNG.
     bytes root_entropy = 1;
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -24,7 +24,7 @@ service MobilecoindAPI {
 
     // Utilities
     rpc GenerateEntropy (google.protobuf.Empty) returns (GenerateEntropyResponse) {}
-    rpc GetAccountKey (GetAccountKeyRequest) returns (GetAccountKeyResponse) {}
+    rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 
     // b58 Codes
@@ -318,7 +318,7 @@ message GenerateEntropyResponse {
 }
 
 // Generate an AccountKey from a 32 byte root entropy value.
-message GetAccountKeyRequest {
+message GetAccountKeyFromRootEntropyRequest {
     bytes entropy = 1;
 }
 message GetAccountKeyResponse {

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -315,12 +315,12 @@ message GetUnspentTxOutListResponse {
 // - empty request
 message GenerateEntropyResponse {
 	  // 32 bytes generated using a cryptographically secure RNG.
-    bytes entropy = 1;
+    bytes root_entropy = 1;
 }
 
 // Generate an AccountKey from a 32 byte root entropy value.
 message GetAccountKeyFromRootEntropyRequest {
-    bytes entropy = 1;
+    bytes root_entropy = 1;
 }
 // Generate an AccountKey from a mnemonic.
 message GetAccountKeyFromMnemonicRequest {
@@ -371,7 +371,7 @@ message ParseTransferCodeRequest {
     string b58_code = 1;
 }
 message ParseTransferCodeResponse {
-    bytes entropy = 1;
+    bytes root_entropy = 1;
     external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
     UnspentTxOut utxo = 4;
@@ -379,7 +379,7 @@ message ParseTransferCodeResponse {
 
 // Encode entropy/tx_public_key/memo into a base-58 "MobileCoin Transfer Code".
 message CreateTransferCodeRequest {
-    bytes entropy = 1;
+    bytes root_entropy = 1;
     external.CompressedRistretto tx_public_key = 2;
     string memo = 3;
 }
@@ -490,7 +490,7 @@ message GenerateTransferCodeTxResponse {
     TxProposal tx_proposal = 1;
 
     // The entropy for constructing the AccountKey that can access the funds.
-    bytes entropy = 2;
+    bytes root_entropy = 2;
 
     // The TxOut public key that has the funds.
     external.CompressedRistretto tx_public_key = 3;

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -24,6 +24,7 @@ service MobilecoindAPI {
 
     // Utilities
     rpc GenerateEntropy (google.protobuf.Empty) returns (GenerateEntropyResponse) {}
+    rpc GenerateMnemonic (google.protobuf.Empty) returns (GenerateMnemonicResponse) {}
     rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
     rpc GetAccountKeyFromMnemonic (GetAccountKeyFromMnemonicRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
@@ -316,6 +317,13 @@ message GetUnspentTxOutListResponse {
 message GenerateEntropyResponse {
 	  // 32 bytes generated using a cryptographically secure RNG.
     bytes root_entropy = 1;
+}
+
+// Generate a new random mnemomic.
+// - empty request
+message GenerateMnemonicResponse {
+	// mnemonic generated using a cryptographically secure RNG.
+    string mnemonic = 1;
 }
 
 // Generate an AccountKey from a 32 byte root entropy value.

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -335,13 +335,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         Ok(response)
     }
 
-    fn generate_entropy_impl(
+    fn generate_root_entropy_impl(
         &mut self,
         _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GenerateEntropyResponse, RpcStatus> {
+    ) -> Result<mc_mobilecoind_api::GenerateRootEntropyResponse, RpcStatus> {
         let mut rng = rand::thread_rng();
         let root_id = RootIdentity::from_random(&mut rng);
-        let mut response = mc_mobilecoind_api::GenerateEntropyResponse::new();
+        let mut response = mc_mobilecoind_api::GenerateRootEntropyResponse::new();
         response.set_root_entropy(root_id.root_entropy.as_ref().to_vec());
         Ok(response)
     }
@@ -901,7 +901,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         request: mc_mobilecoind_api::GenerateTransferCodeTxRequest,
     ) -> Result<mc_mobilecoind_api::GenerateTransferCodeTxResponse, RpcStatus> {
         // Generate entropy.
-        let entropy_response = self.generate_entropy_impl(mc_mobilecoind_api::Empty::new())?;
+        let entropy_response = self.generate_root_entropy_impl(mc_mobilecoind_api::Empty::new())?;
         let entropy = entropy_response.get_root_entropy().to_vec();
 
         let mut entropy_bytes = [0; 32];
@@ -1825,7 +1825,7 @@ build_api! {
     get_unspent_tx_out_list GetUnspentTxOutListRequest GetUnspentTxOutListResponse get_unspent_tx_out_list_impl,
 
     // Utilities
-    generate_entropy Empty GenerateEntropyResponse generate_entropy_impl,
+    generate_root_entropy Empty GenerateRootEntropyResponse generate_root_entropy_impl,
     generate_mnemonic Empty GenerateMnemonicResponse generate_mnemonic_impl,
     get_account_key_from_root_entropy GetAccountKeyFromRootEntropyRequest GetAccountKeyResponse get_account_key_from_root_entropy_impl,
     get_account_key_from_mnemonic GetAccountKeyFromMnemonicRequest GetAccountKeyResponse get_account_key_from_mnemonic_impl,
@@ -2227,7 +2227,7 @@ mod test {
 
         // call get entropy
         let response = client
-            .generate_entropy(&mc_mobilecoind_api::Empty::default())
+            .generate_root_entropy(&mc_mobilecoind_api::Empty::default())
             .unwrap();
         let entropy = response.get_root_entropy().to_vec();
         assert_eq!(entropy.len(), 32);


### PR DESCRIPTION
### Motivation

We're moving away from root entropy and into using a string mnemonic and we'd like `mobilecoind` (and `mobilecoind-json`) to reflect this change.

### In this PR
* Update the `mobilecoind` and `mobilecoind-json` APIs to support generating a string mnemonic and deriving an `AccountKey` from it.

### Future Work
* Transfer codes ("gift codes") need to be migrated into using the new bip39 entropy.

