### PR TITLE
minor fixes in fog test client

### DIFF
--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -4,7 +4,9 @@
 
 use mc_common::logger::{create_app_logger, o};
 
-use mc_fog_test_client::{config::Config, error::TestClientError, test_client::TestClient};
+use mc_fog_test_client::{
+    config::TestClientConfig, error::TestClientError, test_client::TestClient,
+};
 
 use structopt::StructOpt;
 
@@ -12,7 +14,7 @@ fn main() {
     mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) = create_app_logger(o!());
 
-    let config = Config::from_args();
+    let config = TestClientConfig::from_args();
 
     let account_keys = config.load_accounts(&logger);
 

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -13,7 +13,7 @@ pub const TEST_FOG_REPORT_ID: &str = "";
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "test-client", about = "Test client for Fog infrastructure.")]
-pub struct Config {
+pub struct TestClientConfig {
     /// Account key directory.
     #[structopt(long)]
     pub key_dir: PathBuf,
@@ -50,7 +50,7 @@ pub struct Config {
     pub transfer_amount: u64,
 }
 
-impl Config {
+impl TestClientConfig {
     pub fn load_accounts(&self, logger: &Logger) -> Vec<AccountKey> {
         // Load key_dir or read from bootstrap keys.
         let key_dir: String = self.key_dir.clone().to_str().unwrap().to_string();

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -17,7 +17,7 @@ use mc_util_uri::ConsensusClientUri;
 use more_asserts::assert_gt;
 use std::{
     thread,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 
 pub struct TestClient {
@@ -272,7 +272,7 @@ impl TestClient {
 
         log::debug!(self.logger, "Generating and testing transactions");
 
-        let start_time = SystemTime::now();
+        let start_time = Instant::now();
         for ti in 0..self.transactions as usize {
             log::debug!(self.logger, "Transation: {:?}", ti);
             // Rust doesn't allow multiple mutable borrows to vector contents.
@@ -382,10 +382,7 @@ impl TestClient {
             self.logger,
             "{} transactions took {}s",
             self.transactions,
-            start_time
-                .elapsed()
-                .expect("Could not get elapsed time")
-                .as_secs()
+            start_time.elapsed().as_secs()
         );
         Ok(())
     }


### PR DESCRIPTION
For measuring elapsed time, the Instant (which corresponds to
monotonic time) is always preferable to using SystemTime
(which corresponds to the OS-configured wall clock)