### PR TITLE
Fix fees in TransactionManager::select_utxos_for_optimization

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -483,6 +483,9 @@ message GenerateOptimizationTxRequest {
 
     // Subaddress to operate on.
     uint64 subaddress = 2;
+
+    // Add an optional fee
+    uint64 fee = 3;
 }
 message GenerateOptimizationTxResponse {
     TxProposal tx_proposal = 1;

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -604,7 +604,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             }
 
             // Calculate the fee - right now this is constant.
-            let fee = MINIMUM_FEE;
+            let fee = get_fees(0);
 
             // See if the total amount we are trying to merge into our biggest UTXO is
             // bigger than the fee. If it's smaller, the merge would just lose

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1060,7 +1060,7 @@ mod test {
             utxos[4].value = 2000 * MILLIMOB_TO_PICOMOB;
             utxos[5].value = 1000 * MILLIMOB_TO_PICOMOB;
 
-            let (selected_utxos, fee) =
+            let selected_utxos =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
@@ -1068,7 +1068,6 @@ mod test {
                 .unwrap();
 
             assert_eq!(selected_utxos, vec![utxos[0].clone(), utxos[4].clone()]);
-            assert_eq!(fee, MINIMUM_FEE);
         }
 
         // Optimizing with max_inputs=3 should select 100, 150, 2000;
@@ -1082,7 +1081,7 @@ mod test {
             utxos[4].value = 2000 * MILLIMOB_TO_PICOMOB;
             utxos[5].value = 1000 * MILLIMOB_TO_PICOMOB;
 
-            let (selected_utxos, fee) =
+            let selected_utxos =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
@@ -1093,7 +1092,6 @@ mod test {
                 selected_utxos,
                 vec![utxos[0].clone(), utxos[2].clone(), utxos[4].clone()]
             );
-            assert_eq!(fee, MINIMUM_FEE);
         }
     }
 
@@ -1150,7 +1148,7 @@ mod test {
             utxos[2].value = MINIMUM_FEE / 10;
             utxos[3].value = MINIMUM_FEE / 5;
 
-            let (selected_utxos, fee) =
+            let selected_utxos =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
@@ -1162,7 +1160,6 @@ mod test {
                 selected_utxos,
                 vec![utxos[3].clone(), utxos[0].clone(), utxos[1].clone()]
             );
-            assert_eq!(fee, MINIMUM_FEE);
         }
     }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -886,7 +886,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // Generate optimization tx.
         let tx_proposal = self
             .transactions_manager
-            .generate_optimization_tx(&monitor_id, request.subaddress)
+            .generate_optimization_tx(&monitor_id, request.subaddress, request.fee)
             .map_err(|err| {
                 rpc_internal_error(
                     "transactions_manager.generate_optimization_tx",


### PR DESCRIPTION
### Motivation

The UTXO optimziation selection function was still using (and returning) a hard-coded fee, this makes it use a provided fee instead, and plumbs that fee back out to gRPC

### In this PR
* Makes `TransactionManager::select_utxos_for_optimization()` take a fee amount, rather than return it.
* Adds a `fee` argument to `TransactionManager::generate_optimization_tx()`.
* Adds a `fee` field to the `GenerateOptimizationTxRequest` gRPC message.