### PR TITLE
Update proc-macro2, quote, and syn to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "lazycell",
  "log 0.4.11",
  "peeking_take_while",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "regex",
  "rustc-hash",
@@ -508,7 +508,7 @@ dependencies = [
  "clap",
  "heck",
  "log 0.4.11",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "serde",
  "serde_json",
@@ -967,7 +967,7 @@ name = "datatest-derive"
 version = "0.6.4"
 source = "git+https://github.com/mobilecoinfoundation/datatest.git?rev=dc3521f692228b846a2312e7ceece50e7664be6e#dc3521f692228b846a2312e7ceece50e7664be6e"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -1035,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70806b70be328e646f243680a3fc93b3cfdd6db373faa5110660a5dd5af243bc"
 dependencies = [
  "heck",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -1046,7 +1046,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -1130,7 +1130,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -1225,7 +1225,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "synstructure",
@@ -1400,7 +1400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -2881,7 +2881,7 @@ dependencies = [
 name = "mc-crypto-digestible-derive"
 version = "1.1.2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -4873,9 +4873,9 @@ dependencies = [
 name = "mc-util-logger-macros"
 version = "1.1.2"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.29",
+ "quote 1.0.9",
+ "syn 1.0.67",
 ]
 
 [[package]]
@@ -5059,7 +5059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -5197,7 +5197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
 dependencies = [
  "cfg-if 0.1.10",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -5525,7 +5525,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -5536,7 +5536,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -5646,7 +5646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "version_check 0.9.3",
@@ -5658,7 +5658,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "syn-mid",
@@ -5688,9 +5688,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -5745,7 +5745,7 @@ source = "git+https://github.com/danburkert/prost?rev=6113789f70b69709820becba42
 dependencies = [
  "anyhow",
  "itertools 0.9.0",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -5817,7 +5817,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
 ]
 
 [[package]]
@@ -6528,7 +6528,7 @@ version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -6585,7 +6585,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -6906,7 +6906,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "serde",
  "serde_derive",
@@ -6920,7 +6920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "serde",
  "serde_derive",
@@ -6969,7 +6969,7 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -7003,7 +7003,7 @@ version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "unicode-xid 0.2.0",
 ]
@@ -7014,7 +7014,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -7025,7 +7025,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "unicode-xid 0.2.0",
@@ -7104,7 +7104,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
 ]
@@ -7160,7 +7160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "standback",
  "syn 1.0.67",
@@ -7787,7 +7787,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.11",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "wasm-bindgen-shared",
@@ -7821,7 +7821,7 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "wasm-bindgen-backend",
@@ -8018,7 +8018,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.29",
  "quote 1.0.9",
  "syn 1.0.67",
  "synstructure",

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -8,12 +8,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quote = "0.6"
-
-[dependencies.proc-macro2]
-version = "0.4"
-features = ["nightly"]
-
-[dependencies.syn]
-version = "0.15"
-features = ["full", "extra-traits"]
+proc-macro2 = { version = "1.0", features = ["nightly"] }
+quote = "1.0"
+syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/util/logger-macros/src/lib.rs
+++ b/util/logger-macros/src/lib.rs
@@ -33,12 +33,12 @@ fn test_with_logger_impl(item: TokenStream) -> Result<TokenStream> {
         }
     };
 
-    let orig_ident = original_fn.ident.clone();
-    let orig_name = original_fn.ident.to_string();
+    let orig_ident = original_fn.sig.ident.clone();
+    let orig_name = original_fn.sig.ident.to_string();
 
-    let new_name = format!("__wrapped_{}", original_fn.ident.to_string());
-    original_fn.ident = syn::Ident::new(&new_name[..], original_fn.ident.span());
-    let new_ident = original_fn.ident.clone();
+    let new_name = format!("__wrapped_{}", original_fn.sig.ident.to_string());
+    original_fn.sig.ident = syn::Ident::new(&new_name[..], original_fn.sig.ident.span());
+    let new_ident = original_fn.sig.ident.clone();
 
     let mut new_fn: syn::ItemFn = parse_quote! {
         #[test]
@@ -86,12 +86,12 @@ fn bench_with_logger_impl(item: TokenStream) -> Result<TokenStream> {
         }
     };
 
-    let orig_ident = original_fn.ident.clone();
-    let orig_name = original_fn.ident.to_string();
+    let orig_ident = original_fn.sig.ident.clone();
+    let orig_name = original_fn.sig.ident.to_string();
 
-    let new_name = format!("__wrapped_{}", original_fn.ident.to_string());
-    original_fn.ident = syn::Ident::new(&new_name[..], original_fn.ident.span());
-    let new_ident = original_fn.ident.clone();
+    let new_name = format!("__wrapped_{}", original_fn.sig.ident.to_string());
+    original_fn.sig.ident = syn::Ident::new(&new_name[..], original_fn.sig.ident.span());
+    let new_ident = original_fn.sig.ident.clone();
 
     let mut new_fn: syn::ItemFn = parse_quote! {
         #[bench]


### PR DESCRIPTION
### Motivation

This PR updates the `mc-util-logger-macros` crate to use the 1.0 releases of `proc-macro2`, `quote`, and `syn`.

### In this PR
* Update `proc-macro2`, `quote`, and `syn`
