### PR TITLE
Prefer Path over PathBuf

### DIFF
--- a/attest/core/build.rs
+++ b/attest/core/build.rs
@@ -28,7 +28,7 @@ use std::{
     env,
     fs::{read, remove_file, write},
     ops::Deref,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 
@@ -72,8 +72,8 @@ impl RngCallback for RngForMbedTls {
     }
 }
 
-fn purge_expired_cert(path: &PathBuf) {
-    let mut bytes = match read(path.clone()) {
+fn purge_expired_cert(path: &Path) {
+    let mut bytes = match read(path) {
         Ok(bytes) => bytes,
         Err(_) => {
             return;
@@ -98,14 +98,14 @@ fn purge_expired_cert(path: &PathBuf) {
             // If certificate expired or expires in the next 24 hours, delete it so it gets
             // regenerated.
             if utc_now + Duration::hours(24) > not_after {
-                remove_file(path.clone())
+                remove_file(path)
                     .unwrap_or_else(|e| panic!("failed deleting expired cert {:?}: {:?}", path, e));
             }
         }
         Err(_) => {
             // Failed getting expiration date from certificate, delete it so it gets
             // regenerated.
-            remove_file(path.clone()).unwrap_or_else(|e| {
+            remove_file(path).unwrap_or_else(|e| {
                 panic!("failed deleting non-parseable cert {:?}: {:?}", path, e)
             });
         }

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -13,7 +13,7 @@ use std::{
     fs::{create_dir_all, read, read_dir, remove_dir_all, remove_file, rename, File},
     io::Write,
     marker::PhantomData,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{Instant, SystemTime},
 };
 
@@ -325,7 +325,7 @@ pub struct ScpLogReader<V: Value> {
 
 impl<V: Value> ScpLogReader<V> {
     /// Create a new ScpLogReader.
-    pub fn new(path: &PathBuf) -> Result<Self, String> {
+    pub fn new(path: &Path) -> Result<Self, String> {
         let mut files: Vec<_> = read_dir(path)
             .map_err(|e| format!("failed reading dir {:?}: {:?}", path, e))?
             .filter_map(|entry| {
@@ -390,15 +390,15 @@ mod tests {
         let dir = TempDir::new("test").unwrap();
         let out_path = dir.path().join("debug_output");
 
-        let cur_slot = out_path.clone().join("cur-slot");
+        let cur_slot = out_path.join("cur-slot");
         create_dir_all(cur_slot.as_path()).unwrap();
 
-        let slot_states = out_path.clone().join("slot-states");
+        let slot_states = out_path.join("slot-states");
         create_dir_all(slot_states.as_path()).unwrap();
 
         assert!(out_path.exists());
 
         let node = MockScpNode::<&'static str>::new();
-        let _logging_scp_node = LoggingScpNode::new(node, out_path.clone(), logger).unwrap();
+        let _logging_scp_node = LoggingScpNode::new(node, out_path, logger).unwrap();
     }
 }

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -20,7 +20,7 @@ use std::{
     env,
     fs::File,
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 use structopt::StructOpt;
@@ -73,8 +73,7 @@ fn main() -> Result<(), ConsensusServiceError> {
 
     setup_ledger_dir(&config.origin_block_path, &config.ledger_path);
 
-    let local_ledger =
-        LedgerDB::open(config.ledger_path.clone()).expect("Failed creating LedgerDB");
+    let local_ledger = LedgerDB::open(&config.ledger_path).expect("Failed creating LedgerDB");
 
     let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
 
@@ -114,7 +113,7 @@ fn main() -> Result<(), ConsensusServiceError> {
     panic!("Oh oh, our threads died");
 }
 
-fn setup_ledger_dir(config_origin_path: &Option<PathBuf>, ledger_path: &PathBuf) {
+fn setup_ledger_dir(config_origin_path: &Option<PathBuf>, ledger_path: &Path) {
     if let Some(origin_block_path) = config_origin_path.clone() {
         // Copy origin block to ledger_db path if there are not already contents in
         // ledger_db. If ledger_path does not exist, create the dir.

--- a/ledger/db/src/metrics.rs
+++ b/ledger/db/src/metrics.rs
@@ -12,7 +12,7 @@ use mc_util_metrics::{
     IntGauge, IntGaugeVec, MetricFamily, Opts,
 };
 use std::{
-    path::PathBuf,
+    path::Path,
     time::{Duration, Instant},
 };
 
@@ -104,7 +104,7 @@ pub struct LedgerMetrics {
 }
 
 impl LedgerMetrics {
-    pub fn new(db_path: &PathBuf) -> Self {
+    pub fn new(db_path: &Path) -> Self {
         let db_path_str = db_path
             .to_str()
             .expect("failed converting ledger path to string");

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -310,7 +310,7 @@ fn main() {
 
     // Open ledger
     log::info!(logger, "Opening ledger db {:?}", config.ledger_path);
-    let ledger_db = LedgerDB::open(config.ledger_path.clone()).expect("Could not read ledger DB");
+    let ledger_db = LedgerDB::open(&config.ledger_path).expect("Could not read ledger DB");
 
     // Figure out the first block to sync from.
     let first_desired_block = match config.start_from {

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -25,8 +25,8 @@ fn main() {
 
     log::debug!(logger, "Creating local ledger at {:?}", config.ledger_db);
     // Open LedgerDB
-    LedgerDB::create(config.ledger_db.clone()).expect("Could not create ledger_db");
-    let mut local_ledger = LedgerDB::open(config.ledger_db).expect("Failed creating LedgerDB");
+    LedgerDB::create(&config.ledger_db).expect("Could not create ledger_db");
+    let mut local_ledger = LedgerDB::open(&config.ledger_db).expect("Failed creating LedgerDB");
 
     // Sync Origin Block
     log::debug!(logger, "Getting origin block");

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -67,7 +67,7 @@ fn main() {
     if false {
         // let mut ledger = LedgerDB::open(format!("../../target/sample_data/{}/ledger",
         // NETWORK)).expect("Failed opening local LedgerDB");
-        let mut ledger = LedgerDB::open(PathBuf::from("../../target/sample_data/ledger"))
+        let mut ledger = LedgerDB::open(&PathBuf::from("../../target/sample_data/ledger"))
             .expect("Failed opening local LedgerDB");
         _make_ledger_long(&mut ledger);
         return;
@@ -79,7 +79,7 @@ fn main() {
     )
     .expect("failed copying ledger");
 
-    let ledger = LedgerDB::open(ledger_path).expect("Failed opening local LedgerDB");
+    let ledger = LedgerDB::open(&ledger_path).expect("Failed opening local LedgerDB");
     log::info!(
         logger,
         "num_blocks = {}, num_txos = {}",

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -135,8 +135,8 @@ pub fn get_test_monitor_data_and_id(
 fn generate_ledger_db(path: &str) -> LedgerDB {
     // DELETE the old database if it already exists.
     let _ = std::fs::remove_file(format!("{}/data.mdb", path));
-    LedgerDB::create(PathBuf::from(path)).expect("Could not create ledger_db");
-    let db = LedgerDB::open(PathBuf::from(path)).expect("Could not open ledger_db");
+    LedgerDB::create(&PathBuf::from(path)).expect("Could not create ledger_db");
+    let db = LedgerDB::open(&PathBuf::from(path)).expect("Could not open ledger_db");
     db
 }
 

--- a/slam/src/main.rs
+++ b/slam/src/main.rs
@@ -116,8 +116,7 @@ fn main() {
     )
     .expect("failed copying ledger");
 
-    let ledger_db =
-        LedgerDB::open(ledger_dir.path().to_path_buf()).expect("Could not open ledger_db");
+    let ledger_db = LedgerDB::open(ledger_dir.path()).expect("Could not open ledger_db");
 
     BLOCK_HEIGHT.store(ledger_db.num_blocks().unwrap(), Ordering::SeqCst);
 

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -26,8 +26,8 @@ pub const INITIALIZE_LEDGER_AMOUNT: u64 = 1_000_000 * 1_000_000_000;
 /// Creates a LedgerDB instance.
 pub fn create_ledger() -> LedgerDB {
     let temp_dir = TempDir::new("test").unwrap();
-    let path = temp_dir.path().to_path_buf();
-    LedgerDB::create(path.clone()).unwrap();
+    let path = temp_dir.path();
+    LedgerDB::create(path).unwrap();
     LedgerDB::open(path).unwrap()
 }
 

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -14,7 +14,7 @@ use mc_transaction_core::{
 use mc_util_from_random::FromRandom;
 use rand::{RngCore, SeedableRng};
 use rand_hc::Hc128Rng as FixedRng;
-use std::{path::PathBuf, vec::Vec};
+use std::{path::Path, vec::Vec};
 
 /// Deterministically populates a testnet ledger.
 ///
@@ -33,7 +33,7 @@ use std::{path::PathBuf, vec::Vec};
 /// This will panic if it attempts to distribute the total value of mobilecoin
 /// into fewer than 16 outputs.
 pub fn bootstrap_ledger(
-    path: &PathBuf,
+    path: &Path,
     recipients: &[PublicAddress],
     outputs_per_recipient_per_block: usize,
     num_blocks: usize,
@@ -43,9 +43,9 @@ pub fn bootstrap_ledger(
     logger: Logger,
 ) {
     // Create the DB
-    std::fs::create_dir_all(path.clone()).expect("Could not create ledger dir");
-    LedgerDB::create(path.clone()).expect("Could not create ledger_db");
-    let mut db = LedgerDB::open(path.clone()).expect("Could not open ledger_db");
+    std::fs::create_dir_all(path).expect("Could not create ledger dir");
+    LedgerDB::create(path).expect("Could not create ledger_db");
+    let mut db = LedgerDB::open(path).expect("Could not open ledger_db");
 
     let num_outputs: u64 = (recipients.len() * outputs_per_recipient_per_block * num_blocks) as u64;
     assert!(num_outputs >= 16);

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -8,12 +8,7 @@ use crate::{read_keyfile, read_pubfile, write_keyfile, write_pubfile};
 use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
 use rand::SeedableRng;
 use rand_hc::Hc128Rng as FixedRng;
-use std::{
-    cmp::Ordering,
-    ffi::OsStr,
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{cmp::Ordering, ffi::OsStr, fs, path::Path};
 
 pub const DEFAULT_SEED: [u8; 32] = [1; 32];
 
@@ -78,7 +73,7 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(
             entries.push(filename);
         }
     }
-    entries.sort_by(compare_keyfile_names);
+    entries.sort_by(|a, b| compare_keyfile_names(a, b));
     let result: Vec<PublicAddress> = entries
         .iter()
         .map(|f| read_pubfile(f).expect("Could not read pubfile"))
@@ -97,7 +92,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
             entries.push(filename);
         }
     }
-    entries.sort_by(compare_keyfile_names);
+    entries.sort_by(|a, b| compare_keyfile_names(a, b));
     let result: Vec<RootIdentity> = entries
         .iter()
         .map(|f| read_keyfile(f).expect("Could not read keyfile"))
@@ -111,7 +106,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
 // The implementation is, first sort by length, and then if there's a tie,
 // sort lexicographically. This makes keyfile_name(a) < keyfile_name(b) iff a <
 // b
-fn compare_keyfile_names(a: &PathBuf, b: &PathBuf) -> Ordering {
+fn compare_keyfile_names(a: &Path, b: &Path) -> Ordering {
     let a = a.as_os_str();
     let b = b.as_os_str();
     a.len().cmp(&b.len()).then_with(|| a.cmp(b))
@@ -120,7 +115,7 @@ fn compare_keyfile_names(a: &PathBuf, b: &PathBuf) -> Ordering {
 #[cfg(test)]
 mod testing {
     use super::*;
-    use std::{collections::HashSet, iter::FromIterator};
+    use std::{collections::HashSet, iter::FromIterator, path::PathBuf};
     use tempdir::TempDir;
 
     #[test]
@@ -134,7 +129,7 @@ mod testing {
             PathBuf::from(keyfile_name(100)).with_extension("json"),
         ];
         let mut entries2 = entries.clone();
-        entries2.sort_by(compare_keyfile_names);
+        entries2.sort_by(|a, b| compare_keyfile_names(a, b));
         assert_eq!(entries, entries2);
     }
 

--- a/watcher/src/bin/db-dump.rs
+++ b/watcher/src/bin/db-dump.rs
@@ -28,7 +28,7 @@ fn main() {
 
     let config = Config::from_args();
     let watcher_db =
-        WatcherDB::open_ro(config.watcher_db, logger).expect("Failed opening watcher db");
+        WatcherDB::open_ro(&config.watcher_db, logger).expect("Failed opening watcher db");
 
     let last_synced_blocks = watcher_db
         .last_synced_blocks()

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let sources_config = config.sources_config();
 
     let watcher_db = create_or_open_rw_watcher_db(
-        config.watcher_db,
+        &config.watcher_db,
         &sources_config.tx_source_urls()[..],
         logger.clone(),
     )

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -24,7 +24,7 @@ use lmdb::{
 use mc_util_repr_bytes::typenum::Unsigned;
 use std::{
     convert::{TryFrom, TryInto},
-    path::PathBuf,
+    path::Path,
     str::FromStr,
     sync::Arc,
 };
@@ -145,14 +145,14 @@ pub struct WatcherDB {
 
 impl WatcherDB {
     /// Open an existing WatcherDB for read-only operations.
-    pub fn open_ro(path: PathBuf, logger: Logger) -> Result<Self, WatcherDBError> {
+    pub fn open_ro(path: &Path, logger: Logger) -> Result<Self, WatcherDBError> {
         let env = Arc::new(
             Environment::new()
                 .set_max_dbs(10)
                 .set_map_size(MAX_LMDB_FILE_SIZE)
                 // TODO - needed because currently our test cloud machines have slow disks.
                 .set_flags(EnvironmentFlags::NO_SYNC)
-                .open(path.as_ref())?,
+                .open(path)?,
         );
 
         let metadata_store = MetadataStore::<WatcherDbMetadataStoreSettings>::new(&env)?;
@@ -193,7 +193,7 @@ impl WatcherDB {
 
     /// Open an existing WatcherDB for read-write operations.
     pub fn open_rw(
-        path: PathBuf,
+        path: &Path,
         tx_source_urls: &[Url],
         logger: Logger,
     ) -> Result<Self, WatcherDBError> {
@@ -204,12 +204,12 @@ impl WatcherDB {
     }
 
     /// Create a fresh WatcherDB.
-    pub fn create(path: PathBuf) -> Result<(), WatcherDBError> {
+    pub fn create(path: &Path) -> Result<(), WatcherDBError> {
         let env = Arc::new(
             Environment::new()
                 .set_max_dbs(10)
                 .set_map_size(MAX_LMDB_FILE_SIZE)
-                .open(path.as_ref())?,
+                .open(path)?,
         );
 
         MetadataStore::<WatcherDbMetadataStoreSettings>::create(&env)?;
@@ -1000,17 +1000,17 @@ impl WatcherDB {
 
 /// Open an existing WatcherDB or create a new one in read-write mode.
 pub fn create_or_open_rw_watcher_db(
-    watcher_db_path: PathBuf,
+    watcher_db_path: &Path,
     src_urls: &[Url],
     logger: Logger,
 ) -> Result<WatcherDB, WatcherDBError> {
     // Create the path if it does not exist.
     if !watcher_db_path.exists() {
-        std::fs::create_dir_all(watcher_db_path.clone())?;
+        std::fs::create_dir_all(watcher_db_path)?;
     }
 
     // Attempt to open the WatcherDB and see if it has anything in it.
-    if let Ok(watcher_db) = WatcherDB::open_rw(watcher_db_path.clone(), src_urls, logger.clone()) {
+    if let Ok(watcher_db) = WatcherDB::open_rw(watcher_db_path, src_urls, logger.clone()) {
         if let Ok(last_synced) = watcher_db.last_synced_blocks() {
             if last_synced.values().any(|val| val.is_some()) {
                 // Successfully opened a ledger that has blocks in it.
@@ -1026,7 +1026,7 @@ pub fn create_or_open_rw_watcher_db(
     }
 
     // WatcherDB does't exist, or is empty. Create a new WatcherDB, and open it.
-    WatcherDB::create(watcher_db_path.clone())?;
+    WatcherDB::create(watcher_db_path)?;
     WatcherDB::open_rw(watcher_db_path, src_urls, logger)
 }
 
@@ -1048,8 +1048,8 @@ pub mod tests {
 
     pub fn setup_watcher_db(src_urls: &[Url], logger: Logger) -> WatcherDB {
         let db_tmp = TempDir::new("wallet_db").expect("Could not make tempdir for wallet db");
-        WatcherDB::create(db_tmp.path().to_path_buf()).unwrap();
-        WatcherDB::open_rw(db_tmp.path().to_path_buf(), src_urls, logger).unwrap()
+        WatcherDB::create(db_tmp.path()).unwrap();
+        WatcherDB::open_rw(db_tmp.path(), src_urls, logger).unwrap()
     }
 
     pub fn setup_blocks() -> Vec<(Block, BlockContents)> {


### PR DESCRIPTION
### Motivation

The newer clippy prefers `Path` objects, as `PathBuf` implements `AsRef<Path>` and this allows to save a bunch of `.clone()`s and `.to_path_buf()` calls.

### In this PR
* Use `Path` where appropriate.
