### PR TITLE
Undo block version bump

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -12,9 +12,16 @@ use std::{env::var, path::PathBuf};
 // if you do.
 const SGX_VERSION: &str = "2.9.101.2";
 
+/// The consensus enclave product ID, this must remain as "1"
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
+
+/// The Consensus Enclave Version: Increment this whenever releasing to mainnet.
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 2;
+
+/// The name of the enclave, used to construct consistent paths.
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
+
+/// The relative location (to this file) where the trusted crate lives.
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 
 fn main() {

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -12,16 +12,9 @@ use std::{env::var, path::PathBuf};
 // if you do.
 const SGX_VERSION: &str = "2.9.101.2";
 
-/// The consensus enclave product ID, this must remain as "1"
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
-
-/// The Consensus Enclave Version: Increment this whenever releasing to mainnet.
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 2;
-
-/// The name of the enclave, used to construct consistent paths.
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
-
-/// The relative location (to this file) where the trusted crate lives.
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 
 fn main() {

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1317,16 +1317,18 @@ mod ledger_db_test {
                 Err(Error::InvalidBlock)
             );
 
-            let invalid_block = Block::new_with_parent(
-                last_block.version - 1,
-                &last_block,
-                &Default::default(),
-                &block_contents,
-            );
-            assert_eq!(
-                ledger_db.append_block(&invalid_block, &block_contents, None),
-                Err(Error::InvalidBlock)
-            );
+            if last_block.version > 0 {
+                let invalid_block = Block::new_with_parent(
+                    last_block.version - 1,
+                    &last_block,
+                    &Default::default(),
+                    &block_contents,
+                );
+                assert_eq!(
+                    ledger_db.append_block(&invalid_block, &block_contents, None),
+                    Err(Error::InvalidBlock)
+                );
+            }
         }
     }
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -9,10 +9,8 @@ use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
-/// Version identifier.
-/// This is the current version, which also implies it is the max version that
-/// could be considered valid.
-pub const BLOCK_VERSION: u32 = 1;
+/// The current block format version.
+pub const BLOCK_VERSION: u32 = 0;
 
 /// The index of a block in the blockchain.
 pub type BlockIndex = u64;


### PR DESCRIPTION
### Motivation

Bumping the block version represents a breaking change to clients, and the impetus to bump the block version is a semantic change to this field. This updates the release branch to revert this change.

### In this PR
* Revert the actual block version bump, while keeping the rest of PR 

### Future Work
* Re-designing the ledger to handle changes in an extensible way.

