### PR TITLE
Update RustCrypto depedencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -1203,9 +1203,9 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -1221,7 +1221,7 @@ dependencies = [
  "rand 0.8.4",
  "serde",
  "serde_bytes",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
@@ -2175,7 +2175,7 @@ dependencies = [
  "mc-util-uri",
  "protobuf",
  "rand_core 0.6.3",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "slip10_ed25519",
  "tiny-bip39",
  "zeroize",
@@ -2363,7 +2363,7 @@ dependencies = [
  "hkdf",
  "mc-account-keys",
  "mc-crypto-keys",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "slip10_ed25519",
  "tiny-bip39",
  "zeroize",
@@ -2414,7 +2414,7 @@ dependencies = [
  "mc-util-uri",
  "protobuf",
  "rand 0.8.4",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "slip10_ed25519",
  "tiny-bip39",
  "zeroize",
@@ -2474,7 +2474,7 @@ dependencies = [
  "rand_core 0.6.3",
  "rand_hc 0.3.1",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2526,7 +2526,7 @@ dependencies = [
  "rand_hc 0.3.1",
  "rjson",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
 ]
 
@@ -2558,7 +2558,7 @@ dependencies = [
  "rand 0.8.4",
  "reqwest",
  "serde_json",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2642,7 +2642,7 @@ dependencies = [
  "rand_hc 0.3.1",
  "retry",
  "secrecy",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "tempdir",
 ]
 
@@ -2894,7 +2894,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -2994,7 +2994,7 @@ dependencies = [
  "semver 1.0.4",
  "serde",
  "serde_json",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "signature",
  "tempdir",
  "x25519-dalek",
@@ -3031,7 +3031,7 @@ dependencies = [
  "rand_hc 0.3.1",
  "secrecy",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -3175,7 +3175,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-serial",
  "mc-util-uri",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -4358,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.2"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126762b52a0017e74dd490b13fe04a53c1d5e51e66ca1762fa344118696d5357"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
  "aead",
  "aes",
@@ -4461,7 +4461,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_hc 0.3.1",
  "retry",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -4496,7 +4496,7 @@ name = "mc-sgx-css"
 version = "1.1.2"
 dependencies = [
  "displaydoc",
- "sha2 0.9.5",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -4673,7 +4673,7 @@ dependencies = [
  "rand_core 0.6.3",
  "rand_hc 0.3.1",
  "serde",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
  "tempdir",
  "zeroize",
@@ -4715,7 +4715,7 @@ dependencies = [
  "prost",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
  "yaml-rust",
  "zeroize",
@@ -4851,7 +4851,7 @@ dependencies = [
  "prometheus",
  "protobuf",
  "rand 0.8.4",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "signal-hook",
  "subtle 2.4.1",
  "tempfile",
@@ -5584,9 +5584,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -6426,7 +6426,7 @@ dependencies = [
  "curve25519-dalek",
  "merlin",
  "rand_core 0.6.3",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "subtle 2.4.1",
  "zeroize",
 ]
@@ -6639,9 +6639,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -6705,9 +6705,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest 0.9.0",
 ]
@@ -7209,7 +7209,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.5",
+ "sha2 0.9.8",
  "thiserror",
  "unicode-normalization",
  "zeroize",

--- a/account-keys/slip10/Cargo.toml
+++ b/account-keys/slip10/Cargo.toml
@@ -13,7 +13,7 @@ mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 
 displaydoc = { version = "0.2", default-features = false }
 hkdf = "0.9"
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 slip10_ed25519 = "0.1"
 tiny-bip39 = "0.8"
 zeroize = "1.2"

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -35,13 +35,13 @@ mc-util-uri = { path = "../util/uri" }
 mc-api = { path = "../api" }
 
 # third-party
-aes-gcm = { version = "0.9.2", default-features = false }
+aes-gcm = { version = "0.9.4", default-features = false }
 anyhow = "1.0"
 displaydoc = { version = "0.2", default-features = false }
 jni = { version = "0.19.0", default-features = false }
 protobuf = "2.22.1"
 rand = { version = "0.8", default-features = false }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "0.8"
 zeroize = "1.1"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -31,9 +31,9 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] }
 mc-attest-net = { path = "../net" }
 mc-util-encodings = { path = "../../util/encodings" }
 mc-util-from-random = { path = "../../util/from-random" }
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 rand_hc = "0.3"
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 
 [build-dependencies]
 mc-util-build-script = { path = "../../util/build/script" }

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -45,7 +45,7 @@ displaydoc = { version = "0.2", default-features = false }
 hex_fmt = "0.3"
 rjson = "0.3.1"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 prost = { version = "0.8", default-features = false }
 

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -27,7 +27,7 @@ pem = "0.8"
 percent-encoding = "2.1.0"
 reqwest = { version = "0.10" , default-features = false, features = ["rustls-tls", "gzip"] }
 serde_json = "1.0"
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 
 [dev-dependencies]
 rand = "0.8"

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -18,13 +18,13 @@ mc-util-grpc = { path = "../util/grpc" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 cookie = "0.15"
 displaydoc = { version = "0.2", default-features = false }
 grpcio = "0.9.0"
 retry = "1.3"
 secrecy = "0.8"
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 
 [dev-dependencies]
 rand = "0.8"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -295,8 +295,8 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
-source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9a22d2a3e5b829277cc05f4833751dd86c155218#9a22d2a3e5b829277cc05f4833751dd86c155218"
+version = "0.2.1"
+source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55#9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55"
 dependencies = [
  "libc",
 ]
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -560,9 +560,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -1003,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.2"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126762b52a0017e74dd490b13fe04a53c1d5e51e66ca1762fa344118696d5357"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
  "aead",
  "aes",
@@ -1304,9 +1304,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1513,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -1544,9 +1544,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -38,7 +38,7 @@ mc-sgx-types = { path = "../../../sgx/types" }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
 mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 
 [build-dependencies]
 mc-util-build-script = { path = "../../../util/build/script" }
@@ -61,7 +61,7 @@ overflow-checks = false
 bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "675330c754f28876dbf94fc303fe73666cf8f8f4" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
-cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9a22d2a3e5b829277cc05f4833751dd86c155218" }
+cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55" }
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "78bdc2a0b0af852cb4e47a0ca9be74bdf77c57b6" }

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -15,9 +15,9 @@ mc-crypto-rand = { path = "../../../crypto/rand", default-features = false }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 digest = { version = "0.9", default-features = false }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 
 [build-dependencies]
 mc-sgx-build = { path = "../../../sgx/build" }

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -10,7 +10,7 @@ blake2 = { version = "0.9.2", default-features = false }
 digest = { version = "0.9" }
 displaydoc = { version = "0.2", default-features = false }
 hkdf = { version = "0.9.0", default-features = false }
-mc-oblivious-aes-gcm = { version = "0.9.2", default-features = false, features = ["aes", "alloc", "zeroize"] }
+mc-oblivious-aes-gcm = { version = "0.9.5-pre1", default-features = false, features = ["aes", "alloc", "zeroize"] }
 rand_core = { version = "0.6", default-features = false }
 
 mc-crypto-keys = { path = "../keys", default-features = false }

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -9,5 +9,5 @@ readme = "README.md"
 [dependencies]
 mc-crypto-digestible = { path = ".." }
 
-signature = { version = "1.2", default-features = false }
+signature = { version = "1.3.1", default-features = false }
 schnorrkel-og = { version = "0.10.1", default-features = false }

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -14,15 +14,15 @@ mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
 binascii = "0.1.2"
 digest = { version = "0.9", default-features = false }
-ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
+ed25519 = { version = "1.2.0", default-features = false, features = ["serde"] }
 displaydoc = { version = "0.2", default-features = false }
 hex_fmt = "0.3"
 rand_core = { version = "0.6", default-features = false }
 rand_hc = "0.3"
 schnorrkel-og = { version = "0.10.1", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.9.5", default-features = false }
-signature = { version = "1.2", default-features = false, features = ["digest-preview"] }
+sha2 = { version = "0.9.8", default-features = false }
+signature = { version = "1.3.1", default-features = false, features = ["digest-preview"] }
 x25519-dalek = { version = "2.0.0-pre.0", default-features = false, features = ["nightly", "u64_backend"] }
 zeroize = { version = "1", default-features = false }
 

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 mc-util-serial = { path = "../../util/serial", default-features = false }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 displaydoc = { version = "0.2", default-features = false }
 generic-array = "0.14"
 rand_core = { version = "0.6", default-features = false }

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-util-from-random = { path = "../../util/from-random" }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 aead = "0.4"
 digest = { version = "0.9", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
@@ -17,7 +17,7 @@ hkdf = "0.9.0"
 rand_core = "0.6"
 secrecy = "0.8"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = "1.1.0"
 

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -18,8 +18,8 @@ mc-util-grpc = { path = "../../util/grpc" }
 mc-util-serial = { path = "../../util/serial" }
 mc-util-uri = { path = "../../util/uri" }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 cookie = "0.15"
 displaydoc = { version = "0.2", default-features = false }
 grpcio = "0.9.0"
-sha2 = "0.9.5"
+sha2 = "0.9.8"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -324,8 +324,8 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
-source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9a22d2a3e5b829277cc05f4833751dd86c155218#9a22d2a3e5b829277cc05f4833751dd86c155218"
+version = "0.2.1"
+source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55#9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55"
 dependencies = [
  "libc",
 ]
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -595,9 +595,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.2"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126762b52a0017e74dd490b13fe04a53c1d5e51e66ca1762fa344118696d5357"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
  "aead",
  "aes",
@@ -1444,9 +1444,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -1684,9 +1684,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
 ]

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -45,7 +45,7 @@ mc-sgx-types = { path = "../../../../sgx/types" }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
 mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 
 [build-dependencies]
 mc-util-build-sgx = { path = "../../../../util/build/sgx" }
@@ -69,7 +69,7 @@ overflow-checks = false
 bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "675330c754f28876dbf94fc303fe73666cf8f8f4" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
-cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9a22d2a3e5b829277cc05f4833751dd86c155218" }
+cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55" }
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "78bdc2a0b0af852cb4e47a0ca9be74bdf77c57b6" }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -13,27 +13,27 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
  "cpufeatures",
- "ctr 0.7.0",
+ "ctr",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr 0.8.0",
+ "ctr",
  "ghash",
  "subtle",
 ]
@@ -325,8 +325,8 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
-source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9a22d2a3e5b829277cc05f4833751dd86c155218#9a22d2a3e5b829277cc05f4833751dd86c155218"
+version = "0.2.1"
+source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55#9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55"
 dependencies = [
  "libc",
 ]
@@ -354,15 +354,6 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "ctr"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -411,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -495,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -614,9 +605,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -1091,14 +1082,14 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.2"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126762b52a0017e74dd490b13fe04a53c1d5e51e66ca1762fa344118696d5357"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
  "aead",
  "aes",
  "cipher",
- "ctr 0.7.0",
+ "ctr",
  "ghash",
  "subtle",
  "zeroize",
@@ -1444,9 +1435,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polyval"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1652,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -1683,9 +1674,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
 ]

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -70,7 +70,7 @@ overflow-checks = false
 bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "675330c754f28876dbf94fc303fe73666cf8f8f4" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
-cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9a22d2a3e5b829277cc05f4833751dd86c155218" }
+cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55" }
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "78bdc2a0b0af852cb4e47a0ca9be74bdf77c57b6" }

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -15,7 +15,7 @@ balanced-tree-index = "2.0"
 mc-oblivious-traits = "2.0"
 
 # third-party
-aes = { version = "0.7.4", default-features = false, features = ["ctr"] }
+aes = { version = "0.7.5", default-features = false, features = ["ctr"] }
 displaydoc = { version = "0.2", default-features = false }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 rand_core = { version = "0.6", default-features = false }

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -34,7 +34,7 @@ pem = "0.8"
 prost = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-signature = "1.2.2"
+signature = "1.3.1"
 structopt = "0.3"
 x509-signature = "0.5"
 zeroize = "1"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -15,7 +15,7 @@ mc-fog-sig-authority = { path = "./authority" }
 
 displaydoc = "0.2"
 pem = "0.8"
-signature = { version = "1.2.2" }
+signature = { version = "1.3.1" }
 x509-signature = "0.5"
 
 [dev-dependencies]

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -8,7 +8,7 @@ description = "Create and verify fog authority signatures"
 [dependencies]
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 
-signature = { version = "1.2.2", default-features = false, features = ["digest-preview"]  }
+signature = { version = "1.3.1", default-features = false, features = ["digest-preview"]  }
 
 [dev-dependencies]
 mc-util-from-random = { path = "../../../util/from-random" }

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -12,7 +12,7 @@ mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-fog-report-types = { path = "../../report/types", default-features = false }
 
 displaydoc = { version = "0.2", default-features = false }
-signature = { version = "1.2.2" }
+signature = { version = "1.3.1" }
 
 [dev-dependencies]
 mc-util-from-random = { path = "../../../util/from-random" }

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
  "aes",
@@ -325,8 +325,8 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
-source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9a22d2a3e5b829277cc05f4833751dd86c155218#9a22d2a3e5b829277cc05f4833751dd86c155218"
+version = "0.2.1"
+source = "git+https://github.com/mobilecoinfoundation/RustCrypto-utils.git?rev=9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55#9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55"
 dependencies = [
  "libc",
 ]
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
 ]
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf038a7b6fd7ef78ad3348b63f3a17550877b0e28f8d68bcc94894d1412158bc"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "serde",
  "signature",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -605,9 +605,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-aes-gcm"
-version = "0.9.2"
+version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126762b52a0017e74dd490b13fe04a53c1d5e51e66ca1762fa344118696d5357"
+checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
  "aead",
  "aes",
@@ -1463,9 +1463,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -1672,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -1703,9 +1703,9 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
 ]

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -51,7 +51,7 @@ mc-sgx-types = { path = "../../../../sgx/types" }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
 mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 
 [build-dependencies]
 mc-util-build-sgx = { path = "../../../../util/build/sgx" }
@@ -75,7 +75,7 @@ overflow-checks = false
 bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "675330c754f28876dbf94fc303fe73666cf8f8f4" }
 
 # Patched to disable the cpuid instruction because that is incompatible with our sgx builds.
-cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9a22d2a3e5b829277cc05f4833751dd86c155218" }
+cpufeatures = { git = "https://github.com/mobilecoinfoundation/RustCrypto-utils.git", rev = "9881a8f8aeb869ccdbefacfc19c7e5d2ef1ffb55" }
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "78bdc2a0b0af852cb4e47a0ca9be74bdf77c57b6" }

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -10,12 +10,12 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 # External dependencies
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.22.1"
 rand_core = { version = "0.6", features = ["std"] }
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "0.8"
 zeroize = "1.1"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -41,7 +41,7 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 mc-watcher = { path = "../watcher" }
 
-aes-gcm = "0.9.2"
+aes-gcm = "0.9.4"
 blake2 = { version = "0.9.2", default-features = false }
 crossbeam-channel = "0.5"
 displaydoc = "0.2"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -25,7 +25,7 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
 crossbeam-channel = "0.5"
-ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
+ed25519 = { version = "1.2.0", default-features = false, features = ["serde"] }
 displaydoc = "0.2"
 grpcio = "0.9.0"
 mockall = "0.10.2"

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4"
 rand = "0.8"
 rand_hc = "0.3"
 retry = "1.3"
-sha2 = { version = "0.9.5", features = ["asm"] }
+sha2 = { version = "0.9.8", features = ["asm"] }
 
 [dev-dependencies]
 mc-common = { path = "../../common", features = ["loggers"] }

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 displaydoc = {version = "0.2", default-features = false }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # External dependencies
-aes = { version = "0.7", default-features = false, features = ["ctr"] }
+aes = { version = "0.7.5", default-features = false, features = ["ctr"] }
 displaydoc = { version = "0.2", default-features = false }
 generic-array = { version = "0.14", features = ["serde", "more_lengths"] }
 hex_fmt = "0.3"
@@ -16,7 +16,7 @@ merlin = { version = "3.0", default-features = false }
 prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -11,7 +11,7 @@ hmac = { version = "0.11", default-features = false }
 prost = { version = "0.8", default-features = false, features = ["prost-derive"] }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
-sha2 = { version = "0.9.5", default-features = false }
+sha2 = { version = "0.9.8", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = "1"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.4"
 prometheus = "0.12"
 protobuf = "2.22.1"
 rand = "0.8"
-sha2 = "0.9.5"
+sha2 = "0.9.8"
 signal-hook = "0.3"
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -11,7 +11,7 @@ mc-crypto-keys = { path = "../../crypto/keys" }
 
 base64 = "0.13"
 displaydoc = { version = "0.2", default-features = false }
-ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
+ed25519 = { version = "1.2.0", default-features = false, features = ["serde"] }
 hex = "0.4"
 percent-encoding = "2.1.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }


### PR DESCRIPTION
### Motivation

Because we don't have a custom `x86_64-unknown-linux-sgx` target, we must patch `cpufeatures` to only use `target_features` in enclaves, which in turn has knock-on effects on when/how we can update the rest of these crates from upstream. This updates all these dependencies to their latest releases.

### In this PR
 * Update aes from 0.7.4 to 0.7.5.
 * Update aes-gcm from 0.9.2 to 0.9.4.
 * Update cpufeatures from 0.1.5 to 0.2.1.
 * Update ed25519 from 1.0.1 to 1.2.0.
 * Update ghash from 0.4.2 to 0.4.4.
 * Update libc from 0.2.98 to 0.2.103.
 * Update mc-oblivious-aes-gcm from 0.9.2 to 0.9.5-pre1.
 * Update polyval from 0.5.1 to 0.5.3.
 * Update sha2 from 0.9.5 to 0.9.8.
 * Update signature from 0.2.2 to 1.3.1.
