### PR TITLE
Update ingress manifest to include HAProxy annotations

### DIFF
--- a/deploy/00-node-grpc-ingress.yaml
+++ b/deploy/00-node-grpc-ingress.yaml
@@ -7,6 +7,14 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "GRPCS"
     cert-manager.io/cluster-issuer: letsencrypt-production
+
+    ### HAProxy Ingress
+    haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
+    haproxy.org/server-ssl: "true"             # The backend (server) is http
+    haproxy.org/abortonclose: "true"
+    haproxy.org/backend-config-snippet: |-
+      http-reuse aggressive
+
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
Soundtrack of this PR: [RJD2: The Proxy](https://www.youtube.com/watch?v=LjYo0cwXLWM)

### Motivation

Ingress objects are very opinionated in CD.  This change allows for either an nginx or haproxy ingress controller.

### In this PR
* Updated annotations to configure an HAProxy ingress controller to use HTTP-2/gRPC

### Future Work
* Nothing planned.