### PR TITLE
replace from_iter with collect where possible

### DIFF
--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -163,8 +163,8 @@ impl ByzantineLedger {
         };
 
         Self {
-            task_sender,
             worker_handle,
+            task_sender,
             is_behind,
             highest_peer_block,
             highest_issued_msg,

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -30,7 +30,6 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
     cmp::min,
     collections::{BTreeSet, HashMap},
-    iter::FromIterator,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
@@ -407,12 +406,12 @@ impl<
         // Fairness heuristics:
         // * Values are proposed in the order that they were received.
         // * Each node limits the total number of values it proposes per slot.
-        let values = BTreeSet::from_iter(
-            self.pending_values
-                .iter()
-                .take(MAX_PENDING_VALUES_TO_NOMINATE)
-                .cloned(),
-        );
+        let values = self
+            .pending_values
+            .iter()
+            .take(MAX_PENDING_VALUES_TO_NOMINATE)
+            .cloned()
+            .collect();
 
         let msg_opt = self
             .scp_node

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -10,10 +10,7 @@ use mc_util_uri::{
     AdminUri, ConnectionUri, ConsensusClientUri as ClientUri, ConsensusPeerUri as PeerUri,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::Debug, fs, iter::FromIterator, path::PathBuf, str::FromStr, string::String, sync::Arc,
-    time::Duration,
-};
+use std::{fmt::Debug, fs, path::PathBuf, str::FromStr, string::String, sync::Arc, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
@@ -135,8 +132,11 @@ impl NetworkConfig {
             panic!("invalid quorum set: {:?}", self.quorum_set);
         }
 
-        let mut peer_map: HashMap<ResponderId, NodeID> =
-            HashMap::from_iter(self.broadcast_peers.iter().cloned().map(|uri| {
+        let mut peer_map: HashMap<ResponderId, NodeID> = self
+            .broadcast_peers
+            .iter()
+            .cloned()
+            .map(|uri| {
                 (
                     uri.responder_id().unwrap_or_else(|e| {
                         panic!("unable to get responder_id for {}: {:?}", uri, e)
@@ -144,7 +144,8 @@ impl NetworkConfig {
                     uri.node_id()
                         .unwrap_or_else(|e| panic!("unable to get node_id for {}: {:?}", uri, e)),
                 )
-            }));
+            })
+            .collect();
 
         if let Some(known_peers) = self.known_peers.as_ref() {
             for uri in known_peers.iter() {

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -12,10 +12,7 @@ use mc_transaction_core::{
 use mc_util_from_random::FromRandom;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_core::RngCore;
-use std::{
-    iter::FromIterator,
-    sync::{Arc, Mutex, MutexGuard},
-};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 #[derive(Default)]
 pub struct MockLedgerInner {
@@ -75,7 +72,7 @@ impl MockLedger {
         }
 
         let key_images = block_contents.key_images.clone();
-        inner.key_images = HashMap::from_iter(key_images.iter().map(|ki| (*ki, block.index)));
+        inner.key_images = key_images.iter().map(|ki| (*ki, block.index)).collect();
 
         inner
             .key_images_by_block_number

--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -24,7 +24,6 @@ use mc_util_uri::ConnectionUri;
 use retry::delay::Fibonacci;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    iter::FromIterator,
     sync::{Arc, Condvar, Mutex},
     thread,
     time::{Duration, Instant},
@@ -423,12 +422,11 @@ fn get_blocks<BC: BlockchainConnection + 'static>(
         .expect("waiting on condvar failed");
 
     // Filter out results with no blocks
-    HashMap::from_iter(
-        worker_results
-            .clone()
-            .into_iter()
-            .filter(|(_responder_id, blocks)| !blocks.is_empty()),
-    )
+    worker_results
+        .clone()
+        .into_iter()
+        .filter(|(_responder_id, blocks)| !blocks.is_empty())
+        .collect()
 }
 
 fn verify_block_ids(

--- a/ledger/sync/src/network_state/scp_network_state.rs
+++ b/ledger/sync/src/network_state/scp_network_state.rs
@@ -174,7 +174,7 @@ mod tests {
     use super::*;
     use mc_consensus_scp::{core_types::Ballot, msg::*};
     use mc_peers_test_utils::test_node_id;
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, iter::FromIterator};
 
     #[test]
     fn test_new() {

--- a/ledger/sync/src/network_state/scp_network_state.rs
+++ b/ledger/sync/src/network_state/scp_network_state.rs
@@ -13,7 +13,6 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
-    iter::FromIterator,
 };
 
 pub struct SCPNetworkState<ID: GenericNodeId + Send = NodeID> {
@@ -71,20 +70,23 @@ impl<ID: GenericNodeId + Send + AsRef<ResponderId> + DeserializeOwned + Serializ
     fn is_blocking_and_quorum(&self, responder_ids: &HashSet<ResponderId>) -> bool {
         // Construct a map of responder id -> dummy message so that we could leverage
         // the existing quorum findBlockingSet/findQuorum code.
-        let msg_map = HashMap::from_iter(responder_ids.iter().map(|responder_id| {
-            (
-                responder_id.clone(),
-                Msg::<&str, ResponderId>::new(
+        let msg_map = responder_ids
+            .iter()
+            .map(|responder_id| {
+                (
                     responder_id.clone(),
-                    QuorumSet::empty(),
-                    1,
-                    Topic::Externalize(ExternalizePayload {
-                        C: Ballot::new(1, &["fake"]),
-                        HN: 1,
-                    }),
-                ),
-            )
-        }));
+                    Msg::<&str, ResponderId>::new(
+                        responder_id.clone(),
+                        QuorumSet::empty(),
+                        1,
+                        Topic::Externalize(ExternalizePayload {
+                            C: Ballot::new(1, &["fake"]),
+                            HN: 1,
+                        }),
+                    ),
+                )
+            })
+            .collect();
 
         let quorum_set: QuorumSet<ResponderId> = (&self.local_quorum_set).into();
 
@@ -123,11 +125,12 @@ impl<ID: GenericNodeId + Send + AsRef<ResponderId> + DeserializeOwned + Serializ
             .map(|(id, _block_index)| id.clone())
             .collect();
 
-        self.is_blocking_and_quorum(&HashSet::from_iter(
-            peers_on_higher_block
+        self.is_blocking_and_quorum(
+            &peers_on_higher_block
                 .iter()
-                .map(|node_id| node_id.as_ref().clone()),
-        ))
+                .map(|node_id| node_id.as_ref().clone())
+                .collect(),
+        )
     }
 
     /// Returns the highest block index the network agrees on (the highest block
@@ -138,7 +141,7 @@ impl<ID: GenericNodeId + Send + AsRef<ResponderId> + DeserializeOwned + Serializ
         // for the highest slot index the network agrees on.
         let mut seen_block_indexes: Vec<BlockIndex> =
             self.peer_to_current_slot().values().cloned().collect();
-        seen_block_indexes.sort();
+        seen_block_indexes.sort_unstable();
         seen_block_indexes.dedup();
 
         // For each potential block index we saw (from the highest to the lowest), see
@@ -151,11 +154,12 @@ impl<ID: GenericNodeId + Send + AsRef<ResponderId> + DeserializeOwned + Serializ
                 .map(|(id, _block_index)| id.clone())
                 .collect();
 
-            if self.is_blocking_and_quorum(&HashSet::from_iter(
-                peers_on_higher_block
+            if self.is_blocking_and_quorum(
+                &peers_on_higher_block
                     .iter()
-                    .map(|node_id| node_id.as_ref().clone()),
-            )) {
+                    .map(|node_id| node_id.as_ref().clone())
+                    .collect(),
+            ) {
                 // Found a block index the network agrees on.
                 return Some(*highest_block_index);
             }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -9,7 +9,7 @@ use mc_api::external::{
 };
 use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom, iter::FromIterator};
+use std::convert::TryFrom;
 
 #[derive(Deserialize, Default, Debug)]
 pub struct JsonPasswordRequest {
@@ -994,11 +994,12 @@ impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
         proposal
             .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
         proposal.set_fee(src.fee);
-        proposal.set_outlay_index_to_tx_out_index(HashMap::from_iter(
+        proposal.set_outlay_index_to_tx_out_index(
             src.outlay_index_to_tx_out_index
                 .iter()
-                .map(|(key, val)| (*key as u64, *val as u64)),
-        ));
+                .map(|(key, val)| (*key as u64, *val as u64))
+                .collect(),
+        );
         proposal.set_outlay_confirmation_numbers(RepeatedField::from_vec(
             src.outlay_confirmation_numbers.clone(),
         ));
@@ -1295,6 +1296,7 @@ mod test {
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
+    use std::{collections::HashMap, iter::FromIterator};
 
     /// Test conversion of TxProposal
     #[test]

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -26,7 +26,7 @@ use rand::Rng;
 use std::{
     cmp::Reverse,
     convert::TryFrom,
-    iter::{empty, FromIterator},
+    iter::empty,
     str::FromStr,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -847,16 +847,19 @@ impl<T: UserTxConnection + 'static, FPR: FogPubkeyResolver> TransactionsManager<
             .map_err(|err| Error::TxBuildError(format!("build tx failed: {}", err)))?;
 
         // Map each TxOut in the constructed transaction to its respective outlay.
-        let outlay_index_to_tx_out_index =
-            HashMap::from_iter(tx.prefix.outputs.iter().enumerate().filter_map(
-                |(tx_out_index, tx_out)| {
-                    if let Some(outlay_index) = tx_out_to_outlay_index.get(tx_out) {
-                        Some((*outlay_index, tx_out_index))
-                    } else {
-                        None
-                    }
-                },
-            ));
+        let outlay_index_to_tx_out_index = tx
+            .prefix
+            .outputs
+            .iter()
+            .enumerate()
+            .filter_map(|(tx_out_index, tx_out)| {
+                if let Some(outlay_index) = tx_out_to_outlay_index.get(tx_out) {
+                    Some((*outlay_index, tx_out_index))
+                } else {
+                    None
+                }
+            })
+            .collect::<HashMap<_, _>>();
 
         // Sanity check: All of our outlays should have a unique index in the map.
         assert_eq!(outlay_index_to_tx_out_index.len(), destinations.len());

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -28,7 +28,6 @@ use std::{
     convert::TryFrom,
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
-    iter::FromIterator,
     ops::Range,
     str::FromStr,
     sync::{Arc, Mutex},
@@ -83,14 +82,13 @@ impl<L: Ledger + Sync> MockPeerConnection<L> {
     }
 
     pub fn msgs(&self) -> Vec<ConsensusMsg> {
-        Vec::from_iter(
-            self.state
-                .lock()
-                .expect("mutex poisoned")
-                .msgs
-                .iter()
-                .cloned(),
-        )
+        self.state
+            .lock()
+            .expect("mutex poisoned")
+            .msgs
+            .iter()
+            .cloned()
+            .collect()
     }
 
     pub fn reset_call_count(&mut self) {

--- a/util/build/script/src/env.rs
+++ b/util/build/script/src/env.rs
@@ -9,7 +9,6 @@ use std::{
     collections::{hash_map::Iter as HashMapIter, hash_set::Iter as HashSetIter, HashMap, HashSet},
     convert::TryFrom,
     env::{split_paths, var, var_os, vars, VarError},
-    iter::FromIterator,
     num::ParseIntError,
     path::{Path, PathBuf},
     str::FromStr,
@@ -337,12 +336,11 @@ impl Environment {
                     ))
                 }
             },
-            authors: HashSet::from_iter(
-                var(ENV_CARGO_PKG_AUTHORS)
-                    .map_err(|e| EnvironmentError::Var(ENV_CARGO_PKG_AUTHORS.to_owned(), e))?
-                    .split(':')
-                    .map(ToOwned::to_owned),
-            ),
+            authors: var(ENV_CARGO_PKG_AUTHORS)
+                .map_err(|e| EnvironmentError::Var(ENV_CARGO_PKG_AUTHORS.to_owned(), e))?
+                .split(':')
+                .map(ToOwned::to_owned)
+                .collect(),
             name: var(ENV_CARGO_PKG_NAME)
                 .map_err(|e| EnvironmentError::Var(ENV_CARGO_PKG_NAME.to_owned(), e))?,
             description: var(ENV_CARGO_PKG_DESCRIPTION)
@@ -369,12 +367,11 @@ impl Environment {
                     .map_err(|e| EnvironmentError::Var(ENV_CARGO_CFG_TARGET_FAMILY.to_owned(), e))?
                     .as_ref(),
             )?,
-            target_features: HashSet::from_iter(
-                var(ENV_CARGO_CFG_TARGET_FEATURE)
-                    .map_err(|e| EnvironmentError::Var(ENV_CARGO_CFG_TARGET_FEATURE.to_owned(), e))?
-                    .split(',')
-                    .map(ToOwned::to_owned),
-            ),
+            target_features: var(ENV_CARGO_CFG_TARGET_FEATURE)
+                .map_err(|e| EnvironmentError::Var(ENV_CARGO_CFG_TARGET_FEATURE.to_owned(), e))?
+                .split(',')
+                .map(ToOwned::to_owned)
+                .collect(),
             target_has_atomic,
             target_has_atomic_load_store,
             target_os: var(ENV_CARGO_CFG_TARGET_OS)


### PR DESCRIPTION
### Motivation

Future clippy prefers `.collect()` over `::from_iter()`.

### In this PR
* Switch to `.collect()` where possible.
* Some small misc changes (see specific comments)
