### PR TITLE
Fix trival format error build issue on native Windows builds.

### DIFF
--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -37,7 +37,7 @@ fn env_var_exists(name: &str) -> &'static str {
     match env::var(name) {
         Ok(_) => "true",
         Err(env::VarError::NotPresent) => "false",
-        Err(e) => panic!(e),
+        Err(e) => panic!("{}", e),
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure why, but when attempting to build the mc-util-build-info
crate natively on Windows, I hit this error:

```
error: panic message is not a string literal
  --> util\build\info\build.rs:40:26
   |
40 |         Err(e) => panic!(e),
   |                          ^
   |
   = note: `-D non-fmt-panic` implied by `-D warnings`
   = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
   |
40 |         Err(e) => panic!("{}", e),
   |                          ^^^^^
help: or use std::panic::panic_any instead
   |
40 |         Err(e) => std::panic::panic_any(e),
   |                   ^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

error: could not compile `mc-util-build-info`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed

C:\Users\isis\source\repos\mobilecoin>
```

This change fixes it in a way that is forwards-compatible with Rust Edition 2021.
