### PR TITLE
Increasing the number of retries to get tx_recovery test to pass.

### DIFF
--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -163,7 +163,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
     // Make the users poll for transactions, until their num blocks matches
     // ledger_db, or we time out
     {
-        let mut retries = 60;
+        let mut retries = 200;
         loop {
             let user_num_blocks = users.poll(view);
             if user_num_blocks


### PR DESCRIPTION
Soundtrack of this PR: [https://www.youtube.com/watch?v=zF5gcEQVxL4]()

### Motivation

This test: cargo test -p mc-fog-ingest-server --test tx_recovery 
was failing on my machine saying 'test_ingest_sql' panicked at 'users did not converge to ledger_db.num_blocks before we ran out of retry attempts', and it seems to be due to a race condition where there are insufficient retries. It seems sufficient to resolve this by increasing the number of retries.

### In this PR

I increased the number of retries.

### Future Work

Potentially useful to configure for the machine if this varies between devices.
