### PR TITLE
Sam/sync keys from remote api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates 2.0.3",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,9 +396,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -1101,6 +1115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1206,12 @@ dependencies = [
  "quote 1.0.10",
  "syn 1.0.81",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -3179,23 +3205,34 @@ dependencies = [
 name = "mc-fog-ingest-client"
 version = "1.2.0-pre0"
 dependencies = [
+ "assert_cmd",
  "displaydoc",
  "grpcio",
  "hex",
+ "maplit",
  "mc-account-keys",
  "mc-api",
+ "mc-attest-net",
  "mc-common",
  "mc-crypto-keys",
  "mc-fog-api",
+ "mc-fog-ingest-enclave",
+ "mc-fog-ingest-server",
+ "mc-fog-sql-recovery-db",
+ "mc-fog-test-infra",
  "mc-fog-types",
  "mc-fog-uri",
+ "mc-ledger-db",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-uri",
+ "mc-watcher",
+ "predicates 1.0.5",
  "protobuf",
  "retry",
  "serde_json",
  "structopt",
+ "tempdir",
 ]
 
 [[package]]
@@ -5063,9 +5100,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -5240,7 +5277,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates",
+ "predicates 1.0.5",
  "predicates-tree",
 ]
 
@@ -5616,6 +5653,17 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
+dependencies = [
+ "difflib",
+ "itertools 0.10.1",
+ "predicates-core",
 ]
 
 [[package]]

--- a/fog/api/proto/ingest.proto
+++ b/fog/api/proto/ingest.proto
@@ -61,6 +61,11 @@ service AccountIngestAPI {
 
     /// Get list of missed block ranges.
     rpc GetMissedBlockRanges(google.protobuf.Empty) returns (GetMissedBlockRangesResponse) {}
+
+    /// Establishes a peer connection to another ingest enclave, requests the
+    /// peer's private key, and then sets it as the current enclave's private
+    /// key.
+    rpc SyncKeysFromRemote(SyncKeysFromRemoteRequest) returns (ingest_common.IngestSummary) {}
 }
 
 message ReportLostIngressKeyRequest {
@@ -83,4 +88,10 @@ message SetPubkeyExpiryWindowRequest {
     /// all fog ingest servers crash without retiring completely, and the ingress private key is lost,
     /// more data must be downloaded by the clients and scanned to recover their balances.
     uint64 pubkey_expiry_window = 1;
+}
+
+message SyncKeysFromRemoteRequest {
+    /// The uri for the server that will report the private key that will  be
+    /// synced.
+    string peer_uri = 1;
 }

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -13,6 +13,21 @@ path = "src/lib.rs"
 name = "fog_ingest_client"
 path = "src/main.rs"
 
+[dev-dependencies]
+mc-attest-net = { path = "../../../attest/net" }
+mc-fog-ingest-server = { path = "../server" }
+mc-fog-test-infra = { path = "../../test_infra" }
+mc-fog-ingest-enclave = { path = "../enclave" }
+mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
+mc-ledger-db = { path = "../../../ledger/db" }
+mc-watcher = { path = "../../../watcher" }
+
+# third party
+assert_cmd = "2.0.2"
+tempdir = "0.3"
+maplit = "1"
+predicates = "1"
+
 [dependencies]
 # third party
 displaydoc = { version = "0.2", default-features = false }

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -68,4 +68,8 @@ pub enum IngestConfigCommand {
 
     /// Gets the list of reported missed block ranges.
     GetMissedBlockRanges,
+
+    /// Retrieves a private key from a remote ingest enclave and sets it as
+    /// the current enclaves's private key.
+    SyncKeysFromRemote { peer_uri: String },
 }

--- a/fog/ingest/client/src/main.rs
+++ b/fog/ingest/client/src/main.rs
@@ -51,6 +51,10 @@ fn main() -> ClientResult<()> {
         IngestConfigCommand::GetMissedBlockRanges => {
             get_missed_block_ranges(&logger, &ingest_client)
         }
+
+        IngestConfigCommand::SyncKeysFromRemote { peer_uri } => {
+            sync_keys_from_remote(&logger, &ingest_client, peer_uri)
+        }
     }
 }
 
@@ -148,6 +152,19 @@ fn get_missed_block_ranges(
             .collect::<Vec<_>>())
     );
 
+    Ok(())
+}
+
+fn sync_keys_from_remote(
+    logger: &Logger,
+    ingest_client: &FogIngestGrpcClient,
+    peer_uri: String,
+) -> ClientResult<()> {
+    let status = ingest_client
+        .sync_keys_from_remote(peer_uri)
+        .expect("rpc failed");
+    log::info!(logger, "Done, status: {:?}", status);
+    println!("{}", ingest_summary_to_json(&status));
     Ok(())
 }
 

--- a/fog/ingest/client/tests/sync_keys_from_remote.rs
+++ b/fog/ingest/client/tests/sync_keys_from_remote.rs
@@ -1,0 +1,183 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+use assert_cmd::Command;
+use maplit::btreeset;
+use mc_api::external;
+use mc_attest_net::{Client as AttestClient, RaClient};
+use mc_common::logger::{test_with_logger, Logger};
+use mc_fog_api::ingest_common::IngestSummary;
+use mc_fog_ingest_server::server::{IngestServer, IngestServerConfig};
+use mc_fog_sql_recovery_db::{test_utils::SqlRecoveryDbTestContext, SqlRecoveryDb};
+use mc_fog_test_infra::get_enclave_path;
+use mc_fog_uri::{ConnectionUri, FogIngestUri, IngestPeerUri};
+use mc_ledger_db::LedgerDB;
+use mc_watcher::watcher_db::WatcherDB;
+use predicates::prelude::*;
+use std::{str::FromStr, time::Duration};
+use tempdir::TempDir;
+
+const OMAP_CAPACITY: u64 = 256;
+const BASE_PORT: u32 = 3220;
+
+#[test_with_logger]
+fn test_sync_keys_from_remote(logger: Logger) {
+    let ingest_server_set_up_data = set_up_ingest_servers(logger);
+
+    let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+    cmd.arg("--uri")
+        .arg(ingest_server_set_up_data.backup_ingest_server_client_uri)
+        .arg("sync-keys-from-remote")
+        .arg(ingest_server_set_up_data.primary_ingest_server_peer_uri)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "{}",
+            hex::encode(
+                ingest_server_set_up_data
+                    .primary_ingest_server_ingress_pubkey
+                    .get_data()
+            )
+        )));
+}
+
+/// Contains data pertaining to the set up of the two ingest servers that are
+/// used in the test.
+struct IngestServerSetUpData {
+    /// The primary ingest server that will provide the back up server with its
+    /// ingress public key.
+    _primary_ingest_server: IngestServer<AttestClient, SqlRecoveryDb>,
+    /// The back up ingest server that will field grpc requests from our command
+    /// line program and sync the ingress public key from the primary ingest
+    /// server.
+    _backup_ingest_server: IngestServer<AttestClient, SqlRecoveryDb>,
+    /// The url that can be used to address the backup ingest server of grpc.
+    backup_ingest_server_client_uri: String,
+    /// The url that can be used to address by a peer ingest server to
+    /// addressthe primary ingest server.
+    primary_ingest_server_peer_uri: String,
+    /// The primary ingest server's ingress public key.
+    primary_ingest_server_ingress_pubkey: external::CompressedRistretto,
+}
+
+fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
+    let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
+    let db = db_test_context.get_db_instance();
+
+    let primary_ingest_server_peer_uri_str = format!("insecure-igp://127.0.0.1:{}/", BASE_PORT + 5);
+    let primary_node_ingest_summary: IngestSummary;
+
+    // Set up the primary ingest server
+    let (primary_ingest_server, primary_ingest_server_ingress_pubkey) = {
+        let igp_uri = IngestPeerUri::from_str(&primary_ingest_server_peer_uri_str).unwrap();
+        let local_node_id = igp_uri.responder_id().unwrap();
+
+        let config = IngestServerConfig {
+            ias_spid: Default::default(),
+            local_node_id: local_node_id.clone(),
+            client_listen_uri: FogIngestUri::from_str(&format!(
+                "insecure-fog-ingest://0.0.0.0:{}/",
+                BASE_PORT + 4
+            ))
+            .unwrap(),
+            peer_listen_uri: igp_uri.clone(),
+            peers: btreeset![igp_uri.clone()],
+            fog_report_id: Default::default(),
+            max_transactions: 10_000,
+            pubkey_expiry_window: 100,
+            peer_checkup_period: None,
+            watcher_timeout: Duration::default(),
+            state_file: None,
+            enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
+            omap_capacity: OMAP_CAPACITY,
+        };
+
+        // Set up the Watcher DB - create a new watcher DB for each phase
+        let db_tmp = TempDir::new("wallet_db").expect("Could not make tempdir for wallet db");
+        WatcherDB::create(db_tmp.path()).unwrap();
+        let watcher = WatcherDB::open_ro(db_tmp.path(), logger.clone()).unwrap();
+
+        // Set up an empty ledger db.
+        let ledger_db_path =
+            TempDir::new("ledger_db").expect("Could not make tempdir for ledger db");
+        LedgerDB::create(ledger_db_path.path()).unwrap();
+        let ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
+
+        let ra_client = AttestClient::new("").expect("Could not create IAS client");
+        let mut node = IngestServer::new(
+            config,
+            ra_client,
+            db.clone(),
+            watcher,
+            ledger_db,
+            logger.clone(),
+        );
+        node.start().expect("Could not start Ingest Service");
+        node.activate().expect("Could not activate Ingest");
+
+        primary_node_ingest_summary = node.get_ingest_summary();
+        let ingress_pubkey = primary_node_ingest_summary.get_ingress_pubkey();
+
+        (node, ingress_pubkey)
+    };
+
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    let backup_ingest_server_client_uri_str =
+        format!("insecure-fog-ingest://0.0.0.0:{}/", BASE_PORT + 8);
+
+    // Set up the backup ingest server
+    let backup_ingest_server = {
+        let igp_uri =
+            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{}/", BASE_PORT + 9))
+                .unwrap();
+        let local_node_id = igp_uri.responder_id().unwrap();
+
+        let config = IngestServerConfig {
+            ias_spid: Default::default(),
+            local_node_id,
+            client_listen_uri: FogIngestUri::from_str(&backup_ingest_server_client_uri_str)
+                .unwrap(),
+            peer_listen_uri: igp_uri.clone(),
+            peers: btreeset![igp_uri.clone()],
+            fog_report_id: Default::default(),
+            max_transactions: 10_000,
+            pubkey_expiry_window: 100,
+            peer_checkup_period: Some(std::time::Duration::from_millis(10000)),
+            watcher_timeout: Duration::default(),
+            state_file: None,
+            enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
+            omap_capacity: OMAP_CAPACITY,
+        };
+
+        let db_tmp = TempDir::new("wallet_db").expect("Could not make tempdir for wallet db");
+        WatcherDB::create(db_tmp.path()).unwrap();
+        let watcher = WatcherDB::open_ro(db_tmp.path(), logger.clone()).unwrap();
+
+        // Set up an empty ledger db.
+        let ledger_db_path =
+            TempDir::new("ledger_db").expect("Could not make tempdir for ledger db");
+        LedgerDB::create(ledger_db_path.path()).unwrap();
+        let ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
+
+        let ra_client = AttestClient::new("").expect("Could not create IAS client");
+        let mut node = IngestServer::new(
+            config,
+            ra_client,
+            db.clone(),
+            watcher,
+            ledger_db,
+            logger.clone(),
+        );
+
+        node.start().expect("Could not start Ingest Service");
+        node
+    };
+
+    return IngestServerSetUpData {
+        _primary_ingest_server: primary_ingest_server,
+        _backup_ingest_server: backup_ingest_server,
+        backup_ingest_server_client_uri: backup_ingest_server_client_uri_str.to_owned(),
+        primary_ingest_server_peer_uri: primary_ingest_server_peer_uri_str.to_owned(),
+        primary_ingest_server_ingress_pubkey: primary_ingest_server_ingress_pubkey.clone(),
+    };
+}

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -182,7 +182,9 @@ where
         request: SyncKeysFromRemoteRequest,
         logger: &Logger,
     ) -> Result<IngestSummary, RpcStatus> {
-        let peer_uri = IngestPeerUri::from_str(request.get_peer_uri()).unwrap();
+        let peer_uri = IngestPeerUri::from_str(request.get_peer_uri())
+            .map_err(|err| rpc_invalid_arg_error("invalid peer uri", err, logger))?;
+
         self.controller
             .sync_keys_from_remote(&peer_uri)
             .map_err(|err| rpc_database_err(err, logger))

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -174,6 +174,19 @@ where
 
         Ok(response)
     }
+
+    /// Retrieves a private key from a remote encalve and then sets it as the
+    /// current enclave's private key.
+    pub fn sync_keys_from_remote_impl(
+        &mut self,
+        request: SyncKeysFromRemoteRequest,
+        logger: &Logger,
+    ) -> Result<IngestSummary, RpcStatus> {
+        let peer_uri = IngestPeerUri::from_str(request.get_peer_uri()).unwrap();
+        self.controller
+            .sync_keys_from_remote(&peer_uri)
+            .map_err(|err| rpc_database_err(err, logger))
+    }
 }
 
 impl<
@@ -273,6 +286,23 @@ where
         let _timer = SVC_COUNTERS.req(&ctx);
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             send_result(ctx, sink, self.get_missed_block_ranges_impl(logger), logger)
+        })
+    }
+
+    fn sync_keys_from_remote(
+        &mut self,
+        ctx: RpcContext,
+        request: SyncKeysFromRemoteRequest,
+        sink: UnarySink<IngestSummary>,
+    ) {
+        let _timer = SVC_COUNTERS.req(&ctx);
+        mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
+            send_result(
+                ctx,
+                sink,
+                self.sync_keys_from_remote_impl(request, logger),
+                logger,
+            )
         })
     }
 }


### PR DESCRIPTION
### Motivation

The ops team needs to be able to easily sync an ingress private key from one ingest server to another. Currently, there is no way to do this using the fog ingest client CLI.

### In this PR
* Exposes a new SyncKeysFromRemote grpc method for the Fog Ingest Server.
* Enables  the fog ingest client to call this method.
* Enables the fog ingest client CLI to call this method.

Fixes this [ticket](https://app.asana.com/0/1200353042931237/1200512973791593/f).


### Testing
* Adds new end-to-end test that ensures that the fog ingest client CLI can call this new method and uses the command's output (an IngestSummary) to confirm that the server's ingress key's value was updated to that of the remote server. 

### Future Work
* This PR adds a new model for testing the fog ingest CLI. To ensure that the other CLI paths are WAI, we could add similar tests.

