### PR TITLE
remove unnecessary format! calls

### DIFF
--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -683,7 +683,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
         if let Some(C) = &self.C {
             // C is less-than-and-compatible-with H
             if let Some(H) = &self.H {
-                assert!(C.N <= H.N, format!("C.N: {}, H.N: {}", C.N, H.N));
+                assert!(C.N <= H.N, "C.N: {}, H.N: {}", C.N, H.N);
                 assert_eq!(C.X, H.X);
             } else {
                 panic!("C is Some but H is None");
@@ -751,7 +751,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 
         // Invariants: p' is less-than-and-incompatible-with p.
         if let (Some(p), Some(pp)) = (&self.P, &self.PP) {
-            assert!(pp < p, format!("p: {:?}, pp: {:?}", p, pp));
+            assert!(pp < p, "p: {:?}, pp: {:?}", p, pp);
             assert_ne!(p.X, pp.X);
         }
 
@@ -784,11 +784,9 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
                     // decreasing H here does not cause failures or decrease performance
                     log::debug!(
                         self.logger,
-                        "{}",
-                        format!(
-                            "Step 2: Ignoring decreasing H. self.H.N: {:?}, h.N: {:?}",
-                            current_h.N, h.N
-                        )
+                        "Step 2: Ignoring decreasing H. self.H.N: {:?}, h.N: {:?}",
+                        current_h.N,
+                        h.N,
                     );
                 }
                 self.H = Some(core::cmp::max(&h, current_h).clone());
@@ -798,7 +796,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
         }
 
         if let (Some(C), Some(H)) = (&self.C, &self.H) {
-            assert!(C.N <= H.N, format!("C.N: {}, H.N: {}", C.N, H.N));
+            assert!(C.N <= H.N, "C.N: {}, H.N: {}", C.N, H.N);
         }
 
         // (3) Identify "voted committed" ballots.
@@ -856,7 +854,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
                     // B <= C less-than-and-compatible-with H
                     assert!(self.B <= c);
                     assert_eq!(c.X, h.X);
-                    assert!(c.N <= h.N, format!("c.N: {}, h.N: {}", c.N, h.N));
+                    assert!(c.N <= h.N, "c.N: {}, h.N: {}", c.N, h.N);
 
                     self.C = Some(c);
                 }
@@ -864,7 +862,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
         }
 
         if let (Some(C), Some(H)) = (&self.C, &self.H) {
-            assert!(C.N <= H.N, format!("C.N: {}, H.N: {}", C.N, H.N));
+            assert!(C.N <= H.N, "C.N: {}, H.N: {}", C.N, H.N);
         }
 
         // (4) Identify "accepted committed" ballots.
@@ -896,7 +894,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
                 }
             }
             self.H = Some(h.clone());
-            assert!(c.N <= h.N, format!("c.N: {}, h.N: {}", c.N, h.N));
+            assert!(c.N <= h.N, "c.N: {}, h.N: {}", c.N, h.N);
 
             // "if h is not less-than-and-incompatible-with b, set b to h."
             //
@@ -1142,12 +1140,9 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
             } else {
                 log::debug!(
                     self.logger,
-                    "{}",
-                    format!(
-                        "Externalize: Ignoring decreasing H. self.H.N: {:?}, hn: {:?}",
-                        self.H.as_ref().unwrap().N,
-                        hn
-                    )
+                    "Externalize: Ignoring decreasing H. self.H.N: {:?}, hn: {:?}",
+                    self.H.as_ref().unwrap().N,
+                    hn,
                 );
             }
         }
@@ -1717,7 +1712,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
                 // Range of ballots for which the local node issues "vote-or-accept commit(b)".
                 let mut candidates: HashMap<Vec<V>, (u32, u32)> = Default::default();
                 if let (Some(C), Some(H)) = (&self.C, &self.H) {
-                    assert!(C.N <= H.N, format!("C.N: {}, H.N: {}", C.N, H.N));
+                    assert!(C.N <= H.N, "C.N: {}, H.N: {}", C.N, H.N);
                     candidates.insert(self.B.X.clone(), (C.N, H.N));
                 }
 

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -890,7 +890,7 @@ pub mod tx_out_store_tests {
         // unrecognized hash.
         let unrecognized_hash: Hash = [0u8; 32];
         match tx_out_store.get_tx_out_index_by_hash(&unrecognized_hash, &ro_transaction) {
-            Ok(index) => panic!(format!("Returned index {:?} for unrecognized hash.", index)),
+            Ok(index) => panic!("Returned index {:?} for unrecognized hash.", index),
             Err(Error::NotFound) => {
                 // This is expected.
             }
@@ -936,10 +936,7 @@ pub mod tx_out_store_tests {
         let unrecognized_public_key = CompressedRistrettoPublic::from(&[0; 32]);
         match tx_out_store.get_tx_out_index_by_public_key(&unrecognized_public_key, &ro_transaction)
         {
-            Ok(index) => panic!(format!(
-                "Returned index {:?} for unrecognized public key.",
-                index
-            )),
+            Ok(index) => panic!("Returned index {:?} for unrecognized public key.", index),
             Err(Error::NotFound) => {
                 // This is expected.
             }

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -686,7 +686,7 @@ mod mlsag_tests {
 
             match signature.verify(&params.message, &params.ring, &output_commitment) {
                 Err(Error::InvalidKeyImage) => {} // This is expected.
-                Err(e) => panic!(format!("Unexpected error {}", e)),
+                Err(e) => panic!("Unexpected error {}", e),
                 Ok(()) => panic!("Signature should be rejected."),
             }
         }

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -831,9 +831,9 @@ mod rct_bulletproofs_tests {
             ) {
                 Err(Error::ValueNotConserved) => {} // Expected
                 Err(e) => {
-                    panic!(alloc::format!("Unexpected error {}", e));
+                    panic!("Unexpected error {}", e);
                 }
-                _ => panic!()
+                _ => panic!("Unexpected success")
             }
 
         }

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -822,9 +822,9 @@ mod tests {
         match validate_signature(&tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!(alloc::format!("Unexpected error {}", e));
+                panic!("Unexpected error {}", e);
             }
-            Ok(()) => panic!(),
+            Ok(()) => panic!("Unexpected success"),
         }
     }
 
@@ -841,9 +841,9 @@ mod tests {
         match validate_signature(&tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!(alloc::format!("Unexpected error {}", e));
+                panic!("Unexpected error {}", e);
             }
-            Ok(()) => panic!(),
+            Ok(()) => panic!("Unexpected success"),
         }
     }
 
@@ -858,9 +858,9 @@ mod tests {
         match validate_signature(&tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!(alloc::format!("Unexpected error {}", e));
+                panic!("Unexpected error {}", e);
             }
-            Ok(()) => panic!(),
+            Ok(()) => panic!("Unexpected success"),
         }
     }
 


### PR DESCRIPTION
New `clippy` identified a few places where we use `format!()` unnecessarily, so here's a PR to get rid of that.