### PR TITLE
Expose "get_ingress_key_record" API in the "fog_ingest_client" CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
@@ -170,9 +170,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
 dependencies = [
  "addr2line",
  "cc",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a03ce013ffccead76c11a15751231f777d9295b845cc1266ed4d34fcbd7977"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "glob"
@@ -2157,9 +2157,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "libloading"
@@ -3227,17 +3227,20 @@ dependencies = [
  "mc-fog-api",
  "mc-fog-ingest-enclave",
  "mc-fog-ingest-server",
+ "mc-fog-recovery-db-iface",
  "mc-fog-sql-recovery-db",
  "mc-fog-test-infra",
  "mc-fog-types",
  "mc-fog-uri",
  "mc-ledger-db",
+ "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-uri",
  "mc-watcher",
  "predicates 2.0.3",
  "protobuf",
+ "rand 0.8.4",
  "retry",
  "serde_json",
  "structopt",
@@ -3840,7 +3843,6 @@ dependencies = [
  "mc-fog-view-connection",
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
- "mc-sgx-css",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-transaction-std",
@@ -3935,25 +3937,15 @@ dependencies = [
 name = "mc-fog-test-client"
 version = "1.2.0-pre0"
 dependencies = [
- "displaydoc",
- "grpcio",
- "lazy_static",
  "mc-account-keys",
  "mc-common",
  "mc-crypto-rand",
  "mc-fog-sample-paykit",
- "mc-fog-uri",
- "mc-sgx-css",
  "mc-transaction-core",
  "mc-transaction-std",
- "mc-util-grpc",
  "mc-util-keyfile",
- "mc-util-metrics",
  "mc-util-uri",
  "more-asserts",
- "once_cell",
- "serde",
- "serde_json",
  "structopt",
 ]
 
@@ -4952,7 +4944,6 @@ dependencies = [
  "mc-crypto-rand",
  "mc-util-from-random",
  "mc-util-serial",
- "mc-util-test-helper",
  "pem",
  "rand 0.8.4",
  "rand_hc 0.3.1",
@@ -5299,7 +5290,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates 1.0.8",
+ "predicates 1.0.5",
  "predicates-tree",
 ]
 
@@ -5408,12 +5399,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 
 [[package]]
 name = "once_cell"
@@ -5669,9 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
 dependencies = [
  "difference",
  "float-cmp 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.15.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -170,9 +170,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.59"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4717cfcbfaa661a0fd48f8453951837ae7e8f81e481fbb136e3202d72805a744"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+checksum = "81a03ce013ffccead76c11a15751231f777d9295b845cc1266ed4d34fcbd7977"
 
 [[package]]
 name = "glob"
@@ -2157,9 +2157,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libloading"
@@ -3843,6 +3843,7 @@ dependencies = [
  "mc-fog-view-connection",
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
+ "mc-sgx-css",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-transaction-std",
@@ -3937,15 +3938,25 @@ dependencies = [
 name = "mc-fog-test-client"
 version = "1.2.0-pre0"
 dependencies = [
+ "displaydoc",
+ "grpcio",
+ "lazy_static",
  "mc-account-keys",
  "mc-common",
  "mc-crypto-rand",
  "mc-fog-sample-paykit",
+ "mc-fog-uri",
+ "mc-sgx-css",
  "mc-transaction-core",
  "mc-transaction-std",
+ "mc-util-grpc",
  "mc-util-keyfile",
+ "mc-util-metrics",
  "mc-util-uri",
  "more-asserts",
+ "once_cell",
+ "serde",
+ "serde_json",
  "structopt",
 ]
 
@@ -4944,6 +4955,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-util-from-random",
  "mc-util-serial",
+ "mc-util-test-helper",
  "pem",
  "rand 0.8.4",
  "rand_hc 0.3.1",
@@ -5290,7 +5302,7 @@ dependencies = [
  "fragile",
  "lazy_static",
  "mockall_derive",
- "predicates 1.0.5",
+ "predicates 1.0.8",
  "predicates-tree",
 ]
 
@@ -5399,9 +5411,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.24.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -5657,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "1.0.5"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
 dependencies = [
  "difference",
  "float-cmp 0.8.0",

--- a/fog/api/proto/ingest.proto
+++ b/fog/api/proto/ingest.proto
@@ -66,6 +66,12 @@ service AccountIngestAPI {
     /// peer's private key, and then sets it as the current enclave's private
     /// key.
     rpc SyncKeysFromRemote(SyncKeysFromRemoteRequest) returns (ingest_common.IngestSummary) {}
+
+    /// Retrieves the entire system's ingress public keys. This means that the
+    /// keys that aren't associated with the particular ingest server instance
+    /// fulfilling this request will be returned. The returned ingress public
+    /// keys are  filtered according to teh GetIngressKeyRecordsRequest parameters.
+    rpc GetIngressKeyRecords(GetIngressKeyRecordsRequest) returns (GetIngressKeyRecordsResponse) {}
 }
 
 message ReportLostIngressKeyRequest {
@@ -94,4 +100,49 @@ message SyncKeysFromRemoteRequest {
     /// The uri for the server that will report the private key that will  be
     /// synced.
     string peer_uri = 1;
+}
+
+message GetIngressKeyRecordsRequest {
+    /// Ingress keys are "started" at certain blocks. Only ingress keys that
+    /// are "started"  at this block index will be included in the response.
+    uint64 start_block_at_least = 1;
+
+    /// If true the response will include ingress keys that have been lost.
+    bool should_include_lost_keys = 2;
+
+    /// If true the response will include ingress keys that have been retired.
+    bool should_include_retired_keys = 3;
+}
+
+message GetIngressKeyRecordsResponse {
+    /// The records that filtered according to the GetIngressKeyRecordsRequest.
+    repeated IngressPublicKeyRecord records = 1;
+}
+
+/// Corresponds to the IngressPublicKeyRecord struct found in
+/// mc-fog-recovery-db-iface.
+message IngressPublicKeyRecord {
+    /// The ingress public key this data refers to
+    external.CompressedRistretto ingress_public_key = 1;
+    /// The first block that fog promises to scan with this key after publishing
+    /// it. This should be the latest block that existed before we published
+    /// it (or, a block close to but before that)
+    uint64 start_block = 2;
+    /// The largest pubkey expiry value that we have ever published for this
+    /// key. If less than start_block, it means we have never published this
+    /// key.
+    uint64 pubkey_expiry = 3;
+    /// Whether this key is retiring / retired.
+    /// When a key is retired, we stop publishing reports about it.
+    bool retired = 4;
+    /// Whether this key is lost.
+    /// When a key is lost, we no longer have it and no blocks can be scanned
+    /// with it anymore. To enable the view server to make progress, the
+    /// remaining blocks we promised to scan are "missed" and the users
+    /// learn about them as missed blocks, which they have to download.
+    bool lost = 5;
+    /// The last block scanned by this key.
+    /// This is inherently racy since other partcipants may be writing
+    /// concurrently with us, but this number is a lower bound.
+    uint64 last_scanned_block = 6;
 }

--- a/fog/api/proto/ingest.proto
+++ b/fog/api/proto/ingest.proto
@@ -70,7 +70,7 @@ service AccountIngestAPI {
     /// Retrieves the entire system's ingress public keys. This means that the
     /// keys that aren't associated with the particular ingest server instance
     /// fulfilling this request will be returned. The returned ingress public
-    /// keys are  filtered according to teh GetIngressKeyRecordsRequest parameters.
+    /// keys are filtered according to the GetIngressKeyRecordsRequest parameters.
     rpc GetIngressKeyRecords(GetIngressKeyRecordsRequest) returns (GetIngressKeyRecordsResponse) {}
 }
 

--- a/fog/api/proto/ingest.proto
+++ b/fog/api/proto/ingest.proto
@@ -104,7 +104,7 @@ message SyncKeysFromRemoteRequest {
 
 message GetIngressKeyRecordsRequest {
     /// Ingress keys are "started" at certain blocks. Only ingress keys that
-    /// are "started"  at this block index will be included in the response.
+    /// are "started" at this block index will be included in the response.
     uint64 start_block_at_least = 1;
 
     /// If true the response will include ingress keys that have been lost.

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -21,8 +21,8 @@ mc-fog-ingest-enclave = { path = "../enclave" }
 mc-fog-recovery-db-iface = { path = "../../recovery_db_iface" }
 mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
 mc-ledger-db = { path = "../../../ledger/db" }
-mc-watcher = { path = "../../../watcher" }
 mc-util-from-random = { path = "../../../util/from-random" }
+mc-watcher = { path = "../../../watcher" }
 
 # third party
 assert_cmd = "2.0.2"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -18,15 +18,18 @@ mc-attest-net = { path = "../../../attest/net" }
 mc-fog-ingest-server = { path = "../server" }
 mc-fog-test-infra = { path = "../../test_infra" }
 mc-fog-ingest-enclave = { path = "../enclave" }
+mc-fog-recovery-db-iface = { path = "../../recovery_db_iface" }
 mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-watcher = { path = "../../../watcher" }
+mc-util-from-random = { path = "../../../util/from-random" }
 
 # third party
 assert_cmd = "2.0.2"
 tempdir = "0.3"
 maplit = "1"
 predicates = "2"
+rand = "0.8"
 
 [dependencies]
 # third party

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -72,4 +72,21 @@ pub enum IngestConfigCommand {
     /// Retrieves a private key from a remote ingest enclave and sets it as
     /// the current enclaves's private key.
     SyncKeysFromRemote { peer_uri: String },
+
+    ///  Retrieves the ingress public keys for the entire system (as opposed to
+    ///  those of a single IngestServer) and filters according to the provided
+    ///  parameters.
+    GetIngressPublicKeyRecords {
+        /// Ingress keys are "started" at certain blocks. Only ingress keys that
+        /// are "started"  at this block index will be included in the response.
+        #[structopt(short = "s", long = "start-block-at-least")]
+        start_block_at_least: u64,
+        /// If true the response will include ingress keys that have been lost.
+        #[structopt(short = "l", long = "include-lost")]
+        should_include_lost_keys: bool,
+        /// If true the response will include ingress keys that have been
+        /// retired.
+        #[structopt(short = "r", long = "include-retired")]
+        should_include_retired_keys: bool,
+    },
 }

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -79,7 +79,7 @@ pub enum IngestConfigCommand {
     GetIngressPublicKeyRecords {
         /// Ingress keys are "started" at certain blocks. Only ingress keys that
         /// are "started"  at this block index will be included in the response.
-        #[structopt(short = "s", long = "start-block-at-least")]
+        #[structopt(default_value, short = "s", long = "start-block-at-least")]
         start_block_at_least: u64,
         /// If true the response will include ingress keys that have been lost.
         #[structopt(short = "l", long = "include-lost")]

--- a/fog/ingest/client/tests/get_ingress_key_records.rs
+++ b/fog/ingest/client/tests/get_ingress_key_records.rs
@@ -1,0 +1,265 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+use assert_cmd::Command;
+use maplit::btreeset;
+use mc_api::external;
+use mc_attest_net::{Client as AttestClient, RaClient};
+use mc_common::logger::{test_with_logger, Logger};
+use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_fog_ingest_server::server::{IngestServer, IngestServerConfig};
+use mc_fog_recovery_db_iface::RecoveryDb;
+use mc_fog_sql_recovery_db::{test_utils::SqlRecoveryDbTestContext, SqlRecoveryDb};
+use mc_fog_test_infra::get_enclave_path;
+use mc_fog_uri::{ConnectionUri, FogIngestUri, IngestPeerUri};
+use mc_ledger_db::LedgerDB;
+use mc_util_from_random::FromRandom;
+use mc_watcher::watcher_db::WatcherDB;
+use predicates::prelude::*;
+use rand::{rngs::StdRng, SeedableRng};
+use std::{str::FromStr, time::Duration};
+use tempdir::TempDir;
+
+const OMAP_CAPACITY: u64 = 256;
+const BASE_PORT: u32 = 3220;
+
+#[test_with_logger]
+fn test_get_ingress_key_records(logger: Logger) {
+    let ingest_server_set_up_data = set_up_ingest_servers(logger);
+
+    // Test that the command excludes retired and lost keys by default.
+    {
+        let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+        cmd.arg("--uri")
+            .arg(&ingest_server_set_up_data.ingest_server_client_uri)
+            .arg("get-ingress-public-key-records")
+            .arg("--start-block-at-least")
+            .arg("0")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            )))
+            .stdout(
+                predicate::str::contains(format!(
+                    "{}",
+                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                ))
+                .not(),
+            )
+            .stdout(
+                predicate::str::contains(format!(
+                    "{}",
+                    hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+                ))
+                .not(),
+            );
+    }
+    // Test that the "--include-lost" option includes active and lost keys.
+    {
+        let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+        cmd.arg("--uri")
+            .arg(&ingest_server_set_up_data.ingest_server_client_uri)
+            .arg("get-ingress-public-key-records")
+            .arg("--start-block-at-least")
+            .arg("0")
+            .arg("--include-lost")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            )))
+            .stdout(
+                predicate::str::contains(format!(
+                    "{}",
+                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                ))
+                .not(),
+            )
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            )));
+    }
+
+    // Test that the "--include-retired" option includes active and retired keys.
+    {
+        let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+        cmd.arg("--uri")
+            .arg(&ingest_server_set_up_data.ingest_server_client_uri)
+            .arg("get-ingress-public-key-records")
+            .arg("--start-block-at-least")
+            .arg("0")
+            .arg("--include-retired")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            )))
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+            )))
+            .stdout(
+                predicate::str::contains(format!(
+                    "{}",
+                    hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+                ))
+                .not(),
+            );
+    }
+
+    // Test that the "--include-lost" and "--include-retired" options
+    // include active, retired, and lost keys.
+    {
+        let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+        cmd.arg("--uri")
+            .arg(&ingest_server_set_up_data.ingest_server_client_uri)
+            .arg("get-ingress-public-key-records")
+            .arg("--start-block-at-least")
+            .arg("0")
+            .arg("--include-lost")
+            .arg("--include-retired")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            )))
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+            )))
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            )));
+    }
+    // Test that the "--start-block-at-least" option works correctly.
+    // This should exclude the retired ingress key because its start block is
+    // 123.
+    {
+        let mut cmd = Command::cargo_bin("fog_ingest_client").unwrap();
+        cmd.arg("--uri")
+            .arg(&ingest_server_set_up_data.ingest_server_client_uri)
+            .arg("get-ingress-public-key-records")
+            .arg("--start-block-at-least")
+            .arg("200")
+            .arg("--include-lost")
+            .arg("--include-retired")
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            )))
+            .stdout(
+                predicate::str::contains(format!(
+                    "{}",
+                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                ))
+                .not(),
+            )
+            .stdout(predicate::str::contains(format!(
+                "{}",
+                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            )));
+    }
+}
+
+/// Contains data pertaining to the set up of the ingest server and the ingress
+/// public keys.
+struct IngestServerSetUpData {
+    /// The ingest server that handles incoming client requests.
+    _ingest_server: IngestServer<AttestClient, SqlRecoveryDb>,
+    /// The db context that is used to created the RecoveryDb. This must be
+    /// included here to ensure that the RecoveryDb is not dropped at the end
+    /// of the set up method.
+    _db_test_context: SqlRecoveryDbTestContext,
+    /// The url that can be used to address the ingest server.
+    ingest_server_client_uri: String,
+    /// An ingress public key that has been retired.
+    retired_ingress_pubkey: external::CompressedRistretto,
+    /// An ingress public key that has been lost.
+    lost_ingress_pubkey: external::CompressedRistretto,
+    /// The ingest server's active ingress public key.
+    active_ingress_pubkey: external::CompressedRistretto,
+}
+
+fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
+    let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
+    let db = db_test_context.get_db_instance();
+
+    let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+
+    let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+    db.new_ingress_key(&ingress_key1, 123).unwrap();
+    let ingress_key2 = CompressedRistrettoPublic::from_random(&mut rng);
+    db.new_ingress_key(&ingress_key2, 456).unwrap();
+    let ingress_key3 = CompressedRistrettoPublic::from_random(&mut rng);
+    db.new_ingress_key(&ingress_key3, 789).unwrap();
+
+    db.retire_ingress_key(&ingress_key1, true).unwrap();
+    db.report_lost_ingress_key(ingress_key2.clone()).unwrap();
+
+    let ingest_server_client_uri = &format!("insecure-fog-ingest://0.0.0.0:{}/", BASE_PORT + 4);
+    let ingest_server = {
+        let igp_uri =
+            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{}/", BASE_PORT + 5))
+                .unwrap();
+        let local_node_id = igp_uri.responder_id().unwrap();
+
+        let config = IngestServerConfig {
+            ias_spid: Default::default(),
+            local_node_id: local_node_id.clone(),
+            client_listen_uri: FogIngestUri::from_str(&ingest_server_client_uri).unwrap(),
+            peer_listen_uri: igp_uri.clone(),
+            peers: btreeset![igp_uri.clone()],
+            fog_report_id: Default::default(),
+            max_transactions: 10_000,
+            pubkey_expiry_window: 100,
+            peer_checkup_period: None,
+            watcher_timeout: Duration::default(),
+            state_file: None,
+            enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
+            omap_capacity: OMAP_CAPACITY,
+        };
+
+        // Set up the Watcher DB - create a new watcher DB for each phase
+        let db_tmp = TempDir::new("wallet_db").expect("Could not make tempdir for wallet db");
+        WatcherDB::create(db_tmp.path()).unwrap();
+        let watcher = WatcherDB::open_ro(db_tmp.path(), logger.clone()).unwrap();
+
+        // Set up an empty ledger db.
+        let ledger_db_path =
+            TempDir::new("ledger_db").expect("Could not make tempdir for ledger db");
+        LedgerDB::create(ledger_db_path.path()).unwrap();
+        let ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
+
+        let ra_client = AttestClient::new("").expect("Could not create IAS client");
+        let mut node = IngestServer::new(
+            config,
+            ra_client,
+            db.clone(),
+            watcher,
+            ledger_db,
+            logger.clone(),
+        );
+        node.start().expect("Could not start Ingest Service");
+
+        node
+    };
+
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    return IngestServerSetUpData {
+        _ingest_server: ingest_server,
+        _db_test_context: db_test_context,
+        ingest_server_client_uri: ingest_server_client_uri.to_owned(),
+        retired_ingress_pubkey: external::CompressedRistretto::from(&ingress_key1),
+        lost_ingress_pubkey: external::CompressedRistretto::from(&ingress_key2),
+        active_ingress_pubkey: external::CompressedRistretto::from(&ingress_key3),
+    };
+}

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -24,7 +24,8 @@ use mc_fog_api::{
 };
 use mc_fog_ingest_enclave::{Error as EnclaveError, IngestEnclave, IngestSgxEnclave};
 use mc_fog_recovery_db_iface::{
-    IngressPublicKeyRecord, IngressPublicKeyStatus, RecoveryDb, ReportData, ReportDb,
+    IngressPublicKeyRecord, IngressPublicKeyRecordFilters, IngressPublicKeyStatus, RecoveryDb,
+    ReportData, ReportDb,
 };
 use mc_fog_types::{common::BlockRange, ingest::TxsForIngest};
 use mc_fog_uri::IngestPeerUri;
@@ -1441,8 +1442,10 @@ where
     ) -> Result<Vec<IngressPublicKeyRecord>, <DB as RecoveryDb>::Error> {
         self.recovery_db.get_ingress_key_records(
             start_block_at_least,
-            should_include_lost_keys,
-            should_include_retired_keys,
+            IngressPublicKeyRecordFilters {
+                should_include_lost_keys: should_include_lost_keys,
+                should_include_retired_keys: should_include_retired_keys,
+            },
         )
     }
 }

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -1443,8 +1443,8 @@ where
         self.recovery_db.get_ingress_key_records(
             start_block_at_least,
             IngressPublicKeyRecordFilters {
-                should_include_lost_keys: should_include_lost_keys,
-                should_include_retired_keys: should_include_retired_keys,
+                should_include_lost_keys,
+                should_include_retired_keys,
             },
         )
     }

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -23,7 +23,9 @@ use mc_fog_api::{
     report_parse::try_extract_unvalidated_ingress_pubkey_from_fog_report,
 };
 use mc_fog_ingest_enclave::{Error as EnclaveError, IngestEnclave, IngestSgxEnclave};
-use mc_fog_recovery_db_iface::{IngressPublicKeyStatus, RecoveryDb, ReportData, ReportDb};
+use mc_fog_recovery_db_iface::{
+    IngressPublicKeyRecord, IngressPublicKeyStatus, RecoveryDb, ReportData, ReportDb,
+};
 use mc_fog_types::{common::BlockRange, ingest::TxsForIngest};
 use mc_fog_uri::IngestPeerUri;
 use mc_sgx_report_cache_api::ReportableEnclave;
@@ -1427,5 +1429,20 @@ where
         }
 
         Ok(())
+    }
+
+    /// Returns a vector of ingress key records. Filters the results according
+    /// to the parameters.
+    pub fn get_ingress_key_records(
+        &self,
+        start_block_at_least: u64,
+        should_include_lost_keys: bool,
+        should_include_retired_keys: bool,
+    ) -> Result<Vec<IngressPublicKeyRecord>, <DB as RecoveryDb>::Error> {
+        self.recovery_db.get_ingress_key_records(
+            start_block_at_least,
+            should_include_lost_keys,
+            should_include_retired_keys,
+        )
     }
 }

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -84,6 +84,8 @@ pub trait RecoveryDb {
     fn get_ingress_key_records(
         &self,
         start_block_at_least: u64,
+        should_include_lost_keys: bool,
+        should_include_retired_keys: bool,
     ) -> Result<Vec<IngressPublicKeyRecord>, Self::Error>;
 
     /// Adds a new ingest invocation to the database, optionally decommissioning

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -22,6 +22,15 @@ pub use types::{
     IngressPublicKeyStatus, ReportData,
 };
 
+/// Contains fields that are used as filters in  queries for ingress keys.
+pub struct IngressPublicKeyRecordFilters {
+    /// If set to true, the query will include ingress keys that are lost.
+    pub should_include_lost_keys: bool,
+
+    /// If set to true, the query will include ingress keys that are retired.
+    pub should_include_retired_keys: bool,
+}
+
 /// A generic error type for recovery db operations
 pub trait RecoveryDbError: Debug + Display + Send + Sync {}
 impl<T> RecoveryDbError for T where T: Debug + Display + Send + Sync {}
@@ -84,8 +93,7 @@ pub trait RecoveryDb {
     fn get_ingress_key_records(
         &self,
         start_block_at_least: u64,
-        should_include_lost_keys: bool,
-        should_include_retired_keys: bool,
+        ingress_public_key_record_filters: IngressPublicKeyRecordFilters,
     ) -> Result<Vec<IngressPublicKeyRecord>, Self::Error>;
 
     /// Adds a new ingest invocation to the database, optionally decommissioning

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -2331,4 +2331,178 @@ mod tests {
             }]
         );
     }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_not_include_retired_keys_does_not_return_retired_keys(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ false,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 123).unwrap();
+
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ true,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap(),
+            vec![IngressPublicKeyRecord {
+                key: ingress_key1.clone(),
+                status: IngressPublicKeyStatus {
+                    start_block: 123,
+                    pubkey_expiry: 0,
+                    retired: false,
+                    lost: false,
+                },
+                last_scanned_block: None,
+            }],
+        );
+        db.retire_ingress_key(&ingress_key1, true).unwrap();
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ true,
+                /* should_include_retired_keys */ false
+            )
+            .unwrap()
+            .len(),
+            0
+        );
+    }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_not_include_lost_keys_does_not_return_lost_keys(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ false,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 123).unwrap();
+
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ true,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap(),
+            vec![IngressPublicKeyRecord {
+                key: ingress_key1.clone(),
+                status: IngressPublicKeyStatus {
+                    start_block: 123,
+                    pubkey_expiry: 0,
+                    retired: false,
+                    lost: false,
+                },
+                last_scanned_block: None,
+            }],
+        );
+
+        db.report_lost_ingress_key(ingress_key1).unwrap();
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ false,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap()
+            .len(),
+            0
+        );
+    }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_not_include_lost_keys_or_retired_keys_does_not_return_lost_keys_or_retired_keys(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ false,
+                /* should_include_retired_keys */ true
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 123).unwrap();
+
+        let ingress_key2 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
+        db.new_ingress_key(&ingress_key2, 456).unwrap();
+
+        assert_eq!(
+            HashSet::<IngressPublicKeyRecord>::from_iter(
+                db.get_ingress_key_records(
+                    0, /* should_include_lost_keys= */ true,
+                    /* should_include_retired_keys */ true
+                )
+                .unwrap()
+            ),
+            HashSet::<IngressPublicKeyRecord>::from_iter(vec![
+                IngressPublicKeyRecord {
+                    key: ingress_key1.clone(),
+                    status: IngressPublicKeyStatus {
+                        start_block: 123,
+                        pubkey_expiry: 0,
+                        retired: false,
+                        lost: false,
+                    },
+                    last_scanned_block: None,
+                },
+                IngressPublicKeyRecord {
+                    key: ingress_key2.clone(),
+                    status: IngressPublicKeyStatus {
+                        start_block: 456,
+                        pubkey_expiry: 0,
+                        retired: false,
+                        lost: false,
+                    },
+                    last_scanned_block: None,
+                }
+            ]),
+        );
+
+        db.retire_ingress_key(&ingress_key1, true).unwrap();
+        db.report_lost_ingress_key(ingress_key2).unwrap();
+
+        assert_eq!(
+            db.get_ingress_key_records(
+                0, /* should_include_lost_keys= */ false,
+                /* should_include_retired_keys */ false
+            )
+            .unwrap()
+            .len(),
+            0
+        );
+    }
 }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -216,8 +216,11 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
         let _metrics_timer = counters::LOAD_INGRESS_KEYS_TIME.start_timer();
 
         match self.db.get_ingress_key_records(
-            0, /* should_include_lost_keys= */ true,
-            /* should_include_retired_keys */ true,
+            0,
+            IngressKeyRecordFilters {
+                should_include_lost_keys: true,
+                should_include_retired_keys: true,
+            },
         ) {
             Ok(records) => {
                 log::trace!(self.logger, "get_ingress_key_records: {:?}", records);

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -215,7 +215,10 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
     fn load_ingress_keys(&self) {
         let _metrics_timer = counters::LOAD_INGRESS_KEYS_TIME.start_timer();
 
-        match self.db.get_ingress_key_records(0) {
+        match self.db.get_ingress_key_records(
+            0, /* should_include_lost_keys= */ true,
+            /* should_include_retired_keys */ true,
+        ) {
             Ok(records) => {
                 log::trace!(self.logger, "get_ingress_key_records: {:?}", records);
 

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -5,7 +5,7 @@
 use crate::{block_tracker::BlockTracker, counters};
 use mc_common::logger::{log, Logger};
 use mc_crypto_keys::CompressedRistrettoPublic;
-use mc_fog_recovery_db_iface::{IngressPublicKeyRecord, RecoveryDb};
+use mc_fog_recovery_db_iface::{IngressPublicKeyRecord, IngressPublicKeyRecordFilters, RecoveryDb};
 use mc_fog_types::ETxOutRecord;
 use std::{
     sync::{
@@ -217,7 +217,7 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
 
         match self.db.get_ingress_key_records(
             0,
-            IngressKeyRecordFilters {
+            IngressPublicKeyRecordFilters {
                 should_include_lost_keys: true,
                 should_include_retired_keys: true,
             },


### PR DESCRIPTION
### Motivation

The ops team has requested a "fog_ingest_client" CLI API that allows them to list all of the ingress public keys for the fog system. 

### In this PR
* Exposes this API. Ingress keys can be filtered by start block, lost status, and retired status.

Fixes this [ticket](https://app.asana.com/0/1200353042931237/1200512973791588/f).

### Future Work
* Potentially exposes more CLI options that filter the ingress keys even more.

