### PR TITLE
remove unnecessary question-mark operator  

### DIFF
--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -478,7 +478,7 @@ impl TryFrom<Vec<u8>> for Quote {
     type Error = QuoteError;
 
     fn try_from(src: Vec<u8>) -> Result<Self, QuoteError> {
-        Ok(Self::try_from(&src[..])?)
+        Self::try_from(&src[..])
     }
 }
 

--- a/attest/trusted/src/lib.rs
+++ b/attest/trusted/src/lib.rs
@@ -55,7 +55,7 @@ pub fn seal<S: Sealed>(obj: &S::Source) -> Result<S, S::Error> {
     let mac_txt = S::compute_mac_txt(obj);
     let blob = IntelSealed::seal_raw(&buf[..], mac_txt.as_ref())
         .map_err(error_conversion_helper::<S::Error>)?;
-    Ok(S::validate_mac_txt(blob)?)
+    S::validate_mac_txt(blob)
 }
 
 /// Unseal a Sealed object and return a Sealed::Source

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -194,7 +194,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
         func: impl FnOnce(&mut Self, CallOption) -> StdResult<T, GrpcError>,
     ) -> StdResult<T, ThickClientAttestationError> {
         self.authenticated_call(|this, call_option| {
-            Ok(this.attested_call(|this| func(this, call_option))?)
+            this.attested_call(|this| func(this, call_option))
         })
     }
 

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -361,9 +361,8 @@ impl<T: Digestible> DigestibleVerifier<RistrettoSignature, T> for RistrettoPubli
         signature: &RistrettoSignature,
     ) -> Result<(), SignatureError> {
         let message = message.digest32::<MerlinTranscript>(context);
-        Ok(self
-            .verify_schnorrkel(context, &message, &signature)
-            .map_err(|_e| SignatureError::new())?)
+        self.verify_schnorrkel(context, &message, &signature)
+            .map_err(|_e| SignatureError::new())
     }
 }
 

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -135,9 +135,7 @@ macro_rules! derive_repr_bytes_from_as_ref_and_try_from {
             type Error = <$mytype as ::core::convert::TryFrom<&'static [u8]>>::Error;
 
             fn from_bytes(src: &$crate::GenericArray<u8, Self::Size>) -> Result<Self, Self::Error> {
-                Ok(<Self as ::core::convert::TryFrom<&[u8]>>::try_from(
-                    src.as_slice(),
-                )?)
+                <Self as ::core::convert::TryFrom<&[u8]>>::try_from(src.as_slice())
             }
 
             fn to_bytes(&self) -> $crate::GenericArray<u8, Self::Size> {
@@ -323,9 +321,8 @@ macro_rules! derive_serde_from_repr_bytes {
                         }
                         let value =
                             &<GenericArray<u8, <$mytype as ReprBytes>::Size>>::from_slice(value);
-                        Ok(<$mytype as ReprBytes>::from_bytes(value).map_err(|err| {
-                            <E as $crate::_exports::serde::de::Error>::custom(err)
-                        })?)
+                        <$mytype as ReprBytes>::from_bytes(value)
+                            .map_err(|err| <E as $crate::_exports::serde::de::Error>::custom(err))
                     }
 
                     fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -162,9 +162,8 @@ pub trait ConnectionUri:
 
     /// Retrieve the TLS chain file path to use for this connection.
     fn tls_chain_path(&self) -> StdResult<String, String> {
-        Ok(self
-            .get_param("tls-chain")
-            .ok_or_else(|| format!("Missing tls-chain query parameter for {}", self.url()))?)
+        self.get_param("tls-chain")
+            .ok_or_else(|| format!("Missing tls-chain query parameter for {}", self.url()))
     }
 
     /// Retrieve the TLS chain to use for this connection.
@@ -176,9 +175,8 @@ pub trait ConnectionUri:
 
     /// Retrieve the TLS key file path to use for this connection.
     fn tls_key_path(&self) -> StdResult<String, String> {
-        Ok(self
-            .get_param("tls-key")
-            .ok_or_else(|| format!("Missing tls-key query parameter for {}", self.url()))?)
+        self.get_param("tls-key")
+            .ok_or_else(|| format!("Missing tls-key query parameter for {}", self.url()))
     }
 
     /// Retrieve the TLS key to use for this connection.


### PR DESCRIPTION
### Motivation

Make future `clippy` happy.

### In this PR
* There are a few instances where we use the question-mark operator unnecessarily. This PR removes them.


