### PR TITLE
Expose the `get_value_mask` function of `transaction_core::amount`

### DIFF
--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -90,9 +90,9 @@ impl Amount {
     }
 }
 
-/// Computes `Blake2B(value_mask | shared_secret)`, hashed to Ristretto, then
-/// interprets the first 8 canonical bytes as as u64 in little-endian
-/// representation.
+/// Computes `Blake2B(value_mask | shared_secret)`, hashed to a Ristretto
+/// scalar, then interprets the first 8 canonical bytes as a u64 number in
+/// little-endian representation.
 ///
 /// # Arguments
 /// * `shared_secret` - The shared secret, e.g. `rB`.

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -31,7 +31,7 @@ pub mod validation;
 #[cfg(test)]
 pub mod proptest_fixtures;
 
-pub use amount::{Amount, AmountError, Commitment, CompressedCommitment};
+pub use amount::{get_value_mask, Amount, AmountError, Commitment, CompressedCommitment};
 pub use blockchain::*;
 
 /// Get the shared secret for a transaction output.


### PR DESCRIPTION
This slightly refactors the `get_value_mask` function to return the u64
mask instead of a Ristretto scalar. This is because the u64 is what
all of the callers need and use, so there is less code duplication
if the function actually returns that.

This also makes the `get_value_mask` function exposed as part of the
public transaction-core API. This is because it is needed in fog,
to support a version of TxOut's where we don't store the compressed
commitment in Fog, and instead the user reconstructs that from the
other data in the TxOut.