### PR TITLE
Use mbedtls with -fvisibility=hidden patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2236,7 +2236,7 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=c7fa3f0c737f36af8f437e147131d1f5c8a90b0e#c7fa3f0c737f36af8f437e147131d1f5c8a90b0e"
+source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=540ac851954a04a16258ebef2f81d5208211fc55#540ac851954a04a16258ebef2f81d5208211fc55"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=c7fa3f0c737f36af8f437e147131d1f5c8a90b0e#c7fa3f0c737f36af8f437e147131d1f5c8a90b0e"
+source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=540ac851954a04a16258ebef2f81d5208211fc55#540ac851954a04a16258ebef2f81d5208211fc55"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,8 +175,9 @@ grpcio = { git = "https://github.com/mobilecoinofficial/grpc-rs", rev = "10ba9f8
 protoc-grpcio = { git = "https://github.com/mobilecoinofficial/protoc-grpcio", rev = "9e63f09ec408722f731c9cb60bf06c3d46bcabec" }
 
 # mbedtls patched to allow certificate verification with a profile
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "c7fa3f0c737f36af8f437e147131d1f5c8a90b0e" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "c7fa3f0c737f36af8f437e147131d1f5c8a90b0e" }
+# and for a symbol visibility fix during compilation
+mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "540ac851954a04a16258ebef2f81d5208211fc55" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "540ac851954a04a16258ebef2f81d5208211fc55" }
 
 # prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
 # current revision is from jun 13 2020, waiting for a new prost release

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -95,7 +95,7 @@ $(ARCHS_IOS):
 	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
 		rm -f $(IOS_LIB_STRIPPED) || true
 	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
-		ld -r -arch $(LD_ARCH) -x -keep_private_externs \
+		ld -r -arch $(LD_ARCH) -x \
 			-exported_symbols_list exported-symbols.def \
 			-o $(IOS_LIB_STRIPPED) \
 			extracted/*.o

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -11,7 +11,7 @@ export IAS_MODE ?= DEV
 
 ### Build Configuration
 
-CARGO_PROFILE ?= release
+CARGO_PROFILE ?= mobile
 CARGO_BUILD_FLAGS ?=
 CARGO_TARGET_DIR ?= ../target
 
@@ -59,7 +59,12 @@ ifeq ($(CARGO_PROFILE),release)
   BUILD_CONFIG_FOLDER = release
   CARGO_BUILD_FLAGS += --release
 else
-  BUILD_CONFIG_FOLDER = debug
+  ifeq ($(CARGO_PROFILE),mobile)
+    BUILD_CONFIG_FOLDER = mobile
+    CARGO_BUILD_FLAGS += -Z unstable-options --profile=mobile
+  else
+    BUILD_CONFIG_FOLDER = debug
+  endif
 endif
 
 .PHONY: $(ARCHS_IOS)


### PR DESCRIPTION
This tries to make `mbedtls` built with `-fvisibility=hidden` so that perhaps when rust links things, the linker can remove unused symbols from `mbedtls`.

https://github.com/mobilecoinofficial/rust-mbedtls/commit/540ac851954a04a16258ebef2f81d5208211fc55

However it didn't seem to affect the result in libmobilecoin built on ios, I still see this with `rust-nm libmobilecoin_stripped.a -g -m | less`:

```
00000000004b1b10 (__TEXT,__text) private external _psa_driver_wrapper_cipher_abort
00000000004b1aa0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_decrypt
00000000004b1ac0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_decrypt_setup
00000000004b1a90 (__TEXT,__text) private external _psa_driver_wrapper_cipher_encrypt
00000000004b1ab0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_encrypt_setup
00000000004b1b00 (__TEXT,__text) private external _psa_driver_wrapper_cipher_finish
00000000004b1ad0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_generate_iv
00000000004b1ae0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_set_iv
00000000004b1af0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_update
00000000004b1a50 (__TEXT,__text) private external _psa_driver_wrapper_export_key
00000000004b1a70 (__TEXT,__text) private external _psa_driver_wrapper_export_public_key
00000000004b1a10 (__TEXT,__text) private external _psa_driver_wrapper_generate_key
00000000004b19f0 (__TEXT,__text) private external _psa_driver_wrapper_get_key_buffer_size
00000000004b1a30 (__TEXT,__text) private external _psa_driver_wrapper_import_key
00000000004b19b0 (__TEXT,__text) private external _psa_driver_wrapper_sign_hash
00000000004b19d0 (__TEXT,__text) private external _psa_driver_wrapper_verify_hash
                 (undefined) external _psa_export_key_internal
                 (undefined) external _psa_export_public_key_internal
                 (undefined) external _psa_generate_key_internal
                 (undefined) external _psa_import_key_into_slot
                 (undefined) external _psa_sign_hash_internal
                 (undefined) external _psa_verify_hash_internal
```

Perhaps rust doesn't run ld at all when building static library targets?

Edit:

Tried turning on lto by using the `mobile` profile when building libmobilecoin, but that also didn't seem to help anything.

```
chris@Chriss-MacBook-Pro mobile % du libmobilecoin_stripped.a 
36808	libmobilecoin_stripped.a
chris@Chriss-MacBook-Pro mobile % du ../release/libmobilecoin_stripped.a 
36784	../release/libmobilecoin_stripped.a
chris@Chriss-MacBook-Pro mobile % rust-nm -m libmobilecoin_stripped.a | grep "_psa"
00000000004b1c40 (__TEXT,__text) private external _psa_driver_wrapper_cipher_abort
00000000004b1bd0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_decrypt
00000000004b1bf0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_decrypt_setup
00000000004b1bc0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_encrypt
00000000004b1be0 (__TEXT,__text) private external _psa_driver_wrapper_cipher_encrypt_setup
00000000004b1c30 (__TEXT,__text) private external _psa_driver_wrapper_cipher_finish
00000000004b1c00 (__TEXT,__text) private external _psa_driver_wrapper_cipher_generate_iv
00000000004b1c10 (__TEXT,__text) private external _psa_driver_wrapper_cipher_set_iv
00000000004b1c20 (__TEXT,__text) private external _psa_driver_wrapper_cipher_update
00000000004b1b80 (__TEXT,__text) private external _psa_driver_wrapper_export_key
00000000004b1ba0 (__TEXT,__text) private external _psa_driver_wrapper_export_public_key
00000000004b1b40 (__TEXT,__text) private external _psa_driver_wrapper_generate_key
00000000004b1b20 (__TEXT,__text) private external _psa_driver_wrapper_get_key_buffer_size
00000000004b1b60 (__TEXT,__text) private external _psa_driver_wrapper_import_key
00000000004b1ae0 (__TEXT,__text) private external _psa_driver_wrapper_sign_hash
00000000004b1b00 (__TEXT,__text) private external _psa_driver_wrapper_verify_hash
                 (undefined) external _psa_export_key_internal
                 (undefined) external _psa_export_public_key_internal
                 (undefined) external _psa_generate_key_internal
                 (undefined) external _psa_import_key_into_slot
                 (undefined) external _psa_sign_hash_internal
                 (undefined) external _psa_verify_hash_internal
chris@Chriss-MacBook-Pro mobile % cd ..
chris@Chriss-MacBook-Pro x86_64-apple-ios % cd ..
chris@Chriss-MacBook-Pro target % cd ..
```