### PR TITLE
Libmobilecoin M1 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cesu8"

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -33,10 +33,17 @@ endif
 ### Local Variables
 
 CARGO_PACKAGE = libmobilecoin
-ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios
+ARCHS_IOS = aarch64-apple-ios-sim aarch64-apple-ios-macabi aarch64-apple-ios x86_64-apple-ios-macabi x86_64-apple-ios x86_64-apple-darwin
 IOS_LIB = libmobilecoin.a
 IOS_LIB_STRIPPED = libmobilecoin_stripped.a
 IOS_C_HEADERS = include/*
+
+### Helper Function
+
+define BINARY_copy
+	mkdir -p out/ios/target/$(1)/release
+	cp $(CARGO_TARGET_DIR)/$(1)/release/libmobilecoin_stripped.a out/ios/target/$(1)/release;
+endef
 
 ####################################
 ############## Targets #############
@@ -47,8 +54,8 @@ all: setup ios
 
 .PHONY: setup
 setup:
-	rustup target add $(ARCHS_IOS)
-	rustup component add llvm-tools-preview
+	rustup target add x86_64-apple-ios aarch64-apple-ios
+	rustup component add llvm-tools-preview rust-src
 	rustup run --install stable cargo install cargo-binutils
 
 .PHONY: ios
@@ -65,10 +72,14 @@ endif
 .PHONY: $(ARCHS_IOS)
 x86_64-apple-ios aarch64-apple-ios: CARGO_ENV_FLAGS += CFLAGS="-DPB_NO_PACKED_STRUCTS=1"
 x86_64-apple-ios aarch64-apple-ios: CARGO_ENV_FLAGS += CXXFLAGS="-DPB_NO_PACKED_STRUCTS=1"
-x86_64-apple-ios: LD_ARCH = x86_64
-aarch64-apple-ios: LD_ARCH = arm64
+
+x86_64-apple-ios x86_64-apple-ios-macabi x86_64-apple-darwin: LD_ARCH = x86_64
+aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-ios-macabi: LD_ARCH = arm64
+
+x86_64-apple-ios-macabi aarch64-apple-ios-sim aarch64-apple-ios-macabi: CARGO_BUILD_FLAGS += -Zbuild-std
+
 $(ARCHS_IOS):
-	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS)
+	(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS) -vv
 
 	@# Extract object files from static archive.
 	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
@@ -98,7 +109,7 @@ $(ARCHS_IOS):
 .PHONY: out/ios/$(IOS_LIB)
 out/ios/$(IOS_LIB): $(ARCHS_IOS)
 	mkdir -p out/ios
-	lipo -create -output $@ $(foreach arch,$^,$(CARGO_TARGET_DIR)/$(arch)/$(BUILD_CONFIG_FOLDER)/$(IOS_LIB_STRIPPED))
+	$(foreach arch,$^,$(call BINARY_copy,$(arch)))
 
 	mkdir -p out/ios/include
 	cp $(IOS_C_HEADERS) out/ios/include

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -79,7 +79,7 @@ aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-ios-macabi: LD_ARCH = arm6
 x86_64-apple-ios-macabi aarch64-apple-ios-sim aarch64-apple-ios-macabi: CARGO_BUILD_FLAGS += -Zbuild-std
 
 $(ARCHS_IOS):
-	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS) -vv
+	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS)
 
 	@# Extract object files from static archive.
 	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -54,7 +54,7 @@ all: setup ios
 
 .PHONY: setup
 setup:
-	rustup target add x86_64-apple-ios aarch64-apple-ios
+	rustup target add x86_64-apple-ios aarch64-apple-ios x86_64-apple-darwin
 	rustup component add llvm-tools-preview rust-src
 	rustup run --install stable cargo install cargo-binutils
 

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -79,7 +79,7 @@ aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-ios-macabi: LD_ARCH = arm6
 x86_64-apple-ios-macabi aarch64-apple-ios-sim aarch64-apple-ios-macabi: CARGO_BUILD_FLAGS += -Zbuild-std
 
 $(ARCHS_IOS):
-	(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS) -vv
+	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS) -vv
 
 	@# Extract object files from static archive.
 	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \


### PR DESCRIPTION
### Motivation

We want to build `libmobilecoin` for the new M1 targets.

### In this PR
* Bump version of `cc` crate because we need https://github.com/alexcrichton/cc-rs/commit/178fd031e74f643721605e25110ee6abce8dbe05
* Add new targets and stop using `lipo` in `libmobilecoin/Makefile`

Note that currently the build only works for all targets on an Intel Mac. `x86_64-apple-ios` and `x86_64-apple-darwin` fail on an M1 due to weird linker issues.

### Future Work
* Make all targets buildable on an M1 mac
