### PR TITLE
[🍒  pick] Bitcode for `release-1.2.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ mobilecoind/clients/python/mob_client/blockchain_pb2.py
 
 # css files (should not be committed)
 *.css
+
+# libmobilecoin/rust-bitcode build
+libmobilecoin/rust-bitcode/*

--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -14,8 +14,9 @@ export IAS_MODE ?= DEV
 CARGO_PROFILE ?= mobile-release
 CARGO_BUILD_FLAGS ?=
 CARGO_TARGET_DIR ?= ../target
+RUST_BITCODE_DIR ?= rust-bitcode
 
-$(info CARGO_PROFILE)
+$(info profile: $(CARGO_PROFILE))
 
 ### Toolchain
 
@@ -36,16 +37,50 @@ endif
 
 CARGO_PACKAGE = libmobilecoin
 ARCHS_IOS = aarch64-apple-ios-sim aarch64-apple-ios-macabi aarch64-apple-ios x86_64-apple-ios-macabi x86_64-apple-ios x86_64-apple-darwin
+
+# add l_ prefix to build-targets that use the legacy build-process
+ALL_LEGACY_ARCHS_IOS = l_aarch64-apple-ios-sim l_aarch64-apple-ios-macabi l_aarch64-apple-ios l_x86_64-apple-ios-macabi l_x86_64-apple-ios l_x86_64-apple-darwin
+
 IOS_LIB = libmobilecoin.a
 IOS_LIB_STRIPPED = libmobilecoin_stripped.a
 IOS_C_HEADERS = include/*
 
+RUST_COMMIT = 4e282795d
+RUST_COMMIT_NAME = nightly-2021-08-01
+SWIFT_VERSION = 5.3.2
+
 ### Helper Function
 
+# First argument $(1) is a build-target, $(2) is the output directory
 define BINARY_copy
-	mkdir -p out/ios/target/$(1)/${CARGO_PROFILE}
-	cp $(CARGO_TARGET_DIR)/$(1)/${CARGO_PROFILE}/libmobilecoin_stripped.a out/ios/target/$(1)/${CARGO_PROFILE};
+	mkdir -p out/ios/$(2)/$(1)/${CARGO_PROFILE}
+	cp $(CARGO_TARGET_DIR)/$(1)/${CARGO_PROFILE}/libmobilecoin.a out/ios/$(2)/$(1)/${CARGO_PROFILE};
 endef
+
+# First argument $(1) is a build-target
+define TOOLCHAIN_install	
+	$(if \
+		$(shell rustup toolchain list | \
+		  		grep "ios-$(1)-$(RUST_COMMIT_NAME)-swift-$(subst $(DOT),$(DASH),$(SWIFT_VERSION))" | \
+	    		wc -l | \
+	    		awk '{$$1=$$1;print}' | \
+	    		grep '1'), \
+		@echo "toolchain ios-$(1)-$(RUST_COMMIT_NAME)-swift-$(subst $(DOT),$(DASH),$(SWIFT_VERSION)) already installed", \
+		@echo "toolchain ios-$(1)-$(RUST_COMMIT_NAME)-swift-$(subst $(DOT),$(DASH),$(SWIFT_VERSION)) not installed"; \
+		$(info "Compiling & Installing Rust $(RUST_COMMIT_NAME) toolchain") \
+		$(info "with LLVM matching swift version - $(SWIFT_VERSION)") \
+		$(info "from `rust` commit - $(RUST_COMMIT)") \
+		$(info "for build-target - $(1)") \
+		cd rust-bitcode && \
+		./build-install.sh -t $@ -l $(SWIFT_VERSION) -r $(RUST_COMMIT) -n $(RUST_COMMIT_NAME); \
+	)
+endef
+
+define RUSTBITCODE_init	
+endef
+
+DOT:= .
+DASH:= -
 
 ####################################
 ############## Targets #############
@@ -55,13 +90,16 @@ endef
 all: setup ios
 
 .PHONY: setup
-setup:
-	rustup target add x86_64-apple-ios aarch64-apple-ios x86_64-apple-darwin
-	rustup component add llvm-tools-preview rust-src
-	rustup run --install stable cargo install cargo-binutils
-
+setup: 
+	mkdir -p rust-bitcode
+	cd rust-bitcode && \
+	git init && \
+	git remote add origin git@github.com:mobilecoinofficial/rust-bitcode; \
+	git fetch --depth 1 origin a49da0265778fce5dd6521ba609b4c1d0a0959ad; \
+	git checkout FETCH_HEAD;
+	
 .PHONY: ios
-ios: out/ios/$(IOS_LIB)
+ios: out/ios/target
 
 CARGO_BUILD_FLAGS += --lib -Z avoid-dev-deps
 ifeq ($(CARGO_PROFILE),release)
@@ -74,50 +112,89 @@ else
   CARGO_BUILD_FLAGS += -Z unstable-options --profile ${CARGO_PROFILE}
 endif
 
+LEGACY_CARGO_BUILD_FLAGS = $(CARGO_BUILD_FLAGS) 
+
 .PHONY: $(ARCHS_IOS)
 x86_64-apple-ios aarch64-apple-ios: CARGO_ENV_FLAGS += CFLAGS="-DPB_NO_PACKED_STRUCTS=1"
 x86_64-apple-ios aarch64-apple-ios: CARGO_ENV_FLAGS += CXXFLAGS="-DPB_NO_PACKED_STRUCTS=1"
-
-x86_64-apple-ios x86_64-apple-ios-macabi x86_64-apple-darwin: LD_ARCH = x86_64
-aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-ios-macabi: LD_ARCH = arm64
-
-x86_64-apple-ios-macabi aarch64-apple-ios-sim aarch64-apple-ios-macabi: CARGO_BUILD_FLAGS += -Zbuild-std
-
 $(ARCHS_IOS):
-	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS)
+	$(call TOOLCHAIN_install,$@)
+	$(CARGO_ENV_FLAGS) $(CARGO) +ios-$@-$(RUST_COMMIT_NAME)-swift-$(subst $(DOT),$(DASH),$(SWIFT_VERSION)) build --package $(CARGO_PACKAGE) --target $@ $(CARGO_BUILD_FLAGS)
+
+
+.PHONY: out/ios/target
+out/ios/target: $(ARCHS_IOS)
+	mkdir -p out/ios
+	$(foreach arch,$^,$(call BINARY_copy,$(arch),target))
+
+	mkdir -p out/ios/include
+	cp $(IOS_C_HEADERS) out/ios/include
+
+
+# Legacy build process uses standard rustup toolchains for building
+# Output is in out/ios/legacy/
+.PHONY: legacy
+legacy: legacy_setup legacy_ios
+
+
+.PHONY: legacy_setup
+legacy_setup:
+	rustup target add x86_64-apple-ios aarch64-apple-ios
+	rustup component add llvm-tools-preview rust-src
+	rustup run --install stable cargo install cargo-binutils
+
+
+.PHONY: legacy_ios
+legacy_ios: out/ios/legacy
+
+
+.PHONY: legacy_x86_64-apple-darwin
+legacy_x86_64-apple-darwin: out/ios/legacy/x86_64-apple-darwin
+
+
+.PHONY: $(ALL_LEGACY_ARCHS_IOS)
+l_x86_64-apple-ios l_aarch64-apple-ios: CARGO_ENV_FLAGS += CFLAGS="-DPB_NO_PACKED_STRUCTS=1"
+l_x86_64-apple-ios l_aarch64-apple-ios: CARGO_ENV_FLAGS += CXXFLAGS="-DPB_NO_PACKED_STRUCTS=1"
+l_x86_64-apple-ios l_x86_64-apple-ios-macabi l_x86_64-apple-darwin: LD_ARCH = x86_64
+l_aarch64-apple-ios l_aarch64-apple-ios-sim l_aarch64-apple-ios-macabi: LD_ARCH = arm64
+l_x86_64-apple-ios-macabi l_aarch64-apple-ios-sim l_aarch64-apple-ios-macabi: LEGACY_CARGO_BUILD_FLAGS += -Zbuild-std
+$(ALL_LEGACY_ARCHS_IOS):
+	$(CARGO_ENV_FLAGS) $(CARGO) build --package $(CARGO_PACKAGE) --target $(subst l_,,$@) $(LEGACY_CARGO_BUILD_FLAGS)
 
 	@# Extract object files from static archive.
-	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
+	@cd $(CARGO_TARGET_DIR)/$(subst l_,,$@)/$(BUILD_CONFIG_FOLDER) && \
 		rm -rf extracted 2>/dev/null; \
 		mkdir -p extracted
-	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER)/extracted && \
+	cd $(CARGO_TARGET_DIR)/$(subst l_,,$@)/$(BUILD_CONFIG_FOLDER)/extracted && \
 		ar -t ../$(IOS_LIB) \
 			| grep '\.o$$' \
 			| xargs ar -x ../$(IOS_LIB)
 
 	@# Create list of libmobilecoin symbols.
-	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
+	cd $(CARGO_TARGET_DIR)/$(subst l_,,$@)/$(BUILD_CONFIG_FOLDER) && \
 		rust-nm -jgU extracted/mobilecoin*.mobilecoin.*.o -s __TEXT __text \
 			| grep '\<_mc_' \
 			> exported-symbols.def
 
 	@# Link extracted object files back into static arch. Removes all symbols not needed
 	@# by exported libmobilecoin symbols.
-	@cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
+	@cd $(CARGO_TARGET_DIR)/$(subst l_,,$@)/$(BUILD_CONFIG_FOLDER) && \
 		rm -f $(IOS_LIB_STRIPPED) || true
-	cd $(CARGO_TARGET_DIR)/$@/$(BUILD_CONFIG_FOLDER) && \
+	cd $(CARGO_TARGET_DIR)/$(subst l_,,$@)/$(BUILD_CONFIG_FOLDER) && \
 		ld -r -arch $(LD_ARCH) -x -keep_private_externs \
 			-exported_symbols_list exported-symbols.def \
 			-o $(IOS_LIB_STRIPPED) \
 			extracted/*.o
 
-.PHONY: out/ios/$(IOS_LIB)
-out/ios/$(IOS_LIB): $(ARCHS_IOS)
-	mkdir -p out/ios
-	$(foreach arch,$^,$(call BINARY_copy,$(arch)))
+
+.PHONY: out/ios/legacy
+out/ios/legacy: $(ALL_LEGACY_ARCHS_IOS)
+	mkdir -p out/ios/legacy
+	$(foreach arch,$^,$(call BINARY_copy,$(subst l_,,$(arch)),legacy))
 
 	mkdir -p out/ios/include
 	cp $(IOS_C_HEADERS) out/ios/include
+
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
### Motivation

Add support for Apple's `Bitcode` and reduce the size of our SDK & its dependencies. With this enabled the compressed "downloadable" size **shrinks by ~25%.**  

#### `ENABLE_BITCODE = YES`

```
App Thinning Size Report for All Variants of Example
App + On Demand Resources size: 7.2 MB compressed, 19.7 MB uncompressed
App size: 7.2 MB compressed, 19.7 MB uncompressed
```

#### `ENABLE_BITCODE = NO`

```
App Thinning Size Report for All Variants of Example
App + On Demand Resources size: 9.6 MB compressed, 35.6 MB uncompressed
App size: 9.6 MB compressed, 35.6 MB uncompressed
```

### In this PR

#### `rust-bitcode`

Shallow clone [`rust-bitcode`](https://github.com/mobilecoinofficial/rust-bitcode) to compile `rustup` toolchains that include LLVM compatible with Apple's Xcode build system.

#### No more symbol stripping

Remove "symbol" stripping step from the `Makefile` because it's not compatible with enabling `Bitcode`. While this step had large impact on the size of the archive `.a` (10mb vs 55mb) it has a small impact on the "downloadable" size (~0.2mb). This is because un-linked symbols are not included in final binary regardless of whether or not they get stripped.

#### Remove build-target `x86_64-apple-darwin`

To my knowledge MobileCoin and Signal are not using this target, and it does not support `Bitcode`.