### PR TITLE
Revert "Bump bitflags from 1.2.1 to 1.3.2 (#1016)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitmaps"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -37,7 +37,7 @@ mc-sgx-types = { path = "../../sgx/types" }
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps"] }
 
 binascii = "0.1.2"
-bitflags = "1.3"
+bitflags = "1.2"
 cfg-if = "1.0"
 chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 digest = { version = "0.9", default-features = false }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -134,9 +134,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -163,9 +163,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"


### PR DESCRIPTION
This reverts commit f56a1020f176bc6fe6c3dcf4e8db08686214b20c.

The most recent merge introduces a dependency conflict, because nix 0.22.1 depends on bitflags < 1.3, for MSRV reasons. This reverts the bitflag bump, which we can re-introduce after [nix 0.23 is released](https://github.com/nix-rust/nix/issues/1510), hopefully within the next few days.