### PR TITLE
Update hostname to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,16 +1708,6 @@ checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
 name = "hostname"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
-dependencies = [
- "libc",
- "winutil",
-]
-
-[[package]]
-name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
@@ -2543,7 +2533,7 @@ dependencies = [
  "displaydoc",
  "hashbrown 0.6.3",
  "hex_fmt",
- "hostname 0.1.5",
+ "hostname",
  "lazy_static",
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -6466,7 +6456,7 @@ checksum = "efe1c6c258797410d14ef90993e00916318d17461b201538d76fd8d3031cad4e"
 dependencies = [
  "backtrace",
  "failure",
- "hostname 0.3.1",
+ "hostname",
  "httpdate",
  "im",
  "lazy_static",
@@ -7929,15 +7919,6 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "winutil"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -60,7 +60,7 @@ slog = { version = "2.7", default-features = false, features = ["dynamic-keys", 
 slog-scope = { version = "4.1.2", optional = true }
 
 # loggers-only dependencies
-hostname = { version = "0.1", optional = true }
+hostname = { version = "0.3.1", optional = true }
 lazy_static = { version = "1.4", optional = true }
 mc-util-build-info = { path = "../util/build/info", optional = true }
 sentry = { version = "0.18", optional = true, default-features = false, features = ["with_client_implementation", "with_reqwest_transport", "with_panic", "with_failure", "with_device_info", "with_rust_info", "with_rustls"] }

--- a/common/src/logger/loggers/mod.rs
+++ b/common/src/logger/loggers/mod.rs
@@ -63,12 +63,15 @@ fn create_stderr_logger() -> slog::Fuse<slog_async::Async> {
 /// Create a GELF (https://docs.graylog.org/en/3.0/pages/gelf.html) logger.
 fn create_gelf_logger() -> Option<slog::Fuse<slog_async::Async>> {
     env::var("MC_LOG_GELF").ok().map(|remote_host_port| {
-        let local_hostname = hostname::get_hostname().unwrap();
+        let local_hostname = hostname::get().expect("Could not retrieve hostname");
 
         let drain = slog_envlogger::new(
-            Gelf::new(&local_hostname, &remote_host_port[..])
-                .expect("failed creating Gelf logger for")
-                .fuse(),
+            Gelf::new(
+                local_hostname.to_str().expect("Invalid UTF-8 in hostname"),
+                &remote_host_port[..],
+            )
+            .expect("failed creating Gelf logger for")
+            .fuse(),
         );
 
         slog_async::Async::new(drain)


### PR DESCRIPTION
### Motivation

This PR updates the `hostname` dependency of `mc-common` (used when constructing loggers in untrusted space) to 0.3.1. This removes the last user of hostname 0.1, which means we only need to build one version of that crate.

### In this PR
* Update `hostname` to 0.3.1