### PR TITLE
update pre-commit hook to remove duplicates when formatting

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -110,7 +110,7 @@ elif [[ -n "$diff" ]]; then
 		echo "Do you want to fix all these files automatically? (y/N) "
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
-			echo -e "$diff" | while read file; do
+			echo -e "$diff" | sort -u | while read file; do
 				$CARGOFMT $file
 			done
 			echo "You should attempt this commit again to pick up these changes."


### PR DESCRIPTION
sometimes, when there is a really large diff, the pre commit hook
formatting step takes 20+ minutes. I believe that this is because
it formats the same file hundreds of times if there are a hundred
different segments of the diff related to that file. This minor
change removes duplicates before running cargo fmt.