### PR TITLE
Update Python client library to reflect changes to protocol.

### DIFF
--- a/mobilecoind/clients/python/cli/benchmark.py
+++ b/mobilecoind/clients/python/cli/benchmark.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     print("\n...testing `mobilecoind.add_monitor`")
     print("{:>18}, {:>18}".format("num_subaddresses", "duration (sec)"))
     for count in subaddress_counts:
-        entropy_bytes = mobilecoind.generate_entropy().entropy
+        entropy_bytes = mobilecoind.generate_entropy()
         account_key = mobilecoind.get_account_key(entropy_bytes).account_key
         start = datetime.datetime.now()
         monitor_id = mobilecoind.add_monitor(account_key,
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         print("\n...testing block processing rate with new monitor with {} subaddresses".format(count))
         accum_count = 0
         accum_rate_times_count = 0
-        entropy_bytes = mobilecoind.generate_entropy().entropy
+        entropy_bytes = mobilecoind.generate_entropy()
         account_key = mobilecoind.get_account_key(entropy_bytes).account_key
         monitor_id = mobilecoind.add_monitor(account_key,
                                              first_subaddress = mobilecoin.DEFAULT_SUBADDRESS_INDEX,

--- a/mobilecoind/clients/python/cli/check_balance.py
+++ b/mobilecoind/clients/python/cli/check_balance.py
@@ -20,13 +20,23 @@ if __name__ == '__main__':
         description='Processes all downloaded blocks to display current balance information for a provided master key.'
     )
     parser.add_argument('-k', '--key', help='account master key', type=str, required=True)
+    parser.add_argument('-m', '--mnemonic', help='account key as mnemonic string', type=str)
     parser.add_argument('-s', '--subaddress', help='(optional) subaddress', nargs='?', const=mobilecoin.DEFAULT_SUBADDRESS_INDEX, type=int, default=mobilecoin.DEFAULT_SUBADDRESS_INDEX)
     parser.add_argument('--first-block', help='(optional) first ledger block to scan', nargs='?', const=0, type=int, dest='first_block', default=0)
     args = parser.parse_args()
 
+    # determine account key from entropy
+    if args.key:
+        entropy_bytes = bytes.fromhex(args.key)
+        account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+        entropy_display = entropy_bytes.hex()
+    elif:
+        account_key = mobilecoind.get_account_key_from_mnemonic(args.mnemonic)
+        entropy_display = mnemonic
+    else:
+        raise ValueError("One of --mnemonic or --key must be specified!")
+
     # create a monitor
-    entropy_bytes = bytes.fromhex(args.key)
-    account_key = mobilecoind.get_account_key(entropy_bytes).account_key
     monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress, first_block=args.first_block).monitor_id
 
     # Wait for the monitor to process the complete ledger (this also downloads the complete ledger)
@@ -49,7 +59,7 @@ if __name__ == '__main__':
 
     # print account information
     print("\n")
-    print("    {:<18}{}".format("Master Key:", args.key))
+    print("    {:<18}{}".format("Master Key:", entropy_display))
     print("    {:<18}{}".format("Subaddress Index:", args.subaddress))
     print("    {:<18}{}".format("Address Code:", public_address.b58_code))
     print("    {:<18}{}".format("Address URL:", "mob58://"+ public_address.b58_code))

--- a/mobilecoind/clients/python/cli/get_public_address.py
+++ b/mobilecoind/clients/python/cli/get_public_address.py
@@ -19,18 +19,25 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Displays public address information for a provided master key, or for a random master key if no key is provided.')
     parser.add_argument('-k', '--key', help='account master key', type=str)
+    parser.add_argument('-m', '--mnemonic', help='account key as mnemonic string', type=str)
     parser.add_argument('-s', '--subaddress', help='(optional) subaddress', nargs='?', const=mobilecoin.DEFAULT_SUBADDRESS_INDEX, type=int, default=mobilecoin.DEFAULT_SUBADDRESS_INDEX)
     args = parser.parse_args()
 
     # create a monitor and use it to calculate the public address
-    entropy_bytes = bytes.fromhex(args.key) if args.key else mobilecoind.generate_entropy().entropy
-    account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+    if args.key:
+        entropy_bytes = bytes.fromhex(args.key) if args.key else mobilecoind.generate_entropy()
+        account_key = mobilecoind.get_account_key(entropy_bytes).account_key
+        entropy_display = entropy_bytes.hex()
+    else:
+        mnemonic = args.mnemonic if args.mnemonic else mobilecoind.generate_mnemonic()
+        account_key = mobilecoind.get_account_key_from_mnemonic(mnemonic)
+        entropy_display = mnemonic
     monitor_id = mobilecoind.add_monitor(account_key, first_subaddress=args.subaddress).monitor_id
     public_address = mobilecoind.get_public_address(monitor_id, subaddress_index=args.subaddress).public_address
 
     # print the public address information
     print("\n")
-    print("    {:<18}{}".format("Master Key:", entropy_bytes.hex()))
+    print("    {:<18}{}".format("Master Key:", entropy_display))
     print("    {:<18}{}".format("Subaddress Index:", args.subaddress))
     print("    {:<18}{}".format("Address Code:", public_address.b58_code))
     print("    {:<18}{}".format("Address URL:", "mob58://"+ public_address.b58_code))

--- a/mobilecoind/clients/python/lib/mobilecoin/client.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/client.py
@@ -142,16 +142,29 @@ class Client(object):
     # Utilities
     #
 
-    def generate_entropy(self):
+    def generate_entropy(self) -> bytes:
         """ Generate 32 bytes of entropy using a cryptographically secure RNG.
         """
-        return self.stub.GenerateEntropy(empty_pb2.Empty())
+        response = self.stub.GenerateRootEntropy(empty_pb2.Empty())
+        return response.root_entropy
+
+    def generate_mnemonic(self) -> str:
+        """ Generate entropy mnemonic using a cryptographically secure RNG.
+        """
+        response = self.stub.GenerateMnemonic(empty_pb2.Empty())
+        return response.mnemonic
 
     def get_account_key(self, entropy: bytes):
         """ Get the private keys from entropy.
         """
-        request = GetAccountKeyRequest(entropy=entropy)
-        return self.stub.GetAccountKey(request)
+        request = GetAccountKeyFromRootEntropyRequest(root_entropy=entropy)
+        return self.stub.GetAccountKeyFromRootEntropy(request)
+
+    def get_account_key_from_mnemonic(self, mnemonic: str):
+        """ Get the private keys from the entropy mnemonic.
+        """
+        request = GetAccountKeyFromMnemonicRequest(mnemonic=mnemonic)
+        return self.stub.GetAccountKeyFromMnemonic(request)
 
     def get_public_address(self,
                            monitor_id: bytes,

--- a/mobilecoind/clients/python/mailchimp/allocate_mobilecoins.py
+++ b/mobilecoind/clients/python/mailchimp/allocate_mobilecoins.py
@@ -50,7 +50,7 @@ def allocate_MOB(mailchimp_member_record, amount_picoMOB):
         sys.exit()
 
     # create and fund a new MobileCoin TestNet account
-    recipient_entropy = mobilecoind.generate_entropy().entropy
+    recipient_entropy = mobilecoind.generate_entropy()
     recipient_account_key = mobilecoind.get_account_key(recipient_entropy).account_key
     print("# generated entropy {} for email {}".format(recipient_entropy.hex(), new_user_email))
 


### PR DESCRIPTION
Since protocol added mnemonic entropy.

Soundtrack of this PR: [Skeleton](https://www.youtube.com/watch?v=-dl2JmOLwtI)

### Motivation

Python client library crashes with current version of API, since #779 

### In this PR
* A simple update to the Python code to reference the current mobilecoind protocol.
* Backwards-compatible with jupyter example.

### Future Work
* Probably belongs in #592 
* Update jupyter notebook example to use mnemonics by default.