### PR TITLE
Make fog ingest handle errors recovering the statefile more intelligently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ version = "1.1.0"
 dependencies = [
  "cargo-emit",
  "criterion",
+ "displaydoc",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -29,6 +29,9 @@ mc-sgx-types = { path = "../../../sgx/types" }
 mc-sgx-urts = { path = "../../../sgx/urts" }
 mc-util-serial = { path = "../../../util/serial" }
 
+# third-party
+displaydoc = "0.2"
+
 [dev-dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-crypto-rand = { path = "../../../crypto/rand" }

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -10,14 +10,18 @@ pub use mc_fog_ingest_enclave_api::{
     Error, IngestEnclave, IngestEnclaveInitParams, IngestEnclaveProxy, Result, SealedIngestKey,
 };
 
+use displaydoc::Display;
 use mc_attest_core::{
     IasNonce, Quote, QuoteNonce, Report, SgxError, TargetInfo, VerificationReport, DEBUG_ENCLAVE,
 };
 use mc_attest_enclave_api::{EnclaveMessage, PeerAuthRequest, PeerAuthResponse, PeerSession};
-use mc_common::ResponderId;
+use mc_common::{
+    logger::{log, Logger},
+    ResponderId,
+};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic, X25519Public};
 use mc_enclave_boundary::untrusted::make_variable_length_ecall;
-use mc_fog_ingest_enclave_api::EnclaveCall;
+use mc_fog_ingest_enclave_api::{EnclaveCall, Error as EnclaveError};
 use mc_fog_kex_rng::KexRngPubkey;
 use mc_fog_recovery_db_iface::ETxOutRecord;
 use mc_fog_types::ingest::TxsForIngest;
@@ -30,6 +34,15 @@ use std::{path, result::Result as StdResult, sync::Arc};
 
 /// The default filename of the fog ingest's SGX enclave binary.
 pub const ENCLAVE_FILE: &str = "libingest-enclave.signed.so";
+
+/// An error that occurs when calling IngestSgxEnclave::new
+#[derive(Display, Debug)]
+pub enum NewEnclaveError {
+    /// When creating the new enclave: {0}
+    Create(SgxError),
+    /// When initializing the new enclave: {0}
+    Init(EnclaveError),
+}
 
 /// A handle to an ingest enclave, on the untrusted side
 #[derive(Clone)]
@@ -66,7 +79,8 @@ impl IngestSgxEnclave {
         peer_self_id: &ResponderId,
         sealed_key: &Option<SealedIngestKey>,
         omap_capacity: u64,
-    ) -> IngestSgxEnclave {
+        logger: &Logger,
+    ) -> StdResult<IngestSgxEnclave, NewEnclaveError> {
         let mut launch_token: sgx_launch_token_t = [0; 1024];
         let mut launch_token_updated: i32 = 0;
         // FIXME: this must be filled in from the build.rs
@@ -81,12 +95,16 @@ impl IngestSgxEnclave {
             &mut launch_token_updated,
             &mut misc_attr,
         )
-        .unwrap_or_else(|err| {
-            panic!(
-                "SgxEnclave::create(file_name={:?}, debug={}) failed: {:?}",
-                &enclave_path, DEBUG_ENCLAVE as i32, err
-            )
-        });
+        .map_err(|err| {
+            log::error!(
+                logger,
+                "SgxEnclave::create(file_name={:?}, debug={}) failed: {}",
+                &enclave_path,
+                DEBUG_ENCLAVE as i32,
+                err
+            );
+            NewEnclaveError::Create(SgxError::from(err))
+        })?;
         let sgx_enclave = IngestSgxEnclave {
             eid: enclave.geteid(),
             enclave: Arc::new(enclave),
@@ -100,9 +118,9 @@ impl IngestSgxEnclave {
 
         sgx_enclave
             .enclave_init(params)
-            .expect("enclave_init failed");
+            .map_err(|err| NewEnclaveError::Init(err))?;
 
-        sgx_enclave
+        Ok(sgx_enclave)
     }
 
     /// Takes serialized data, and fires to the corresponding ECALL.

--- a/fog/ingest/enclave/tests/graceful_teardown.rs
+++ b/fog/ingest/enclave/tests/graceful_teardown.rs
@@ -22,6 +22,8 @@ fn ingest_enclave_graceful_teardown(logger: Logger) {
             &ResponderId::from_str("127.0.0.1:3040").unwrap(),
             &None,
             OMAP_CAP,
-        );
+            &logger,
+        )
+        .expect("could not initialize enclave");
     }
 }

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -22,7 +22,9 @@ use mc_fog_api::{
     ingest_common::{IngestControllerMode, IngestStateFile, IngestSummary},
     report_parse::try_extract_unvalidated_ingress_pubkey_from_fog_report,
 };
-use mc_fog_ingest_enclave::{Error as EnclaveError, IngestEnclave, IngestSgxEnclave};
+use mc_fog_ingest_enclave::{
+    Error as EnclaveError, IngestEnclave, IngestSgxEnclave, NewEnclaveError,
+};
 use mc_fog_recovery_db_iface::{IngressPublicKeyStatus, RecoveryDb, ReportData, ReportDb};
 use mc_fog_types::{common::BlockRange, ingest::TxsForIngest};
 use mc_fog_uri::IngestPeerUri;
@@ -109,10 +111,26 @@ where
                                 None
                             }
                             _ => {
-                                // TODO: Should we delete the file, to avoid a crash loop?
-                                // We could move it to a backup location or something, like, `.1`,
-                                // `.2`, etc. up to some maximum.
-                                panic!("Could not read state file ({:?}): {}", file, io_error);
+                                log::error!(
+                                    logger,
+                                    "Could not read state file ({:?}): {}",
+                                    file,
+                                    io_error
+                                );
+                                // Move the statefile to .bak, to try to prevent a crashloop
+                                // This server can still be useful starting in idle mode because
+                                // another server can give it the
+                                // correct key. We could delete it
+                                // instead, but it might help for debugging to keep it as .bak
+                                if let Err(err) = file.move_to_bak() {
+                                    log::error!(
+                                        logger,
+                                        "Could not move the state file ({:?}) to .bak: {}",
+                                        file,
+                                        err
+                                    );
+                                }
+                                None
                             }
                         }
                     }
@@ -124,12 +142,41 @@ where
             .map(|x| x.sealed_ingress_key.clone());
 
         // Initialize the enclave
-        let enclave = IngestSgxEnclave::new(
+        let enclave = match IngestSgxEnclave::new(
             config.enclave_path.clone(),
             &config.local_node_id,
             &cached_key,
             config.omap_capacity,
-        );
+            &logger,
+        ) {
+            Ok(enclave) => enclave,
+            Err(NewEnclaveError::Create(err)) => {
+                panic!("Could not create new enclave: {}", err);
+            }
+            Err(NewEnclaveError::Init(err)) => {
+                log::error!(
+                    logger,
+                    "Enclave init failed, sealed key may have been rejected: {}",
+                    err
+                );
+                // Move the statefile to .bak, to try to prevent a crashloop
+                // This server can still be useful starting in idle mode because another
+                // server can give it the correct key.
+                // We could delete it instead, but it might help for debugging to keep it as
+                // .bak
+                if let Some(file) = config.state_file.as_ref() {
+                    if let Err(err) = file.move_to_bak() {
+                        log::error!(
+                            logger,
+                            "Could not move the state file ({:?}) to .bak: {}",
+                            file,
+                            err
+                        );
+                    }
+                }
+                panic!("Enclave init failed, going down");
+            }
+        };
 
         // Initialize report cache
         let report_cache = Arc::new(Mutex::new(ReportCache::new(
@@ -156,7 +203,7 @@ where
             report_cache,
             grpc_env,
             last_sealed_key: Arc::new(Mutex::new(None)),
-            logger,
+            logger: logger.clone(),
         };
 
         // Attempt to restore state from state file if provided
@@ -166,10 +213,12 @@ where
             result
                 .restore_state_from_summary(summary)
                 .unwrap_or_else(|err| {
-                    panic!(
-                        "Could not restore state from state file ({:?}), {:?}: {}",
+                    // Note: We don't panic or nuke the statefile because this server may have recovered
+                    // the right key successfully, even if restore_state_from_summary fails
+                    log::error!(logger,
+                        "Could not restore state from state file ({:?}), {:?}: {}. Starting in idle instead",
                         config.state_file, summary, err
-                    )
+                    );
                 });
         }
 

--- a/fog/ingest/server/src/state_file.rs
+++ b/fog/ingest/server/src/state_file.rs
@@ -57,4 +57,12 @@ impl StateFile {
         file.write_all(&proto_data)?;
         file.sync_all()
     }
+
+    /// Rename the statefile to "backup". This is done if loading the statefile
+    /// fails, in order to prevent a crash loop.
+    pub fn move_to_bak(&self) -> Result<()> {
+        let bak = self.file_path.with_extension("bak");
+        std::fs::rename(&self.file_path, &bak)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
0. Add functionality to delete the statefile (except instead of deleting,
   we rename it to `.bak`, in case it will help debug something.)
1. Delete the statefile if initializing the ingest enclave fails.
   This is generally going to indicate that we couldn't unseal the
   private key. (Enclave creation failing is a separate issue, and
   that could be caused by an SGX daemon not being woken up yet)
2. If we did successfully load a key, don't panic even if restoring
   from state file failed.

Besides this, we generally improved error handling around the creation
of the `IngestSgxEnclave` object

This resolve issue #1082