### PR TITLE
Fix sample-paykit subaddress index handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "grpcio",
  "link-cplusplus",
  "mc-account-keys",
+ "mc-api",
  "mc-attest-core",
  "mc-common",
  "mc-connection",

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/sample_paykit_remote_wallet.rs"
 [dependencies]
 # mobilecoin
 mc-account-keys = { path = "../../account-keys" }
+mc-api = { path = "../../api" }
 mc-attest-core = { path = "../../attest/core" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-connection = { path = "../../connection" }

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -604,11 +604,6 @@ pub struct OwnedTxOut {
 impl OwnedTxOut {
     /// Try to decrypt a TxOutRecord by view-key matching it, producing an
     /// OwnedTxOut or an error
-    //
-    // FIXME: FOG-237 Confirm that this subaddress matched the tx. Should use
-    // view_key_matches_output function At time of writing this is not used by
-    // mobilecoind or other mobilecoin rust code, but it is used by the swift sdk,
-    // so we need to backport that into the rust sample paykit.
     pub fn new(
         rec: TxOutRecord,
         account_key: &AccountKey,

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -36,6 +36,9 @@ pub use memo_handler::{MemoHandler, MemoHandlerError};
 const MAX_INPUTS: usize = mc_transaction_core::constants::MAX_INPUTS as usize;
 
 /// Highest subaddress index we support.
+/// If TxOut's are found which belong to us but at an unsupported subaddress index, this will be detected,
+/// and a "SubaddressNotFound" error will be returned, and the client will not spend this TxOut, and the
+/// balance of this account will not reflect such TxOut's.
 /// This has to cover at least the default and change subaddress indexes.
 const MAX_SUBADDRESS_INDEX: u64 = CHANGE_SUBADDRESS_INDEX;
 

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -36,10 +36,11 @@ pub use memo_handler::{MemoHandler, MemoHandlerError};
 const MAX_INPUTS: usize = mc_transaction_core::constants::MAX_INPUTS as usize;
 
 /// Highest subaddress index we support.
-/// If TxOut's are found which belong to us but at an unsupported subaddress index, this will be detected,
-/// and a "SubaddressNotFound" error will be returned, and the client will not spend this TxOut, and the
-/// balance of this account will not reflect such TxOut's.
-/// This has to cover at least the default and change subaddress indexes.
+/// If TxOut's are found which belong to us but at an unsupported subaddress
+/// index, this will be detected, and a "SubaddressNotFound" error will be
+/// returned, and the client will not spend this TxOut, and the balance of this
+/// account will not reflect such TxOut's. This has to cover at least the
+/// default and change subaddress indexes.
 const MAX_SUBADDRESS_INDEX: u64 = CHANGE_SUBADDRESS_INDEX;
 
 /// This object keeps track of all TxOut's that are known to be ours, and which

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -83,7 +83,7 @@ impl Client {
         address_book: Vec<PublicAddress>,
         logger: Logger,
     ) -> Self {
-        let tx_data = CachedTxData::new(address_book, logger.clone());
+        let tx_data = CachedTxData::new(account_key.clone(), address_book, logger.clone());
 
         Client {
             consensus_service_conn,
@@ -132,11 +132,8 @@ impl Client {
     ///   balance
     pub fn check_balance(&mut self) -> Result<(u64, BlockCount)> {
         mc_common::trace_time!(self.logger, "MobileCoinClient.get_balance");
-        self.tx_data.poll_fog(
-            &mut self.fog_view,
-            &mut self.fog_key_image,
-            &self.account_key,
-        )?;
+        self.tx_data
+            .poll_fog(&mut self.fog_view, &mut self.fog_key_image)?;
         Ok(self.compute_balance())
     }
 
@@ -390,6 +387,8 @@ impl Client {
 
         log::info!(self.logger, "Retrieved {} TXOs", outputs_and_proofs.len());
 
+        assert_eq!(outputs_and_proofs.len(), inputs.len());
+
         // This is where we replace the TxOut object with the one we got from fog ledger
         Ok(outputs_and_proofs
             .into_iter()
@@ -496,6 +495,16 @@ impl Client {
     pub fn get_fee(&mut self) -> Result<u64> {
         Ok(self.consensus_service_conn.fetch_block_info()?.minimum_fee)
     }
+
+    /// Get the public b58 address for this client
+    pub fn get_b58_address(&self) -> String {
+        let public_address = self.account_key.default_subaddress();
+
+        let mut wrapper = mc_api::printable::PrintableWrapper::new();
+        wrapper.set_public_address((&public_address).into());
+
+        wrapper.b58_encode().unwrap()
+    }
 }
 
 /// Builds a transaction that spends `inputs`, sends `amount` to the recipient,
@@ -598,17 +607,19 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         let onetime_private_key = recover_onetime_private_key(
             &RistrettoPublic::try_from(&input_txo.tx_out.public_key)?,
             source_account_key.view_private_key(),
-            &source_account_key.default_subaddress_spend_private(),
+            &source_account_key.subaddress_spend_private(input_txo.subaddress_index),
         );
 
         let key_image = KeyImage::from(&onetime_private_key);
+        assert_eq!(key_image, input_txo.key_image);
         log::trace!(
             logger,
-            "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}",
+            "Adding input: ring {:?}, utxo index {:?}, key image {:?}, pubkey {:?}, subaddress index {}",
             ring,
             real_key_index,
             key_image,
-            input_txo.tx_out.public_key
+            input_txo.tx_out.public_key,
+            input_txo.subaddress_index,
         );
 
         let ring_len = ring.len();

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -32,6 +32,9 @@ pub enum TxOutMatchingError {
 
     /// Error decompressing FogTxOut: {0}
     FogTxOut(FogTxOutError),
+
+    /// Subaddress not found
+    SubaddressNotFound,
 }
 
 impl From<AmountError> for TxOutMatchingError {

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -284,16 +284,18 @@ impl TestClient {
             let (src_balance, src_cursor) = source_client.check_balance()?;
             log::info!(
                 self.logger,
-                "client {} has a balance of {} after {} blocks",
+                "client {} ({}) has a balance of {} after {} blocks",
                 split_index,
+                source_client.get_b58_address(),
                 src_balance,
                 src_cursor
             );
             let (tgt_balance, tgt_cursor) = target_client.check_balance()?;
             log::info!(
                 self.logger,
-                "client {} has a balance of {} after {} blocks",
+                "client {} ({}) has a balance of {} after {} blocks",
                 split_index + 1,
+                target_client.get_b58_address(),
                 tgt_balance,
                 tgt_cursor
             );

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -9,7 +9,10 @@ use crate::{
 };
 
 use lmdb::{Cursor, Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
-use mc_common::{logger::Logger, HashMap};
+use mc_common::{
+    logger::{log, Logger},
+    HashMap,
+};
 use mc_transaction_core::{ring_signature::KeyImage, tx::TxOut};
 use mc_util_serial::Message;
 use std::{convert::TryFrom, sync::Arc};
@@ -296,6 +299,7 @@ impl UtxoStore {
 
         for key_image in removed_key_images.iter() {
             let utxo_id = UtxoId::from(key_image);
+            log::info!(self.logger, "removing utxo for key image {:?}", key_image);
 
             removed_utxos.push(self.get_utxo_by_id(db_txn, &utxo_id)?);
 

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -299,7 +299,7 @@ impl UtxoStore {
 
         for key_image in removed_key_images.iter() {
             let utxo_id = UtxoId::from(key_image);
-            log::info!(self.logger, "removing utxo for key image {:?}", key_image);
+            log::debug!(self.logger, "removing utxo for key image {:?}", key_image);
 
             removed_utxos.push(self.get_utxo_by_id(db_txn, &utxo_id)?);
 


### PR DESCRIPTION
### Motivation

The current implementation of the sample paykit makes the incorrect assumption that all TxOuts are on the default subaddress index (0). However, at some point, we started sending change outputs to subaddress index 1.
For this to work properly the sample paykit needs to support tracking of which subaddress index each TxOut it is aware of belongs to, and use that information when generating transactions (and key images).

### In this PR
* Make the sample paykit support tracking subaddress indices, similar to how mobilecoind and full-service do it.
* Make sample paykit use that information to properly construct transactions.

### Future Work
* The Swift and Android SDKs have the same problem and need to incorporate similar changes. I will reach out to @voloshyn to coordinate the work on this.
* Even after this change,`test_client` in its current form cannot be used with testnet. This is because testnet is unaware of RTH memos, and the hashes end up being different. To use test_client with testnet, disable memos and use `NoMemoBuilder`. It might be nice to add a configuration flag to enable/disable the memos so that we can go back to using this.

Thank you @garbageslam for your help in debugging this!

