### PR TITLE
Unfork and update Prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cargo-emit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5731,20 +5737,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
- "bytes 0.5.4",
+ "bytes 1.1.0",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.67",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,12 +193,6 @@ mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.g
 # packed_simd_2 has unreleased fixes for build issues we're experiencing
 packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd.git", rev = "f60e900f4ceb71303baa37ff8b41ee7d490c01bf" }
 
-# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
-# current revision is from jun 13 2020, waiting for a new prost release
-# https://github.com/danburkert/prost/issues/329
-prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-
 # Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
 lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }
 

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -44,5 +44,5 @@ mc-util-test-vector = { path = "../util/test-vector" }
 datatest = "0.6.4"
 generic-array = "0.14"
 pem = "0.8"
-prost = { version = "0.6.1", default-features = false }
+prost = { version = "0.8", default-features = false }
 rand = "0.8"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -23,7 +23,7 @@ mc-crypto-noise = { path = "../../crypto/noise", default-features = false }
 aead = "0.4"
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = "0.6"
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -47,7 +47,7 @@ rjson = "0.3.1"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 sha2 = { version = "0.9.5", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
-prost = { version = "0.6.1", default-features = false }
+prost = { version = "0.8", default-features = false }
 
 [dev-dependencies]
 mc-util-serial = { path = "../../util/serial" }

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -10,4 +10,4 @@ mc-sgx-compat = { path = "../../sgx/compat" }
 mc-sgx-types = { path = "../../sgx/types" }
 
 displaydoc = { version = "0.2", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -43,7 +43,7 @@ mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
 
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps"] }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -196,9 +196,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-emit"
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1337,8 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1346,8 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -73,12 +73,6 @@ mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.g
 # packed_simd_2 has unreleased fixes for our nightly version
 packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd.git", rev = "f60e900f4ceb71303baa37ff8b41ee7d490c01bf" }
 
-# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
-# current revision is from jun 13 2020, waiting for a new prost release
-# https://github.com/danburkert/prost/issues/329
-prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "9b48418556b0af476be2313309bc5a23fb8b351d" }
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 displaydoc = { version = "0.2", default-features = false }
 futures = "0.3"
 grpcio = "0.9.0"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 protobuf = "2.22.1"
 
 mc-api = { path = "../../api" }

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-emit"
@@ -571,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1477,8 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1486,8 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -81,12 +81,6 @@ mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.g
 # packed_simd_2 has unreleased fixes for our nightly version
 packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd.git", rev = "f60e900f4ceb71303baa37ff8b41ee7d490c01bf" }
 
-# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
-# current revision is from jun 13 2020, waiting for a new prost release
-# https://github.com/danburkert/prost/issues/329
-prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "9b48418556b0af476be2313309bc5a23fb8b351d" }
 

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -12,7 +12,7 @@ mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
 displaydoc = { version = "0.2", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-emit"
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1477,8 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1486,8 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -82,12 +82,6 @@ mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.g
 # packed_simd_2 has unreleased fixes for our nightly version
 packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd.git", rev = "f60e900f4ceb71303baa37ff8b41ee7d490c01bf" }
 
-# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
-# current revision is from jun 13 2020, waiting for a new prost release
-# https://github.com/danburkert/prost/issues/329
-prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "9b48418556b0af476be2313309bc5a23fb8b351d" }
 

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -16,7 +16,7 @@ mc-consensus-api = { path = "../../../consensus/api" }
 mc-fog-report-types = { path = "../types" }
 
 [dev-dependencies]
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-fog-report-api-test-utils = { path = "test-utils" }
 

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -7,5 +7,5 @@ readme = "README.md"
 
 [dependencies]
 mc-util-serial = { path = "../../../../util/serial" }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 protobuf = "2.22.1"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -31,7 +31,7 @@ displaydoc = "0.2"
 futures = "0.3"
 grpcio = "0.9.0"
 pem = "0.8"
-prost = "0.6.1"
+prost = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 signature = "1.2.2"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-crypto-digestible = { path = "../../../crypto/digestible", default-features = false }
 
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -35,7 +35,7 @@ diesel = { version = "1.4.5", features = ["chrono", "postgres", "r2d2"] }
 diesel-derive-enum = { version = "1", features = ["postgres"] }
 diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 displaydoc = { version = "0.2", default-features = false }
-prost = "0.6.1"
+prost = "0.8"
 r2d2 = "0.8.9"
 rand = "0.8"
 rand_core = "0.6"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -17,7 +17,7 @@ mc-fog-kex-rng = { path = "../kex_rng" }
 # third-party
 crc = { version = "1.8.1", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -232,9 +232,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cargo-emit"
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1496,8 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1505,8 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.6.1"
-source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba4242824b4fb3ffec#6113789f70b69709820becba4242824b4fb3ffec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -87,12 +87,6 @@ mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.g
 # packed_simd_2 has unreleased fixes for our nightly version
 packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd.git", rev = "f60e900f4ceb71303baa37ff8b41ee7d490c01bf" }
 
-# prost is patched with no_std support (https://github.com/danburkert/prost/pull/319)
-# current revision is from jun 13 2020, waiting for a new prost release
-# https://github.com/danburkert/prost/issues/329
-prost = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "6113789f70b69709820becba4242824b4fb3ffec" }
-
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "9b48418556b0af476be2313309bc5a23fb8b351d" }
 

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -24,7 +24,7 @@ displaydoc = { version = "0.2", default-features = false }
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
 mockall = "0.8.3"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.8", optional = true }
 rand_core = "0.6"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -49,7 +49,7 @@ grpcio = "0.9.0"
 hex_fmt = "0.3"
 lmdb-rkv = "0.14.0"
 num_cpus = "1.12"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 protobuf = "2.22.1"
 reqwest = { version = "0.10", default-features = false, features = ["rustls-tls", "gzip"] }
 rand = "0.8"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -10,7 +10,7 @@ sgx = []
 
 [dependencies]
 cfg-if = "0.1"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 
 mc-common = { path = "../../common", default-features = false }
 

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -9,7 +9,7 @@ mc-common = { path = "../../common", features = ["log"] }
 mc-sgx-slog = { path = "../slog" }
 mc-sgx-types = { path = "../types" }
 
-prost = { version = "0.6.1", default-features = false }
+prost = { version = "0.8", default-features = false }
 
 [build-dependencies]
 mc-sgx-build = { path = "../build" }

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -13,7 +13,7 @@ hex_fmt = "0.3"
 hkdf = { version = "0.9", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 merlin = { version = "3.0", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 sha2 = { version = "0.9.5", default-features = false }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
 hmac = { version = "0.11", default-features = false }
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 sha2 = { version = "0.9.5", default-features = false }

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -9,4 +9,4 @@ mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
 displaydoc = { version = "0.2", default-features = false }
 lmdb-rkv = "0.14.0"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [dependencies]
 generic-array = "0.14"
-prost = { version = "0.6.1", optional = true, default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", optional = true, default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc"] }
 
 [features]

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -242,11 +242,10 @@ macro_rules! derive_prost_message_from_repr_bytes {
                         ));
                     }
                     let result = <Self as $crate::ReprBytes>::from_bytes(
-                        (&buf.bytes()[0..expected_size])
+                        buf.copy_to_bytes(expected_size).as_ref()[..]
                             .try_into()
-                            .expect("buffer size arithmetic"),
+                            .expect("Buffer sizing issue"),
                     );
-                    buf.advance(expected_size);
                     *self = result
                         .map_err(|e| $crate::_exports::prost::DecodeError::new(e.to_string()))?;
                     Ok(())

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -12,6 +12,6 @@ edition = "2018"
 std = [ "serde/std", "serde_cbor/std" ]
 
 [dependencies]
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"] }

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.3"
 grpcio = "0.9.0"
 hex = "0.4"
 lmdb-rkv = "0.14.0"
-prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rayon = "1.2"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 structopt = "0.3"


### PR DESCRIPTION
### Motivation

Reducing the number of forks which our code depends on is an unqualified good.

### In this PR
* Remove crates.io patches.
* Update `prost` to 0.8.
* Adjust `repr-bytes` usage to handle `bytes` 1.0 API changes.