### PR TITLE
impl From instead of Into, misc small fixes

### DIFF
--- a/account-keys/slip10/src/lib.rs
+++ b/account-keys/slip10/src/lib.rs
@@ -42,18 +42,18 @@ impl AsRef<[u8]> for Slip10Key {
 /// Create the view and spend private keys, and return them in reverse order,
 /// e.g. `(spend, view)`, to match
 /// [`AccountKey::new()`](mc_account_key::AccountKey::new)
-impl Into<(RistrettoPrivate, RistrettoPrivate)> for Slip10Key {
-    fn into(self) -> (RistrettoPrivate, RistrettoPrivate) {
+impl From<Slip10Key> for (RistrettoPrivate, RistrettoPrivate) {
+    fn from(src: Slip10Key) -> (RistrettoPrivate, RistrettoPrivate) {
         let mut okm = [0u8; 64];
 
-        let view_kdf = Hkdf::<Sha512>::new(Some(b"mobilecoin-ristretto255-view"), self.as_ref());
+        let view_kdf = Hkdf::<Sha512>::new(Some(b"mobilecoin-ristretto255-view"), src.as_ref());
         view_kdf
             .expand(b"", &mut okm)
             .expect("Invalid okm length when creating private view key");
         let view_scalar = Scalar::from_bytes_mod_order_wide(&okm);
         let view_private_key = RistrettoPrivate::from(view_scalar);
 
-        let spend_kdf = Hkdf::<Sha512>::new(Some(b"mobilecoin-ristretto255-spend"), self.as_ref());
+        let spend_kdf = Hkdf::<Sha512>::new(Some(b"mobilecoin-ristretto255-spend"), src.as_ref());
         spend_kdf
             .expand(b"", &mut okm)
             .expect("Invalid okm length when creating private spend key");

--- a/attest/ake/src/event.rs
+++ b/attest/ake/src/event.rs
@@ -123,16 +123,16 @@ where
     }
 }
 
-impl<Handshake, KexAlgo, Cipher, DigestType> Into<Vec<u8>>
-    for AuthRequestOutput<Handshake, KexAlgo, Cipher, DigestType>
+impl<Handshake, KexAlgo, Cipher, DigestType>
+    From<AuthRequestOutput<Handshake, KexAlgo, Cipher, DigestType>> for Vec<u8>
 where
     Handshake: HandshakePattern,
     KexAlgo: Kex,
     Cipher: AeadMut + NewAead + NoiseCipher + Sized,
     DigestType: BlockInput + Clone + Default + FixedOutput + Update + Reset,
 {
-    fn into(self) -> Vec<u8> {
-        self.data
+    fn from(src: AuthRequestOutput<Handshake, KexAlgo, Cipher, DigestType>) -> Vec<u8> {
+        src.data
     }
 }
 
@@ -274,9 +274,9 @@ impl AsRef<[u8]> for AuthResponseOutput {
     }
 }
 
-impl Into<Vec<u8>> for AuthResponseOutput {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<AuthResponseOutput> for Vec<u8> {
+    fn from(src: AuthResponseOutput) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -304,9 +304,9 @@ impl AsRef<[u8]> for AuthResponseInput {
     }
 }
 
-impl Into<Vec<u8>> for AuthResponseInput {
-    fn into(self) -> Vec<u8> {
-        self.data
+impl From<AuthResponseInput> for Vec<u8> {
+    fn from(src: AuthResponseInput) -> Vec<u8> {
+        src.data
     }
 }
 

--- a/attest/api/src/conversions.rs
+++ b/attest/api/src/conversions.rs
@@ -28,16 +28,16 @@ where
     }
 }
 
-impl Into<AuthResponseOutput> for AuthMessage {
-    fn into(self) -> AuthResponseOutput {
-        let mut taken_self = self;
+impl From<AuthMessage> for AuthResponseOutput {
+    fn from(src: AuthMessage) -> AuthResponseOutput {
+        let mut taken_self = src;
         AuthResponseOutput::from(taken_self.take_data())
     }
 }
 
-impl Into<PeerAuthRequest> for AuthMessage {
-    fn into(self) -> PeerAuthRequest {
-        self.data.into()
+impl From<AuthMessage> for PeerAuthRequest {
+    fn from(src: AuthMessage) -> PeerAuthRequest {
+        src.data.into()
     }
 }
 
@@ -49,9 +49,9 @@ impl From<PeerAuthRequest> for AuthMessage {
     }
 }
 
-impl Into<ClientAuthRequest> for AuthMessage {
-    fn into(self) -> ClientAuthRequest {
-        self.data.into()
+impl From<AuthMessage> for ClientAuthRequest {
+    fn from(src: AuthMessage) -> ClientAuthRequest {
+        src.data.into()
     }
 }
 
@@ -63,9 +63,9 @@ impl From<ClientAuthRequest> for AuthMessage {
     }
 }
 
-impl Into<PeerAuthResponse> for AuthMessage {
-    fn into(self) -> PeerAuthResponse {
-        self.data.into()
+impl From<AuthMessage> for PeerAuthResponse {
+    fn from(src: AuthMessage) -> PeerAuthResponse {
+        src.data.into()
     }
 }
 
@@ -77,9 +77,9 @@ impl From<PeerAuthResponse> for AuthMessage {
     }
 }
 
-impl Into<ClientAuthResponse> for AuthMessage {
-    fn into(self) -> ClientAuthResponse {
-        self.data.into()
+impl From<AuthMessage> for ClientAuthResponse {
+    fn from(src: AuthMessage) -> ClientAuthResponse {
+        src.data.into()
     }
 }
 
@@ -91,12 +91,12 @@ impl From<ClientAuthResponse> for AuthMessage {
     }
 }
 
-impl<S: Session> Into<EnclaveMessage<S>> for Message {
-    fn into(self) -> EnclaveMessage<S> {
+impl<S: Session> From<Message> for EnclaveMessage<S> {
+    fn from(src: Message) -> EnclaveMessage<S> {
         EnclaveMessage {
-            aad: self.aad,
-            channel_id: S::from(&self.channel_id),
-            data: self.data,
+            aad: src.aad,
+            channel_id: S::from(&src.channel_id),
+            data: src.data,
         }
     }
 }

--- a/attest/core/src/error.rs
+++ b/attest/core/src/error.rs
@@ -582,9 +582,9 @@ impl Hash for SgxError {
     }
 }
 
-impl Into<sgx_status_t> for SgxError {
-    fn into(self) -> sgx_status_t {
-        self.0
+impl From<SgxError> for sgx_status_t {
+    fn from(src: SgxError) -> sgx_status_t {
+        src.0
     }
 }
 

--- a/attest/core/src/ias/verifier.rs
+++ b/attest/core/src/ias/verifier.rs
@@ -479,8 +479,7 @@ impl IasReportVerifier {
             })
             // Then construct a set of chains, one for each signer certificate
             .filter_map(|cert| {
-                let mut signer_chain: Vec<Certificate> = Vec::new();
-                signer_chain.push(cert);
+                let mut signer_chain: Vec<Certificate> = vec![cert];
                 'outer: loop {
                     // Exclude any signing changes greater than our max depth
                     if signer_chain.len() > MAX_CHAIN_DEPTH {
@@ -1773,7 +1772,7 @@ mod test {
         let quote =
             Quote::from_base64(BASE64_QUOTE).expect("Could not parse quote from base64 file");
         let verifier = BasenameVerifier {
-            basename: Basename::from(quote.basename().expect("Could not read basename")),
+            basename: quote.basename().expect("Could not read basename"),
         };
 
         assert!(verifier.verify(&quote));
@@ -1823,9 +1822,7 @@ mod test {
         let quote =
             Quote::from_base64(BASE64_QUOTE).expect("Could not parse quote from base64 file");
         let verifier = EpidGroupIdVerifier {
-            epid_group_id: EpidGroupId::from(
-                quote.epid_group_id().expect("Could not read EPID Group ID"),
-            ),
+            epid_group_id: quote.epid_group_id().expect("Could not read EPID Group ID"),
         };
 
         assert!(verifier.verify(&quote));
@@ -1997,7 +1994,7 @@ mod test {
     #[test]
     fn attributes_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut attributes = REPORT_BODY_SRC.attributes.clone();
+        let mut attributes = REPORT_BODY_SRC.attributes;
         attributes.flags = 0;
         let verifier = AttributesVerifier {
             attributes: Attributes::from(attributes),
@@ -2021,7 +2018,7 @@ mod test {
     #[test]
     fn config_id_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut config_id = REPORT_BODY_SRC.config_id.clone();
+        let mut config_id = REPORT_BODY_SRC.config_id;
         config_id[0] = 0;
         let verifier = ConfigIdVerifier {
             config_id: ConfigId::from(config_id),
@@ -2078,7 +2075,7 @@ mod test {
     #[test]
     fn cpu_svn_newer_pass() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut cpu_svn = REPORT_BODY_SRC.cpu_svn.clone();
+        let mut cpu_svn = REPORT_BODY_SRC.cpu_svn;
         cpu_svn.svn[0] = 0;
         let verifier = CpuVersionVerifier {
             cpu_svn: CpuSecurityVersion::from(cpu_svn),
@@ -2091,7 +2088,7 @@ mod test {
     #[test]
     fn cpu_svn_older_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut cpu_svn = REPORT_BODY_SRC.cpu_svn.clone();
+        let mut cpu_svn = REPORT_BODY_SRC.cpu_svn;
         cpu_svn.svn[0] = 0xff;
         let verifier = CpuVersionVerifier {
             cpu_svn: CpuSecurityVersion::from(cpu_svn),
@@ -2121,7 +2118,7 @@ mod test {
     /// Allow debug off means debug enclaves fail
     #[test]
     fn no_debug_fail() {
-        let mut report_body = REPORT_BODY_SRC.clone();
+        let mut report_body = REPORT_BODY_SRC;
         report_body.attributes.flags |= SGX_FLAGS_DEBUG;
         let report_body = ReportBody::from(report_body);
         let verifier = DebugVerifier { allow_debug: false };
@@ -2145,7 +2142,7 @@ mod test {
     #[test]
     fn data_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut data = REPORT_BODY_SRC.report_data.d.clone();
+        let mut data = REPORT_BODY_SRC.report_data.d;
         data[0] = 0;
         let verifier = DataVerifier {
             data: ReportDataMask::new_with_mask(&data, &ONES[..])
@@ -2170,7 +2167,7 @@ mod test {
     #[test]
     fn ext_prod_id_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut ext_prod_id = REPORT_BODY_SRC.isv_ext_prod_id.clone();
+        let mut ext_prod_id = REPORT_BODY_SRC.isv_ext_prod_id;
         ext_prod_id[0] = 0;
         let verifier = ExtendedProductIdVerifier {
             ext_prod_id: ExtendedProductId::from(ext_prod_id),
@@ -2194,7 +2191,7 @@ mod test {
     #[test]
     fn family_id_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
-        let mut family_id = REPORT_BODY_SRC.isv_family_id.clone();
+        let mut family_id = REPORT_BODY_SRC.isv_family_id;
         family_id[0] = 0;
         let verifier = FamilyIdVerifier {
             family_id: FamilyId::from(family_id),
@@ -2208,7 +2205,7 @@ mod test {
     fn misc_select_success() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
         let verifier = MiscSelectVerifier {
-            misc_select: MiscSelect::from(REPORT_BODY_SRC.misc_select),
+            misc_select: REPORT_BODY_SRC.misc_select,
         };
 
         assert!(verifier.verify(&report_body));
@@ -2219,7 +2216,7 @@ mod test {
     fn misc_select_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
         let verifier = MiscSelectVerifier {
-            misc_select: MiscSelect::from(REPORT_BODY_SRC.misc_select - 1),
+            misc_select: REPORT_BODY_SRC.misc_select - 1,
         };
 
         assert!(!verifier.verify(&report_body));
@@ -2230,7 +2227,7 @@ mod test {
     fn product_id_success() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
         let verifier = ProductIdVerifier {
-            product_id: ProductId::from(REPORT_BODY_SRC.isv_prod_id),
+            product_id: REPORT_BODY_SRC.isv_prod_id,
         };
 
         assert!(verifier.verify(&report_body));
@@ -2241,7 +2238,7 @@ mod test {
     fn product_id_fail() {
         let report_body = ReportBody::from(&REPORT_BODY_SRC);
         let verifier = ProductIdVerifier {
-            product_id: ProductId::from(REPORT_BODY_SRC.isv_prod_id - 1),
+            product_id: REPORT_BODY_SRC.isv_prod_id - 1,
         };
 
         assert!(!verifier.verify(&report_body));

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -478,9 +478,9 @@ impl AsRef<[u8]> for VerificationSignature {
     }
 }
 
-impl Into<Vec<u8>> for VerificationSignature {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<VerificationSignature> for Vec<u8> {
+    fn from(src: VerificationSignature) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -690,8 +690,7 @@ impl VerificationReport {
             })
             // Then construct a set of chains, one for each signer certificate
             .filter_map(|cert| {
-                let mut signer_chain: Vec<Certificate> = Vec::new();
-                signer_chain.push(cert);
+                let mut signer_chain: Vec<Certificate> = vec![cert];
                 'outer: loop {
                     // Exclude any signing changes greater than our max depth
                     if signer_chain.len() > MAX_CHAIN_DEPTH {

--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -102,9 +102,9 @@ impl From<sgx_quote_sign_type_t> for QuoteSignType {
     }
 }
 
-impl Into<sgx_quote_sign_type_t> for QuoteSignType {
-    fn into(self) -> sgx_quote_sign_type_t {
-        match self {
+impl From<QuoteSignType> for sgx_quote_sign_type_t {
+    fn from(src: QuoteSignType) -> sgx_quote_sign_type_t {
+        match src {
             QuoteSignType::Unlinkable => sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
             QuoteSignType::Linkable => sgx_quote_sign_type_t::SGX_LINKABLE_SIGNATURE,
         }

--- a/attest/core/src/seal.rs
+++ b/attest/core/src/seal.rs
@@ -92,8 +92,8 @@ macro_rules! impl_sealed_traits {
                 <Self as ::mc_attest_core::Sealed>::as_bytes(self)
             }
         }
-        impl Into<::alloc::vec::Vec<u8>> for $sealed {
-            fn into(self) -> ::alloc::vec::Vec<u8> {
+        impl From<$sealed> for ::alloc::vec::Vec<u8> {
+            fn from(src: $sealed) -> ::alloc::vec::Vec<u8> {
                 <Self as ::mc_attest_core::Sealed>::to_bytes(self)
             }
         }
@@ -133,9 +133,9 @@ impl AsRef<[u8]> for IntelSealed {
     }
 }
 
-impl Into<Vec<u8>> for IntelSealed {
-    fn into(self) -> Vec<u8> {
-        self.payload
+impl From<IntelSealed> for Vec<u8> {
+    fn from(src: IntelSealed) -> Vec<u8> {
+        src.payload
     }
 }
 

--- a/attest/core/src/traits.rs
+++ b/attest/core/src/traits.rs
@@ -206,9 +206,9 @@ macro_rules! impl_sgx_wrapper_reqs {
             }
         }
 
-        impl Into<$inner> for $wrapper {
-            fn into(self) -> $inner {
-                self.0
+        impl From<$wrapper> for $inner {
+            fn from(src: $wrapper) -> $inner {
+                src.0
             }
         }
 

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -27,9 +27,9 @@ impl From<Vec<u8>> for ClientAuthRequest {
     }
 }
 
-impl Into<Vec<u8>> for ClientAuthRequest {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<ClientAuthRequest> for Vec<u8> {
+    fn from(src: ClientAuthRequest) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -38,9 +38,9 @@ impl Into<Vec<u8>> for ClientAuthRequest {
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ClientAuthResponse(Vec<u8>);
 
-impl Into<Vec<u8>> for ClientAuthResponse {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<ClientAuthResponse> for Vec<u8> {
+    fn from(src: ClientAuthResponse) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -61,9 +61,9 @@ impl From<Vec<u8>> for PeerAuthRequest {
     }
 }
 
-impl Into<Vec<u8>> for PeerAuthRequest {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<PeerAuthRequest> for Vec<u8> {
+    fn from(src: PeerAuthRequest) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -72,9 +72,9 @@ impl Into<Vec<u8>> for PeerAuthRequest {
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct PeerAuthResponse(Vec<u8>);
 
-impl Into<Vec<u8>> for PeerAuthResponse {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<PeerAuthResponse> for Vec<u8> {
+    fn from(src: PeerAuthResponse) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -134,9 +134,9 @@ impl From<Vec<u8>> for ClientSession {
     }
 }
 
-impl Into<Vec<u8>> for ClientSession {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<ClientSession> for Vec<u8> {
+    fn from(src: ClientSession) -> Vec<u8> {
+        src.0
     }
 }
 
@@ -167,9 +167,9 @@ impl From<Vec<u8>> for PeerSession {
     }
 }
 
-impl Into<Vec<u8>> for PeerSession {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<PeerSession> for Vec<u8> {
+    fn from(src: PeerSession) -> Vec<u8> {
+        src.0
     }
 }
 

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -331,8 +331,8 @@ mod tests {
         let node_id = test_node_id(1);
         let quorum_set = QuorumSet::new_with_node_ids(1, vec![test_node_id(2)]);
         Node::<&'static str, TransactionValidationError>::new(
-            node_id.clone(),
-            quorum_set.clone(),
+            node_id,
+            quorum_set,
             Arc::new(trivial_validity_fn),
             Arc::new(trivial_combine_fn),
             slot_index,

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -115,15 +115,15 @@ impl From<ConsensusGrpcError> for RpcStatus {
 
 /// Convert a `ConsensusGrpcError` into either `ProposeTxResponse` or
 /// `RpcStatus`, depending on which error it holds.
-impl Into<Result<ProposeTxResponse, RpcStatus>> for ConsensusGrpcError {
-    fn into(self) -> Result<ProposeTxResponse, RpcStatus> {
-        match self {
-            Self::TransactionValidation(err) => {
+impl From<ConsensusGrpcError> for Result<ProposeTxResponse, RpcStatus> {
+    fn from(src: ConsensusGrpcError) -> Result<ProposeTxResponse, RpcStatus> {
+        match src {
+            ConsensusGrpcError::TransactionValidation(err) => {
                 let mut resp = ProposeTxResponse::new();
                 resp.set_result(ProposeTxResult::from(err));
                 Ok(resp)
             }
-            _ => Err(RpcStatus::from(self)),
+            _ => Err(RpcStatus::from(src)),
         }
     }
 }

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -102,10 +102,10 @@ impl PeerApiService {
     ) -> Self {
         Self {
             consensus_enclave,
-            ledger,
             tx_manager,
             incoming_consensus_msgs_sender,
             scp_client_value_sender,
+            ledger,
             fetch_latest_msg_fn,
             known_responder_ids,
             logger,

--- a/crypto/digestible/derive/test/tests/behavior.rs
+++ b/crypto/digestible/derive/test/tests/behavior.rs
@@ -221,7 +221,7 @@ fn tricky_struct() {
                 type_name: b"str",
                 data: b"var".to_vec(),
             }),
-            expected_var_ast.clone(),
+            expected_var_ast,
         ],
         is_completed: true,
     });

--- a/crypto/digestible/test-utils/tests/sanity.rs
+++ b/crypto/digestible/test-utils/tests/sanity.rs
@@ -97,7 +97,7 @@ fn digest_sequence_append_bytes() {
     let seq3 = ASTNode::from(ASTSequence {
         context: b"list3",
         len: 2,
-        elems: vec![prim1.clone(), prim2.clone()],
+        elems: vec![prim1, prim2],
     });
 
     ast_test_case(
@@ -203,7 +203,7 @@ fn digest_variant_append_bytes() {
         context: b"enum",
         name: b"enum_type".to_vec(),
         which: 0,
-        value: Some(Box::new(prim1.clone())),
+        value: Some(Box::new(prim1)),
     });
 
     ast_test_case(
@@ -221,7 +221,7 @@ fn digest_variant_append_bytes() {
         context: b"enum",
         name: b"enum_type".to_vec(),
         which: 1,
-        value: Some(Box::new(prim2.clone())),
+        value: Some(Box::new(prim2)),
     });
 
     ast_test_case(

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -538,9 +538,9 @@ impl<'de> Deserialize<'de> for X25519Private {
 /// let keyout: Vec<u8> = privkey.into();
 /// assert_eq!(&key as &[u8], keyout.as_slice());
 /// ```
-impl Into<Vec<u8>> for X25519Private {
-    fn into(self) -> Vec<u8> {
-        self.0.to_bytes().to_vec()
+impl From<X25519Private> for Vec<u8> {
+    fn from(src: X25519Private) -> Vec<u8> {
+        src.0.to_bytes().to_vec()
     }
 }
 

--- a/crypto/noise/src/handshake_hash.rs
+++ b/crypto/noise/src/handshake_hash.rs
@@ -111,9 +111,9 @@ where
 }
 
 /// A HandshakeHash may be consumed to reveal the result.
-impl<DigestType: Default + FixedOutput + Update> Into<Vec<u8>> for HandshakeHash<DigestType> {
-    fn into(self) -> Vec<u8> {
-        self.hash.expose_secret().clone()
+impl<DigestType: Default + FixedOutput + Update> From<HandshakeHash<DigestType>> for Vec<u8> {
+    fn from(src: HandshakeHash<DigestType>) -> Vec<u8> {
+        src.hash.expose_secret().clone()
     }
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,4 +4,5 @@ merge_imports = true
 
 ignore = [
     "sgx/types",   # copy-pasta from rust-sgx-sdk
+    "sgx/urts",    # came from Baidu
 ]

--- a/sgx/core-types/src/_macros.rs
+++ b/sgx/core-types/src/_macros.rs
@@ -82,9 +82,9 @@ macro_rules! impl_ffi_wrapper_base {
             }
         }
 
-        impl Into<$inner> for $wrapper {
-            fn into(self) -> $inner {
-                self.0
+        impl From<$wrapper> for $inner {
+            fn from(src: $wrapper) -> $inner {
+                src.0
             }
         }
     )*}

--- a/sgx/core-types/src/misc_attribute.rs
+++ b/sgx/core-types/src/misc_attribute.rs
@@ -154,9 +154,10 @@ impl ReprBytes for MiscAttribute {
     type Error = EncodingError;
 
     fn from_bytes(src: &GenericArray<u8, Self::Size>) -> Result<Self, Self::Error> {
-        let mut inner = sgx_misc_attribute_t::default();
-        inner.secs_attr = Attributes::try_from(&src[ATTRIBUTES_START..ATTRIBUTES_END])?.into();
-        inner.misc_select = u32::from_le_bytes(src[SELECT_START..SELECT_END].try_into()?);
+        let inner = sgx_misc_attribute_t {
+            secs_attr: Attributes::try_from(&src[ATTRIBUTES_START..ATTRIBUTES_END])?.into(),
+            misc_select: u32::from_le_bytes(src[SELECT_START..SELECT_END].try_into()?),
+        };
         Ok(Self(inner))
     }
 

--- a/sgx/css-dump/rustfmt.toml
+++ b/sgx/css-dump/rustfmt.toml
@@ -1,3 +1,0 @@
-edition = "2018"
-merge_imports = true
-wrap_comments = true

--- a/sgx/sync/src/condvar.rs
+++ b/sgx/sync/src/condvar.rs
@@ -4,14 +4,15 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//  * Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//  * Neither the name of Baidu, Inc., nor the names of its contributors may be
-//    used to endorse or promote products derived from this software without
-//    specific prior written permission.
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the
+//    distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -26,16 +27,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //!
-//! The Intel(R) Software Guard Extensions SDK already supports mutex and
-//! conditional variable synchronization mechanisms by means of the following
-//! API and data types defined in the Types and Enumerations section. Some
-//! functions included in the trusted Thread Synchronization library may make
-//! calls outside the enclave (OCALLs). If you use any of the APIs below, you
-//! must first import the needed OCALL functions from sgx_tstdc.edl. Otherwise,
-//! you will get a linker error when the enclave is being built; see Calling
-//! Functions outside the Enclave for additional details. The table below
-//! illustrates the primitives that the Intel(R) SGX Thread Synchronization
-//! library supports, as well as the OCALLs that each API function needs.
+//! The Intel(R) Software Guard Extensions SDK already supports mutex and conditional
+//! variable synchronization mechanisms by means of the following APIand data types
+//! defined in the Types and Enumerations section. Some functions included in the
+//! trusted Thread Synchronization library may make calls outside the enclave (OCALLs).
+//! If you use any of the APIs below, you must first import the needed OCALL functions
+//! from sgx_tstdc.edl. Otherwise, you will get a linker error when the enclave is
+//! being built; see Calling Functions outside the Enclave for additional details.
+//! The table below illustrates the primitives that the Intel(R) SGX Thread
+//! Synchronization library supports, as well as the OCALLs that each API function needs.
+//!
 use super::{
     mutex::{self, SgxMutexGuard, SgxThreadMutex},
     poison::{LockResult, PoisonError},
@@ -116,23 +117,20 @@ unsafe impl Sync for SgxThreadCondvar {}
 
 impl SgxThreadCondvar {
     ///
-    /// The function initializes a trusted condition variable within the
-    /// enclave.
+    /// The function initializes a trusted condition variable within the enclave.
     ///
     /// # Description
     ///
-    /// When a thread creates a condition variable within an enclave, it simply
-    /// initializes the various fields of the object to indicate that the
-    /// condition variable is available. The results of using a condition
-    /// variable in a wait, signal or broadcast operation before it has been
-    /// fully initialized are undefined. To avoid race conditions in the
-    /// initialization of a condition variable, it is recommended statically
-    /// initializing the condition variable with the macro
-    /// SGX_THREAD_COND_INITIALIZER.
+    /// When a thread creates a condition variable within an enclave, it simply initializes the various
+    /// fields of the object to indicate that the condition variable is available. The results of using
+    /// a condition variable in a wait, signal or broadcast operation before it has been fully initialized
+    /// are undefined. To avoid race conditions in the initialization of a condition variable, it is
+    /// recommended statically initializing the condition variable with the macro SGX_THREAD_COND_INITIALIZER.
     ///
     /// # Requirements
     ///
     /// Library: libsgx_tstdc.a
+    ///
     pub const fn new() -> Self {
         SgxThreadCondvar {
             cond: UnsafeCell::new(mc_sgx_types::SGX_THREAD_COND_INITIALIZER),
@@ -144,27 +142,23 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// A condition variable is always used in conjunction with a mutex. To wait
-    /// on a condition variable, a thread first needs to acquire the
-    /// condition variable spin lock. After the spin lock is acquired, the
-    /// thread updates the condition variable waiting queue. To avoid the
-    /// lost wake-up signal problem, the condition variable spin lock is
-    /// released after the mutex. This order ensures the function atomically
-    /// releases the mutex and causes the calling thread to block on the
-    /// condition variable, with respect to other threads accessing the
-    /// mutex and the condition variable. After releasing the condition
-    /// variable spin lock, the thread makes an OCALL to get suspended. When
-    /// the thread is awakened, it acquires the condition variable
-    /// spin lock. The thread then searches the condition variable queue. If the
-    /// thread is in the queue, it means that the thread was already waiting
-    /// on the condition variable outside the enclave, and it has been
-    /// awakened unexpectedly. When this happens, the thread releases the
-    /// condition variable spin lock, makes an OCALL and simply goes back to
-    /// sleep. Otherwise, another thread has signaled or broadcasted
-    /// the condition variable and this thread may proceed. Before returning,
-    /// the thread releases the condition variable spin lock and acquires
-    /// the mutex, ensuring that upon returning from the function call the
-    /// thread still owns the mutex.
+    /// A condition variable is always used in conjunction with a mutex. To wait on a
+    /// condition variable, a thread first needs to acquire the condition variable spin
+    /// lock. After the spin lock is acquired, the thread updates the condition variable
+    /// waiting queue. To avoid the lost wake-up signal problem, the condition variable
+    /// spin lock is released after the mutex. This order ensures the function atomically
+    /// releases the mutex and causes the calling thread to block on the condition variable,
+    /// with respect to other threads accessing the mutex and the condition variable.
+    /// After releasing the condition variable spin lock, the thread makes an OCALL to
+    /// get suspended. When the thread is awakened, it acquires the condition variable
+    /// spin lock. The thread then searches the condition variable queue. If the thread
+    /// is in the queue, it means that the thread was already waiting on the condition
+    /// variable outside the enclave, and it has been awakened unexpectedly. When this
+    /// happens, the thread releases the condition variable spin lock, makes an OCALL
+    /// and simply goes back to sleep. Otherwise, another thread has signaled or broadcasted
+    /// the condition variable and this thread may proceed. Before returning, the thread
+    /// releases the condition variable spin lock and acquires the mutex, ensuring that
+    /// upon returning from the function call the thread still owns the mutex.
     ///
     /// # Requirements
     ///
@@ -174,19 +168,18 @@ impl SgxThreadCondvar {
     ///
     /// **mutex**
     ///
-    /// The trusted mutex object that will be unlocked when the thread is
-    /// blocked inthe condition variable
+    /// The trusted mutex object that will be unlocked when the thread is blocked inthe condition variable
     ///
     /// # Errors
     ///
     /// **EINVAL**
     ///
-    /// The trusted condition variable or mutex object is invalid or the mutex
-    /// is not locked.
+    /// The trusted condition variable or mutex object is invalid or the mutex is not locked.
     ///
     /// **EPERM**
     ///
     /// The trusted mutex is locked by another thread.
+    ///
     #[inline]
     pub unsafe fn wait(&self, mutex: &SgxThreadMutex) -> SysError {
         rsgx_thread_cond_wait(&mut *self.cond.get(), mutex.get_raw())
@@ -197,16 +190,14 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// To signal a condition variable, a thread starts acquiring the condition
-    /// variable spin-lock. Then it inspects the status of the condition
-    /// variable queue. If the queue is empty it means that there are not
-    /// any threads waiting on the condition variable. When that happens,
-    /// the thread releases the condition variable and returns. However, if
-    /// the queue is not empty, the thread removes the first thread waiting
-    /// in the queue. The thread then makes an OCALL to wake up the thread that
-    /// is suspended outside the enclave, but first the thread releases the
-    /// condition variable spin-lock. Upon returning from the OCALL, the
-    /// thread continues normal execution.
+    /// To signal a condition variable, a thread starts acquiring the condition variable
+    /// spin-lock. Then it inspects the status of the condition variable queue. If the
+    /// queue is empty it means that there are not any threads waiting on the condition
+    /// variable. When that happens, the thread releases the condition variable and returns.
+    /// However, if the queue is not empty, the thread removes the first thread waiting
+    /// in the queue. The thread then makes an OCALL to wake up the thread that is suspended
+    /// outside the enclave, but first the thread releases the condition variable spin-lock.
+    /// Upon returning from the OCALL, the thread continues normal execution.
     ///
     /// # Requirements
     ///
@@ -217,22 +208,21 @@ impl SgxThreadCondvar {
     /// **EINVAL**
     ///
     /// The trusted condition variable is invalid.
+    ///
     #[inline]
     pub unsafe fn signal(&self) -> SysError {
         rsgx_thread_cond_signal(&mut *self.cond.get())
     }
 
     ///
-    /// The function wakes all pending threads waiting on the condition
-    /// variable.
+    /// The function wakes all pending threads waiting on the condition variable.
     ///
     /// # Description
     ///
-    /// Broadcast and signal operations on a condition variable are analogous.
-    /// The only difference is that during a broadcast operation, the thread
-    /// removes all the threads waiting on the condition variable queue and
-    /// wakes up all the threads suspended outside the enclave in a single
-    /// OCALL.
+    /// Broadcast and signal operations on a condition variable are analogous. The
+    /// only difference is that during a broadcast operation, the thread removes all
+    /// the threads waiting on the condition variable queue and wakes up all the
+    /// threads suspended outside the enclave in a single OCALL.
     ///
     /// # Requirements
     ///
@@ -247,6 +237,7 @@ impl SgxThreadCondvar {
     /// **ENOMEM**
     ///
     /// Internal memory allocation failed.
+    ///
     #[inline]
     pub unsafe fn broadcast(&self) -> SysError {
         rsgx_thread_cond_broadcast(&mut *self.cond.get())
@@ -257,11 +248,10 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// The procedure first confirms that there are no threads waiting on the
-    /// condition variable before it is destroyed. The destroy operation
-    /// acquires the spin lock at the beginning of the operation to prevent
-    /// other threads from signaling to or waiting on the condition
-    /// variable.
+    /// The procedure first confirms that there are no threads waiting on the condition
+    /// variable before it is destroyed. The destroy operation acquires the spin lock at
+    /// the beginning of the operation to prevent other threads from signaling to or
+    /// waiting on the condition variable.
     ///
     /// # Requirements
     ///
@@ -276,6 +266,7 @@ impl SgxThreadCondvar {
     /// **EBUSY**
     ///
     /// The condition variable has pending threads waiting on it.
+    ///
     #[inline]
     pub unsafe fn destroy(&self) -> SysError {
         rsgx_thread_cond_destroy(&mut *self.cond.get())
@@ -304,6 +295,7 @@ impl SgxThreadCondvar {
 /// attempt to use multiple mutexes on the same condition variable will result
 /// in a runtime panic. If this is not desired, then the unsafe primitives in
 /// `sys` do not have this restriction but may result in undefined behavior.
+///
 pub struct SgxCondvar {
     inner: Box<SgxThreadCondvar>,
     mutex: AtomicUsize,
@@ -311,8 +303,8 @@ pub struct SgxCondvar {
 
 impl SgxCondvar {
     ///
-    /// Creates a new condition variable which is ready to be waited on and
-    /// notified.
+    /// Creates a new condition variable which is ready to be waited on and notified.
+    ///
     pub fn new() -> Self {
         SgxCondvar {
             inner: Box::new(SgxThreadCondvar::new()),
@@ -376,6 +368,7 @@ impl SgxCondvar {
     /// This function will return an error if the mutex being waited on is
     /// poisoned when this thread re-acquires the lock. For more information,
     /// see information about [poisoning] on the [`Mutex`] type.
+    ///
     pub fn wait_until<'a, T, F>(
         &self,
         mut guard: SgxMutexGuard<'a, T>,
@@ -393,8 +386,8 @@ impl SgxCondvar {
     /// Wakes up one blocked thread on this condvar.
     ///
     /// If there is a blocked thread on this condition variable, then it will
-    /// be woken up from its call to [`wait`]. Calls to `signal` are not
-    /// buffered in any way.
+    /// be woken up from its call to [`wait`]. Calls to `signal` are not buffered
+    /// in any way.
     ///
     /// To wake up all threads, see [`broadcast`].
     pub fn signal(&self) {

--- a/sgx/sync/src/condvar.rs
+++ b/sgx/sync/src/condvar.rs
@@ -4,15 +4,14 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-//  * Neither the name of Baidu, Inc., nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without
+//    specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -27,16 +26,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //!
-//! The Intel(R) Software Guard Extensions SDK already supports mutex and conditional
-//! variable synchronization mechanisms by means of the following APIand data types
-//! defined in the Types and Enumerations section. Some functions included in the
-//! trusted Thread Synchronization library may make calls outside the enclave (OCALLs).
-//! If you use any of the APIs below, you must first import the needed OCALL functions
-//! from sgx_tstdc.edl. Otherwise, you will get a linker error when the enclave is
-//! being built; see Calling Functions outside the Enclave for additional details.
-//! The table below illustrates the primitives that the Intel(R) SGX Thread
-//! Synchronization library supports, as well as the OCALLs that each API function needs.
-//!
+//! The Intel(R) Software Guard Extensions SDK already supports mutex and
+//! conditional variable synchronization mechanisms by means of the following
+//! API and data types defined in the Types and Enumerations section. Some
+//! functions included in the trusted Thread Synchronization library may make
+//! calls outside the enclave (OCALLs). If you use any of the APIs below, you
+//! must first import the needed OCALL functions from sgx_tstdc.edl. Otherwise,
+//! you will get a linker error when the enclave is being built; see Calling
+//! Functions outside the Enclave for additional details. The table below
+//! illustrates the primitives that the Intel(R) SGX Thread Synchronization
+//! library supports, as well as the OCALLs that each API function needs.
 use super::{
     mutex::{self, SgxMutexGuard, SgxThreadMutex},
     poison::{LockResult, PoisonError},
@@ -117,20 +116,23 @@ unsafe impl Sync for SgxThreadCondvar {}
 
 impl SgxThreadCondvar {
     ///
-    /// The function initializes a trusted condition variable within the enclave.
+    /// The function initializes a trusted condition variable within the
+    /// enclave.
     ///
     /// # Description
     ///
-    /// When a thread creates a condition variable within an enclave, it simply initializes the various
-    /// fields of the object to indicate that the condition variable is available. The results of using
-    /// a condition variable in a wait, signal or broadcast operation before it has been fully initialized
-    /// are undefined. To avoid race conditions in the initialization of a condition variable, it is
-    /// recommended statically initializing the condition variable with the macro SGX_THREAD_COND_INITIALIZER.
+    /// When a thread creates a condition variable within an enclave, it simply
+    /// initializes the various fields of the object to indicate that the
+    /// condition variable is available. The results of using a condition
+    /// variable in a wait, signal or broadcast operation before it has been
+    /// fully initialized are undefined. To avoid race conditions in the
+    /// initialization of a condition variable, it is recommended statically
+    /// initializing the condition variable with the macro
+    /// SGX_THREAD_COND_INITIALIZER.
     ///
     /// # Requirements
     ///
     /// Library: libsgx_tstdc.a
-    ///
     pub const fn new() -> Self {
         SgxThreadCondvar {
             cond: UnsafeCell::new(mc_sgx_types::SGX_THREAD_COND_INITIALIZER),
@@ -142,23 +144,27 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// A condition variable is always used in conjunction with a mutex. To wait on a
-    /// condition variable, a thread first needs to acquire the condition variable spin
-    /// lock. After the spin lock is acquired, the thread updates the condition variable
-    /// waiting queue. To avoid the lost wake-up signal problem, the condition variable
-    /// spin lock is released after the mutex. This order ensures the function atomically
-    /// releases the mutex and causes the calling thread to block on the condition variable,
-    /// with respect to other threads accessing the mutex and the condition variable.
-    /// After releasing the condition variable spin lock, the thread makes an OCALL to
-    /// get suspended. When the thread is awakened, it acquires the condition variable
-    /// spin lock. The thread then searches the condition variable queue. If the thread
-    /// is in the queue, it means that the thread was already waiting on the condition
-    /// variable outside the enclave, and it has been awakened unexpectedly. When this
-    /// happens, the thread releases the condition variable spin lock, makes an OCALL
-    /// and simply goes back to sleep. Otherwise, another thread has signaled or broadcasted
-    /// the condition variable and this thread may proceed. Before returning, the thread
-    /// releases the condition variable spin lock and acquires the mutex, ensuring that
-    /// upon returning from the function call the thread still owns the mutex.
+    /// A condition variable is always used in conjunction with a mutex. To wait
+    /// on a condition variable, a thread first needs to acquire the
+    /// condition variable spin lock. After the spin lock is acquired, the
+    /// thread updates the condition variable waiting queue. To avoid the
+    /// lost wake-up signal problem, the condition variable spin lock is
+    /// released after the mutex. This order ensures the function atomically
+    /// releases the mutex and causes the calling thread to block on the
+    /// condition variable, with respect to other threads accessing the
+    /// mutex and the condition variable. After releasing the condition
+    /// variable spin lock, the thread makes an OCALL to get suspended. When
+    /// the thread is awakened, it acquires the condition variable
+    /// spin lock. The thread then searches the condition variable queue. If the
+    /// thread is in the queue, it means that the thread was already waiting
+    /// on the condition variable outside the enclave, and it has been
+    /// awakened unexpectedly. When this happens, the thread releases the
+    /// condition variable spin lock, makes an OCALL and simply goes back to
+    /// sleep. Otherwise, another thread has signaled or broadcasted
+    /// the condition variable and this thread may proceed. Before returning,
+    /// the thread releases the condition variable spin lock and acquires
+    /// the mutex, ensuring that upon returning from the function call the
+    /// thread still owns the mutex.
     ///
     /// # Requirements
     ///
@@ -168,18 +174,19 @@ impl SgxThreadCondvar {
     ///
     /// **mutex**
     ///
-    /// The trusted mutex object that will be unlocked when the thread is blocked inthe condition variable
+    /// The trusted mutex object that will be unlocked when the thread is
+    /// blocked inthe condition variable
     ///
     /// # Errors
     ///
     /// **EINVAL**
     ///
-    /// The trusted condition variable or mutex object is invalid or the mutex is not locked.
+    /// The trusted condition variable or mutex object is invalid or the mutex
+    /// is not locked.
     ///
     /// **EPERM**
     ///
     /// The trusted mutex is locked by another thread.
-    ///
     #[inline]
     pub unsafe fn wait(&self, mutex: &SgxThreadMutex) -> SysError {
         rsgx_thread_cond_wait(&mut *self.cond.get(), mutex.get_raw())
@@ -190,14 +197,16 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// To signal a condition variable, a thread starts acquiring the condition variable
-    /// spin-lock. Then it inspects the status of the condition variable queue. If the
-    /// queue is empty it means that there are not any threads waiting on the condition
-    /// variable. When that happens, the thread releases the condition variable and returns.
-    /// However, if the queue is not empty, the thread removes the first thread waiting
-    /// in the queue. The thread then makes an OCALL to wake up the thread that is suspended
-    /// outside the enclave, but first the thread releases the condition variable spin-lock.
-    /// Upon returning from the OCALL, the thread continues normal execution.
+    /// To signal a condition variable, a thread starts acquiring the condition
+    /// variable spin-lock. Then it inspects the status of the condition
+    /// variable queue. If the queue is empty it means that there are not
+    /// any threads waiting on the condition variable. When that happens,
+    /// the thread releases the condition variable and returns. However, if
+    /// the queue is not empty, the thread removes the first thread waiting
+    /// in the queue. The thread then makes an OCALL to wake up the thread that
+    /// is suspended outside the enclave, but first the thread releases the
+    /// condition variable spin-lock. Upon returning from the OCALL, the
+    /// thread continues normal execution.
     ///
     /// # Requirements
     ///
@@ -208,21 +217,22 @@ impl SgxThreadCondvar {
     /// **EINVAL**
     ///
     /// The trusted condition variable is invalid.
-    ///
     #[inline]
     pub unsafe fn signal(&self) -> SysError {
         rsgx_thread_cond_signal(&mut *self.cond.get())
     }
 
     ///
-    /// The function wakes all pending threads waiting on the condition variable.
+    /// The function wakes all pending threads waiting on the condition
+    /// variable.
     ///
     /// # Description
     ///
-    /// Broadcast and signal operations on a condition variable are analogous. The
-    /// only difference is that during a broadcast operation, the thread removes all
-    /// the threads waiting on the condition variable queue and wakes up all the
-    /// threads suspended outside the enclave in a single OCALL.
+    /// Broadcast and signal operations on a condition variable are analogous.
+    /// The only difference is that during a broadcast operation, the thread
+    /// removes all the threads waiting on the condition variable queue and
+    /// wakes up all the threads suspended outside the enclave in a single
+    /// OCALL.
     ///
     /// # Requirements
     ///
@@ -237,7 +247,6 @@ impl SgxThreadCondvar {
     /// **ENOMEM**
     ///
     /// Internal memory allocation failed.
-    ///
     #[inline]
     pub unsafe fn broadcast(&self) -> SysError {
         rsgx_thread_cond_broadcast(&mut *self.cond.get())
@@ -248,10 +257,11 @@ impl SgxThreadCondvar {
     ///
     /// # Description
     ///
-    /// The procedure first confirms that there are no threads waiting on the condition
-    /// variable before it is destroyed. The destroy operation acquires the spin lock at
-    /// the beginning of the operation to prevent other threads from signaling to or
-    /// waiting on the condition variable.
+    /// The procedure first confirms that there are no threads waiting on the
+    /// condition variable before it is destroyed. The destroy operation
+    /// acquires the spin lock at the beginning of the operation to prevent
+    /// other threads from signaling to or waiting on the condition
+    /// variable.
     ///
     /// # Requirements
     ///
@@ -266,7 +276,6 @@ impl SgxThreadCondvar {
     /// **EBUSY**
     ///
     /// The condition variable has pending threads waiting on it.
-    ///
     #[inline]
     pub unsafe fn destroy(&self) -> SysError {
         rsgx_thread_cond_destroy(&mut *self.cond.get())
@@ -295,7 +304,6 @@ impl SgxThreadCondvar {
 /// attempt to use multiple mutexes on the same condition variable will result
 /// in a runtime panic. If this is not desired, then the unsafe primitives in
 /// `sys` do not have this restriction but may result in undefined behavior.
-///
 pub struct SgxCondvar {
     inner: Box<SgxThreadCondvar>,
     mutex: AtomicUsize,
@@ -303,8 +311,8 @@ pub struct SgxCondvar {
 
 impl SgxCondvar {
     ///
-    /// Creates a new condition variable which is ready to be waited on and notified.
-    ///
+    /// Creates a new condition variable which is ready to be waited on and
+    /// notified.
     pub fn new() -> Self {
         SgxCondvar {
             inner: Box::new(SgxThreadCondvar::new()),
@@ -368,7 +376,6 @@ impl SgxCondvar {
     /// This function will return an error if the mutex being waited on is
     /// poisoned when this thread re-acquires the lock. For more information,
     /// see information about [poisoning] on the [`Mutex`] type.
-    ///
     pub fn wait_until<'a, T, F>(
         &self,
         mut guard: SgxMutexGuard<'a, T>,
@@ -386,8 +393,8 @@ impl SgxCondvar {
     /// Wakes up one blocked thread on this condvar.
     ///
     /// If there is a blocked thread on this condition variable, then it will
-    /// be woken up from its call to [`wait`]. Calls to `signal` are not buffered
-    /// in any way.
+    /// be woken up from its call to [`wait`]. Calls to `signal` are not
+    /// buffered in any way.
     ///
     /// To wake up all threads, see [`broadcast`].
     pub fn signal(&self) {

--- a/sgx/sync/src/mutex.rs
+++ b/sgx/sync/src/mutex.rs
@@ -4,15 +4,14 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-//  * Neither the name of Baidu, Inc., nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without
+//    specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -27,16 +26,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //!
-//! The Intel(R) Software Guard Extensions SDK already supports mutex and conditional
-//! variable synchronization mechanisms by means of the following APIand data types
-//! defined in the Types and Enumerations section. Some functions included in the
-//! trusted Thread Synchronization library may make calls outside the enclave (OCALLs).
-//! If you use any of the APIs below, you must first import the needed OCALL functions
-//! from sgx_tstdc.edl. Otherwise, you will get a linker error when the enclave is
-//! being built; see Calling Functions outside the Enclave for additional details.
-//! The table below illustrates the primitives that the Intel(R) SGX Thread
-//! Synchronization library supports, as well as the OCALLs that each API function needs.
-//!
+//! The Intel(R) Software Guard Extensions SDK already supports mutex and
+//! conditional variable synchronization mechanisms by means of the following
+//! API and data types defined in the Types and Enumerations section. Some
+//! functions included in the trusted Thread Synchronization library may make
+//! calls outside the enclave (OCALLs). If you use any of the APIs below, you
+//! must first import the needed OCALL functions from sgx_tstdc.edl. Otherwise,
+//! you will get a linker error when the enclave is being built; see Calling
+//! Functions outside the Enclave for additional details. The table below
+//! illustrates the primitives that the Intel(R) SGX Thread Synchronization
+//! library supports, as well as the OCALLs that each API function needs.
 
 use alloc::boxed::Box;
 
@@ -121,13 +120,15 @@ impl SgxThreadMutex {
     /// # Description
     ///
     /// When a thread creates a mutex within an enclave, sgx_thread_mutex_
-    /// init simply initializes the various fields of the mutex object to indicate that
-    /// the mutex is available. rsgx_thread_mutex_init creates a non-recursive
-    /// mutex. The results of using a mutex in a lock or unlock operation before it has
-    /// been fully initialized (for example, the function call to rsgx_thread_mutex_
-    /// init returns) are undefined. To avoid race conditions in the initialization of a
-    /// trusted mutex, it is recommended statically initializing the mutex with the
-    /// macro SGX_THREAD_MUTEX_INITIALIZER, SGX_THREAD_NON_RECURSIVE_MUTEX_INITIALIZER ,
+    /// init simply initializes the various fields of the mutex object to
+    /// indicate that the mutex is available. rsgx_thread_mutex_init creates
+    /// a non-recursive mutex. The results of using a mutex in a lock or
+    /// unlock operation before it has been fully initialized (for example,
+    /// the function call to rsgx_thread_mutex_ init returns) are undefined.
+    /// To avoid race conditions in the initialization of a trusted mutex,
+    /// it is recommended statically initializing the mutex with the
+    /// macro SGX_THREAD_MUTEX_INITIALIZER,
+    /// SGX_THREAD_NON_RECURSIVE_MUTEX_INITIALIZER ,
     /// of, or SGX_THREAD_RECURSIVE_MUTEX_INITIALIZER instead.
     ///
     /// # Requirements
@@ -137,7 +138,6 @@ impl SgxThreadMutex {
     /// # Return value
     ///
     /// The trusted mutex object to be initialized.
-    ///
     pub const fn new() -> Self {
         SgxThreadMutex {
             lock: UnsafeCell::new(mc_sgx_types::SGX_THREAD_NONRECURSIVE_MUTEX_INITIALIZER),
@@ -149,25 +149,26 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// To acquire a mutex, a thread first needs to acquire the corresponding spin
-    /// lock. After the spin lock is acquired, the thread checks whether the mutex is
-    /// available. If the queue is empty or the thread is at the head of the queue the
-    /// thread will now become the owner of the mutex. To confirm its ownership, the
-    /// thread updates the refcount and owner fields. If the mutex is not available, the
-    /// thread searches the queue. If the thread is already in the queue, but not at the
-    /// head, it means that the thread has previously tried to lock the mutex, but it
-    /// did not succeed and had to wait outside the enclave and it has been
-    /// awakened unexpectedly. When this happens, the thread makes an OCALL and
-    /// simply goes back to sleep. If the thread is trying to lock the mutex for the first
-    /// time, it will update the waiting queue and make an OCALL to get suspended.
-    /// Note that threads release the spin lock after acquiring the mutex or before
-    /// leaving the enclave.
+    /// To acquire a mutex, a thread first needs to acquire the corresponding
+    /// spin lock. After the spin lock is acquired, the thread checks
+    /// whether the mutex is available. If the queue is empty or the thread
+    /// is at the head of the queue the thread will now become the owner of
+    /// the mutex. To confirm its ownership, the thread updates the refcount
+    /// and owner fields. If the mutex is not available, the thread searches
+    /// the queue. If the thread is already in the queue, but not at the
+    /// head, it means that the thread has previously tried to lock the mutex,
+    /// but it did not succeed and had to wait outside the enclave and it
+    /// has been awakened unexpectedly. When this happens, the thread makes
+    /// an OCALL and simply goes back to sleep. If the thread is trying to
+    /// lock the mutex for the first time, it will update the waiting queue
+    /// and make an OCALL to get suspended. Note that threads release the
+    /// spin lock after acquiring the mutex or before leaving the enclave.
     ///
     /// **Note**
     ///
-    /// A thread should not exit an enclave returning from a root ECALL after acquiring
-    /// the ownership of a mutex. Do not split the critical section protected by a
-    /// mutex across root ECALLs.
+    /// A thread should not exit an enclave returning from a root ECALL after
+    /// acquiring the ownership of a mutex. Do not split the critical
+    /// section protected by a mutex across root ECALLs.
     ///
     /// # Requirements
     ///
@@ -178,7 +179,6 @@ impl SgxThreadMutex {
     /// **EINVAL**
     ///
     /// The trusted mutex object is invalid.
-    ///
     #[inline]
     pub unsafe fn lock(&self) -> SysError {
         rsgx_thread_mutex_lock(&mut *self.lock.get())
@@ -189,18 +189,18 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// A thread may check the status of the mutex, which implies acquiring the spin
-    /// lock and verifying that the mutex is available and that the queue is empty or
-    /// the thread is at the head of the queue. When this happens, the thread
-    /// acquires the mutex, releases the spin lock and returns 0. Otherwise, the
-    /// thread releases the spin lock and returns EINVAL/EBUSY. The thread is not suspended
-    /// in this case.
+    /// A thread may check the status of the mutex, which implies acquiring the
+    /// spin lock and verifying that the mutex is available and that the
+    /// queue is empty or the thread is at the head of the queue. When this
+    /// happens, the thread acquires the mutex, releases the spin lock and
+    /// returns 0. Otherwise, the thread releases the spin lock and returns
+    /// EINVAL/EBUSY. The thread is not suspended in this case.
     ///
     /// **Note**
     ///
-    /// A thread should not exit an enclave returning from a root ECALL after acquiring
-    /// the ownership of a mutex. Do not split the critical section protected by a
-    /// mutex across root ECALLs.
+    /// A thread should not exit an enclave returning from a root ECALL after
+    /// acquiring the ownership of a mutex. Do not split the critical
+    /// section protected by a mutex across root ECALLs.
     ///
     /// # Requirements
     ///
@@ -214,8 +214,8 @@ impl SgxThreadMutex {
     ///
     /// **EBUSY**
     ///
-    /// The mutex is locked by another thread or has pending threads to acquire the mutex
-    ///
+    /// The mutex is locked by another thread or has pending threads to acquire
+    /// the mutex
     #[inline]
     pub unsafe fn try_lock(&self) -> SysError {
         rsgx_thread_mutex_trylock(&mut *self.lock.get())
@@ -226,12 +226,13 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// Before a thread releases a mutex, it has to verify it is the owner of the mutex. If
-    /// that is the case, the thread decreases the refcount by 1 and then may either
-    /// continue normal execution or wakeup the first thread in the queue. Note that
-    /// to ensure the state of the mutex remains consistent, the thread that is
-    /// awakened by the thread releasing the mutex will then try to acquire the
-    /// mutex almost as in the initial call to the rsgx_thread_mutex_lock routine.
+    /// Before a thread releases a mutex, it has to verify it is the owner of
+    /// the mutex. If that is the case, the thread decreases the refcount by
+    /// 1 and then may either continue normal execution or wakeup the first
+    /// thread in the queue. Note that to ensure the state of the mutex
+    /// remains consistent, the thread that is awakened by the thread
+    /// releasing the mutex will then try to acquire the mutex almost as in
+    /// the initial call to the rsgx_thread_mutex_lock routine.
     ///
     /// # Requirements
     ///
@@ -246,7 +247,6 @@ impl SgxThreadMutex {
     /// **EPERM**
     ///
     /// The mutex is locked by another thread.
-    ///
     #[inline]
     pub unsafe fn unlock(&self) -> SysError {
         rsgx_thread_mutex_unlock(&mut *self.lock.get())
@@ -257,15 +257,16 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// rsgx_thread_mutex_destroy resets the mutex, which brings it to its initial
-    /// status. In this process, certain fields are checked to prevent releasing a mutex
-    /// that is still owned by a thread or on which threads are still waiting.
+    /// rsgx_thread_mutex_destroy resets the mutex, which brings it to its
+    /// initial status. In this process, certain fields are checked to
+    /// prevent releasing a mutex that is still owned by a thread or on
+    /// which threads are still waiting.
     ///
     /// **Note**
     ///
-    /// Locking or unlocking a mutex after it has been destroyed results in undefined
-    /// behavior. After a mutex is destroyed, it must be re-created before it can be
-    /// used again.
+    /// Locking or unlocking a mutex after it has been destroyed results in
+    /// undefined behavior. After a mutex is destroyed, it must be
+    /// re-created before it can be used again.
     ///
     /// # Requirements
     ///
@@ -279,8 +280,8 @@ impl SgxThreadMutex {
     ///
     /// **EBUSY**
     ///
-    /// The mutex is locked by another thread or has pending threads to acquire the mutex.
-    ///
+    /// The mutex is locked by another thread or has pending threads to acquire
+    /// the mutex.
     #[inline]
     pub unsafe fn destroy(&self) -> SysError {
         rsgx_thread_mutex_destroy(&mut *self.lock.get())
@@ -319,7 +320,6 @@ impl SgxThreadMutex {
 /// data. The `PoisonError` type has an `into_inner` method which will return
 /// the guard that would have otherwise been returned on a successful lock. This
 /// allows access to the data, despite the lock being poisoned.
-///
 pub struct SgxMutex<T: ?Sized> {
     inner: Box<SgxThreadMutex>,
     poison: poison::Flag,
@@ -337,7 +337,6 @@ unsafe impl<T: ?Sized + Send> Sync for SgxMutex<T> {}
 impl<T> SgxMutex<T> {
     ///
     /// Creates a new mutex in an unlocked state ready for use.
-    ///
     pub fn new(t: T) -> SgxMutex<T> {
         SgxMutex {
             inner: Box::new(SgxThreadMutex::new()),
@@ -353,10 +352,11 @@ impl<T: ?Sized> SgxMutex<T> {
     ///
     /// Acquires a mutex, blocking the current thread until it is able to do so.
     ///
-    /// This function will block the local thread until it is available to acquire
-    /// the mutex. Upon returning, the thread is the only thread with the lock
-    /// held. An RAII guard is returned to allow scoped unlock of the lock. When
-    /// the guard goes out of scope, the mutex will be unlocked.
+    /// This function will block the local thread until it is available to
+    /// acquire the mutex. Upon returning, the thread is the only thread
+    /// with the lock held. An RAII guard is returned to allow scoped unlock
+    /// of the lock. When the guard goes out of scope, the mutex will be
+    /// unlocked.
     ///
     /// The exact behavior on locking a mutex in the thread which already holds
     /// the lock is left unspecified. However, this function will not return on
@@ -513,7 +513,6 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for SgxMutex<T> {
 /// Deref and DerefMut implementations.
 ///
 /// This structure is created by the lock and try_lock methods on Mutex.
-///
 pub struct SgxMutexGuard<'a, T: ?Sized + 'a> {
     __lock: &'a SgxMutex<T>,
     __poison: poison::Guard,

--- a/sgx/sync/src/mutex.rs
+++ b/sgx/sync/src/mutex.rs
@@ -4,14 +4,15 @@
 // modification, are permitted provided that the following conditions
 // are met:
 //
-//  * Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//  * Neither the name of Baidu, Inc., nor the names of its contributors may be
-//    used to endorse or promote products derived from this software without
-//    specific prior written permission.
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the
+//    distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -26,16 +27,16 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 //!
-//! The Intel(R) Software Guard Extensions SDK already supports mutex and
-//! conditional variable synchronization mechanisms by means of the following
-//! API and data types defined in the Types and Enumerations section. Some
-//! functions included in the trusted Thread Synchronization library may make
-//! calls outside the enclave (OCALLs). If you use any of the APIs below, you
-//! must first import the needed OCALL functions from sgx_tstdc.edl. Otherwise,
-//! you will get a linker error when the enclave is being built; see Calling
-//! Functions outside the Enclave for additional details. The table below
-//! illustrates the primitives that the Intel(R) SGX Thread Synchronization
-//! library supports, as well as the OCALLs that each API function needs.
+//! The Intel(R) Software Guard Extensions SDK already supports mutex and conditional
+//! variable synchronization mechanisms by means of the following APIand data types
+//! defined in the Types and Enumerations section. Some functions included in the
+//! trusted Thread Synchronization library may make calls outside the enclave (OCALLs).
+//! If you use any of the APIs below, you must first import the needed OCALL functions
+//! from sgx_tstdc.edl. Otherwise, you will get a linker error when the enclave is
+//! being built; see Calling Functions outside the Enclave for additional details.
+//! The table below illustrates the primitives that the Intel(R) SGX Thread
+//! Synchronization library supports, as well as the OCALLs that each API function needs.
+//!
 
 use alloc::boxed::Box;
 
@@ -120,15 +121,13 @@ impl SgxThreadMutex {
     /// # Description
     ///
     /// When a thread creates a mutex within an enclave, sgx_thread_mutex_
-    /// init simply initializes the various fields of the mutex object to
-    /// indicate that the mutex is available. rsgx_thread_mutex_init creates
-    /// a non-recursive mutex. The results of using a mutex in a lock or
-    /// unlock operation before it has been fully initialized (for example,
-    /// the function call to rsgx_thread_mutex_ init returns) are undefined.
-    /// To avoid race conditions in the initialization of a trusted mutex,
-    /// it is recommended statically initializing the mutex with the
-    /// macro SGX_THREAD_MUTEX_INITIALIZER,
-    /// SGX_THREAD_NON_RECURSIVE_MUTEX_INITIALIZER ,
+    /// init simply initializes the various fields of the mutex object to indicate that
+    /// the mutex is available. rsgx_thread_mutex_init creates a non-recursive
+    /// mutex. The results of using a mutex in a lock or unlock operation before it has
+    /// been fully initialized (for example, the function call to rsgx_thread_mutex_
+    /// init returns) are undefined. To avoid race conditions in the initialization of a
+    /// trusted mutex, it is recommended statically initializing the mutex with the
+    /// macro SGX_THREAD_MUTEX_INITIALIZER, SGX_THREAD_NON_RECURSIVE_MUTEX_INITIALIZER ,
     /// of, or SGX_THREAD_RECURSIVE_MUTEX_INITIALIZER instead.
     ///
     /// # Requirements
@@ -138,6 +137,7 @@ impl SgxThreadMutex {
     /// # Return value
     ///
     /// The trusted mutex object to be initialized.
+    ///
     pub const fn new() -> Self {
         SgxThreadMutex {
             lock: UnsafeCell::new(mc_sgx_types::SGX_THREAD_NONRECURSIVE_MUTEX_INITIALIZER),
@@ -149,26 +149,25 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// To acquire a mutex, a thread first needs to acquire the corresponding
-    /// spin lock. After the spin lock is acquired, the thread checks
-    /// whether the mutex is available. If the queue is empty or the thread
-    /// is at the head of the queue the thread will now become the owner of
-    /// the mutex. To confirm its ownership, the thread updates the refcount
-    /// and owner fields. If the mutex is not available, the thread searches
-    /// the queue. If the thread is already in the queue, but not at the
-    /// head, it means that the thread has previously tried to lock the mutex,
-    /// but it did not succeed and had to wait outside the enclave and it
-    /// has been awakened unexpectedly. When this happens, the thread makes
-    /// an OCALL and simply goes back to sleep. If the thread is trying to
-    /// lock the mutex for the first time, it will update the waiting queue
-    /// and make an OCALL to get suspended. Note that threads release the
-    /// spin lock after acquiring the mutex or before leaving the enclave.
+    /// To acquire a mutex, a thread first needs to acquire the corresponding spin
+    /// lock. After the spin lock is acquired, the thread checks whether the mutex is
+    /// available. If the queue is empty or the thread is at the head of the queue the
+    /// thread will now become the owner of the mutex. To confirm its ownership, the
+    /// thread updates the refcount and owner fields. If the mutex is not available, the
+    /// thread searches the queue. If the thread is already in the queue, but not at the
+    /// head, it means that the thread has previously tried to lock the mutex, but it
+    /// did not succeed and had to wait outside the enclave and it has been
+    /// awakened unexpectedly. When this happens, the thread makes an OCALL and
+    /// simply goes back to sleep. If the thread is trying to lock the mutex for the first
+    /// time, it will update the waiting queue and make an OCALL to get suspended.
+    /// Note that threads release the spin lock after acquiring the mutex or before
+    /// leaving the enclave.
     ///
     /// **Note**
     ///
-    /// A thread should not exit an enclave returning from a root ECALL after
-    /// acquiring the ownership of a mutex. Do not split the critical
-    /// section protected by a mutex across root ECALLs.
+    /// A thread should not exit an enclave returning from a root ECALL after acquiring
+    /// the ownership of a mutex. Do not split the critical section protected by a
+    /// mutex across root ECALLs.
     ///
     /// # Requirements
     ///
@@ -179,6 +178,7 @@ impl SgxThreadMutex {
     /// **EINVAL**
     ///
     /// The trusted mutex object is invalid.
+    ///
     #[inline]
     pub unsafe fn lock(&self) -> SysError {
         rsgx_thread_mutex_lock(&mut *self.lock.get())
@@ -189,18 +189,18 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// A thread may check the status of the mutex, which implies acquiring the
-    /// spin lock and verifying that the mutex is available and that the
-    /// queue is empty or the thread is at the head of the queue. When this
-    /// happens, the thread acquires the mutex, releases the spin lock and
-    /// returns 0. Otherwise, the thread releases the spin lock and returns
-    /// EINVAL/EBUSY. The thread is not suspended in this case.
+    /// A thread may check the status of the mutex, which implies acquiring the spin
+    /// lock and verifying that the mutex is available and that the queue is empty or
+    /// the thread is at the head of the queue. When this happens, the thread
+    /// acquires the mutex, releases the spin lock and returns 0. Otherwise, the
+    /// thread releases the spin lock and returns EINVAL/EBUSY. The thread is not suspended
+    /// in this case.
     ///
     /// **Note**
     ///
-    /// A thread should not exit an enclave returning from a root ECALL after
-    /// acquiring the ownership of a mutex. Do not split the critical
-    /// section protected by a mutex across root ECALLs.
+    /// A thread should not exit an enclave returning from a root ECALL after acquiring
+    /// the ownership of a mutex. Do not split the critical section protected by a
+    /// mutex across root ECALLs.
     ///
     /// # Requirements
     ///
@@ -214,8 +214,8 @@ impl SgxThreadMutex {
     ///
     /// **EBUSY**
     ///
-    /// The mutex is locked by another thread or has pending threads to acquire
-    /// the mutex
+    /// The mutex is locked by another thread or has pending threads to acquire the mutex
+    ///
     #[inline]
     pub unsafe fn try_lock(&self) -> SysError {
         rsgx_thread_mutex_trylock(&mut *self.lock.get())
@@ -226,13 +226,12 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// Before a thread releases a mutex, it has to verify it is the owner of
-    /// the mutex. If that is the case, the thread decreases the refcount by
-    /// 1 and then may either continue normal execution or wakeup the first
-    /// thread in the queue. Note that to ensure the state of the mutex
-    /// remains consistent, the thread that is awakened by the thread
-    /// releasing the mutex will then try to acquire the mutex almost as in
-    /// the initial call to the rsgx_thread_mutex_lock routine.
+    /// Before a thread releases a mutex, it has to verify it is the owner of the mutex. If
+    /// that is the case, the thread decreases the refcount by 1 and then may either
+    /// continue normal execution or wakeup the first thread in the queue. Note that
+    /// to ensure the state of the mutex remains consistent, the thread that is
+    /// awakened by the thread releasing the mutex will then try to acquire the
+    /// mutex almost as in the initial call to the rsgx_thread_mutex_lock routine.
     ///
     /// # Requirements
     ///
@@ -247,6 +246,7 @@ impl SgxThreadMutex {
     /// **EPERM**
     ///
     /// The mutex is locked by another thread.
+    ///
     #[inline]
     pub unsafe fn unlock(&self) -> SysError {
         rsgx_thread_mutex_unlock(&mut *self.lock.get())
@@ -257,16 +257,15 @@ impl SgxThreadMutex {
     ///
     /// # Description
     ///
-    /// rsgx_thread_mutex_destroy resets the mutex, which brings it to its
-    /// initial status. In this process, certain fields are checked to
-    /// prevent releasing a mutex that is still owned by a thread or on
-    /// which threads are still waiting.
+    /// rsgx_thread_mutex_destroy resets the mutex, which brings it to its initial
+    /// status. In this process, certain fields are checked to prevent releasing a mutex
+    /// that is still owned by a thread or on which threads are still waiting.
     ///
     /// **Note**
     ///
-    /// Locking or unlocking a mutex after it has been destroyed results in
-    /// undefined behavior. After a mutex is destroyed, it must be
-    /// re-created before it can be used again.
+    /// Locking or unlocking a mutex after it has been destroyed results in undefined
+    /// behavior. After a mutex is destroyed, it must be re-created before it can be
+    /// used again.
     ///
     /// # Requirements
     ///
@@ -280,8 +279,8 @@ impl SgxThreadMutex {
     ///
     /// **EBUSY**
     ///
-    /// The mutex is locked by another thread or has pending threads to acquire
-    /// the mutex.
+    /// The mutex is locked by another thread or has pending threads to acquire the mutex.
+    ///
     #[inline]
     pub unsafe fn destroy(&self) -> SysError {
         rsgx_thread_mutex_destroy(&mut *self.lock.get())
@@ -320,6 +319,7 @@ impl SgxThreadMutex {
 /// data. The `PoisonError` type has an `into_inner` method which will return
 /// the guard that would have otherwise been returned on a successful lock. This
 /// allows access to the data, despite the lock being poisoned.
+///
 pub struct SgxMutex<T: ?Sized> {
     inner: Box<SgxThreadMutex>,
     poison: poison::Flag,
@@ -337,6 +337,7 @@ unsafe impl<T: ?Sized + Send> Sync for SgxMutex<T> {}
 impl<T> SgxMutex<T> {
     ///
     /// Creates a new mutex in an unlocked state ready for use.
+    ///
     pub fn new(t: T) -> SgxMutex<T> {
         SgxMutex {
             inner: Box::new(SgxThreadMutex::new()),
@@ -352,11 +353,10 @@ impl<T: ?Sized> SgxMutex<T> {
     ///
     /// Acquires a mutex, blocking the current thread until it is able to do so.
     ///
-    /// This function will block the local thread until it is available to
-    /// acquire the mutex. Upon returning, the thread is the only thread
-    /// with the lock held. An RAII guard is returned to allow scoped unlock
-    /// of the lock. When the guard goes out of scope, the mutex will be
-    /// unlocked.
+    /// This function will block the local thread until it is available to acquire
+    /// the mutex. Upon returning, the thread is the only thread with the lock
+    /// held. An RAII guard is returned to allow scoped unlock of the lock. When
+    /// the guard goes out of scope, the mutex will be unlocked.
     ///
     /// The exact behavior on locking a mutex in the thread which already holds
     /// the lock is left unspecified. However, this function will not return on
@@ -513,6 +513,7 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for SgxMutex<T> {
 /// Deref and DerefMut implementations.
 ///
 /// This structure is created by the lock and try_lock methods on Mutex.
+///
 pub struct SgxMutexGuard<'a, T: ?Sized + 'a> {
     __lock: &'a SgxMutex<T>,
     __poison: poison::Guard,

--- a/transaction/core/src/ring_signature/curve_scalar.rs
+++ b/transaction/core/src/ring_signature/curve_scalar.rs
@@ -96,9 +96,9 @@ impl AsRef<Scalar> for CurveScalar {
     }
 }
 
-impl Into<Scalar> for CurveScalar {
-    fn into(self) -> Scalar {
-        self.scalar
+impl From<CurveScalar> for Scalar {
+    fn from(src: CurveScalar) -> Scalar {
+        src.scalar
     }
 }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -410,7 +410,7 @@ pub mod transaction_builder_tests {
 
         InputCredentials::new(
             ring,
-            membership_proofs.clone(),
+            membership_proofs,
             real_index,
             onetime_private_key,
             *account.view_private_key(),
@@ -700,7 +700,7 @@ pub mod transaction_builder_tests {
 
         let input_credentials = InputCredentials::new(
             ring,
-            membership_proofs.clone(),
+            membership_proofs,
             real_index,
             onetime_private_key,
             *alice.view_private_key(),

--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -37,7 +37,7 @@ fn env_var_exists(name: &str) -> &'static str {
     match env::var(name) {
         Ok(_) => "true",
         Err(env::VarError::NotPresent) => "false",
-        Err(e) => panic!(e),
+        Err(e) => panic!("{}", e),
     }
 }
 

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -41,11 +41,11 @@ impl From<AuthorizationHeaderError> for AuthenticatorError {
     }
 }
 
-impl<T> Into<Result<T, RpcStatus>> for AuthenticatorError {
-    fn into(self) -> Result<T, RpcStatus> {
+impl<T> From<AuthenticatorError> for Result<T, RpcStatus> {
+    fn from(src: AuthenticatorError) -> Result<T, RpcStatus> {
         Err(RpcStatus::new(
             RpcStatusCode::UNAUTHENTICATED,
-            Some(self.to_string()),
+            Some(src.to_string()),
         ))
     }
 }
@@ -241,7 +241,7 @@ mod test {
     fn authenticate_token() {
         let shared_secret = [66; 32];
         let authenticator = TokenAuthenticator::new(
-            shared_secret.clone(),
+            shared_secret,
             TOKEN_MAX_LIFETIME,
             SystemTimeProvider::default(),
         );
@@ -272,10 +272,8 @@ mod test {
         }
 
         // Authorizing with a valid Authorization header should succeed.
-        let generator = TokenBasicCredentialsGenerator::new(
-            shared_secret.clone(),
-            SystemTimeProvider::default(),
-        );
+        let generator =
+            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
         let creds = generator
             .generate_for(TEST_USERNAME)
             .expect("failed generating token");

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -173,10 +173,8 @@ mod tests {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator = TokenBasicCredentialsGenerator::new(
-            shared_secret.clone(),
-            SystemTimeProvider::default(),
-        );
+        let generator =
+            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
         let authenticator = TokenAuthenticator::new(
             shared_secret,
             TOKEN_MAX_LIFETIME,
@@ -212,10 +210,8 @@ mod tests {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator = TokenBasicCredentialsGenerator::new(
-            shared_secret.clone(),
-            SystemTimeProvider::default(),
-        );
+        let generator =
+            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
 
         // Signature will fail if authenticator uses a different shared secret.
         let authenticator =

--- a/util/grpc/src/server_cert_reloader.rs
+++ b/util/grpc/src/server_cert_reloader.rs
@@ -157,7 +157,7 @@ mod tests {
         let env = Arc::new(EnvBuilder::new().build());
         let service = HealthService::new(None, logger.clone()).into_service();
 
-        let mut server = ServerBuilder::new(env.clone())
+        let mut server = ServerBuilder::new(env)
             .register_service(service)
             .bind_with_fetcher(
                 "localhost",
@@ -180,7 +180,7 @@ mod tests {
         let cred = ChannelCredentialsBuilder::new()
             .root_cert(cert.into())
             .build();
-        let ch = ChannelBuilder::new(env.clone())
+        let ch = ChannelBuilder::new(env)
             .override_ssl_target(ssl_target)
             .secure_connect(&format!("localhost:{}", port), cred);
         HealthClient::new(ch)
@@ -391,7 +391,7 @@ mod tests {
         let env = Arc::new(EnvBuilder::new().build());
         let service = HealthService::new(None, logger.clone()).into_service();
 
-        let mut server = ServerBuilder::new(env.clone())
+        let mut server = ServerBuilder::new(env)
             .register_service(service)
             .bind_using_uri(&uri, logger.clone())
             .build()

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -158,7 +158,7 @@ macro_rules! derive_repr_bytes_from_as_ref_and_try_from {
     };
 }
 
-/// Derive From<...> for Vec<u8>  from a ReprBytes implementation
+/// Derive From<...> for Vec<u8> from a ReprBytes implementation
 #[cfg(feature = "alloc")]
 #[macro_export]
 macro_rules! derive_into_vec_from_repr_bytes {

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -158,14 +158,14 @@ macro_rules! derive_repr_bytes_from_as_ref_and_try_from {
     };
 }
 
-/// Derive Into<Vec<u8>> from a ReprBytes implementation
+/// Derive From<...> for Vec<u8>  from a ReprBytes implementation
 #[cfg(feature = "alloc")]
 #[macro_export]
 macro_rules! derive_into_vec_from_repr_bytes {
     ($mytype:ty) => {
-        impl Into<$crate::_exports::alloc::vec::Vec<u8>> for $mytype {
-            fn into(self) -> $crate::_exports::alloc::vec::Vec<u8> {
-                <$mytype as $crate::ReprBytes>::map_bytes(&self, |slice| slice.to_vec())
+        impl From<$mytype> for $crate::_exports::alloc::vec::Vec<u8> {
+            fn from(src: $mytype) -> $crate::_exports::alloc::vec::Vec<u8> {
+                <$mytype as $crate::ReprBytes>::map_bytes(&src, |slice| slice.to_vec())
             }
         }
     };

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -87,7 +87,7 @@ impl SourceConfig {
     pub fn tx_source_url(&self) -> Url {
         let mut url = self.tx_source_url.clone();
         if !url.ends_with('/') {
-            url.push_str("/");
+            url.push('/');
         }
         Url::from_str(&url).unwrap_or_else(|err| panic!("invalid url {}: {}", url, err))
     }


### PR DESCRIPTION
### Motivation

Newer `clippy` versions complain about implementing `Into` instead of `From`, since `Into` can be automatically be provided when `From` is implemented.
Additionally, it is more diligent at finding some unnecessary `.clone()`s, unnecessary `::from()` calls and some other small bits and pieces I picked along the way.

### In this PR
* Addressing some future `clippy` complaints to make the new rust PR smaller.

### Future Work
* Do this in other repos.

