### PR TITLE
Work around broken cargo trim -d

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,8 +138,10 @@ commands:
 
             # Configure cargo-trim with the project's Cargo.lock files
             mkdir -p ~/.config
-            cargo trim --directory "$(pwd)"
-            cargo trim --directory "$(pwd)/consensus/enclave/trusted"
+            cargo trim init
+            pushd "consensus/enclave/trusted"
+            cargo trim init
+            popd
 
             # Clean dependencies not in the Cargo.lock
             time cargo trim --orphan


### PR DESCRIPTION
### Motivation

PRs to master are still failing, due to a bug / change in `cargo trim` (the `--directory` argument doesn't appear to function)

### In this PR
* Run `cargo trim init` in the top-level and trusted enclave directories directly.