### PR TITLE
Update link in `transaction/core/README.md`

### DIFF
--- a/transaction/core/README.md
+++ b/transaction/core/README.md
@@ -12,7 +12,7 @@ This crate provides a `no_std` implementation of the MobileCoin transaction.
 
 ### References
 
-* [CryptoNote Whitepaper](https://cryptonote.org/whitepaper.pdf)
+* [CryptoNote Whitepaper](https://bytecoin.org/old/whitepaper.pdf)
 * [CryptoNote One Time Addresses](https://cryptonote.org/cns/cns007.txt)
 * [Ring Signatures: How to Leak a Secret](https://www.iacr.org/archive/asiacrypt2001/22480554.pdf)
 * [Ring Confidential Transactions](https://eprint.iacr.org/2015/1098.pdf)


### PR DESCRIPTION
The `CryptoNote Whitepaper` has moved, so has the `CryptoNote One Time Addresses` but I can't find its new location

Soundtrack of this PR: [Ivy Lab - Stacked](https://www.youtube.com/watch?v=XOD4WFhTrSg)

### Motivation

Reading docs and found an out of date link

### In this PR

Update whitepaper link.

### Future Work
- Find location of the `CryptoNote One Time Addresses`

