### PR TITLE
Consensus enclaves don't run on sha-ni chips right now.

### DIFF
--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1566,16 +1566,6 @@ dependencies = [
  "cpufeatures",
  "digest",
  "opaque-debug",
- "sha2-asm",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c397a68de3079fa40e34eba871bea7f10de663f27f4c8b865c89ab47f103723"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -38,11 +38,10 @@ mc-sgx-types = { path = "../../../sgx/types" }
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
 mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
 
-# We include this here so we can make sure it uses the compile-only feature
+# We include these here so we can select in-the-enclave features
 cpufeatures = { version = "0.1.5", features = ["compile-only"] }
-
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
-sha2 = { version = "0.9", default-features = false, features = ["asm"] }
+sha2 = { version = "0.9.5", default-features = false }
 
 [build-dependencies]
 mc-util-build-script = { path = "../../../util/build/script" }


### PR DESCRIPTION
### Motivation

The master branch is currently producing a `SIGILL` when trying to verify the quote given by a quoting enclave. None of the CPUs we expect to run an enclave on will support the SHA-NI instructions anyways.

### In this PR
* Disable the `asm` feature from the `sha2` crate (should never be used anyways)

