### PR TITLE
run fog conformance tests in release mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,7 @@ commands:
       - store_artifacts:
           path: /tmp/core_dumps
 
-  # A job that runs the fog-conformance-tests, building things in debug mode
+  # A job that runs the fog-conformance-tests, building things in release mode
   # Note: If we bring back the run-parallel-tests stuff, we could make this use --skip-build,
   # and consume the build targets built in earlier step perhaps
   run-fog-conformance-tests-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ commands:
   # A job that runs the fog-conformance-tests, building things in debug mode
   # Note: If we bring back the run-parallel-tests stuff, we could make this use --skip-build,
   # and consume the build targets built in earlier step perhaps
-  run-fog-conformance-tests-debug:
+  run-fog-conformance-tests-release:
     steps:
       - run:
           name: fog_conformance_tests.py
@@ -410,7 +410,7 @@ commands:
             ./build.sh
             cd ../..
 
-            python ./tools/fog-local-network/fog_conformance_tests.py
+            python ./tools/fog-local-network/fog_conformance_tests.py --release
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -514,7 +514,7 @@ jobs:
       <<: *default-build-environment
     steps:
       - prepare-for-build
-      - run-fog-conformance-tests-debug
+      - run-fog-conformance-tests-release
 
   # Build and lint in debug mode
   build-and-lint-debug:


### PR DESCRIPTION
the tests run locally in 1 minute instead of 29 minutes when we
use --release, so this may improve performance in CI also. the
reason for the performance gain is that all the ORAM servers are
much faster when compiled in release mode

(see stats here: https://github.com/mobilecoinfoundation/mobilecoin/pull/1157)