### PR TITLE
Fix ios libmobilecoin linkage by manually removing dead code

### DIFF
--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -79,6 +79,10 @@ $(ARCHS_IOS):
 			| grep '\.o$$' \
 			| xargs ar -x ../$(IOS_LIB)
 
+	@# Remove psa_crypto_driver_wrappers.c.o file from mbedtls which causes linker errors
+	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER)/extracted && \
+		rm psa_crypto_driver_wrappers.c.o
+
 	@# Create list of libmobilecoin symbols.
 	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
 		rust-nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text \


### PR DESCRIPTION
The swift bindings are trying to update to later versions of libmobilecoin,
but they are failing with a linker error

```
Undefined symbols for architecture x86_64:
  "_psa_export_public_key_internal", referenced from:
      _psa_driver_wrapper_export_public_key in libmobilecoin.a
  "_psa_import_key_into_slot", referenced from:
      _psa_driver_wrapper_import_key in libmobilecoin.a
  "_psa_generate_key_internal", referenced from:
      _psa_driver_wrapper_generate_key in libmobilecoin.a
  "_psa_export_key_internal", referenced from:
      _psa_driver_wrapper_export_key in libmobilecoin.a
  "_psa_verify_hash_internal", referenced from:
      _psa_driver_wrapper_verify_hash in libmobilecoin.a
  "_psa_sign_hash_internal", referenced from:
      _psa_driver_wrapper_sign_hash in libmobilecoin.a
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Git bisect shows that the first bad commit involved a version bump
to mbedtls:

```
$ git bisect bad                                                                                                           ✔  10799  06:04:43

4bb867d40275416b6e7d3eef4cf91edd9eab5e61 is the first bad commit
commit 4bb867d40275416b6e7d3eef4cf91edd9eab5e61
Author: Eran Rundstein <eran@rundste.in>
Date:   Fri Jul 9 15:38:59 2021 -0700

    Feature/update grpc fork (#96)

    * bump grpcio and mbedtls
    * deal with _FORTIFY_SOURCE
    * move mbedtls to 4068177d332c470f281654504a2dc298dd26b4c0
    * bump mobilecoin and update lock files
    * workaround 32 bit builds
    * undo downgrade of boringssl, bump cmake version
    * override cmake to an ios-friendly version
    * update comment
    * update lock file
```

The `psa_driver_wrapper` stuff seems to be new functionality in mbedtls
C library that we are not using, but for some reason it is not being
stripped out by the linker. I confirmed with Adam that "dead_strip"
option is being used in the swift xcode build.

The issue seems to be that mbedtls unconditionally exports some
symbols, that call "internal" symbols that are undefined if the psa
driver is not selected. Then they expect that the linker strips out
the unused public symbols.

The approach taken in this commit is to manually remove the object
code related to the psa driver wrapper. It turns out that this is
pretty straightforward because of how the libmobilecoin makefile
is already working, where it unpacks a static archive into object
files and then builds a list of external symbols to be public and
rebuilds the static archive. We simply remove the object file
containing the offending symbols in the middle here.

In another branch, we are exploring another approach that modifies
the `rust-mbedtls` build to try to allow rustc to eliminate these
symbols earlier in the process, and not treat them as potentially
reachable all the way through to the build of libmobilecoin.a