### PR TITLE
add tests for maximum fog domain vs. 255 b58 pub address limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,6 +4941,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-util-from-random",
  "mc-util-serial",
+ "mc-util-test-helper",
  "pem",
  "rand 0.8.4",
  "rand_hc 0.3.1",

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -42,3 +42,4 @@ x509-signature = "0.5"
 
 [dev-dependencies]
 tempdir = "0.3"
+mc-util-test-helper = { path = "../../util/test-helper" }

--- a/util/keyfile/tests/b58-length.rs
+++ b/util/keyfile/tests/b58-length.rs
@@ -1,0 +1,62 @@
+use mc_account_keys::{AccountKey, RootIdentity};
+use mc_api::printable::PrintableWrapper;
+use mc_util_test_helper::{run_with_several_seeds, CryptoRng, RngCore};
+
+// The limit which we require b58 addresses to be less than
+const B58_ADDRESS_LIMIT: usize = 255;
+// The limit which we impose on fog domains like "fog.mobilecoin.com"
+const DOMAIN_LIMIT: usize = 34;
+
+// Try making a fog address with this domain length, (and an rng), several
+// times. Return true if the b58 encoded public address sometimes matches or
+// exceeds B58_ADDRESS_LIMIT
+fn test_b58pub_length<T: RngCore + CryptoRng>(
+    domain_length: usize,
+    num_trials: usize,
+    rng: &mut T,
+) -> bool {
+    let url = format!(
+        "fog://{}",
+        std::iter::repeat("a")
+            .take(domain_length)
+            .collect::<String>()
+    );
+    for _ in 0..num_trials {
+        let root_id = RootIdentity::random_with_fog(
+            rng,
+            &url,
+            "",
+            b"DEADBEEF", /* Length doesn't matter because fog authority spki is signed when we
+                          * go to public address and signature has fixed
+                          * length in the public address */
+        );
+
+        let acct_key = AccountKey::from(&root_id);
+        let addr = acct_key.default_subaddress();
+
+        let mut wrapper = PrintableWrapper::new();
+        wrapper.set_public_address((&addr).into());
+
+        let data = wrapper.b58_encode().unwrap();
+
+        if data.len() >= B58_ADDRESS_LIMIT {
+            return true;
+        }
+    }
+    return false;
+}
+
+#[test]
+fn test_b58_pub_length() {
+    run_with_several_seeds(|mut rng| {
+        for domain_len in 0..DOMAIN_LIMIT {
+            assert!(
+                !test_b58pub_length(domain_len, 10, &mut rng),
+                "B58 address limit exceeded for domain length = {}",
+                domain_len
+            );
+        }
+
+        assert!(test_b58pub_length(DOMAIN_LIMIT, 10, &mut rng), "Domain limit is not computed correctly, we didn't exceed the limit with urls of length {}", DOMAIN_LIMIT);
+    })
+}


### PR DESCRIPTION
Some exchanges use `VARCHAR(255)` for cryptocurrency public addresses, and it is difficult for them to migrate their SQL DBs.

We want that the mobilecoin b58 printable wrapper address strings are always within 255 bytes.

This imposes a limit on how long the fog report url can be.

The purpose of this test is to experimentally determine exactly what the limit is.

The test uses repetition because b58 encoding length isn't determined completely by payload length, it depends on what bytes are in the payload. So we try it with several choices of the mobilecoin private keys.

The test ensures that:
* Any domain less than the limit leads to a public address less than the 255 limit, trying private keys ten times
* Any domain at or more than the limit does violate the 255 limit at least sometimes, so the domain length limit is tight.

We compute a domain limit of 34 characters, so `fog.mobilecoin.com` would have to be less than 34 characters.