### PR TITLE
Update all our usages of cfg-if to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,7 @@ dependencies = [
  "bincode",
  "bitflags",
  "cargo-emit",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "digest 0.9.0",
  "displaydoc",
@@ -2497,7 +2497,7 @@ dependencies = [
 name = "mc-attest-net"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "displaydoc",
  "mbedtls",
  "mc-attest-core",
@@ -2538,7 +2538,7 @@ version = "1.1.2"
 dependencies = [
  "backtrace",
  "binascii",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "displaydoc",
  "hashbrown 0.6.3",
@@ -2868,7 +2868,7 @@ dependencies = [
 name = "mc-crypto-digestible"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array 0.14.4",
@@ -2991,7 +2991,7 @@ dependencies = [
 name = "mc-crypto-rand"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "getrandom 0.1.14",
  "rand 0.8.3",
  "rand_core 0.6.2",
@@ -4431,7 +4431,7 @@ dependencies = [
 name = "mc-sgx-compat"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-sgx-types",
 ]
 
@@ -4505,7 +4505,7 @@ dependencies = [
 name = "mc-sgx-slog"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-common",
  "mc-sgx-build",
  "prost",

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -38,7 +38,7 @@ mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_dep
 
 binascii = "0.1.2"
 bitflags = "1.2"
-cfg-if = "0.1"
+cfg-if = "1.0"
 chrono = { version = "0.4.10", default-features = false, features = ["alloc"] }
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.2", default-features = false }

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -20,7 +20,7 @@ mc-attest-core = { path = "../../attest/core" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-util-encodings = { path = "../../util/encodings" }
 
-cfg-if = "0.1"
+cfg-if = "1.0"
 displaydoc = "0.2"
 mbedtls = "0.8.1"
 pem = "0.8"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -36,7 +36,7 @@ loggers = [
 ]
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 mc-crypto-digestible = { path = "../crypto/digestible" }
 displaydoc = { version = "0.2", default-features = false }
 hashbrown = { version = "0.6", default-features = false, features = ["serde", "nightly"] }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
  "binascii",
  "bitflags",
  "cargo-emit",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "digest",
  "displaydoc",
@@ -747,7 +747,7 @@ name = "mc-common"
 version = "1.1.2"
 dependencies = [
  "binascii",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "displaydoc",
  "hashbrown",
  "hex_fmt",
@@ -883,7 +883,7 @@ dependencies = [
 name = "mc-crypto-digestible"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
@@ -981,7 +981,7 @@ dependencies = [
 name = "mc-crypto-rand"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "getrandom 0.1.14",
  "rand",
  "rand_core",
@@ -1040,7 +1040,7 @@ dependencies = [
 name = "mc-sgx-compat"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-sgx-alloc",
  "mc-sgx-debug",
  "mc-sgx-panic",
@@ -1102,7 +1102,7 @@ dependencies = [
 name = "mc-sgx-slog"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-common",
  "mc-sgx-build",
  "prost",

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 merlin = { version = "3.0", default-features = false }
 generic-array = "0.14"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 std = ["rand_core/std", "rand/std", "rand/std_rng"]
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 getrandom = "0.1"
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -729,7 +729,7 @@ dependencies = [
  "binascii",
  "bitflags",
  "cargo-emit",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "digest",
  "displaydoc",
@@ -782,7 +782,7 @@ name = "mc-common"
 version = "1.1.2"
 dependencies = [
  "binascii",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "displaydoc",
  "hashbrown",
  "hex_fmt",
@@ -834,7 +834,7 @@ dependencies = [
 name = "mc-crypto-digestible"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
@@ -919,7 +919,7 @@ dependencies = [
 name = "mc-crypto-rand"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "getrandom 0.1.13",
  "rand",
  "rand_core",
@@ -1165,7 +1165,7 @@ dependencies = [
 name = "mc-sgx-compat"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-sgx-alloc",
  "mc-sgx-debug",
  "mc-sgx-panic",
@@ -1234,7 +1234,7 @@ dependencies = [
 name = "mc-sgx-slog"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-common",
  "mc-sgx-build",
  "prost",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "binascii",
  "bitflags",
  "cargo-emit",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "digest",
  "displaydoc",
@@ -801,7 +801,7 @@ name = "mc-common"
 version = "1.1.2"
 dependencies = [
  "binascii",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "displaydoc",
  "hashbrown",
  "hex_fmt",
@@ -853,7 +853,7 @@ dependencies = [
 name = "mc-crypto-digestible"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
@@ -938,7 +938,7 @@ dependencies = [
 name = "mc-crypto-rand"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "getrandom 0.1.13",
  "rand",
  "rand_core",
@@ -1165,7 +1165,7 @@ dependencies = [
 name = "mc-sgx-compat"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-sgx-alloc",
  "mc-sgx-debug",
  "mc-sgx-panic",
@@ -1234,7 +1234,7 @@ dependencies = [
 name = "mc-sgx-slog"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-common",
  "mc-sgx-build",
  "prost",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -739,7 +739,7 @@ dependencies = [
  "binascii",
  "bitflags",
  "cargo-emit",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "chrono",
  "digest",
  "displaydoc",
@@ -792,7 +792,7 @@ name = "mc-common"
 version = "1.1.2"
 dependencies = [
  "binascii",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "displaydoc",
  "hashbrown",
  "hex_fmt",
@@ -844,7 +844,7 @@ dependencies = [
 name = "mc-crypto-digestible"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
@@ -929,7 +929,7 @@ dependencies = [
 name = "mc-crypto-rand"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "getrandom 0.1.13",
  "rand",
  "rand_core",
@@ -1175,7 +1175,7 @@ dependencies = [
 name = "mc-sgx-compat"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-sgx-alloc",
  "mc-sgx-debug",
  "mc-sgx-panic",
@@ -1253,7 +1253,7 @@ dependencies = [
 name = "mc-sgx-slog"
 version = "1.1.2"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "mc-common",
  "mc-sgx-build",
  "prost",

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 # All dependencies are optional
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 mc-sgx-alloc = { path = "../alloc", optional = true }
 mc-sgx-panic = { path = "../panic", optional = true }
 mc-sgx-sync = { path = "../sync", optional = true }

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 sgx = []
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "1.0"
 prost = { version = "0.6.1", default-features = false, features = ["prost-derive"] }
 
 mc-common = { path = "../../common", default-features = false }


### PR DESCRIPTION
### Motivation

This updates all our direct usage of the `cfg-if` crate to the 1.0 stable release. This leaves `rusoto`, `serial_test`, and `slog` as remaining users.

### In this PR
* Update all our direct `cfg-if` uses to 1.0