### PR TITLE
Reduce size of `libmobilecoin` at the expense of compile time (`codegen-units = 1`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,10 @@ inherits = "release"
 debug = false
 lto = true
 
+[profile.mobile-release]
+inherits = "mobile"
+codegen-units = 1
+
 # Skip the need for LD_LIBRARY_PATH in `cargo test`
 [profile.test]
 rpath = true

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -11,9 +11,11 @@ export IAS_MODE ?= DEV
 
 ### Build Configuration
 
-CARGO_PROFILE ?= release
+CARGO_PROFILE ?= mobile-release
 CARGO_BUILD_FLAGS ?=
 CARGO_TARGET_DIR ?= ../target
+
+$(info CARGO_PROFILE)
 
 ### Toolchain
 
@@ -41,8 +43,8 @@ IOS_C_HEADERS = include/*
 ### Helper Function
 
 define BINARY_copy
-	mkdir -p out/ios/target/$(1)/release
-	cp $(CARGO_TARGET_DIR)/$(1)/release/libmobilecoin_stripped.a out/ios/target/$(1)/release;
+	mkdir -p out/ios/target/$(1)/${CARGO_PROFILE}
+	cp $(CARGO_TARGET_DIR)/$(1)/${CARGO_PROFILE}/libmobilecoin_stripped.a out/ios/target/$(1)/${CARGO_PROFILE};
 endef
 
 ####################################
@@ -63,10 +65,13 @@ ios: out/ios/$(IOS_LIB)
 
 CARGO_BUILD_FLAGS += --lib -Z avoid-dev-deps
 ifeq ($(CARGO_PROFILE),release)
-  BUILD_CONFIG_FOLDER = release
+  BUILD_CONFIG_FOLDER = ${CARGO_PROFILE}
   CARGO_BUILD_FLAGS += --release
-else
+else ifeq ($(CARGO_PROFILE),debug)
   BUILD_CONFIG_FOLDER = debug
+else
+  BUILD_CONFIG_FOLDER = ${CARGO_PROFILE}
+  CARGO_BUILD_FLAGS += -Z unstable-options --profile ${CARGO_PROFILE}
 endif
 
 .PHONY: $(ARCHS_IOS)


### PR DESCRIPTION
Soundtrack of this PR: [Fatboy Slim - Mad Flava (Autograf Tribute Mix)](https://www.youtube.com/watch?v=hXv7ogsWY7c)

### Motivation

We needed to reduce the size of our iOS SDK

### In this PR

Add a new build profile `mobile-release` that uses `1` codegen unit instead of the default `16`. 

This reduces the `.a` file size by `~30%` at the expense of compile time. 

Based on [my understanding of codegen units](https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units), this is a low risk change.

#### Bottomline Savings

I verified the space savings carry to the App Store. These lines come from `Packaging.log` which Xcode can generate for our Example App. 

`mobile-release` for `arm64` (iPhone)
```
...
copying file ./Frameworks/LibMobileCoin.framework/LibMobileCoin ... 
2021-10-07 23:38:28 +0000  10727776 bytes for ./Frameworks/LibMobileCoin.framework/LibMobileCoin
...
```

`release` for `arm64` (iPhone)
```
...
copying file ./Frameworks/LibMobileCoin.framework/LibMobileCoin ... 
2021-10-08 00:26:01 +0000  14438976 bytes for ./Frameworks/LibMobileCoin.framework/LibMobileCoin
...
```

### Future Work

Update for `libmobilecoin-ios-artifacts` to pull from the new `mobile-release` profile.

