### PR TITLE
MCC-2313 Dynamic fees MVP

### DIFF
--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -18,6 +18,8 @@ service BlockchainAPI {
 message LastBlockInfoResponse {
     // Block index
     uint64 index = 1;
+    // Current minimum fee
+    uint64 minimum_fee = 2;
 }
 
 // Requests a range [offset, offset+limit) of Blocks.

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -209,7 +209,11 @@ pub trait ConsensusEnclave: ReportableEnclave {
         self_peer_id: &ResponderId,
         self_client_id: &ResponderId,
         sealed_key: &Option<SealedBlockSigningKey>,
+        minimum_fee: Option<u64>,
     ) -> Result<(SealedBlockSigningKey, Vec<String>)>;
+
+    /// Retrieve the current minimum fee
+    fn get_minimum_fee(&self) -> Result<u64>;
 
     /// Retrieve the public identity of the enclave.
     fn get_identity(&self) -> Result<X25519Public>;

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -17,7 +17,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum EnclaveCall {
     /// The [ConsensusEnclave::enclave_init()] method.
-    EnclaveInit(ResponderId, ResponderId, Option<SealedBlockSigningKey>),
+    EnclaveInit(
+        ResponderId,
+        ResponderId,
+        Option<SealedBlockSigningKey>,
+        Option<u64>,
+    ),
 
     /// The [PeerableEnclave::peer_init()] method.
     ///
@@ -125,4 +130,9 @@ pub enum EnclaveCall {
         Block,
         Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>,
     ),
+
+    /// The [ConsensusEnclave::get_minimum_fee()] method.
+    ///
+    /// Retrieves the minimum fee, as initialized.
+    GetMinimumFee,
 }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -23,6 +23,7 @@ use mc_crypto_keys::{
 use mc_crypto_rand::McRng;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
+    constants::MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutMembershipProof},
@@ -32,11 +33,26 @@ use mc_transaction_core::{
 use mc_util_from_random::FromRandom;
 use rand_core::SeedableRng;
 use rand_hc::Hc128Rng;
-use std::{convert::TryFrom, sync::Arc};
+use std::{
+    convert::TryFrom,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
-#[derive(Clone)]
 pub struct ConsensusServiceMockEnclave {
     pub signing_keypair: Arc<Ed25519Pair>,
+    pub minimum_fee: AtomicU64,
+}
+
+impl Clone for ConsensusServiceMockEnclave {
+    fn clone(&self) -> Self {
+        Self {
+            signing_keypair: self.signing_keypair.clone(),
+            minimum_fee: self.minimum_fee.load(Ordering::Acquire).into(),
+        }
+    }
 }
 
 impl Default for ConsensusServiceMockEnclave {
@@ -44,7 +60,10 @@ impl Default for ConsensusServiceMockEnclave {
         let mut csprng = Hc128Rng::seed_from_u64(0);
         let signing_keypair = Arc::new(Ed25519Pair::from_random(&mut csprng));
 
-        Self { signing_keypair }
+        Self {
+            signing_keypair,
+            minimum_fee: MINIMUM_FEE.into(),
+        }
     }
 }
 
@@ -90,8 +109,15 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         _self_peer_id: &ResponderId,
         _self_client_id: &ResponderId,
         _sealed_key: &Option<SealedBlockSigningKey>,
+        minimum_fee: Option<u64>,
     ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
+        self.minimum_fee
+            .store(minimum_fee.unwrap_or(MINIMUM_FEE), Ordering::Release);
         Ok((vec![], vec![]))
+    }
+
+    fn get_minimum_fee(&self) -> Result<u64> {
+        Ok(self.minimum_fee.load(Ordering::Acquire))
     }
 
     fn get_identity(&self) -> Result<X25519Public> {
@@ -217,6 +243,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
                 tx,
                 parent_block.index + 1,
                 proofs,
+                MINIMUM_FEE,
                 &mut rng,
             )?;
 

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -29,7 +29,10 @@ mock! {
             self_peer_id: &ResponderId,
             self_client_id: &ResponderId,
             sealed_key: &Option<SealedBlockSigningKey>,
+            minimum_fee: Option<u64>,
         ) -> ConsensusEnclaveResult<(SealedBlockSigningKey, Vec<String>)>;
+
+        fn get_minimum_fee(&self) -> ConsensusEnclaveResult<u64>;
 
         fn get_identity(&self) -> ConsensusEnclaveResult<X25519Public>;
 

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -34,9 +34,17 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
     // And actually do it
     let outdata = match call_details {
         // Utility methods
-        EnclaveCall::EnclaveInit(peer_self_id, client_self_id, sealed_key) => {
-            serialize(&ENCLAVE.enclave_init(&peer_self_id, &client_self_id, &sealed_key))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
+        EnclaveCall::EnclaveInit(peer_self_id, client_self_id, sealed_key, minimum_fee) => {
+            serialize(&ENCLAVE.enclave_init(
+                &peer_self_id,
+                &client_self_id,
+                &sealed_key,
+                minimum_fee,
+            ))
+            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
+        }
+        EnclaveCall::GetMinimumFee => {
+            serialize(&ENCLAVE.get_minimum_fee()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         // Node-to-Node Attestation
         EnclaveCall::PeerInit(node_id) => {

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -219,7 +219,7 @@ mod tests {
         );
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, minimum_fee);
+            BlockchainApiService::new(ledger_db, authenticator, logger, Some(minimum_fee));
 
         let block_response = blockchain_api_service.get_last_block_info_helper().unwrap();
         assert_eq!(block_response, expected_response);
@@ -236,7 +236,8 @@ mod tests {
             SystemTimeProvider::default(),
         ));
 
-        let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
+        let blockchain_api_service =
+            BlockchainApiService::new(ledger_db, authenticator, logger, None);
 
         let (client, _server) = get_client_server(blockchain_api_service);
 
@@ -268,7 +269,7 @@ mod tests {
             .collect();
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger);
+            BlockchainApiService::new(ledger_db, authenticator, logger, None);
 
         {
             // The empty range [0,0) should return an empty collection of Blocks.
@@ -306,7 +307,7 @@ mod tests {
         let _blocks = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger);
+            BlockchainApiService::new(ledger_db, authenticator, logger, None);
 
         {
             // The range [0, 1000) requests values that don't exist. The response should
@@ -332,7 +333,7 @@ mod tests {
             .collect();
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger);
+            BlockchainApiService::new(ledger_db, authenticator, logger, None);
         blockchain_api_service.set_max_page_size(5);
 
         // The request exceeds the max_page_size, so only max_page_size items should be
@@ -355,7 +356,8 @@ mod tests {
             SystemTimeProvider::default(),
         ));
 
-        let blockchain_api_service = BlockchainApiService::new(ledger_db, authenticator, logger);
+        let blockchain_api_service =
+            BlockchainApiService::new(ledger_db, authenticator, logger, None);
 
         let (client, _server) = get_client_server(blockchain_api_service);
 

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), ConsensusServiceError> {
         &config.peer_responder_id,
         &config.client_responder_id,
         &cached_key,
+        config.minimum_fee().expect("Could not parse minimum fee"),
     );
 
     log::info!(logger, "Enclave target features: {}", features.join(", "));

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -91,6 +91,14 @@ pub struct Config {
     /// hours).
     #[structopt(long, default_value = "86400", parse(try_from_str=parse_duration_in_seconds))]
     pub client_auth_token_max_lifetime: Duration,
+
+    /// Override the hard-coded minimum fee.
+    #[structopt(long, env = "MC_MINIMUM_FEE")]
+    pub minimum_fee: Option<u64>,
+
+    /// Allow extreme (>= 1MOB, <= 0.000_000_01 MOB).
+    #[structopt(long)]
+    pub allow_any_fee: bool,
 }
 
 /// Decodes an Ed25519 private key.
@@ -203,6 +211,20 @@ impl Config {
         NodeID {
             responder_id: self.peer_responder_id.clone(),
             public_key: self.msg_signer_key.public_key(),
+        }
+    }
+
+    /// Get the configured minimum fee.
+    pub fn minimum_fee(&self) -> Result<Option<u64>, String> {
+        if let Some(fee) = self.minimum_fee {
+            // 1 MOB -> 10nMOB
+            if (fee > 1_000_000_000_000 || fee < 10_000) && !self.allow_any_fee {
+                Err(format!("Fee {} picoMOB is out of bounds", fee))
+            } else {
+                Ok(Some(fee))
+            }
+        } else {
+            Ok(None)
         }
     }
 
@@ -432,6 +454,8 @@ mod tests {
             sealed_block_signing_key: PathBuf::default(),
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
+            minimum_fee: None,
+            allow_any_fee: false,
         };
 
         assert_eq!(
@@ -487,6 +511,8 @@ mod tests {
             sealed_block_signing_key: PathBuf::default(),
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
+            minimum_fee: None,
+            allow_any_fee: false,
         };
 
         assert_eq!(

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -338,6 +338,9 @@ impl<
                 self.ledger_db.clone(),
                 self.client_authenticator.clone(),
                 self.logger.clone(),
+                self.config
+                    .minimum_fee()
+                    .expect("Could not read minimum fee"),
             ));
 
         let is_serving_user_requests = self.create_is_serving_user_requests_fn();
@@ -430,6 +433,9 @@ impl<
                 self.ledger_db.clone(),
                 peer_authenticator.clone(),
                 self.logger.clone(),
+                self.config
+                    .minimum_fee()
+                    .expect("Could not read minimum fee"),
             ));
 
         let peer_service = consensus_peer_grpc::create_consensus_peer_api(PeerApiService::new(

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -31,6 +31,7 @@ pub fn validate<R: RngCore + CryptoRng>(
     tx: &Tx,
     current_block_index: u64,
     root_proofs: &[TxOutMembershipProof],
+    minimum_fee: u64,
     csprng: &mut R,
 ) -> TransactionValidationResult<()> {
     validate_number_of_inputs(&tx.prefix, MAX_INPUTS)?;
@@ -49,7 +50,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 
     validate_signature(&tx, csprng)?;
 
-    validate_transaction_fee(&tx)?;
+    validate_transaction_fee(&tx, minimum_fee)?;
 
     validate_key_images_are_unique(&tx)?;
 
@@ -224,9 +225,9 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
         .map_err(TransactionValidationError::InvalidTransactionSignature)
 }
 
-/// The fee amount must be greater than or equal to `MINIMUM_FEE`.
-fn validate_transaction_fee(tx: &Tx) -> TransactionValidationResult<()> {
-    if tx.prefix.fee < MINIMUM_FEE {
+/// The fee amount must be greater than or equal to the given minimum fee.
+fn validate_transaction_fee(tx: &Tx, minimum_fee: u64) -> TransactionValidationResult<()> {
+    if tx.prefix.fee < minimum_fee {
         Err(TransactionValidationError::TxFeeError)
     } else {
         Ok(())
@@ -870,7 +871,7 @@ mod tests {
             // Zero fees gets rejected
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT, 0);
             assert_eq!(
-                validate_transaction_fee(&tx),
+                validate_transaction_fee(&tx, 1000),
                 Err(TransactionValidationError::TxFeeError)
             );
         }
@@ -880,7 +881,7 @@ mod tests {
             let fee = MINIMUM_FEE - 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
             assert_eq!(
-                validate_transaction_fee(&tx),
+                validate_transaction_fee(&tx, MINIMUM_FEE),
                 Err(TransactionValidationError::TxFeeError)
             );
         }
@@ -889,14 +890,14 @@ mod tests {
             // Exact fee amount is okay
             let (tx, _ledger) =
                 create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - MINIMUM_FEE, MINIMUM_FEE);
-            assert_eq!(validate_transaction_fee(&tx), Ok(()));
+            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
         }
 
         {
             // Overpaying fees is okay
             let fee = MINIMUM_FEE + 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
-            assert_eq!(validate_transaction_fee(&tx), Ok(()));
+            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
         }
     }
 


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=l0zaebtU-CA)

### Motivation

See mobilecoinfoundation/rfcs#1 for a detailed discussion.

### In this PR
* Adds a `--minimum-fee` command-line argument that takes a u64 picoMOB minimum fee
* Injects the value into the peer `ResponderId` string (local and remote).
* Stores that value into an `AtomicU64` in the enclave.
* References that when validating transactions.
* Adds a `LastBlockInfoResponse::minimum_fee` member, and set it

### Future Work
* Create a new "units" crate which handles parsing unit-denominated MOB, and does proper `std::chrono`-style unit conversion.

