### PR TITLE
Use a python thread pool to try to accelerate conformance tests

### DIFF
--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -60,7 +60,7 @@ impl MemoHandler {
         let memo_payload = tx_out.decrypt_memo(&shared_secret);
 
         let memo_type = MemoType::try_from(&memo_payload)?;
-        log::info!(self.logger, "Obtained a memo: {:?}", memo_type);
+        log::trace!(self.logger, "Obtained a memo: {:?}", memo_type);
         match memo_type.clone() {
             MemoType::Unused(_) => Ok(None),
             MemoType::AuthenticatedSender(memo) => {


### PR DESCRIPTION
The fog conformance tests are somewhat slow right now which makes it
more difficult to iterate on the tests.

The idea here is that when the multi-balance checker is running,
we should trigger all the remote wallets to do balance checks in
parallel instead of doing them one at a time.

Normally python parallelism is made more difficult because of the
global interpreter lock which prevents python code from running in more
than one thread at once. However, in this case, the test is just
making grpc queries to the remote wallets to ask them to do things,
so all of the "work" here is I/O bound and happening in other processes,
we just need to trigger those processes to do the balance checks and give
us the result earlier.

I set it up so that the thread pool is owned by the multibalance checker,
and it uses `ThreadPool.map(...)` to distribute the work in parallel to
the threads.

One drawback of the way this works is that before, we were destructuring
the results of several iterators and giving them nice names. But I could
not get this named destructuring to work in python when we are passing lambda
functions to the .map function. So instead the lambda is just using tuple
indexing to the get the arguments, and I have code comments that document
what the argument structure is supposed to be.

There was also a logging statement for the follow up balance checks that
I couldn't figure out how to make work with the lambda functions, because
lambda functions can only be a single expression in python. We could move
some of this into a def or something but it seems unattractive. I'm not
sure we really needed this log statement.

There might be a more elegant way to do this in python

---

One drawback of this change is that it adds more nondeterminism to the test.
Since the wallets are not talking to eachother and are all talking in
parallel to the servers anyways, it seems like this should not create
a problem, and anyways the test should work even if they do.
If we need to limit the nondeterminism to debug the test, we can easily
add an argument to make the thread pool use only one thread later.
