### PR TITLE
Documentation and minor bug fix around tombstone block

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -152,7 +152,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         // find the expired entries and remove them, storing their keys in expired,
         // without destroying or re-allocating the cache
         cache.retain(|key, entry| -> bool {
-            if entry.context().tombstone_block() < block_index {
+            if entry.context().tombstone_block() <= block_index {
                 expired.insert(*key);
                 false
             } else {

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -546,20 +546,20 @@ mod tests {
             // By block index 10, one has expired.
             let removed = tx_manager.remove_expired(10);
             assert_eq!(removed.len(), 1);
-            assert_eq!(tx_manager.num_entries(), 14);
+            assert_eq!(tx_manager.num_entries(), 13);
         }
 
         {
             // By block index 15, some have expired.
             let removed = tx_manager.remove_expired(15);
             assert_eq!(removed.len(), 5);
-            assert_eq!(tx_manager.num_entries(), 9);
+            assert_eq!(tx_manager.num_entries(), 8);
         }
 
         {
             // By block index 24, all have expired.
             let removed = tx_manager.remove_expired(24);
-            assert_eq!(removed.len(), 9);
+            assert_eq!(removed.len(), 8);
             assert_eq!(tx_manager.num_entries(), 0);
         }
     }

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -536,9 +536,16 @@ mod tests {
         assert_eq!(tx_manager.num_entries(), 14);
 
         {
-            // By block index 10, none have expired.
-            let removed = tx_manager.remove_expired(10);
+            // By block index 9, none have expired.
+            let removed = tx_manager.remove_expired(9);
             assert_eq!(removed.len(), 0);
+            assert_eq!(tx_manager.num_entries(), 14);
+        }
+
+        {
+            // By block index 10, one has expired.
+            let removed = tx_manager.remove_expired(10);
+            assert_eq!(removed.len(), 1);
             assert_eq!(tx_manager.num_entries(), 14);
         }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -32,8 +32,8 @@ pub struct TransactionBuilder<FPR: FogPubkeyResolver> {
     input_credentials: Vec<InputCredentials>,
     /// The outputs created by the transaction, and associated shared secrets
     outputs_and_shared_secrets: Vec<(TxOut, RistrettoPublic)>,
-    /// The tombstone_block value, a block index after which the transaction
-    /// expires.
+    /// The tombstone_block value, a block index in which the transaction
+    /// expires, and can no longer be added to the blockchain
     tombstone_block: u64,
     /// The fee paid in connection to this transaction
     pub fee: u64,


### PR DESCRIPTION
The tombstone block is defined in the transaction-core on transaction object docstring to mean:

"The block index at which this transaction is no longer valid."

https://github.com/mobilecoinfoundation/mobilecoin/blob/766f4078e000314a2ff9e8ea44a76f1c36fe7853/transaction/core/src/tx.rs#L162

However, in some places in the code it instead means, the block index
*after* which this transaction is no longer valid.

The TxManager prunes a Tx if the tombstone block exceeds the current block index, but not if it equals the current block index:

https://github.com/mobilecoinfoundation/mobilecoin/blob/103aa92bb0c8934d26de01b16c2ef1cbeebe3c95/consensus/service/src/tx_manager/mod.rs#L155

The `TransactionBuilder` (before this commit) documents

```
    /// The tombstone_block value, a block index after which the transaction
    /// expires.
```

The transaction validation code has a test for tombstone blocks:

https://github.com/mobilecoinfoundation/mobilecoin/blob/103aa92bb0c8934d26de01b16c2ef1cbeebe3c95/transaction/core/src/validation/validate.rs#L354

```
/// The transaction must be not have expired, or be too long-lived.
///
/// # Arguments
/// * `current_block_index` - The index of the block currently being built.
/// * `tombstone_block_index` - The block index at which this transaction is no
///   longer considered valid.
pub fn validate_tombstone(
    current_block_index: u64,
    tombstone_block_index: u64,
) -> TransactionValidationResult<()> {
    if current_block_index >= tombstone_block_index {
        return Err(TransactionValidationError::TombstoneBlockExceeded);
    }

    let limit = current_block_index + MAX_TOMBSTONE_BLOCKS;
    if tombstone_block_index > limit {
        return Err(TransactionValidationError::TombstoneBlockTooFar);
    }

    Ok(())
}
```

Therefore, any transaction where `current_block_index >= tombstone_block_index`
is invalid, and will not be proposed by consensus, even if it comes out
of the proposed queue and the `TxManager` didn't filter it.

Therefore this change is a no-op and just attempts to make all the code
use the same test, and have all the documentation read similarly.

Making sure the tombstone block means "The block index at which this transaction is no longer considered valid" is really important to Fog, because we use this with the pubkey expiry of a fog key, to make sure we understand what block ranges need to be scanned and what blocks users need to download if there are missed blocks.