### PR TITLE
LMDB -> Lmdb (since a newer rust version complains about the LMDB enum variant)

### DIFF
--- a/mobilecoind/src/error.rs
+++ b/mobilecoind/src/error.rs
@@ -17,7 +17,7 @@ use retry::Error as RetryError;
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "Failure with LMDB: {}", _0)]
-    LMDB(LmdbError),
+    Lmdb(LmdbError),
 
     #[fail(display = "Failure with LedgerDB: {}", _0)]
     LedgerDB(LedgerDbError),
@@ -127,7 +127,7 @@ impl From<RetryError<ConnectionError>> for Error {
 
 impl From<LmdbError> for Error {
     fn from(e: LmdbError) -> Self {
-        Self::LMDB(e)
+        Self::Lmdb(e)
     }
 }
 

--- a/mobilecoind/src/monitor_store.rs
+++ b/mobilecoind/src/monitor_store.rs
@@ -228,7 +228,7 @@ impl MonitorStore {
                 Ok(data)
             }
             Err(lmdb::Error::NotFound) => Err(Error::MonitorIdNotFound),
-            Err(err) => Err(Error::LMDB(err)),
+            Err(err) => Err(Error::Lmdb(err)),
         }
     }
 
@@ -293,7 +293,7 @@ impl MonitorStore {
                 Ok(())
             }
             Err(lmdb::Error::NotFound) => Err(Error::MonitorIdNotFound),
-            Err(err) => Err(Error::LMDB(err)),
+            Err(err) => Err(Error::Lmdb(err)),
         }
     }
 

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -249,7 +249,7 @@ impl UtxoStore {
                     Ok(())
                 }
                 Err(lmdb::Error::NotFound) => Ok(()),
-                Err(err) => Err(Error::LMDB(err)),
+                Err(err) => Err(Error::Lmdb(err)),
             }?;
         }
 


### PR DESCRIPTION
### Motivation
A newer version of `clippy` is going to complain about `Error::LMDB`, saying that it should be `Lmdb`. In an attempt to reduce the number of changes needed when we upgrade rust, I PRing the backwards-compatible ones in advance.

### In this PR
* Search and replace `LMDB` with `Lmdb`

### Future Work
* Do the same in other repos.

