### PR TITLE
build mc-slam and mc-crypto-x509-test-vectors as part of local network script

### DIFF
--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -410,7 +410,7 @@ class Network:
             )
 
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-slam -p mc-crypto-x509-test-vectors {CARGO_FLAGS}',
             shell=True,
             check=True,
         )


### PR DESCRIPTION
### Motivation

The fog local network script is currently broken and this is part of the fix for it.

### In this PR
* Change the local network python script to build two utilities that are useful for local testing.
