### PR TITLE
Always set DEBUG_ENCLAVE to false in IAS prod mode.

### DIFF
--- a/attest/core/src/lib.rs
+++ b/attest/core/src/lib.rs
@@ -81,8 +81,8 @@ cfg_if! {
             "../data/Dev_AttestationReportSigningCACert.pem"
         ), "\0")];
     } else {
-        /// Whether or not enclaves should be run and validated in debug mode.
-        pub const DEBUG_ENCLAVE: bool = cfg!(debug_assertions);
+        /// Debug enclaves in prod mode are not supported.
+        pub const DEBUG_ENCLAVE: bool = false;
         /// An array of zero-terminated signing certificate PEM files used as root anchors.
         pub const IAS_SIGNING_ROOT_CERT_PEMS: &[&str] = &[concat!(include_str!(
             "../data/AttestationReportSigningCACert.pem"


### PR DESCRIPTION
### Motivation

Intending to support clients connecting to a "Pre-Production" environment, we were setting `DEBUG_ENCLAVE` conditionally, based on whether or not debug assertions were enabled. This has the surprising effect of allowing verifiers compiled in debug mode with `IAS_MODE=PROD` set to allow debug-mode enclaves to verify.

Additionally, now that IAS DEV and "LIV" (PROD) environments both use the same root authority, DEV vs. PROD is sufficient to distinguish whether debug enclaves are supported or not.

We should just remove the conditional and simply make PROD builds always reject debug enclaves, because it removes a footgun.

### In this PR
* Make `DEBUG_ENCLAVE` always `false` when not built with the `sgx-sim` or `ias-dev` features.

