### PR TITLE
Add traits to MemoBuilder that enable it to be used by Fog android bi…

### DIFF
--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
+dyn-clone = { version = "1.0.4", default-features = false }
 hmac = { version = "0.11", default-features = false }
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.8", default-features = false }
@@ -14,7 +15,6 @@ rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.9.5", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = "1"
-dyn-clone = { version = "1.0.4", default-features = false }
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../account-keys" }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -14,6 +14,7 @@ rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.9.5", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = "1"
+dyn-clone = { version = "1.0.4", default-features = false }
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../account-keys" }

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -22,6 +22,8 @@ pub use rth_memo_builder::RTHMemoBuilder;
 /// installed in the transaction builder when that is constructed.
 /// This way low-level handing of memo payloads with TxOuts is not needed,
 /// and just invoking the TransactionBuilder as before will do the right thing.
+///
+/// This trait derives DynClone so that Box<dyn MemoBuilder> can derive Clone.
 pub trait MemoBuilder: Debug + Sync + Send + DynClone {
     /// Set the fee.
     /// The memo builder is in the loop when the fee is set and changed,
@@ -47,6 +49,7 @@ pub trait MemoBuilder: Debug + Sync + Send + DynClone {
     ) -> Result<MemoPayload, NewMemoError>;
 }
 
+// Enables Box<dyn MemoBuilder> to derive Clone:
 clone_trait_object!(MemoBuilder);
 
 /// The empty memo builder always builds UnusedMemo.

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -9,6 +9,8 @@ use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{MemoContext, MemoPayload, NewMemoError};
 
+use dyn_clone::{clone_trait_object, DynClone};
+
 mod rth_memo_builder;
 pub use rth_memo_builder::RTHMemoBuilder;
 
@@ -20,7 +22,7 @@ pub use rth_memo_builder::RTHMemoBuilder;
 /// installed in the transaction builder when that is constructed.
 /// This way low-level handing of memo payloads with TxOuts is not needed,
 /// and just invoking the TransactionBuilder as before will do the right thing.
-pub trait MemoBuilder: Debug {
+pub trait MemoBuilder: Debug + Sync + Send + DynClone {
     /// Set the fee.
     /// The memo builder is in the loop when the fee is set and changed,
     /// and gets a chance to report an error, if the fee is too large, or if it
@@ -44,6 +46,8 @@ pub trait MemoBuilder: Debug {
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
 }
+
+clone_trait_object!(MemoBuilder);
 
 /// The empty memo builder always builds UnusedMemo.
 /// This is the safe and maximally private default.

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -6,10 +6,10 @@
 
 use super::{memo, ChangeDestination};
 use core::fmt::Debug;
+use dyn_clone::{clone_trait_object, DynClone};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{MemoContext, MemoPayload, NewMemoError};
 
-use dyn_clone::{clone_trait_object, DynClone};
 
 mod rth_memo_builder;
 pub use rth_memo_builder::RTHMemoBuilder;


### PR DESCRIPTION
### Motivation
PR #878 added a [TransactionBulider::new_with_box](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/transaction/std/src/transaction_builder.rs#L82), which enables a `TransactionBuilder` to be built with a `MemoBuilder` trait object, rather than a concrete implementation such as `RTHMemoBuilder`. This method enables code reuse because  we won't have to create a new `TransactionBuilder` constructor for every `MemoBuilder` implementation. 

In the fog android-bindings, I wrote this code: 
```
       let memo_builder: MutexGuard<Box<dyn MemoBuilder>> =
            env.get_rust_field(memo_builder, RUST_OBJ_FIELD)?;

        let tx_builder = TransactionBuilder::new_with_box(fog_resolver.clone(), memo_builder.clone()); 
```

and the compiler emitted this error: 

```
error[E0277]: `dyn MemoBuilder` cannot be sent between threads safely

    --> android-bindings/src/bindings.rs:1112:17
     |
1112 |             env.get_rust_field(memo_builder, RUST_OBJ_FIELD)?;
     |                 ^^^^^^^^^^^^^^ `dyn MemoBuilder` cannot be sent between threads safely
     |
     = help: the trait `Send` is not implemented for `dyn MemoBuilder`
     = note: required because of the requirements on the impl of `Send` for `Unique<dyn MemoBuilder>`
     = note: required because it appears within the type `Box<dyn MemoBuilder>`
```
The compiler also threw additional errors because `Sync` and `Clone` were not implemented by `MemoBuilder`.
 Therefore, we need a way to get implement these traits on this `MemoBuilder` trait.

### In this PR
This PR implements the necessary traits. I implemented `Send` and `Sync` by just adding them to the `MemoBuilder` trait definition. Implementing `Clone` was trickier because `dyn` erases the type and [thereby](https://doc.rust-lang.org/std/keyword.dyn.html) requires the trait to be 'object-safe'.   Simply adding `Clone` to the trait definition (and doing no additional work) produces the following error: 
```
error[E0225]: only auto traits can be used as additional traits in a trait object
    --> android-bindings/src/bindings.rs:1111:74
     |
1111 |         let memo_builder: MutexGuard<Box<dyn MemoBuilder + Send + Sync + Clone>> =
     |                                              -----------                 ^^^^^ additional non-auto trait
     |                                              |
     |                                              first non-auto trait
```

To implement `Clone` for this type-erased object, I used the [dyn-clone](https://github.com/dtolnay/dyn-clone) crate. The compiler stopped complaining, and the code compiles. 

Asana [ticket](https://app.asana.com/0/1200318482173758/1200849681806232/f) 

### Future Work
* Update Fog android-bindings to take advantage of this modified `MemoBuilder` trait.


