### PR TITLE
[🍒  Pick] for `release-v1.2.0`  - Add `mobile-codegen` release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,10 @@ inherits = "release"
 debug = false
 lto = true
 
+[profile.mobile-release]
+inherits = "mobile"
+codegen-units = 1
+
 # Skip the need for LD_LIBRARY_PATH in `cargo test`
 [profile.test]
 rpath = true

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -11,9 +11,11 @@ export IAS_MODE ?= DEV
 
 ### Build Configuration
 
-CARGO_PROFILE ?= release
+CARGO_PROFILE ?= mobile-release
 CARGO_BUILD_FLAGS ?=
 CARGO_TARGET_DIR ?= ../target
+
+$(info CARGO_PROFILE)
 
 ### Toolchain
 
@@ -41,8 +43,8 @@ IOS_C_HEADERS = include/*
 ### Helper Function
 
 define BINARY_copy
-	mkdir -p out/ios/target/$(1)/release
-	cp $(CARGO_TARGET_DIR)/$(1)/release/libmobilecoin_stripped.a out/ios/target/$(1)/release;
+	mkdir -p out/ios/target/$(1)/${CARGO_PROFILE}
+	cp $(CARGO_TARGET_DIR)/$(1)/${CARGO_PROFILE}/libmobilecoin_stripped.a out/ios/target/$(1)/${CARGO_PROFILE};
 endef
 
 ####################################
@@ -63,10 +65,13 @@ ios: out/ios/$(IOS_LIB)
 
 CARGO_BUILD_FLAGS += --lib -Z avoid-dev-deps
 ifeq ($(CARGO_PROFILE),release)
-  BUILD_CONFIG_FOLDER = release
+  BUILD_CONFIG_FOLDER = ${CARGO_PROFILE}
   CARGO_BUILD_FLAGS += --release
-else
+else ifeq ($(CARGO_PROFILE),debug)
   BUILD_CONFIG_FOLDER = debug
+else
+  BUILD_CONFIG_FOLDER = ${CARGO_PROFILE}
+  CARGO_BUILD_FLAGS += -Z unstable-options --profile ${CARGO_PROFILE}
 endif
 
 .PHONY: $(ARCHS_IOS)


### PR DESCRIPTION
Reduce size of  archives at the expense of compile time. 

Original PR - https://github.com/mobilecoinfoundation/mobilecoin/pull/1103 

