### PR TITLE
Prevent ingress keys from using start block higher than highest known

### DIFF
--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -716,11 +716,11 @@ where
                         .map(|x| x + 1)
                         .unwrap_or(0),
                 );
-                if !self.recovery_db.new_ingress_key(&our_pubkey, start_block)? {
-                    return Err(PeerBackupError::CreatingNewIngressKey.into());
-                };
 
-                start_block
+                match self.recovery_db.new_ingress_key(&our_pubkey, start_block) {
+                    Ok(accepted_start_block) => accepted_start_block,
+                    Err(_err) => return Err(PeerBackupError::CreatingNewIngressKey.into()),
+                }
             };
         // This unwrap is okay because we are idle right now.
         state

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -50,16 +50,15 @@ pub trait RecoveryDb {
     ///
     /// Arguments:
     /// * key: the public key
-    /// * start_block: the first block we promise to scan with this key
+    /// * start_block: the first block count we promise to scan with this key
     ///
     /// Returns
-    /// * true if the insert was successful, false if this key already exists in
-    ///   the database
+    /// * The accepted start block count
     fn new_ingress_key(
         &self,
         key: &CompressedRistrettoPublic,
-        start_block: u64,
-    ) -> Result<bool, Self::Error>;
+        start_block_count: u64,
+    ) -> Result<u64, Self::Error>;
 
     /// Mark an ingress public key for retiring.
     ///

--- a/fog/sql_recovery_db/src/error.rs
+++ b/fog/sql_recovery_db/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     /// IngressKeys schema violation: {0}
     IngressKeysSchemaViolation(String),
 
+    /// New ingress key wasn't inserted successfully: {0}
+    IngressKeyUnsuccessfulInsert(String),
+
     /// IngestedBlock schema violation: {0}
     IngestedBlockSchemaViolation(String),
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -178,7 +178,7 @@ impl SqlRecoveryDb {
         }
     }
 
-    fn get_highest_known_block_index_impl(&self, conn: &PgConnection) -> Result<Option<u64>, Error> {
+    fn get_highest_known_block_index_impl(conn: &PgConnection) -> Result<Option<u64>, Error> {
         Ok(schema::ingested_blocks::dsl::ingested_blocks
             .select(diesel::dsl::max(schema::ingested_blocks::dsl::block_number))
             .first::<Option<i64>>(conn)?
@@ -205,7 +205,7 @@ impl RecoveryDb for SqlRecoveryDb {
     ) -> Result<u64, Error> {
         let conn = self.pool.get()?;
         conn.build_transaction().read_write().run(|| -> Result<u64, Error> {
-            let highest_known_block_count: u64 = match self.get_highest_known_block_index_impl(&conn) {
+            let highest_known_block_count: u64 = match SqlRecoveryDb::get_highest_known_block_index_impl(&conn) {
                 Ok(block_index) => block_index.unwrap_or(0) + 1,
                 Err(_) => 0,
             };
@@ -936,7 +936,7 @@ impl RecoveryDb for SqlRecoveryDb {
     /// Get the highest block index for which we have any data at all.
     fn get_highest_known_block_index(&self) -> Result<Option<u64>, Self::Error> {
         let conn = self.pool.get()?;
-        self.get_highest_known_block_index_impl(&conn)
+        SqlRecoveryDb::get_highest_known_block_index_impl(&conn)
     }
 
 }

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -204,35 +204,38 @@ impl RecoveryDb for SqlRecoveryDb {
         start_block_count: u64,
     ) -> Result<u64, Error> {
         let conn = self.pool.get()?;
-        conn.build_transaction().read_write().run(|| -> Result<u64, Error> {
-            let highest_known_block_count: u64 = match SqlRecoveryDb::get_highest_known_block_index_impl(&conn) {
-                Ok(block_index) => block_index.unwrap_or(0) + 1,
-                Err(_) => 0,
-            };
+        conn.build_transaction()
+            .read_write()
+            .run(|| -> Result<u64, Error> {
+                let highest_known_block_count: u64 =
+                    match SqlRecoveryDb::get_highest_known_block_index_impl(&conn) {
+                        Ok(block_index) => block_index.unwrap_or(0) + 1,
+                        Err(_) => 0,
+                    };
 
-            let accepted_start_block_count = max(start_block_count, highest_known_block_count);
-            let obj = models::NewIngressKey {
-                ingress_public_key: (*key).into(),
-                start_block: accepted_start_block_count as i64,
-                pubkey_expiry: 0,
-                retired: false,
-                lost: false,
-            };
+                let accepted_start_block_count = max(start_block_count, highest_known_block_count);
+                let obj = models::NewIngressKey {
+                    ingress_public_key: (*key).into(),
+                    start_block: accepted_start_block_count as i64,
+                    pubkey_expiry: 0,
+                    retired: false,
+                    lost: false,
+                };
 
-            let inserted_row_count = diesel::insert_into(schema::ingress_keys::table)
-                .values(&obj)
-                .on_conflict_do_nothing()
-                .execute(&conn)?;
+                let inserted_row_count = diesel::insert_into(schema::ingress_keys::table)
+                    .values(&obj)
+                    .on_conflict_do_nothing()
+                    .execute(&conn)?;
 
-            if inserted_row_count > 0 {
-                Ok(accepted_start_block_count)
-            } else {
-                Err(Error::IngressKeyUnsuccessfulInsert(format!(
-                    "Unable to insert ingress key: {:?}",
-                    key
-                )))
-            }
-        })
+                if inserted_row_count > 0 {
+                    Ok(accepted_start_block_count)
+                } else {
+                    Err(Error::IngressKeyUnsuccessfulInsert(format!(
+                        "Unable to insert ingress key: {:?}",
+                        key
+                    )))
+                }
+            })
     }
 
     fn retire_ingress_key(
@@ -938,7 +941,6 @@ impl RecoveryDb for SqlRecoveryDb {
         let conn = self.pool.get()?;
         SqlRecoveryDb::get_highest_known_block_index_impl(&conn)
     }
-
 }
 
 /// See trait `fog_recovery_db_iface::ReportDb` for documentation.
@@ -2580,20 +2582,24 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn test_new_ingress_key_no_blocks_added_accepted_block_count_is_proposed_start_block(logger: Logger) {
+    fn test_new_ingress_key_no_blocks_added_accepted_block_count_is_proposed_start_block(
+        logger: Logger,
+    ) {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
 
         let proposed_start_block = 120;
         let ingress_key = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
-        let accepted_start_block = db.new_ingress_key(&ingress_key, proposed_start_block).unwrap();
+        let accepted_start_block = db
+            .new_ingress_key(&ingress_key, proposed_start_block)
+            .unwrap();
 
         assert_eq!(accepted_start_block, proposed_start_block);
 
         // Ensures that the accepted start block is recorded in the db.
         let ingress_key_status = db.get_ingress_key_status(&ingress_key).unwrap().unwrap();
-        assert_eq!(accepted_start_block , ingress_key_status.start_block);
+        assert_eq!(accepted_start_block, ingress_key_status.start_block);
     }
 
     #[test_with_logger]
@@ -2632,16 +2638,17 @@ mod tests {
             .unwrap();
 
         assert_eq!(accepted_start_block, highest_known_block_count);
-        
+
         // Ensures that the accepted start block is recorded in the db.
-        let ingress_key_status = db.get_ingress_key_status(&new_ingress_key).unwrap().unwrap();
+        let ingress_key_status = db
+            .get_ingress_key_status(&new_ingress_key)
+            .unwrap()
+            .unwrap();
         assert_eq!(accepted_start_block, ingress_key_status.start_block);
     }
 
     #[test_with_logger]
-    fn test_new_ingress_key_proposed_higher_than_highest_known_accepts_proposed(
-        logger: Logger,
-    ) {
+    fn test_new_ingress_key_proposed_higher_than_highest_known_accepts_proposed(logger: Logger) {
         let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
@@ -2673,16 +2680,17 @@ mod tests {
             .unwrap();
 
         assert_eq!(accepted_start_block, proposed_start_block_count);
-        
+
         // Ensures that the accepted start block is recorded in the db.
-        let ingress_key_status = db.get_ingress_key_status(&new_ingress_key).unwrap().unwrap();
+        let ingress_key_status = db
+            .get_ingress_key_status(&new_ingress_key)
+            .unwrap()
+            .unwrap();
         assert_eq!(accepted_start_block, ingress_key_status.start_block);
     }
 
     #[test_with_logger]
-    fn test_new_ingress_key_proposed_one_more_than_highest_known_accepts_proposed(
-        logger: Logger,
-    ) {
+    fn test_new_ingress_key_proposed_one_more_than_highest_known_accepts_proposed(logger: Logger) {
         let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
@@ -2706,7 +2714,7 @@ mod tests {
         let (block, records) = random_block(&mut rng, highest_known_block_index, num_txs);
         db.add_block_data(&invoc_id, &block, 0, &records).unwrap();
 
-        // Choose 10 to ensure that off by one error is accounted for. 
+        // Choose 10 to ensure that off by one error is accounted for.
         let proposed_start_block_count = 10;
         let mut rng_2: StdRng = SeedableRng::from_seed([127u8; 32]);
         let new_ingress_key =
@@ -2716,9 +2724,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(accepted_start_block, highest_known_block_count);
-        
+
         // Ensures that the accepted start block is recorded in the db.
-        let ingress_key_status = db.get_ingress_key_status(&new_ingress_key).unwrap().unwrap();
+        let ingress_key_status = db
+            .get_ingress_key_status(&new_ingress_key)
+            .unwrap()
+            .unwrap();
         assert_eq!(accepted_start_block, ingress_key_status.start_block);
     }
 }

--- a/fog/test_infra/src/db_tests.rs
+++ b/fog/test_infra/src/db_tests.rs
@@ -495,7 +495,7 @@ pub fn test_recovery_db_ingress_keys<DB: RecoveryDb>(
 
     assert_eq!(db.get_ingress_key_status(&ingress_key1).unwrap(), None);
 
-    assert!(db.new_ingress_key(&ingress_key1, 1).unwrap());
+    assert!(db.new_ingress_key(&ingress_key1, 1).is_ok());
 
     assert_eq!(
         db.get_ingress_key_status(&ingress_key1).unwrap(),
@@ -511,7 +511,7 @@ pub fn test_recovery_db_ingress_keys<DB: RecoveryDb>(
 
     assert_eq!(db.get_ingress_key_status(&ingress_key2).unwrap(), None);
 
-    assert!(db.new_ingress_key(&ingress_key2, 10).unwrap());
+    assert!(db.new_ingress_key(&ingress_key2, 10).is_ok());
 
     assert_eq!(
         db.get_ingress_key_status(&ingress_key2).unwrap(),
@@ -523,8 +523,8 @@ pub fn test_recovery_db_ingress_keys<DB: RecoveryDb>(
         })
     );
 
-    assert!(!db.new_ingress_key(&ingress_key1, 2).unwrap());
-    assert!(!db.new_ingress_key(&ingress_key2, 10).unwrap());
+    assert!(db.new_ingress_key(&ingress_key1, 2).is_err());
+    assert!(db.new_ingress_key(&ingress_key2, 10).is_err());
 
     assert_eq!(
         db.get_ingress_key_status(&ingress_key1).unwrap(),

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -117,7 +117,8 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     let db = db_context.get_db_instance();
 
     let ingress_key = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
-    db.new_ingress_key(&ingress_key, 0).unwrap();
+    let accepted_block_1 = db.new_ingress_key(&ingress_key, 0).unwrap();
+    assert_eq!(accepted_block_1, 0);
 
     // First add some data to the database
     let txs: Vec<ETxOutRecord> = (1u8..21u8)
@@ -190,7 +191,9 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
 
     // Block 3 is missing (on a different key)
     let ingress_key2 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
-    db.new_ingress_key(&ingress_key2, 3).unwrap();
+    let accepted_block_2 = db.new_ingress_key(&ingress_key2, 3).unwrap();
+    assert_eq!(accepted_block_2, 3);
+
     db.set_report(
         &ingress_key2,
         "",


### PR DESCRIPTION
### Motivation

As described in this [ticket](https://app.asana.com/0/1200353042931237/1201342064475415/f), "when ingest creates a new ingress key, it can specify any start_block value, and it currently does this using ledger_db.num_blocks(). But if its ledger_db is slow (because of a race), then this value may be very low, much older than the actual current number of blocks."

### In this PR
* At the DB level, enforce that a new ingress key can't specify a start block that's higher than the highest known block index

Fixes requirement 1 of this [ticket](https://app.asana.com/0/1200353042931237/1201342064475415/f). 

### Future Work
* Investigate if fog view should retrieve the highest known block count from the DB

