### PR TITLE
Add retries to many fog enclave connections using retry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,6 +3207,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-serial",
  "mc-util-uri",
+ "retry",
  "sha2 0.9.8",
 ]
 
@@ -3434,6 +3435,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-uri",
  "protobuf",
+ "retry",
 ]
 
 [[package]]
@@ -4028,6 +4030,7 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-util-grpc",
  "mc-util-serial",
+ "retry",
 ]
 
 [[package]]

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -22,4 +22,5 @@ aes-gcm = "0.9.4"
 cookie = "0.15"
 displaydoc = { version = "0.2", default-features = false }
 grpcio = "0.9.0"
+retry = "1.3"
 sha2 = "0.9.8"

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -25,10 +25,7 @@ pub enum Error {
 
 impl Error {
     pub fn should_retry(&self) -> bool {
-        match self {
-            Error::Rpc(_) | Error::Ake(_) | Error::Cipher(_) => true,
-            _ => false,
-        }
+        matches!(self, Error::Rpc(_) | Error::Ake(_))
     }
 }
 

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -23,6 +23,15 @@ pub enum Error {
     ProtoDecode(DecodeError),
 }
 
+impl Error {
+    pub fn should_retry(&self) -> bool {
+        match self {
+            Error::Rpc(_) | Error::Ake(_) | Error::Cipher(_) => true,
+            _ => false,
+        }
+    }
+}
+
 impl AttestationError for Error {}
 
 impl From<grpcio::Error> for Error {

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -25,6 +25,7 @@ mc-fog-uri = { path = "../../uri" }
 displaydoc = { version = "0.2", default-features = false }
 grpcio = "0.9.0"
 protobuf = "2.22.1"
+retry = "1.3"
 
 [dev-dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }

--- a/fog/ledger/connection/src/error.rs
+++ b/fog/ledger/connection/src/error.rs
@@ -2,6 +2,7 @@
 
 use displaydoc::Display;
 use protobuf::error::ProtobufError;
+use retry::Error as RetryError;
 
 use mc_api::ConversionError;
 
@@ -11,7 +12,7 @@ use mc_fog_enclave_connection::Error as EnclaveConnectionError;
 #[derive(Debug, Display)]
 pub enum Error {
     /// Enclave Connection Error: {0}
-    Connection(EnclaveConnectionError),
+    Connection(RetryError<EnclaveConnectionError>),
     /// Protobuf Error: {0}
     Protobuf(ProtobufError),
     /// Deserialization failed
@@ -22,8 +23,8 @@ pub enum Error {
     Grpc(grpcio::Error),
 }
 
-impl From<EnclaveConnectionError> for Error {
-    fn from(err: EnclaveConnectionError) -> Self {
+impl From<RetryError<EnclaveConnectionError>> for Error {
+    fn from(err: RetryError<EnclaveConnectionError>) -> Self {
         Error::Connection(err)
     }
 }

--- a/fog/ledger/connection/src/key_image.rs
+++ b/fog/ledger/connection/src/key_image.rs
@@ -13,6 +13,7 @@ use mc_fog_types::ledger::{
 use mc_fog_uri::FogLedgerUri;
 use mc_transaction_core::{ring_signature::KeyImage, BlockIndex};
 use mc_util_grpc::ConnectionUriGrpcioChannel;
+use retry::{delay::Fixed, retry};
 use std::sync::Arc;
 
 /// An attested connection to the Fog Key Image service.
@@ -54,8 +55,9 @@ impl FogKeyImageGrpcClient {
                 .collect(),
         };
 
-        let response: CheckKeyImagesResponse =
-            self.conn.encrypted_enclave_request(&request, &[])?;
+        let response: CheckKeyImagesResponse = retry(Fixed::from_millis(100).take(5), || {
+            self.conn.retriable_encrypted_enclave_request(&request, &[])
+        })?;
 
         Ok(response)
     }

--- a/fog/ledger/connection/src/merkle_proof.rs
+++ b/fog/ledger/connection/src/merkle_proof.rs
@@ -11,6 +11,7 @@ use mc_fog_types::ledger::{GetOutputsRequest, GetOutputsResponse, OutputResult};
 use mc_fog_uri::FogLedgerUri;
 use mc_transaction_core::tx::{TxOut, TxOutMembershipProof};
 use mc_util_grpc::ConnectionUriGrpcioChannel;
+use retry::{delay::Fixed, retry};
 use std::sync::Arc;
 
 /// An attested connection to the Fog Merkle Proof service.
@@ -48,7 +49,9 @@ impl FogMerkleProofGrpcClient {
             merkle_root_block,
         };
 
-        let response: GetOutputsResponse = self.conn.encrypted_enclave_request(&request, &[])?;
+        let response: GetOutputsResponse = retry(Fixed::from_millis(100).take(5), || {
+            self.conn.retriable_encrypted_enclave_request(&request, &[])
+        })?;
 
         Ok(response)
     }

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -60,7 +60,7 @@ impl MemoHandler {
         let memo_payload = tx_out.decrypt_memo(&shared_secret);
 
         let memo_type = MemoType::try_from(&memo_payload)?;
-        log::info!(self.logger, "Obtained a memo: {:?}", memo_type);
+        log::trace!(self.logger, "Obtained a memo: {:?}", memo_type);
         match memo_type.clone() {
             MemoType::Unused(_) => Ok(None),
             MemoType::AuthenticatedSender(memo) => {

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -13,7 +13,6 @@ use mc_common::{
     HashMap,
 };
 use mc_crypto_keys::RistrettoPublic;
-use mc_fog_enclave_connection::Error as EnclaveConnectionError;
 use mc_fog_ledger_connection::{
     Error as LedgerConnectionError, FogKeyImageGrpcClient, KeyImageResultExtension,
 };
@@ -489,7 +488,7 @@ impl CachedTxData {
                     }
                 }
             }
-            Err(err @ LedgerConnectionError::Connection(EnclaveConnectionError::Rpc(_))) => {
+            Err(err @ LedgerConnectionError::Connection(_)) => {
                 log::info!(self.logger, "Check key images failed due to {}", err);
                 return Err(err.into());
             }

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -22,3 +22,4 @@ mc-fog-view-protocol = { path = "../protocol" }
 
 # third-party
 grpcio = "0.9.0"
+retry = "1.3"


### PR DESCRIPTION
This addresses many old tickets, and I developed this while trying
to figure out why the test client failed with seemingly retriable errors

There is a large amount of tech debt to resolve the discrepancy
between mc-connection and mc-fog-enclave-connection. They are mostly
supposed to be doing the same thing, but `mc-fog-enclave-connection`
is generic over a protobuf client object that could be ledger key image, merkle proof, or view
(or consensus user tx conceivably). OTOH the mc-connection objects
have been used in production and support more features like the credentials
provider, and before now, doing retries with the retry crate for
connection / attestation issues.

This does not attempt to resolve that issue for now, but it does port
forward the retry aspect of this from "sync_connection".

I decided not to do it in exactly the same way sync_connection, instead
I decided that `enclave_connection` should have a helper function that
converts its result into a `retry::OperationResult`, so that the caller
can use the `retry` call, and we don't need to pass the retry Iterator
into this call. To me this seems simpler and cleaner than what is done
in `mc-connection`, and does not involve any rust macros to get it to work.

This will hopefully make unit tests and CD more stable, as well as making
the test client more stable.