### PR TITLE
Fiddle with dependabot PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,24 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 25
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5


### PR DESCRIPTION
### Motivation

At the moment, dependabot will create a maximum of 10 PRs in each of the enclaves and the root. This often results in multiple broken PRs, as changes to an enclave need to touch the upstream Cargo.lock as well. Originally, this resulted in us saying "oh, well, don't scan the enclaves," but this causes issues with dependencies that *only* exist in the enclave never getting updated.

This will change that so updates which will trigger PRs in multiple workspaces will be more likely to have a PR against the "root" that we can work in (and close the others).

### In this PR
* Bump root limit to 25, reduce enclave limit to 5