### PR TITLE
Make fog-ingest-enclave `set_ingress_private_key` function return bool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2992,6 +2992,7 @@ dependencies = [
  "serde_json",
  "sha2 0.9.5",
  "signature",
+ "subtle 2.4.1",
  "tempdir",
  "x25519-dalek",
  "zeroize",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "serde",
  "sha2",
  "signature",
+ "subtle",
  "x25519-dalek",
  "zeroize",
 ]

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -13,6 +13,7 @@ mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
 binascii = "0.1.2"
+subtle = { version = "2", default-features = false }
 digest = { version = "0.9", default-features = false }
 ed25519 = { version = "1.0.1", default-features = false, features = ["serde"] }
 displaydoc = { version = "0.2", default-features = false }

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -27,6 +27,7 @@ use mc_util_repr_bytes::{
 };
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
+use subtle::{Choice, ConstantTimeEq};
 use schnorrkel_og::{
     context::attach_rng, PublicKey as SchnorrkelPublic, SecretKey as SchnorrkelPrivate,
     Signature as SchnorrkelSignature, SignatureError as SchnorrkelError, SIGNATURE_LENGTH,
@@ -183,6 +184,12 @@ impl KexPrivate for RistrettoPrivate {
 
 impl PrivateKey for RistrettoPrivate {
     type Public = RistrettoPublic;
+}
+
+impl ConstantTimeEq for RistrettoPrivate {
+    fn ct_eq(&self, other: &Self) -> Choice { 
+        self.0.ct_eq(&other.0)
+    }
 }
 
 /// A private ristretto key which is ephemeral, should never be copied,

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -27,13 +27,13 @@ use mc_util_repr_bytes::{
 };
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
-use subtle::{Choice, ConstantTimeEq};
 use schnorrkel_og::{
     context::attach_rng, PublicKey as SchnorrkelPublic, SecretKey as SchnorrkelPrivate,
     Signature as SchnorrkelSignature, SignatureError as SchnorrkelError, SIGNATURE_LENGTH,
 };
 use serde::{Deserialize, Serialize};
 use signature::{Error as SignatureError, Error};
+use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
 /// A Ristretto-format private scalar
@@ -187,7 +187,7 @@ impl PrivateKey for RistrettoPrivate {
 }
 
 impl ConstantTimeEq for RistrettoPrivate {
-    fn ct_eq(&self, other: &Self) -> Choice { 
+    fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }

--- a/fog/ingest/enclave/api/src/lib.rs
+++ b/fog/ingest/enclave/api/src/lib.rs
@@ -25,11 +25,24 @@ use mc_fog_kex_rng::KexRngPubkey;
 use mc_fog_types::{ingest::TxsForIngest, ETxOutRecord};
 use mc_sgx_report_cache_api::ReportableEnclave;
 
+use serde::{Deserialize, Serialize};
+
 /// A generic result type for enclave calls
 pub type Result<T> = StdResult<T, Error>;
 
 /// Type representing the sealed ingest private key
 pub type SealedIngestKey = Vec<u8>;
+
+/// The result returned from the set_ingress_private_key function.
+#[derive(Deserialize, Serialize)]
+pub struct SetIngressPrivateKeyResult {
+    /// The new public key derived from the new private key that's being set.
+    pub new_public_key: RistrettoPublic,
+    /// The private key that gets sealed.
+    pub sealed_key: SealedIngestKey,
+    /// Indicates whether or not the private key changed.
+    pub did_private_key_change: bool,
+}
 
 /// The API of the ingest enclave
 pub trait IngestEnclave: ReportableEnclave {
@@ -66,11 +79,10 @@ pub trait IngestEnclave: ReportableEnclave {
 
     /// Set the private key of the enclave, encrypted by the peer for this
     /// enclave
-    /// The returned bool indicates if the private key changed or not.
     fn set_ingress_private_key(
         &self,
         msg: EnclaveMessage<PeerSession>,
-    ) -> Result<(RistrettoPublic, SealedIngestKey, bool)>;
+    ) -> Result<SetIngressPrivateKeyResult>;
 
     /// Retrieve the current KexRngPubkey for the enclave. This corresponds to
     /// the egress key.

--- a/fog/ingest/enclave/api/src/lib.rs
+++ b/fog/ingest/enclave/api/src/lib.rs
@@ -66,10 +66,11 @@ pub trait IngestEnclave: ReportableEnclave {
 
     /// Set the private key of the enclave, encrypted by the peer for this
     /// enclave
+    /// The returned bool indicates if the private key changed or not.
     fn set_ingress_private_key(
         &self,
         msg: EnclaveMessage<PeerSession>,
-    ) -> Result<(RistrettoPublic, SealedIngestKey)>;
+    ) -> Result<(RistrettoPublic, SealedIngestKey, bool)>;
 
     /// Retrieve the current KexRngPubkey for the enclave. This corresponds to
     /// the egress key.

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -33,6 +33,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPubli
 use mc_crypto_rand::McRng;
 use mc_fog_ingest_enclave_api::{
     Error, IngestEnclave, IngestEnclaveInitParams, Result, SealedIngestKey,
+    SetIngressPrivateKeyResult,
 };
 use mc_fog_kex_rng::KexRngPubkey;
 use mc_fog_recovery_db_iface::ETxOutRecord;
@@ -252,21 +253,25 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> IngestEnclave
     fn set_ingress_private_key(
         &self,
         msg: EnclaveMessage<PeerSession>,
-    ) -> Result<(RistrettoPublic, SealedIngestKey, bool)> {
+    ) -> Result<SetIngressPrivateKeyResult> {
         let key = self.ake.peer_decrypt(msg)?;
-        let new_priv_key = RistrettoPrivate::try_from(&key[..])?;
-        let new_pubkey = RistrettoPublic::from(&new_priv_key);
+        let new_private_key = RistrettoPrivate::try_from(&key[..])?;
+        let new_public_key = RistrettoPublic::from(&new_private_key);
 
-        let sealed_key = seal_private_key(&new_priv_key)?;
+        let sealed_key = seal_private_key(&new_private_key)?;
         let did_private_key_change: bool;
 
         {
             let mut lock = self.ake.get_identity().private_key.lock()?;
-            did_private_key_change = !bool::from(lock.ct_eq(&new_priv_key));
-            *lock = new_priv_key;
+            did_private_key_change = !bool::from(lock.ct_eq(&new_private_key));
+            *lock = new_private_key;
         }
 
-        Ok((new_pubkey, sealed_key, did_private_key_change))
+        Ok(SetIngressPrivateKeyResult {
+            new_public_key,
+            sealed_key,
+            did_private_key_change,
+        })
     }
 
     fn get_kex_rng_pubkey(&self) -> Result<KexRngPubkey> {

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -17,7 +17,7 @@ use mc_attest_enclave_api::{EnclaveMessage, PeerAuthRequest, PeerAuthResponse, P
 use mc_common::ResponderId;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic, X25519Public};
 use mc_enclave_boundary::untrusted::make_variable_length_ecall;
-use mc_fog_ingest_enclave_api::EnclaveCall;
+use mc_fog_ingest_enclave_api::{EnclaveCall, SetIngressPrivateKeyResult};
 use mc_fog_kex_rng::KexRngPubkey;
 use mc_fog_recovery_db_iface::ETxOutRecord;
 use mc_fog_types::ingest::TxsForIngest;
@@ -188,7 +188,7 @@ impl IngestEnclave for IngestSgxEnclave {
     fn set_ingress_private_key(
         &self,
         msg: EnclaveMessage<PeerSession>,
-    ) -> Result<(RistrettoPublic, SealedIngestKey, bool)> {
+    ) -> Result<SetIngressPrivateKeyResult> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::SetIngressPrivateKey(msg))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -188,7 +188,7 @@ impl IngestEnclave for IngestSgxEnclave {
     fn set_ingress_private_key(
         &self,
         msg: EnclaveMessage<PeerSession>,
-    ) -> Result<(RistrettoPublic, SealedIngestKey)> {
+    ) -> Result<(RistrettoPublic, SealedIngestKey, bool)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::SetIngressPrivateKey(msg))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "serde",
  "sha2",
  "signature",
+ "subtle",
  "x25519-dalek",
  "zeroize",
 ]

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -209,9 +209,9 @@ where
             return Err(Error::ServerNotIdle);
         }
 
-        let (_, _, did_private_key_change) = self.enclave.set_ingress_private_key(msg)?;
+        let set_ingress_private_key_result = self.enclave.set_ingress_private_key(msg)?;
 
-        if did_private_key_change {
+        if set_ingress_private_key_result.did_private_key_change {
             // Seal the new private keys we ended up with to disk
             *self.last_sealed_key.lock().unwrap() = None;
             self.write_state_file_inner(&mut state);
@@ -821,8 +821,12 @@ where
         let msg = connection.get_ingress_private_key()?;
 
         log::info!(self.logger, "Setting new private key on local enclave");
-        let (pubkey, _, _) = self.enclave.set_ingress_private_key(msg.into())?;
-        log::info!(self.logger, "Key successfully set in enclave: {}", pubkey);
+        let set_ingress_private_key_result = self.enclave.set_ingress_private_key(msg.into())?;
+        log::info!(
+            self.logger,
+            "Key successfully set in enclave: {}",
+            set_ingress_private_key_result.new_public_key
+        );
 
         *self.last_sealed_key.lock().unwrap() = None;
         self.write_state_file_inner(&mut state);

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -209,25 +209,9 @@ where
             return Err(Error::ServerNotIdle);
         }
 
-        // TODO: We could make enclave.set_ingress_private_key return a bool
-        // which tells us if the key changed, and that would be simpler.
-        // But it's an enclave upgrade if we do that, and we're developing this in
-        // a patch release branch.
-        let old_ingress_pubkey: CompressedRistrettoPublic = self
-            .enclave
-            .get_ingress_pubkey()
-            .expect("Failed to get ingress pubkey")
-            .into();
+        let (_, _, did_private_key_change) = self.enclave.set_ingress_private_key(msg)?;
 
-        self.enclave.set_ingress_private_key(msg)?;
-
-        let new_ingress_pubkey: CompressedRistrettoPublic = self
-            .enclave
-            .get_ingress_pubkey()
-            .expect("Failed to get ingress pubkey")
-            .into();
-
-        if old_ingress_pubkey != new_ingress_pubkey {
+        if did_private_key_change {
             // Seal the new private keys we ended up with to disk
             *self.last_sealed_key.lock().unwrap() = None;
             self.write_state_file_inner(&mut state);
@@ -837,7 +821,7 @@ where
         let msg = connection.get_ingress_private_key()?;
 
         log::info!(self.logger, "Setting new private key on local enclave");
-        let (pubkey, _) = self.enclave.set_ingress_private_key(msg.into())?;
+        let (pubkey, _, _) = self.enclave.set_ingress_private_key(msg.into())?;
         log::info!(self.logger, "Key successfully set in enclave: {}", pubkey);
 
         *self.last_sealed_key.lock().unwrap() = None;

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "serde",
  "sha2",
  "signature",
+ "subtle",
  "x25519-dalek",
  "zeroize",
 ]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "serde",
  "sha2",
  "signature",
+ "subtle",
  "x25519-dalek",
  "zeroize",
 ]


### PR DESCRIPTION
### Motivation

[FOG-180](https://github.com/mobilecoinfoundation/fog/pull/116/files#diff-1bd75fa7d4e53379b9fe76ed5de3edd920c698f1d188a08ae34d2ba9fb414247R212) introduced logic to check if a user's private key had changed. This check introduced additional calls across the enclave border, which increases latency. 

### In this PR
* fog-ingest-enclave `set_ingress_private_key` function returns bool that indicates if the key changed or not.
* fog ingest server controller uses this returned value to decide whether or not to seal the private key to disk.

The `set_ingress_private_key` function runs inside the enclave, so the logic that decides if the key changed or not needs to be constant time. As such, I implemented `subtle::ConstantTimeEq `for `RistrettoPrivate`. 

Fixes this [ticket](https://app.asana.com/0/1200353042931237/1200719673733203/f).

