### PR TITLE
Update base64 to 0.13.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,7 +2776,7 @@ dependencies = [
 name = "mc-consensus-service"
 version = "1.1.2"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "chrono",
  "curve25519-dalek",
  "displaydoc",
@@ -3619,7 +3619,7 @@ dependencies = [
 name = "mc-fog-report-cli"
 version = "1.1.0"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "binascii",
  "grpcio",
  "mc-account-keys",
@@ -4741,7 +4741,7 @@ dependencies = [
 name = "mc-util-encodings"
 version = "1.1.2"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "binascii",
  "displaydoc",
  "hex 0.4.2",
@@ -4785,7 +4785,7 @@ dependencies = [
 name = "mc-util-grpc"
 version = "1.1.2"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "cookie 0.14.3",
  "displaydoc",
  "futures 0.3.8",
@@ -4945,7 +4945,7 @@ dependencies = [
 name = "mc-util-uri"
 version = "1.1.2"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "displaydoc",
  "ed25519",
  "hex 0.4.2",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -99,9 +99,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "binascii"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -34,7 +34,7 @@ mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial" }
 mc-util-uri = { path = "../../util/uri" }
 
-base64 = "0.12"
+base64 = "0.13"
 chrono = "0.4"
 displaydoc = { version = "0.2", default-features = false }
 fs_extra = "1.1"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "binascii"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "binascii"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -21,7 +21,7 @@ mc-fog-report-validation = { path = "../validation" }
 mc-util-keyfile = { path = "../../../util/keyfile" }
 mc-util-uri = { path = "../../../util/uri" }
 
-base64 = "0.12"
+base64 = "0.13"
 binascii = "0.1.4"
 grpcio = "0.9.0"
 structopt = "0.3"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "binascii"

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -8,7 +8,7 @@ description = "Support for various simple encodings (hex strings, base64 strings
 [dependencies]
 mc-util-repr-bytes = { path = "../repr-bytes", default-features = false }
 
-base64 = { version = "0.12", default-features = false }
+base64 = { version = "0.13", default-features = false }
 binascii = "0.1.4"
 displaydoc = { version = "0.2", default-features = false }
 hex = { version = "0.4", default-features = false }

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -15,7 +15,7 @@ mc-util-metrics = { path = "../metrics" }
 mc-util-serial = { path = "../serial", features = ["std"]}
 mc-util-uri = { path = "../uri" }
 
-base64 = "0.12"
+base64 = "0.13"
 cookie = "0.14"
 displaydoc = { version = "0.2", default-features = false }
 futures = "0.3"

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -9,7 +9,7 @@ mc-common = { path = "../../common", default-features = false }
 mc-util-host-cert = { path = "../../util/host-cert", default-features = false }
 mc-crypto-keys = { path = "../../crypto/keys" }
 
-base64 = "0.12"
+base64 = "0.13"
 displaydoc = { version = "0.2", default-features = false }
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 hex = "0.4"


### PR DESCRIPTION
### Motivation

This upgrades our usage of base64 to use v0.13, which reduces the users of the older 0.12 crate to just `reqwest`.

### In this PR
* Upgrade `base64` crate to 0.13.