### PR TITLE
Bump all versions to 1.1.0-pre5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "criterion",
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "grpcio",
  "mc-common",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2172,7 +2172,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "binascii",
  "bincode",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "failure",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-attest-core",
  "mc-sgx-build",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2296,7 +2296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "cookie 0.14.3",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-connection",
  "mc-ledger-db",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "futures 0.3.8",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "failure",
  "mc-attest-ake",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "hex 0.4.2",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "bigint",
  "crossbeam-channel 0.5.0",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-common",
  "mc-consensus-scp",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "digest 0.9.0",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.4",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "digest 0.9.0",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "failure",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "futures 0.3.8",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "curve25519-dalek",
  "failure",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "dirs 2.0.2",
  "failure",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-api",
  "mc-common",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "lmdb-rkv",
  "mc-common",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "failure",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "futures 0.3.8",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "grpcio",
  "hex 0.4.2",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "ed25519",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "grpcio",
  "hex 0.4.2",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-types",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -3180,7 +3180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "sha2 0.9.3",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "hex_fmt",
  "mc-sgx-css",
@@ -3197,21 +3197,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -3247,18 +3247,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "mc-slam"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "curve25519-dalek",
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "hex 0.4.2",
  "mc-api",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.9.1",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -3438,14 +3438,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "json",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "base64 0.12.3",
  "binascii",
@@ -3479,14 +3479,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "rand_core 0.6.2",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "curve25519-dalek",
  "hex 0.3.2",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "base64 0.12.3",
  "cookie 0.14.3",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "grpcio",
  "mc-common",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "hex 0.4.2",
  "mc-common",
@@ -3562,11 +3562,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "hex 0.4.2",
  "mc-account-keys",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "crossbeam-channel 0.5.0",
  "mc-util-metrics",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "chrono",
  "grpcio",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "generic-array 0.14.4",
  "prost",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "prost",
  "serde",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "datatest",
  "serde",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "base64 0.12.3",
  "displaydoc",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/account-keys/slip10/Cargo.toml
+++ b/account-keys/slip10/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-slip10"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "binascii",
  "bitflags",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "failure",
  "mc-attest-core",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "binascii",
  "cfg-if 0.1.10",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "failure",
  "mc-attest-ake",
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "curve25519-dalek",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "digest",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aes-gcm",
  "failure",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "getrandom 0.1.14",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1010,11 +1010,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-sgx-alloc",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1045,29 +1045,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cfg-if 0.1.10",
  "mc-common",
@@ -1096,14 +1096,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1111,11 +1111,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "blake2",
  "bulletproofs",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "failure",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "base64",
  "binascii",
@@ -1177,14 +1177,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "generic-array",
  "prost",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 dependencies = [
  "prost",
  "serde",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/ct-aead/Cargo.toml
+++ b/crypto/ct-aead/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ct-aead"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin DH Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "mc-fog-api"

--- a/fog/api/test-utils/Cargo.toml
+++ b/fog/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog report signatures"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["Mobilecoin"]
 edition = "2018"
 

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 
 

--- a/slam/Cargo.toml
+++ b/slam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-slam"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-std"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "1.1.0-pre4"
+version = "1.1.0-pre5"
 authors = ["MobileCoin"]
 edition = "2018"
 


### PR DESCRIPTION
### Motivation

Required to do a new testnet release w/ upgraded SGX.

### In this PR
* Bump all crate versions to 1.1.0-pre5
