### PR TITLE
Make Encrypted memo changes releasable

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -41,7 +41,7 @@ use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, CompressedCommitment,
 };
-use mc_transaction_std::{InputCredentials, RTHMemoBuilder, TransactionBuilder};
+use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_from_random::FromRandom;
 use mc_util_uri::FogUri;
 use protobuf::Message;
@@ -1072,8 +1072,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
     jni_ffi_call(&env, |env| {
         let fog_resolver: MutexGuard<FogResolver> =
             env.get_rust_field(fog_resolver, RUST_OBJ_FIELD)?;
-        let memo_builder = RTHMemoBuilder::default();
-        // FIXME: Enable recoverable transaction history by configuring memo_builder
+        // TODO: After servers that support memos are deployed, use RTHMemoBuilder here
+        let memo_builder = NoMemoBuilder::default();
         let tx_builder = TransactionBuilder::new(fog_resolver.clone(), memo_builder);
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, tx_builder)?)
     })

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -741,13 +741,13 @@ FfiOptOwnedPtr<McData> mc_transaction_builder_add_output(FfiMutPtr<McTransaction
  * * `LibMcError::AttestationVerification`
  * * `LibMcError::InvalidInput`
  */
-FfiOptOwnedPtr<McData> mc_transaction_builder_add_output_with_fog_hint_address(FfiMutPtr<McTransactionBuilder> transaction_builder,
-                                                                               uint64_t amount,
-                                                                               FfiRefPtr<McPublicAddress> recipient_address,
-                                                                               FfiRefPtr<McPublicAddress> fog_hint_address,
-                                                                               FfiOptMutPtr<McRngCallback> rng_callback,
-                                                                               FfiMutPtr<McMutableBuffer> out_tx_out_confirmation_number,
-                                                                               FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+FfiOptOwnedPtr<McData> mc_transaction_builder_add_output_with_fog_hint_address(FfiMutPtr<McTransactionBuilder> _transaction_builder,
+                                                                               uint64_t _amount,
+                                                                               FfiRefPtr<McPublicAddress> _recipient_address,
+                                                                               FfiRefPtr<McPublicAddress> _fog_hint_address,
+                                                                               FfiOptMutPtr<McRngCallback> _rng_callback,
+                                                                               FfiMutPtr<McMutableBuffer> _out_tx_out_confirmation_number,
+                                                                               FfiOptMutPtr<FfiOptOwnedPtr<McError>> _out_error);
 
 /**
  * # Preconditions

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -23,9 +23,7 @@ use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     BlockIndex,
 };
-use mc_transaction_std::{
-    ChangeDestination, EmptyMemoBuilder, InputCredentials, TransactionBuilder,
-};
+use mc_transaction_std::{ChangeDestination, InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_uri::FogUri;
 use rand::Rng;
 use rayon::prelude::*;
@@ -772,7 +770,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         };
 
         // Create tx_builder.
-        let mut tx_builder = TransactionBuilder::new(fog_resolver, EmptyMemoBuilder::default());
+        let mut tx_builder = TransactionBuilder::new(fog_resolver, NoMemoBuilder::default());
 
         tx_builder
             .set_fee(fee)

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1929,7 +1929,7 @@ mod test {
         tx::{Tx, TxOut},
         Block, BlockContents, BLOCK_VERSION,
     };
-    use mc_transaction_std::{EmptyMemoBuilder, TransactionBuilder};
+    use mc_transaction_std::{NoMemoBuilder, TransactionBuilder};
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
     use mc_util_uri::FogUri;
     use rand::{rngs::StdRng, SeedableRng};
@@ -2804,7 +2804,7 @@ mod test {
         // Insert into database.
         let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
         let mut transaction_builder =
-            TransactionBuilder::new(MockFogResolver::default(), EmptyMemoBuilder::default());
+            TransactionBuilder::new(MockFogResolver::default(), NoMemoBuilder::default());
         let (tx_out, tx_confirmation) = transaction_builder
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
@@ -4886,7 +4886,7 @@ mod test {
         let account_key = AccountKey::from(&root_id);
 
         let mut transaction_builder =
-            TransactionBuilder::new(MockFogResolver::default(), EmptyMemoBuilder::default());
+            TransactionBuilder::new(MockFogResolver::default(), NoMemoBuilder::default());
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,
@@ -4994,7 +4994,7 @@ mod test {
         let account_key = AccountKey::from(key);
 
         let mut transaction_builder =
-            TransactionBuilder::new(MockFogResolver::default(), EmptyMemoBuilder::default());
+            TransactionBuilder::new(MockFogResolver::default(), NoMemoBuilder::default());
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,

--- a/slam/src/main.rs
+++ b/slam/src/main.rs
@@ -25,7 +25,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutMembershipProof},
 };
-use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
+use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_uri::ConnectionUri;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rayon::prelude::*;
@@ -497,8 +497,7 @@ fn build_tx(
     assert_eq!(utxos_with_proofs.len(), rings.len());
 
     // Create tx_builder. No fog reports.
-    let mut tx_builder =
-        TransactionBuilder::new(FogResolver::default(), EmptyMemoBuilder::default());
+    let mut tx_builder = TransactionBuilder::new(FogResolver::default(), NoMemoBuilder::default());
 
     tx_builder
         .set_fee(FEE.load(Ordering::SeqCst))

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -289,7 +289,7 @@ impl TxOut {
         hint: EncryptedFogHint,
     ) -> Result<Self, AmountError> {
         TxOut::new_with_memo(value, recipient, tx_private_key, hint, |_| {
-            Ok(MemoPayload::default())
+            Ok(Some(MemoPayload::default()))
         })
         .map_err(|err| match err {
             NewTxError::Amount(err) => err,
@@ -314,7 +314,7 @@ impl TxOut {
         recipient: &PublicAddress,
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
-        memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
+        memo_fn: impl FnOnce(MemoContext) -> Result<Option<MemoPayload>, NewMemoError>,
     ) -> Result<Self, NewTxError> {
         let target_key = create_tx_out_target_key(tx_private_key, recipient).into();
         let public_key = create_tx_out_public_key(tx_private_key, recipient.spend_public_key());
@@ -327,14 +327,14 @@ impl TxOut {
             tx_public_key: &public_key,
         };
         let memo = memo_fn(memo_ctxt).map_err(NewTxError::Memo)?;
-        let e_memo = memo.encrypt(&shared_secret);
+        let e_memo = memo.map(|memo| memo.encrypt(&shared_secret));
 
         Ok(TxOut {
             amount,
             target_key,
             public_key: public_key.into(),
             e_fog_hint: hint,
-            e_memo: Some(e_memo),
+            e_memo: e_memo,
         })
     }
 
@@ -739,7 +739,7 @@ mod tests {
                 &bob_addr,
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(memo_val.clone()),
+                |_| Ok(Some(memo_val.clone())),
             )
             .unwrap();
 
@@ -772,7 +772,7 @@ mod tests {
                 &bob.change_subaddress(),
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(memo_val.clone()),
+                |_| Ok(Some(memo_val.clone())),
             )
             .unwrap();
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -334,7 +334,7 @@ impl TxOut {
             target_key,
             public_key: public_key.into(),
             e_fog_hint: hint,
-            e_memo: e_memo,
+            e_memo,
         })
     }
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -196,7 +196,12 @@ fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResu
 }
 
 /// All outputs have a memo (old-style TxOuts are rejected)
-#[allow(unused)]
+///
+/// Note: This is only under test for now, and can become live
+/// at the time that we address mobilecoinfoundation/mobilecoin/issues/905
+/// "make memos mandatory". See MCIP #0003 for discussion of interim period
+/// during which memos are optional.
+#[cfg(test)]
 fn validate_memos_exist(tx: &Tx) -> TransactionValidationResult<()> {
     if tx
         .prefix

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -38,7 +38,9 @@ pub fn validate<R: RngCore + CryptoRng>(
 
     validate_number_of_outputs(&tx.prefix, MAX_OUTPUTS)?;
 
-    validate_memos_exist(tx)?;
+    // Bring this back in Issue #905 (Make memos mandatory)
+    // https://github.com/mobilecoinfoundation/mobilecoin/issues/905
+    // validate_memos_exist(tx)?;
 
     validate_ring_sizes(&tx.prefix, RING_SIZE)?;
 
@@ -194,6 +196,7 @@ fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResu
 }
 
 /// All outputs have a memo (old-style TxOuts are rejected)
+#[allow(unused)]
 fn validate_memos_exist(tx: &Tx) -> TransactionValidationResult<()> {
     if tx
         .prefix

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -20,7 +20,7 @@ pub use memo::{
     DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType, SenderMemoCredential,
     UnusedMemo,
 };
-pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, NoMemoBuilder, RTHMemoBuilder};
 pub use transaction_builder::TransactionBuilder;
 
 // Re-export this to help the exported macros work

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -159,7 +159,7 @@ impl MemoBuilder for RTHMemoBuilder {
             .checked_add(1)
             .ok_or(NewMemoError::LimitsExceeded("num_recipients"))?;
         self.last_recipient = ShortAddressHash::from(recipient);
-        Ok(Some(if let Some(cred) = &self.sender_cred {
+        let payload: MemoPayload = if let Some(cred) = &self.sender_cred {
             if let Some(payment_request_id) = self.payment_request_id {
                 AuthenticatedSenderWithPaymentRequestIdMemo::new(
                     cred,
@@ -178,7 +178,8 @@ impl MemoBuilder for RTHMemoBuilder {
             }
         } else {
             UnusedMemo {}.into()
-        }))
+        };
+        Ok(Some(payload))
     }
 
     /// Build a memo for a change output (to ourselves).

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -146,7 +146,7 @@ impl MemoBuilder for RTHMemoBuilder {
         value: u64,
         recipient: &PublicAddress,
         memo_context: MemoContext,
-    ) -> Result<MemoPayload, NewMemoError> {
+    ) -> Result<Option<MemoPayload>, NewMemoError> {
         if self.wrote_destination_memo {
             return Err(NewMemoError::OutputsAfterChange);
         }
@@ -159,7 +159,7 @@ impl MemoBuilder for RTHMemoBuilder {
             .checked_add(1)
             .ok_or(NewMemoError::LimitsExceeded("num_recipients"))?;
         self.last_recipient = ShortAddressHash::from(recipient);
-        Ok(if let Some(cred) = &self.sender_cred {
+        Ok(Some(if let Some(cred) = &self.sender_cred {
             if let Some(payment_request_id) = self.payment_request_id {
                 AuthenticatedSenderWithPaymentRequestIdMemo::new(
                     cred,
@@ -178,7 +178,7 @@ impl MemoBuilder for RTHMemoBuilder {
             }
         } else {
             UnusedMemo {}.into()
-        })
+        }))
     }
 
     /// Build a memo for a change output (to ourselves).
@@ -187,9 +187,9 @@ impl MemoBuilder for RTHMemoBuilder {
         _value: u64,
         _change_destination: &ChangeDestination,
         _memo_context: MemoContext,
-    ) -> Result<MemoPayload, NewMemoError> {
+    ) -> Result<Option<MemoPayload>, NewMemoError> {
         if !self.destination_memo_enabled {
-            return Ok(UnusedMemo {}.into());
+            return Ok(Some(UnusedMemo {}.into()));
         }
         if self.wrote_destination_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
@@ -202,7 +202,7 @@ impl MemoBuilder for RTHMemoBuilder {
             Ok(mut d_memo) => {
                 self.wrote_destination_memo = true;
                 d_memo.set_num_recipients(self.num_recipients);
-                Ok(d_memo.into())
+                Ok(Some(d_memo.into()))
             }
             Err(err) => match err {
                 DestinationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -196,10 +196,6 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     /// Caution: This method should not be used without fully understanding the
     /// implications.
     ///
-    /// Deprecation note: This method will not be public in future versions of
-    /// this crate, we believe the only legitimate use of this is now served
-    /// by add_change_output.
-    ///
     /// Receiving a `TxOut` addressed to a different recipient than what's
     /// contained in the fog hint is normally considered to be a violation
     /// of convention and is likely to be filtered out silently by the
@@ -212,12 +208,12 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     /// * `fog_hint_address` - The public address used to create the fog hint
     /// * `memo_fn` - The memo function to use (see TxOut::new_with_memo)
     /// * `rng` - RNG used to generate blinding for commitment
-    pub fn add_output_with_fog_hint_address<RNG: CryptoRng + RngCore>(
+    fn add_output_with_fog_hint_address<RNG: CryptoRng + RngCore>(
         &mut self,
         value: u64,
         recipient: &PublicAddress,
         fog_hint_address: &PublicAddress,
-        memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
+        memo_fn: impl FnOnce(MemoContext) -> Result<Option<MemoPayload>, NewMemoError>,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         let (hint, pubkey_expiry) = create_fog_hint(fog_hint_address, &self.fog_resolver, rng)?;
@@ -383,7 +379,7 @@ fn create_output_with_fog_hint<RNG: CryptoRng + RngCore>(
     value: u64,
     recipient: &PublicAddress,
     fog_hint: EncryptedFogHint,
-    memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
+    memo_fn: impl FnOnce(MemoContext) -> Result<Option<MemoPayload>, NewMemoError>,
     rng: &mut RNG,
 ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
     let private_key = RistrettoPrivate::from_random(rng);
@@ -461,7 +457,13 @@ pub mod transaction_builder_tests {
         rng: &mut RNG,
     ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
         let (hint, _pubkey_expiry) = create_fog_hint(recipient, fog_resolver, rng)?;
-        create_output_with_fog_hint(value, recipient, hint, |_| Ok(MemoPayload::default()), rng)
+        create_output_with_fog_hint(
+            value,
+            recipient,
+            hint,
+            |_| Ok(Some(MemoPayload::default())),
+            rng,
+        )
     }
 
     /// Creates a ring of of TxOuts.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -193,14 +193,14 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     /// Add an output to the transaction, using `fog_hint_address` to construct
     /// the fog hint.
     ///
-    /// Caution: This method should not be used without fully understanding the
-    /// implications.
-    ///
-    /// Receiving a `TxOut` addressed to a different recipient than what's
-    /// contained in the fog hint is normally considered to be a violation
-    /// of convention and is likely to be filtered out silently by the
-    /// client, except in special circumstances where the recipient is expressly
-    /// expecting it.
+    /// This is a private implementation detail, and generally, fog users expect
+    /// that the transactions that they recieve from fog belong to the account
+    /// that they are using. The only known use-case where recipient and
+    /// fog_hint_address are different is when sending change transactions
+    /// to oneself, when oneself is a fog user. Sending the change to the
+    /// main subaddress means that you don't have to hit fog once for the
+    /// main subaddress and once for the change subaddress, so it cuts the
+    /// number of requests in half.
     ///
     /// # Arguments
     /// * `value` - The value of this output, in picoMOB.


### PR DESCRIPTION
In testing, we discovered that old clients are unable to submit
transactions to new servers, even if the MRENCLAVE value is up to date.
This is because the entire TxPrefix is under the ring signature in the
transaction math, and the TxPrefix is different whether or not a memo
is there. An old server has protobufs that don't include the memo field,
so they compute the hash of the TxPrefix differently from clients that
included an empty memo.

To make this go, we decided to release this change in two steps.
First, we make versions of the servers that tolerate the presence of
the memo and compute the TxPrefix hash in the same way as the clients,
but also accept the state of affairs that there are no memos.

Existing clients can thus continue to work with this server simply by
updating the MRENCLAVE value that they have hard coded.

In a subsequent server release, the memos will become mandatory.
In the transition period before that release, Clients will all start
using the memos, and reading from them, expecting to find data there
(but tolerating the absence of that data, so that these clients work
in the period before this secondary server release, during which
memos are optional.)

The changes are:
* Don't require every TxOut to have a memo during validation
  (but keep that functionality under test, and refer to a ticket to
  bring it back.)
* MemoFn in the TxOut::new, MemoBuilder, and TransactionBuilder pathways
  returns `Result<Option<MemoPayload>,...>` rather than `Result<MemoPayload, ...>`
  to allow that memo builders may omit the memo.
  (This modificaiton will be reverted when memos are made mandatory.)
* A `NoMemoBuilder` is added in the `transaction-std` crate, which always
  produces `None`. This is intended to be used during the transationary
  period when the servers have not yet started accepting memos.
* Make android-bindings, libmobilecoin, mobilecoind, use the `NoMemoBuilder`.
  They can be switched to `EmptyMemoBuilder` or `RTHMemoBuilder` as necessary
  during the next release.