### PR TITLE
Make transaction-core code call it "tx_target_key" and not "onetime_public_key"

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -50,7 +50,7 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_transaction_core::{
     constants::MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
-    onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
+    onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
     ring_signature::{KeyImage, Scalar},
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
@@ -602,9 +602,9 @@ fn mint_aggregate_fee(
 ) -> Result<TxOut> {
     // Create a single TxOut
     let fee_output: TxOut = {
-        let target_key = create_tx_target_key(tx_private_key, fee_recipient).into();
+        let target_key = create_tx_out_target_key(tx_private_key, fee_recipient).into();
         let public_key =
-            create_tx_public_key(tx_private_key, fee_recipient.spend_public_key()).into();
+            create_tx_out_public_key(tx_private_key, fee_recipient.spend_public_key()).into();
 
         let shared_secret = create_shared_secret(fee_recipient.view_public_key(), tx_private_key);
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -50,7 +50,7 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_transaction_core::{
     constants::MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
-    onetime_keys::{create_onetime_public_key, create_shared_secret, create_tx_public_key},
+    onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
     ring_signature::{KeyImage, Scalar},
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
@@ -602,7 +602,7 @@ fn mint_aggregate_fee(
 ) -> Result<TxOut> {
     // Create a single TxOut
     let fee_output: TxOut = {
-        let target_key = create_onetime_public_key(tx_private_key, fee_recipient).into();
+        let target_key = create_tx_target_key(tx_private_key, fee_recipient).into();
         let public_key =
             create_tx_public_key(tx_private_key, fee_recipient.spend_public_key()).into();
 

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -214,7 +214,7 @@ mod test {
     use mc_transaction_core::{
         encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         membership_proofs::Range,
-        onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
+        onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
         Amount,
     };
@@ -236,8 +236,8 @@ mod test {
         for output_index in 0..num_tx_outs {
             let recipient_account_default_subaddress = recipient_account.default_subaddress();
             let target_key =
-                create_tx_target_key(&tx_secret_key, &recipient_account_default_subaddress);
-            let public_key = create_tx_public_key(
+                create_tx_out_target_key(&tx_secret_key, &recipient_account_default_subaddress);
+            let public_key = create_tx_out_public_key(
                 &tx_secret_key,
                 recipient_account_default_subaddress.spend_public_key(),
             );

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -214,7 +214,7 @@ mod test {
     use mc_transaction_core::{
         encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         membership_proofs::Range,
-        onetime_keys::{create_onetime_public_key, create_shared_secret, create_tx_public_key},
+        onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
         Amount,
     };
@@ -236,7 +236,7 @@ mod test {
         for output_index in 0..num_tx_outs {
             let recipient_account_default_subaddress = recipient_account.default_subaddress();
             let target_key =
-                create_onetime_public_key(&tx_secret_key, &recipient_account_default_subaddress);
+                create_tx_target_key(&tx_secret_key, &recipient_account_default_subaddress);
             let public_key = create_tx_public_key(
                 &tx_secret_key,
                 recipient_account_default_subaddress.spend_public_key(),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -826,7 +826,7 @@ pub mod tx_out_store_tests {
         for _i in 0..num_tx_outs {
             let tx_private_key = RistrettoPrivate::from_random(&mut rng);
             let target_key =
-                create_onetime_public_key(&tx_private_key, &recipient_account.default_subaddress());
+                create_tx_target_key(&tx_private_key, &recipient_account.default_subaddress());
             let public_key = create_tx_public_key(
                 &tx_private_key,
                 recipient_account.default_subaddress().spend_public_key(),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -826,8 +826,8 @@ pub mod tx_out_store_tests {
         for _i in 0..num_tx_outs {
             let tx_private_key = RistrettoPrivate::from_random(&mut rng);
             let target_key =
-                create_tx_target_key(&tx_private_key, &recipient_account.default_subaddress());
-            let public_key = create_tx_public_key(
+                create_tx_out_target_key(&tx_private_key, &recipient_account.default_subaddress());
+            let public_key = create_tx_out_public_key(
                 &tx_private_key,
                 recipient_account.default_subaddress().spend_public_key(),
             );

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -96,7 +96,7 @@ fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
 /// * `tx_private_key` - The output's tx_private_key `r`. Must be unique for
 ///   each output.
 /// * `recipient` - The recipient subaddress `(C,D)`.
-pub fn create_tx_target_key(
+pub fn create_tx_out_target_key(
     tx_private_key: &RistrettoPrivate,
     recipient: &PublicAddress,
 ) -> RistrettoPublic {
@@ -111,17 +111,18 @@ pub fn create_tx_target_key(
     RistrettoPublic::from(Hs * G + D)
 }
 
-/// Creates the `tx_public_key = r * D` for an output sent to subaddress (C, D).
+/// Creates the `tx_out_public_key = r * D` for an output sent to subaddress (C,
+/// D).
 ///
 /// # Arguments
 /// * `tx_private_key` - The transaction private key `r`. Must be unique for
 ///   each output.
 /// * `recipient_spend_key` - The recipient's public subaddress spend key `D`.
-pub fn create_tx_public_key(
-    tx_private_key: &RistrettoPrivate,
+pub fn create_tx_out_public_key(
+    tx_out_private_key: &RistrettoPrivate,
     recipient_spend_key: &RistrettoPublic,
 ) -> RistrettoPublic {
-    let r: &Scalar = tx_private_key.as_ref();
+    let r: &Scalar = tx_out_private_key.as_ref();
     let D = recipient_spend_key.as_ref();
     RistrettoPublic::from(r * D)
 }
@@ -184,7 +185,7 @@ pub fn view_key_matches_output(
 /// This assumes that the output belongs to the provided private keys.
 ///
 /// # Arguments
-/// * `tx_public_key` - The output's tx_public_key `R`.
+/// * `tx_out_public_key` - The output's tx_public_key `R`.
 /// * `view_private_key` - A private view key `a`.
 /// * `subaddress_spend_private_key` - A private spend key `d = Hs(a || i) + b`.
 pub fn recover_onetime_private_key(
@@ -230,8 +231,8 @@ mod tests {
         tx_private_key: &RistrettoPrivate,
         recipient: &PublicAddress,
     ) -> (RistrettoPublic, RistrettoPublic) {
-        let tx_target_key = create_tx_target_key(&tx_private_key, recipient);
-        let tx_public_key = create_tx_public_key(&tx_private_key, recipient.spend_public_key());
+        let tx_target_key = create_tx_out_target_key(&tx_private_key, recipient);
+        let tx_public_key = create_tx_out_public_key(&tx_private_key, recipient.spend_public_key());
         (tx_target_key, tx_public_key)
     }
 
@@ -293,7 +294,7 @@ mod tests {
         let recipient_spend_key = RistrettoPublic::from(D);
         assert_eq!(
             expected,
-            create_tx_public_key(&tx_private_key, &recipient_spend_key)
+            create_tx_out_public_key(&tx_private_key, &recipient_spend_key)
         );
     }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -21,7 +21,7 @@ use crate::{
     get_tx_out_shared_secret,
     membership_proofs::Range,
     memo::{EncryptedMemo, MemoPayload},
-    onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
+    onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
     ring_signature::{KeyImage, SignatureRctBulletproofs},
     CompressedCommitment, NewMemoError, NewTxError,
 };
@@ -316,8 +316,8 @@ impl TxOut {
         hint: EncryptedFogHint,
         memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
     ) -> Result<Self, NewTxError> {
-        let target_key = create_tx_target_key(tx_private_key, recipient).into();
-        let public_key = create_tx_public_key(tx_private_key, recipient.spend_public_key());
+        let target_key = create_tx_out_target_key(tx_private_key, recipient).into();
+        let public_key = create_tx_out_public_key(tx_private_key, recipient.spend_public_key());
 
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -21,7 +21,7 @@ use crate::{
     get_tx_out_shared_secret,
     membership_proofs::Range,
     memo::{EncryptedMemo, MemoPayload},
-    onetime_keys::{create_onetime_public_key, create_shared_secret, create_tx_public_key},
+    onetime_keys::{create_shared_secret, create_tx_public_key, create_tx_target_key},
     ring_signature::{KeyImage, SignatureRctBulletproofs},
     CompressedCommitment, NewMemoError, NewTxError,
 };
@@ -316,7 +316,7 @@ impl TxOut {
         hint: EncryptedFogHint,
         memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
     ) -> Result<Self, NewTxError> {
-        let target_key = create_onetime_public_key(tx_private_key, recipient).into();
+        let target_key = create_tx_target_key(tx_private_key, recipient).into();
         let public_key = create_tx_public_key(tx_private_key, recipient.spend_public_key());
 
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);


### PR DESCRIPTION
The documentation in `onetime_keys.rs` explains that the term
`onetime public key` comes from cryptonote papers, and is also called
the "target key". However, in the `TxOut` object, we have gone with
the name `target_key`, while in many functions in `onetime_keys.rs`,
it is still called `onetime_public_key`.

This makes it much more difficult to read and use this code, because
there is no type safety that ensures that `onetime_public_key` is not
used with `tx_out.public_key` rather than `tx_out.target_key`, and
searching for `onetime_public_key` only gives very few hits in the
source code, so you have to read all of the documentation to figure
out how to use any of these functions correctly.

By changing the function names, and input parameter names, to things
like `tx_target_key`, we make it much easier to figure out how to
use these functions correctly with `TxOut` objects.

It's fine to have multiple names for a key in documentation, and
to match the literature. It's not fine to have multiple names in code
for the same thing, and unifying the names in this manner makes the
code substantially more maintainable.