### PR TITLE
Make ledgerdb errors more verbose, log ledger sync errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,7 +2898,7 @@ name = "mc-ledger-db"
 version = "1.0.1-pre1"
 dependencies = [
  "curve25519-dalek",
- "failure",
+ "displaydoc",
  "lazy_static",
  "lmdb-rkv",
  "mc-account-keys",

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -20,7 +20,7 @@ mc-util-lmdb = { path = "../../util/lmdb" }
 mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
-failure = "0.1.8"
+displaydoc = { version = "0.2", default-features = false }
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
 mockall = "0.8.3"

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -1,59 +1,67 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use failure::Fail;
-use mc_transaction_core::membership_proofs::RangeError;
+use displaydoc::Display;
+use mc_transaction_core::{membership_proofs::RangeError, BlockID, BlockIndex};
 use mc_util_lmdb::MetadataStoreError;
 
 /// A Ledger error kind.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Fail)]
+#[derive(Debug, Eq, PartialEq, Clone, Display)]
 pub enum Error {
-    #[fail(display = "NotFound")]
+    /// NotFound
     NotFound,
 
-    #[fail(display = "Serialization")]
+    /// Serialization
     Serialization,
 
-    #[fail(display = "Deserialization")]
+    /// Deserialization
     Deserialization,
 
-    #[fail(display = "NoTransactions")]
+    /// NoTransactions
     NoTransactions,
 
-    #[fail(display = "InvalidBlock")]
-    InvalidBlock,
+    /// InvalidBlockVersion: {0}
+    InvalidBlockVersion(u32),
 
-    #[fail(display = "KeyImageAlreadySpent")]
+    /// NoKeyImages
+    NoKeyImages,
+
+    /// InvalidBlockIndex: {0}
+    InvalidBlockIndex(BlockIndex),
+
+    /// KeyImageAlreadySpent
     KeyImageAlreadySpent,
 
-    #[fail(display = "DuplicateOutputPublicKey")]
+    /// DuplicateOutputPublicKey
     DuplicateOutputPublicKey,
 
-    #[fail(display = "InvalidBlockContents")]
+    /// InvalidBlockContents
     InvalidBlockContents,
 
-    #[fail(display = "InvalidBlockID")]
-    InvalidBlockID,
+    /// InvalidBlockID: {0}
+    InvalidBlockID(BlockID),
 
-    #[fail(display = "NoOutputs")]
+    /// InvalidParentBlockID: {0}
+    InvalidParentBlockID(BlockID),
+
+    /// NoOutputs
     NoOutputs,
 
     /// LMDB error, may mean database is opened multiple times in a process.
-    #[fail(display = "BadRslot")]
     BadRslot,
 
-    #[fail(display = "CapacityExceeded")]
+    /// CapacityExceeded
     CapacityExceeded,
 
-    #[fail(display = "IndexOutOfBounds: {}", _0)]
+    /// IndexOutOfBounds: {0}
     IndexOutOfBounds(u64),
 
-    #[fail(display = "LmdbError")]
-    LmdbError(lmdb::Error),
+    /// Lmdb: {0}
+    Lmdb(lmdb::Error),
 
-    #[fail(display = "RangeError")]
-    RangeError,
+    /// Range
+    Range,
 
-    #[fail(display = "Metadata store error: {}", _0)]
+    /// Metadata store: {0}
     MetadataStore(MetadataStoreError),
 }
 
@@ -62,7 +70,7 @@ impl From<lmdb::Error> for Error {
         match lmdb_error {
             lmdb::Error::NotFound => Error::NotFound,
             lmdb::Error::BadRslot => Error::BadRslot,
-            err => Error::LmdbError(err),
+            err => Error::Lmdb(err),
         }
     }
 }
@@ -93,7 +101,7 @@ impl From<mc_util_serial::EncodeError> for Error {
 
 impl From<RangeError> for Error {
     fn from(_: RangeError) -> Self {
-        Error::RangeError
+        Error::Range
     }
 }
 

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -1007,7 +1007,7 @@ pub mod tx_out_store_tests {
 
         let mut rw_transaction: RwTransaction = env.begin_rw_txn().unwrap();
         match tx_out_store.push(&tx_outs[0], &mut rw_transaction) {
-            Err(Error::LmdbError(lmdb::Error::KeyExist)) => {}
+            Err(Error::Lmdb(lmdb::Error::KeyExist)) => {}
             Ok(_) => panic!("unexpected success"),
             Err(_) => panic!("unexpected error"),
         };
@@ -1032,7 +1032,7 @@ pub mod tx_out_store_tests {
 
         let mut rw_transaction: RwTransaction = env.begin_rw_txn().unwrap();
         match tx_out_store.push(&tx_outs[0], &mut rw_transaction) {
-            Err(Error::LmdbError(lmdb::Error::KeyExist)) => {}
+            Err(Error::Lmdb(lmdb::Error::KeyExist)) => {}
             Ok(_) => panic!("unexpected success"),
             Err(_) => panic!("unexpected error"),
         };

--- a/ledger/sync/src/ledger_sync/ledger_sync_error.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_error.rs
@@ -10,8 +10,8 @@ use retry::Error as RetryError;
 
 #[derive(Debug, Fail)]
 pub enum LedgerSyncError {
-    #[fail(display = "Error occurred with ledger_db.")]
-    DBError,
+    #[fail(display = "Ledger db: {0}", _0)]
+    DBError(LedgerDbError),
 
     #[fail(display = "No potentially safe blocks.")]
     NoSafeBlocks,
@@ -46,7 +46,7 @@ impl<TFE: TransactionFetcherError + 'static> From<TFE> for LedgerSyncError {
 }
 
 impl From<LedgerDbError> for LedgerSyncError {
-    fn from(_x: LedgerDbError) -> Self {
-        LedgerSyncError::DBError
+    fn from(src: LedgerDbError) -> Self {
+        LedgerSyncError::DBError(src)
     }
 }

--- a/ledger/sync/src/ledger_sync/ledger_sync_service_thread.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service_thread.rs
@@ -132,8 +132,11 @@ impl LedgerSyncServiceThread {
             if is_behind {
                 let network_state = network_state.read().expect("lock poisoned");
 
-                let _ = ledger_sync_service
-                    .attempt_ledger_sync(&*network_state, MAX_BLOCKS_PER_SYNC_ITERATION);
+                if let Err(err) = ledger_sync_service
+                    .attempt_ledger_sync(&*network_state, MAX_BLOCKS_PER_SYNC_ITERATION)
+                {
+                    log::error!(logger, "Attempt ledger sync failed: {}", err);
+                }
             } else if !stop_requested.load(Ordering::SeqCst) {
                 log::trace!(
                     logger,

--- a/transaction/core/src/blockchain/block_id.rs
+++ b/transaction/core/src/blockchain/block_id.rs
@@ -2,7 +2,11 @@
 
 use crate::ConvertError;
 use alloc::{vec, vec::Vec};
-use core::{convert::TryFrom, fmt::Debug, hash::Hash};
+use core::{
+    convert::TryFrom,
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
+    hash::Hash,
+};
 use mc_crypto_digestible::Digestible;
 use prost::{
     bytes::{Buf, BufMut},
@@ -30,6 +34,12 @@ impl TryFrom<&[u8]> for BlockID {
 impl AsRef<[u8]> for BlockID {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl Display for BlockID {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", hex_fmt::HexFmt(&self.0),)
     }
 }
 


### PR DESCRIPTION
### Motivation

During some upgrade experiments we learnt that if LedgerSyncService repeatedly fails to append a block due to an incompatible version number, nothing useful is logged. This PR improves that situation.

### In this PR
* More explicit mc-ledger-db Error variants
* failure -> displaydoc
* Explicit logging of failed attempt_ledger_sync calls
