### PR TITLE
Use slip10 accounts instead of legacy root entropy in internal testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,6 +4961,7 @@ dependencies = [
  "base64 0.13.0",
  "hex",
  "mc-account-keys",
+ "mc-account-keys-slip10",
  "mc-api",
  "mc-crypto-rand",
  "mc-util-from-random",

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
     let accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_slip10_identities(
         config.sample_data_dir.join(Path::new("keys")),
     )
-    .expect("Could not read default slip10 identities from keys/")
+    .expect("Could not read default slip10 identities from keys")
     .iter()
     .map(AccountKey::try_from)
     .collect::<Result<_, _>>()

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -94,23 +94,25 @@ fn main() {
     let config = Config::from_args();
 
     // Read account root_entropies from disk
-    let accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_root_entropies(
+    let accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_slip10_identities(
         config.sample_data_dir.join(Path::new("keys")),
     )
-    .expect("Could not read default root entropies from keys")
+    .expect("Could not read default slip10 identities from keys/")
     .iter()
-    .map(AccountKey::from)
-    .collect();
+    .map(AccountKey::try_from)
+    .collect::<Result<_, _>>()
+    .expect("could not convert slip10 identity to account key");
 
-    let fog_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_root_entropies(
+    let fog_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_slip10_identities(
         config
             .sample_data_dir
             .join(Path::new(&config.fog_keys_subdir)),
     )
     .expect("Could not read fog keys")
     .iter()
-    .map(AccountKey::from)
-    .collect();
+    .map(AccountKey::try_from)
+    .collect::<Result<_, _>>()
+    .expect("could not convert slip10 identity to account key");
 
     // Open the ledger_db to process the bootstrapped ledger
     log::info!(logger, "Loading ledger");

--- a/fog/sample-paykit/proto/remote_wallet.proto
+++ b/fog/sample-paykit/proto/remote_wallet.proto
@@ -32,8 +32,8 @@ service RemoteWalletApi {
 }
 
 message FreshBalanceCheckRequest {
-    /// Root entropy for the account the new client will be using.
-    bytes root_entropy = 1;
+    /// Slip10 key for the account the new client will be using.
+    bytes slip10_key = 1;
 
     /// FOG URI (should have view and ledger servers accessible).
     string fog_uri = 2;

--- a/fog/sample-paykit/src/bin/balance_check.rs
+++ b/fog/sample-paykit/src/bin/balance_check.rs
@@ -21,6 +21,7 @@ use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_util_uri::ConsensusClientUri;
 use serde_json::json;
 use std::{
+    convert::TryFrom,
     io::{ErrorKind, Read},
     path::PathBuf,
     str::FromStr,
@@ -52,7 +53,8 @@ fn main() {
 
     let root_identity =
         mc_util_keyfile::read_keyfile(config.keyfile).expect("Could not read private key file");
-    let account_key = AccountKey::from(&root_identity);
+    let account_key = AccountKey::try_from(&root_identity)
+        .expect("Could not convert private key file to account key");
 
     // Note: The balance check program is not supposed to submit anything to
     // consensus or talk to consensus, so this is just a dummy value

--- a/fog/sample-paykit/src/bin/sample_paykit_remote_wallet.rs
+++ b/fog/sample-paykit/src/bin/sample_paykit_remote_wallet.rs
@@ -5,7 +5,7 @@
 //! the sample paykit.
 
 use grpcio::{RpcContext, RpcStatus, UnarySink};
-use mc_account_keys::{AccountKey, RootEntropy, RootIdentity};
+use mc_account_keys::AccountKey;
 use mc_common::logger::{create_root_logger, log, Logger};
 use mc_fog_sample_paykit::{
     empty::Empty,
@@ -20,9 +20,10 @@ use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, send_result, ConnectionUriGrpcioServer,
 };
+use mc_util_keyfile::Slip10IdentityJson;
 use mc_util_uri::{ConsensusClientUri, Uri, UriScheme};
 use std::{
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     str::FromStr,
     sync::{Arc, Mutex},
     thread::sleep,
@@ -76,16 +77,16 @@ impl RemoteWalletService {
         &self,
         request: FreshBalanceCheckRequest,
     ) -> Result<BalanceCheckResponse, RpcStatus> {
-        let id = Slip10Identity {
-            slip10_key: request
-                .slip10_key
+        let id = Slip10IdentityJson {
+            slip10_key: (&request.slip10_key[..])
                 .try_into()
                 .map_err(|err| rpc_invalid_arg_error("slip10 key", err, &self.logger))?,
-            ..Default::Default()
+            ..Default::default()
         };
 
-        let account_key = AccountKey::try_from(&id)
-            .map_err(|err| rpc_invalid_arg_error("could not build account key", err, &self.logger));
+        let account_key = AccountKey::try_from(&id).map_err(|err| {
+            rpc_invalid_arg_error("could not build account key", err, &self.logger)
+        })?;
 
         // Note: The balance check program is not supposed to submit anything to
         // consensus or talk to consensus, so this is just a dummy value

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -8,7 +8,7 @@ use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{AdminUri, ConsensusClientUri};
 use serde::Serialize;
-use std::{convert::TryFrom, path::PathBuf, str::FromStr, time::Duration};
+use std::{convert::TryFrom, path::PathBuf, time::Duration};
 use structopt::StructOpt;
 
 /// StructOpt for test-client binary

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -8,7 +8,7 @@ use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{AdminUri, ConsensusClientUri};
 use serde::Serialize;
-use std::{path::PathBuf, time::Duration};
+use std::{convert::TryFrom, path::PathBuf, str::FromStr, time::Duration};
 use structopt::StructOpt;
 
 /// StructOpt for test-client binary
@@ -126,12 +126,13 @@ impl TestClientConfig {
 
         // Load the key files
         log::info!(logger, "Loading account keys from {:?}", key_dir);
-        mc_util_keyfile::keygen::read_default_root_entropies(&key_dir)
+        mc_util_keyfile::keygen::read_default_slip10_identities(&key_dir)
             .unwrap()
             .iter()
             .take(self.num_clients)
-            .map(AccountKey::from)
-            .collect()
+            .map(AccountKey::try_from)
+            .collect::<Result<_, _>>()
+            .expect("Could not decode slip10 account key")
     }
 }
 

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -100,13 +100,17 @@ fn main() {
     let fog_pubkey = RistrettoPublic::try_from(&config.fog_pubkey)
         .expect("Could not parse fog_pubkey as Ristretto");
 
-    // Read user root entropy keys from disk
-    let root_entropies = mc_util_keyfile::keygen::read_default_root_entropies(config.keys)
-        .expect("Could not read root identity files");
-    assert_ne!(0, root_entropies.len());
+    // Read user slip10 identities from disk
+    let slip10_identities = mc_util_keyfile::keygen::read_default_slip10_identities(config.keys)
+        .expect("Could not read slip10 identity files");
+    assert_ne!(0, slip10_identities.len());
 
     // Create account keys from this
-    let account_keys: Vec<AccountKey> = root_entropies.iter().map(AccountKey::from).collect();
+    let account_keys: Vec<AccountKey> = slip10_identities
+        .iter()
+        .map(AccountKey::try_from)
+        .collect::<Result<Vec<AccountKey>, _>>()
+        .expect("Could not convert private key file to account key");
 
     // Open the ledger db
     let mut ledger = LedgerDB::open(&config.ledger).expect("Could not open ledger db");

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -11,6 +11,7 @@ use mc_fog_uri::FogViewUri;
 use mc_fog_view_connection::FogViewGrpcClient;
 use mc_fog_view_protocol::FogViewConnection;
 use std::{
+    convert::TryFrom,
     path::PathBuf,
     str::FromStr,
     sync::{
@@ -77,7 +78,8 @@ fn main() {
 
     let root_identity =
         mc_util_keyfile::read_keyfile(config.keyfile).expect("Could not read private key file");
-    let account_key = AccountKey::from(&root_identity);
+    let account_key = AccountKey::try_from(&root_identity)
+        .expect("Could not convert private key file to account key");
 
     let num_reqs = Arc::new(AtomicU64::new(0));
     for _ in 0..config.num_workers {

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -26,7 +26,7 @@ service MobilecoindAPI {
     rpc GenerateRootEntropy (google.protobuf.Empty) returns (GenerateRootEntropyResponse) {}
     rpc GenerateMnemonic (google.protobuf.Empty) returns (GenerateMnemonicResponse) {}
     rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
-    rpc GetAccountKeyFromSlip10 (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
+    rpc GetAccountKeyFromSlip10 (GetAccountKeyFromSlip10Request) returns (GetAccountKeyResponse) {}
     rpc GetAccountKeyFromMnemonic (GetAccountKeyFromMnemonicRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -26,6 +26,7 @@ service MobilecoindAPI {
     rpc GenerateRootEntropy (google.protobuf.Empty) returns (GenerateRootEntropyResponse) {}
     rpc GenerateMnemonic (google.protobuf.Empty) returns (GenerateMnemonicResponse) {}
     rpc GetAccountKeyFromRootEntropy (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
+    rpc GetAccountKeyFromSlip10 (GetAccountKeyFromRootEntropyRequest) returns (GetAccountKeyResponse) {}
     rpc GetAccountKeyFromMnemonic (GetAccountKeyFromMnemonicRequest) returns (GetAccountKeyResponse) {}
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
 
@@ -333,6 +334,13 @@ message GenerateMnemonicResponse {
 message GetAccountKeyFromRootEntropyRequest {
     bytes root_entropy = 1;
 }
+
+// Generate an AccountKey from a 32 byte slip10 value.
+message GetAccountKeyFromSlip10Request {
+    bytes slip10_key = 1;
+}
+
+
 // Generate an AccountKey from a mnemonic.
 message GetAccountKeyFromMnemonicRequest {
     string mnemonic = 1;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -17,7 +17,7 @@ use crate::{
 use bip39::{Language, Mnemonic, MnemonicType};
 use grpcio::{EnvBuilder, RpcContext, RpcStatus, RpcStatusCode, ServerBuilder, UnarySink};
 use mc_account_keys::{AccountKey, PublicAddress, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
-use mc_account_keys_slip10::Slip10KeyGenerator;
+use mc_account_keys_slip10::{Slip10Key, Slip10KeyGenerator};
 use mc_common::{
     logger::{log, Logger},
     HashMap,
@@ -381,7 +381,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_account_key_from_slip10_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest,
+        request: mc_mobilecoind_api::GetAccountKeyFromSlip10Request,
     ) -> Result<mc_mobilecoind_api::GetAccountKeyResponse, RpcStatus> {
         // Get the entropy.
         if request.get_slip10_key().len() != 32 {
@@ -395,7 +395,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut slip10_key = [0u8; 32];
         slip10_key.copy_from_slice(request.get_slip10_key());
         let key = Slip10Key::from(slip10_key);
-        let account_key = AccountKey::from(&key);
+        let account_key = AccountKey::from(key);
 
         // Return response.
         let mut response = mc_mobilecoind_api::GetAccountKeyResponse::new();
@@ -1884,7 +1884,7 @@ build_api! {
     generate_root_entropy Empty GenerateRootEntropyResponse generate_root_entropy_impl,
     generate_mnemonic Empty GenerateMnemonicResponse generate_mnemonic_impl,
     get_account_key_from_root_entropy GetAccountKeyFromRootEntropyRequest GetAccountKeyResponse get_account_key_from_root_entropy_impl,
-    get_account_key_from_slip10 GetAccountKeyFromSlip10Request GetAccountKeyResponse get_account_key_from_slip10_key_impl,
+    get_account_key_from_slip10 GetAccountKeyFromSlip10Request GetAccountKeyResponse get_account_key_from_slip10_impl,
     get_account_key_from_mnemonic GetAccountKeyFromMnemonicRequest GetAccountKeyResponse get_account_key_from_mnemonic_impl,
     get_public_address GetPublicAddressRequest GetPublicAddressResponse get_public_address_impl,
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -379,6 +379,30 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         Ok(response)
     }
 
+    fn get_account_key_from_slip10_impl(
+        &mut self,
+        request: mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest,
+    ) -> Result<mc_mobilecoind_api::GetAccountKeyResponse, RpcStatus> {
+        // Get the entropy.
+        if request.get_slip10_key().len() != 32 {
+            return Err(RpcStatus::with_message(
+                RpcStatusCode::INVALID_ARGUMENT,
+                "entropy".into(),
+            ));
+        }
+
+        // Use slip10_key to construct AccountKey.
+        let mut slip10_key = [0u8; 32];
+        slip10_key.copy_from_slice(request.get_slip10_key());
+        let key = Slip10Key::from(slip10_key);
+        let account_key = AccountKey::from(&key);
+
+        // Return response.
+        let mut response = mc_mobilecoind_api::GetAccountKeyResponse::new();
+        response.set_account_key((&account_key).into());
+        Ok(response)
+    }
+
     fn get_account_key_from_mnemonic_impl(
         &mut self,
         request: mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest,
@@ -1860,6 +1884,7 @@ build_api! {
     generate_root_entropy Empty GenerateRootEntropyResponse generate_root_entropy_impl,
     generate_mnemonic Empty GenerateMnemonicResponse generate_mnemonic_impl,
     get_account_key_from_root_entropy GetAccountKeyFromRootEntropyRequest GetAccountKeyResponse get_account_key_from_root_entropy_impl,
+    get_account_key_from_slip10 GetAccountKeyFromSlip10Request GetAccountKeyResponse get_account_key_from_slip10_key_impl,
     get_account_key_from_mnemonic GetAccountKeyFromMnemonicRequest GetAccountKeyResponse get_account_key_from_mnemonic_impl,
     get_public_address GetPublicAddressRequest GetPublicAddressResponse get_public_address_impl,
 

--- a/mobilecoind/strategies/accounts.py
+++ b/mobilecoind/strategies/accounts.py
@@ -38,7 +38,7 @@ def register_account(key_data, stub) -> AccountData:
     # Generate an account key from this root entropy
     resp = stub.GetAccountKeyFromRootEntropy(
         mobilecoind_api_pb2.GetAccountKeyFromRootEntropyRequest(
-            root_entropy=bytes(key_data['root_entropy'])))
+            slip10_key=bytes.fromhex(key_data['slip10_key'])))
     account_key = resp.account_key
 
     # Add this account to the wallet

--- a/mobilecoind/strategies/accounts.py
+++ b/mobilecoind/strategies/accounts.py
@@ -37,7 +37,7 @@ def connect(host, port):
 def register_account(key_data, stub) -> AccountData:
     # Generate an account key from this root entropy
     resp = stub.GetAccountKeyFromRootEntropy(
-        mobilecoind_api_pb2.GetAccountKeyFromRootEntropyRequest(
+        mobilecoind_api_pb2.GetAccountKeyFromSlip10Request(
             slip10_key=bytes.fromhex(key_data['slip10_key'])))
     account_key = resp.account_key
 

--- a/slam/src/main.rs
+++ b/slam/src/main.rs
@@ -103,17 +103,18 @@ fn main() {
     let config = SlamConfig::from_args();
 
     // Read account root_entropies from disk
-    let accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_root_entropies(
+    let accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_slip10_identities(
         config.sample_data_dir.join(Path::new("keys")),
     )
-    .expect("Could not read default root entropies from keys")
+    .expect("Could not read default slip10 identies from keys/")
     .iter()
     .map(|x| {
         let mut root_id = x.clone();
         root_id.fog_report_url = Default::default();
-        AccountKey::from(&root_id)
+        AccountKey::try_from(&root_id)
     })
-    .collect();
+    .collect::<Result<_, _>>()
+    .expect("Could not derive account key from slip10 identities");
 
     // Open the ledger_db to process the bootstrapped ledger
     log::info!(logger, "Loading ledger");

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -154,7 +154,7 @@ class RemoteWallet:
         with grpc.insecure_channel(self.remote_wallet_host_port) as channel:
             stub = remote_wallet_pb2_grpc.RemoteWalletApiStub(channel)
             response = self._retrying_grpc_request(stub.FreshBalanceCheck, remote_wallet_pb2.FreshBalanceCheckRequest(
-                root_entropy=bytes(key['root_entropy']),
+                slip10_key=bytes(key['slip10_key']),
                 fog_uri=self.fog_url,
             ))
 

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -154,7 +154,7 @@ class RemoteWallet:
         with grpc.insecure_channel(self.remote_wallet_host_port) as channel:
             stub = remote_wallet_pb2_grpc.RemoteWalletApiStub(channel)
             response = self._retrying_grpc_request(stub.FreshBalanceCheck, remote_wallet_pb2.FreshBalanceCheckRequest(
-                slip10_key=bytes(key['slip10_key']),
+                slip10_key=key['slip10_key'],
                 fog_uri=self.fog_url,
             ))
 

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -154,7 +154,7 @@ class RemoteWallet:
         with grpc.insecure_channel(self.remote_wallet_host_port) as channel:
             stub = remote_wallet_pb2_grpc.RemoteWalletApiStub(channel)
             response = self._retrying_grpc_request(stub.FreshBalanceCheck, remote_wallet_pb2.FreshBalanceCheckRequest(
-                slip10_key=key['slip10_key'],
+                slip10_key=bytes.fromhex(key['slip10_key']),
                 fog_uri=self.fog_url,
             ))
 

--- a/util/from-random/src/lib.rs
+++ b/util/from-random/src/lib.rs
@@ -13,3 +13,11 @@ pub trait FromRandom: Sized {
     /// Using a mutable RNG, take it's output to securely initialize the object
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> Self;
 }
+
+impl FromRandom for [u8; 32] {
+    fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> [u8; 32] {
+        let mut result = [0u8; 32];
+        csprng.fill_bytes(&mut result);
+        result
+    }
+}

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/bin/read_pubfile.rs"
 
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
+mc-account-keys-slip10 = { path = "../../account-keys/slip10" }
 mc-api = { path = "../../api" }
 mc-crypto-rand = { path = "../../crypto/rand" }
 mc-util-from-random = { path = "../../util/from-random" }

--- a/util/keyfile/src/bin/keygen_main.rs
+++ b/util/keyfile/src/bin/keygen_main.rs
@@ -2,8 +2,7 @@
 
 //! A CLI tool for generating individual MobileCoin identities
 
-use mc_account_keys::{RootEntropy, RootIdentity};
-use mc_util_keyfile::config::Config;
+use mc_util_keyfile::{config::Config, Slip10IdentityJson};
 use structopt::StructOpt;
 
 fn main() {
@@ -15,10 +14,10 @@ fn main() {
 
     let fog_url = config.acct.clone();
     let name = config.name.clone();
-    let root_entropy = config.get_root_entropy();
+    let entropy = config.get_root_entropy();
 
-    let id = RootIdentity {
-        root_entropy: RootEntropy::from(&root_entropy),
+    let id = Slip10IdentityJson {
+        slip10_key: entropy,
         fog_report_url: fog_url.unwrap_or_default(),
         fog_report_id: Default::default(),
         fog_authority_spki: Default::default(),

--- a/util/keyfile/src/bin/main.rs
+++ b/util/keyfile/src/bin/main.rs
@@ -9,7 +9,7 @@ use mc_util_keyfile::Slip10IdentityJson;
 use std::convert::TryFrom;
 
 fn main() {
-    let root_id: Slip10IdentityJson = {
+    let slip10_id: Slip10IdentityJson = {
         let args: Vec<String> = std::env::args().collect();
         match args.get(1) {
             None => mc_util_keyfile::read_keyfile_data(&mut std::io::stdin())
@@ -18,6 +18,6 @@ fn main() {
                 .unwrap_or_else(|_| panic!("Failed when reading from {}", arg)),
         }
     };
-    let acct_key = AccountKey::try_from(&root_id).expect("Failed to build account key");
-    println!("{:?}\n{:?}", root_id, acct_key,);
+    let acct_key = AccountKey::try_from(&slip10_id).expect("Failed to build account key");
+    println!("{:?}\n{:?}", slip10_id, acct_key,);
 }

--- a/util/keyfile/src/bin/main.rs
+++ b/util/keyfile/src/bin/main.rs
@@ -4,10 +4,12 @@
 //! Reads .bin file on stdin, or a path to .bin file, emits description on
 //! stdout
 
-use mc_account_keys::{AccountKey, RootIdentity};
+use mc_account_keys::AccountKey;
+use mc_util_keyfile::Slip10IdentityJson;
+use std::convert::TryFrom;
 
 fn main() {
-    let root_id: RootIdentity = {
+    let root_id: Slip10IdentityJson = {
         let args: Vec<String> = std::env::args().collect();
         match args.get(1) {
             None => mc_util_keyfile::read_keyfile_data(&mut std::io::stdin())
@@ -16,6 +18,6 @@ fn main() {
                 .unwrap_or_else(|_| panic!("Failed when reading from {}", arg)),
         }
     };
-    let acct_key = AccountKey::from(&root_id);
+    let acct_key = AccountKey::try_from(&root_id).expect("Failed to build account key");
     println!("{:?}\n{:?}", root_id, acct_key,);
 }

--- a/util/keyfile/src/json_format.rs
+++ b/util/keyfile/src/json_format.rs
@@ -1,22 +1,95 @@
-//! We mostly try to serialize our types using protobuf,
-//! but early in the project we were using a json-based representation of
-//! account key root entropy. As part of our CD, we maintain the
-//! strategies/test_client code based on this format.
-//!
-//! It is NOT RECOMMENDED to use this for new code, please use protobuf
-//! RootIdentity This is only being used in the .json files.
+//! JSON formats for private keys together with fog data.
+//! Files formatted in this way are sufficient to derive an account key in
+//! a self-contained way without any context, which is useful for many tools.
 
-use mc_account_keys::{RootEntropy, RootIdentity};
-use serde::{Deserialize, Serialize};
+use core::convert::TryFrom;
+use mc_account_keys::{AccountKey, RootEntropy, RootIdentity};
+use mc_account_keys_slip10::{Error as AccountKeyError, Slip10Key};
+use mc_crypto_rand::{CryptoRng, RngCore};
+use mc_util_from_random::FromRandom;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// JSON schema for a slip10 identity
+#[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Serialize, Deserialize)]
+pub struct Slip10IdentityJson {
+    /// Slip10 key
+    #[serde(serialize_with = "as_hex", deserialize_with = "from_hex")]
+    pub slip10_key: [u8; 32],
+    /// User's fog report url, if any.
+    pub fog_report_url: String,
+    /// User's report id, if any.
+    pub fog_report_id: String,
+    /// User's fog authority subjectPublicKeyInfo bytes, if any
+    pub fog_authority_spki: Vec<u8>,
+}
+
+impl Slip10IdentityJson {
+    /// Construct an identity without fog and with a random slip10 key
+    pub fn random<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
+        Self {
+            slip10_key: FromRandom::from_random(rng),
+            ..Default::default()
+        }
+    }
+
+    /// Construct an identity with fog and with a random slip10 key
+    pub fn random_with_fog<T: RngCore + CryptoRng>(
+        rng: &mut T,
+        fog_report_url: &str,
+        fog_report_id: &str,
+        fog_authority_spki: &[u8],
+    ) -> Self {
+        let mut result = Self::random(rng);
+
+        if !fog_report_url.is_empty() {
+            result.fog_report_url = fog_report_url.to_owned();
+            result.fog_report_id = fog_report_id.to_owned();
+            result.fog_authority_spki = fog_authority_spki.to_owned();
+        }
+
+        result
+    }
+}
+
+impl TryFrom<&Slip10IdentityJson> for AccountKey {
+    type Error = AccountKeyError;
+    fn try_from(src: &Slip10IdentityJson) -> Result<AccountKey, AccountKeyError> {
+        Slip10Key::from(src.slip10_key.clone()).try_into_account_key(
+            &src.fog_report_url,
+            &src.fog_report_id,
+            &src.fog_authority_spki,
+        )
+    }
+}
+
+fn as_hex<S>(key: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&hex::encode(&key[..]))
+}
+
+fn from_hex<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+    String::deserialize(deserializer)
+        .and_then(|string| hex::decode(&string).map_err(|err| Error::custom(err.to_string())))
+        .and_then(|bytes| {
+            <[u8; 32] as TryFrom<&[u8]>>::try_from(&bytes)
+                .map_err(|err| Error::custom(err.to_string()))
+        })
+}
 
 /// Historical JSON schema for a root identity
 #[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct RootIdentityJson {
     /// Root entropy used to derive a user's private keys.
     pub root_entropy: [u8; 32],
-    /// User's account server, if any.
+    /// User's fog url, if any.
     pub fog_url: String,
-    /// User's report id
+    /// User's report id, if any.
     pub fog_report_id: String,
     /// User's fog authority subjectPublicKeyInfo bytes, if any
     pub fog_authority_spki: Vec<u8>,

--- a/util/keyfile/src/json_format.rs
+++ b/util/keyfile/src/json_format.rs
@@ -54,7 +54,7 @@ impl Slip10IdentityJson {
 impl TryFrom<&Slip10IdentityJson> for AccountKey {
     type Error = AccountKeyError;
     fn try_from(src: &Slip10IdentityJson) -> Result<AccountKey, AccountKeyError> {
-        Slip10Key::from(src.slip10_key.clone()).try_into_account_key(
+        Slip10Key::from(src.slip10_key).try_into_account_key(
             &src.fog_report_url,
             &src.fog_report_id,
             &src.fog_authority_spki,

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -4,11 +4,13 @@
 //! corresponding to `mc_account_keys::RootIdentity`, and
 //! `mc_account_keys::PublicAddress` respectively.
 
-use crate::{read_keyfile, read_pubfile, write_b58pubfile, write_keyfile, write_pubfile};
-use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
+use crate::{
+    read_keyfile, read_pubfile, write_b58pubfile, write_keyfile, write_pubfile, Slip10IdentityJson,
+};
+use mc_account_keys::{AccountKey, PublicAddress};
 use rand::SeedableRng;
 use rand_hc::Hc128Rng as FixedRng;
-use std::{cmp::Ordering, ffi::OsStr, fs, path::Path};
+use std::{cmp::Ordering, convert::TryFrom, ffi::OsStr, fs, path::Path};
 
 pub const DEFAULT_SEED: [u8; 32] = [1; 32];
 
@@ -16,9 +18,10 @@ pub const DEFAULT_SEED: [u8; 32] = [1; 32];
 pub fn write_keyfiles<P: AsRef<Path>>(
     path: P,
     name: &str,
-    root_id: &RootIdentity,
+    root_id: &Slip10IdentityJson,
 ) -> Result<(), std::io::Error> {
-    let acct_key = AccountKey::from(root_id);
+    let acct_key = AccountKey::try_from(root_id)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?;
     let addr = acct_key.default_subaddress();
 
     fs::create_dir_all(&path)?;
@@ -49,14 +52,14 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
 
     // Generate user keys
     for i in 0..num_accounts {
-        let root_id = RootIdentity::random_with_fog(
+        let id = Slip10IdentityJson::random_with_fog(
             &mut keys_rng,
             fog_url.unwrap_or(""),
             fog_report_id.unwrap_or_default(),
             fog_authority_spki.unwrap_or_default(),
         );
 
-        write_keyfiles(path.as_ref(), &keyfile_name(i), &root_id)?;
+        write_keyfiles(path.as_ref(), &keyfile_name(i), &id)?;
     }
     Ok(())
 }
@@ -80,10 +83,10 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(
     Ok(result)
 }
 
-// Read default root entropies
-pub fn read_default_root_entropies<P: AsRef<Path>>(
+// Read default slip10 identites
+pub fn read_default_slip10_identities<P: AsRef<Path>>(
     path: P,
-) -> Result<Vec<RootIdentity>, std::io::Error> {
+) -> Result<Vec<Slip10IdentityJson>, std::io::Error> {
     let mut entries = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
@@ -92,7 +95,7 @@ pub fn read_default_root_entropies<P: AsRef<Path>>(
         }
     }
     entries.sort_by(|a, b| compare_keyfile_names(a, b));
-    let result: Vec<RootIdentity> = entries
+    let result: Vec<Slip10IdentityJson> = entries
         .iter()
         .map(|f| read_keyfile(f).expect("Could not read keyfile"))
         .collect();
@@ -168,8 +171,8 @@ mod testing {
             assert_eq!(&pub1[..], &pub2[..]);
         }
         {
-            let bin1 = read_default_root_entropies(&dir1).unwrap();
-            let bin2 = read_default_root_entropies(&dir2).unwrap();
+            let bin1 = read_default_slip10_identities(&dir1).unwrap();
+            let bin2 = read_default_slip10_identities(&dir2).unwrap();
 
             assert_eq!(bin1.len(), 10);
             assert_eq!(bin2.len(), 10);
@@ -194,8 +197,8 @@ mod testing {
             assert_eq!(&pub1[..], &pub2[..]);
         }
         {
-            let bin1 = read_default_root_entropies(&dir1).unwrap();
-            let bin2 = read_default_root_entropies(&dir2).unwrap();
+            let bin1 = read_default_slip10_identities(&dir1).unwrap();
+            let bin2 = read_default_slip10_identities(&dir2).unwrap();
 
             assert_eq!(bin1.len(), 10);
             assert_eq!(bin2.len(), 10);
@@ -210,55 +213,88 @@ mod testing {
         write_default_keyfiles(&dir1, 10, None, None, None, DEFAULT_SEED).unwrap();
 
         {
-            let bin1 = read_default_root_entropies(&dir1).unwrap();
+            let bin1 = read_default_slip10_identities(&dir1).unwrap();
             assert_eq!(bin1.len(), 10);
             // Order doesn't matter for the keys - just that they are all processed.
-            let bin_set: HashSet<RootIdentity> = HashSet::from_iter(bin1.iter().cloned());
+            let bin_set: HashSet<Slip10IdentityJson> = HashSet::from_iter(bin1.iter().cloned());
             let expected = vec![
-                RootIdentity::from(&[
-                    2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82, 109,
-                    40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
-                ]),
-                RootIdentity::from(&[
-                    145, 231, 241, 91, 240, 144, 214, 193, 230, 37, 152, 119, 69, 3, 60, 14, 43,
-                    117, 90, 203, 54, 133, 25, 210, 33, 104, 135, 216, 57, 67, 62, 212,
-                ]),
-                RootIdentity::from(&[
-                    29, 186, 225, 89, 96, 98, 80, 144, 202, 70, 150, 149, 157, 150, 60, 120, 14,
-                    200, 137, 235, 152, 231, 77, 80, 71, 212, 32, 82, 69, 206, 81, 55,
-                ]),
-                RootIdentity::from(&[
-                    28, 126, 75, 230, 193, 96, 159, 197, 223, 166, 62, 106, 153, 87, 184, 180, 126,
-                    12, 188, 128, 238, 64, 134, 207, 195, 142, 37, 20, 117, 39, 246, 63,
-                ]),
-                RootIdentity::from(&[
-                    86, 38, 184, 6, 231, 115, 110, 86, 143, 103, 115, 30, 138, 38, 216, 229, 129,
-                    195, 47, 10, 175, 253, 198, 67, 251, 189, 171, 114, 161, 235, 87, 8,
-                ]),
-                RootIdentity::from(&[
-                    77, 190, 236, 181, 53, 105, 80, 210, 166, 168, 216, 199, 228, 200, 146, 11,
-                    243, 21, 55, 191, 160, 155, 194, 74, 110, 129, 37, 21, 75, 113, 65, 97,
-                ]),
-                RootIdentity::from(&[
-                    79, 213, 120, 85, 72, 42, 9, 104, 143, 186, 253, 144, 137, 115, 37, 43, 155,
-                    47, 60, 75, 157, 110, 124, 55, 155, 101, 175, 167, 95, 235, 51, 66,
-                ]),
-                RootIdentity::from(&[
-                    235, 248, 189, 155, 66, 104, 44, 250, 214, 183, 186, 1, 207, 223, 8, 175, 44,
-                    56, 144, 124, 175, 51, 183, 218, 248, 136, 152, 109, 7, 181, 84, 156,
-                ]),
-                RootIdentity::from(&[
-                    114, 112, 34, 231, 208, 185, 252, 112, 117, 246, 59, 224, 40, 126, 182, 209,
-                    39, 130, 89, 86, 102, 77, 203, 73, 253, 88, 59, 238, 85, 130, 15, 200,
-                ]),
-                RootIdentity::from(&[
-                    79, 44, 181, 167, 130, 174, 148, 20, 20, 23, 100, 145, 154, 136, 48, 168, 119,
-                    124, 91, 161, 187, 53, 159, 117, 252, 55, 199, 84, 204, 164, 37, 64,
-                ]),
-                RootIdentity::from(&[
-                    2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82, 109,
-                    40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
-                ]),
+                Slip10IdentityJson {
+                    slip10_key: [
+                        2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82,
+                        109, 40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        145, 231, 241, 91, 240, 144, 214, 193, 230, 37, 152, 119, 69, 3, 60, 14,
+                        43, 117, 90, 203, 54, 133, 25, 210, 33, 104, 135, 216, 57, 67, 62, 212,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        29, 186, 225, 89, 96, 98, 80, 144, 202, 70, 150, 149, 157, 150, 60, 120,
+                        14, 200, 137, 235, 152, 231, 77, 80, 71, 212, 32, 82, 69, 206, 81, 55,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        28, 126, 75, 230, 193, 96, 159, 197, 223, 166, 62, 106, 153, 87, 184, 180,
+                        126, 12, 188, 128, 238, 64, 134, 207, 195, 142, 37, 20, 117, 39, 246, 63,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        86, 38, 184, 6, 231, 115, 110, 86, 143, 103, 115, 30, 138, 38, 216, 229,
+                        129, 195, 47, 10, 175, 253, 198, 67, 251, 189, 171, 114, 161, 235, 87, 8,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        77, 190, 236, 181, 53, 105, 80, 210, 166, 168, 216, 199, 228, 200, 146, 11,
+                        243, 21, 55, 191, 160, 155, 194, 74, 110, 129, 37, 21, 75, 113, 65, 97,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        79, 213, 120, 85, 72, 42, 9, 104, 143, 186, 253, 144, 137, 115, 37, 43,
+                        155, 47, 60, 75, 157, 110, 124, 55, 155, 101, 175, 167, 95, 235, 51, 66,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        235, 248, 189, 155, 66, 104, 44, 250, 214, 183, 186, 1, 207, 223, 8, 175,
+                        44, 56, 144, 124, 175, 51, 183, 218, 248, 136, 152, 109, 7, 181, 84, 156,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        114, 112, 34, 231, 208, 185, 252, 112, 117, 246, 59, 224, 40, 126, 182,
+                        209, 39, 130, 89, 86, 102, 77, 203, 73, 253, 88, 59, 238, 85, 130, 15, 200,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        79, 44, 181, 167, 130, 174, 148, 20, 20, 23, 100, 145, 154, 136, 48, 168,
+                        119, 124, 91, 161, 187, 53, 159, 117, 252, 55, 199, 84, 204, 164, 37, 64,
+                    ],
+                    ..Default::default()
+                },
+                Slip10IdentityJson {
+                    slip10_key: [
+                        2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64, 82,
+                        109, 40, 35, 89, 36, 57, 5, 241, 163, 13, 184, 42, 158, 89, 124,
+                    ],
+                    ..Default::default()
+                },
             ];
 
             assert_eq!(bin_set, HashSet::from_iter(expected.iter().cloned()),);

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -1,39 +1,40 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 mod json_format;
+pub use json_format::Slip10IdentityJson;
 
 pub mod config;
 pub mod keygen;
 
-use json_format::RootIdentityJson;
-use mc_account_keys::{PublicAddress, RootIdentity};
+use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
 use std::{convert::TryInto, fs::File, io::prelude::*, path::Path};
 
 /// Write user root identity to disk
 pub fn write_keyfile<P: AsRef<Path>>(
     path: P,
-    root_id: &RootIdentity,
+    id: &Slip10IdentityJson,
 ) -> Result<(), std::io::Error> {
-    let json = RootIdentityJson::from(root_id);
-    File::create(path)?.write_all(&serde_json::to_vec(&json).map_err(to_io_error)?)?;
+    File::create(path)?.write_all(&serde_json::to_vec(&id).map_err(to_io_error)?)?;
     Ok(())
 }
 
 /// Read user root identity from disk
-pub fn read_keyfile<P: AsRef<Path>>(path: P) -> Result<RootIdentity, std::io::Error> {
+pub fn read_keyfile<P: AsRef<Path>>(path: P) -> Result<Slip10IdentityJson, std::io::Error> {
     read_keyfile_data(&mut File::open(path)?)
 }
 
 /// Read user root identity from any implementor of `Read`
-pub fn read_keyfile_data<R: std::io::Read>(buffer: &mut R) -> Result<RootIdentity, std::io::Error> {
+pub fn read_keyfile_data<R: std::io::Read>(
+    buffer: &mut R,
+) -> Result<Slip10IdentityJson, std::io::Error> {
     let data = {
         let mut data = Vec::new();
         buffer.read_to_end(&mut data)?;
         data
     };
-    let result: RootIdentityJson = serde_json::from_slice(&data).map_err(to_io_error)?;
-    Ok(RootIdentity::from(result))
+    let result: Slip10IdentityJson = serde_json::from_slice(&data).map_err(to_io_error)?;
+    Ok(result)
 }
 
 /// Write user public address to disk
@@ -136,7 +137,6 @@ mod testing {
     use super::*;
 
     use mc_account_keys::AccountKey;
-    use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
     use tempdir::TempDir;
 
@@ -146,7 +146,7 @@ mod testing {
         let dir = TempDir::new("test").unwrap();
 
         {
-            let entropy = RootIdentity::from_random(&mut rng);
+            let entropy = Slip10IdentityJson::random(&mut rng);
             let f1 = dir.path().join("f1");
             write_keyfile(&f1, &entropy).unwrap();
             let result = read_keyfile(&f1).unwrap();
@@ -154,7 +154,7 @@ mod testing {
         }
 
         {
-            let entropy = RootIdentity::random_with_fog(
+            let entropy = Slip10IdentityJson::random_with_fog(
                 &mut rng,
                 "fog://foobar.com",
                 "",


### PR DESCRIPTION
This migrates the `mc-util-keyfile` crate to write private key json
files containing slip10 root entropies instead of the legacy root entropy.
The legacy root entropies are deprecated but they must still exist
in some capacity because there are accounts with money on them IRL.

This will simplify the effort to get uniform integration tests
because many wallet products may never implement root entropies.

The bootstrap program does not need to be touched because it only
reads the public key files.

The keygen program is touched, fog-distro is touched, the sample
paykit is touched, the test-client is touched, slam is touched,
but most of the changes are very localized.

The main thing that would make this not work is if someone somewhere
is storing keyfiles in a persistent way, however this is unlikely
and whatever system that is likely needs to be reworked anyways.

This also changes the conformance tests remote wallet API a bit, but
that should also be fine.

---

This WILL eventually impact SDKs because in dev nets we will now be funding the previous "root entropies" but interpreting
those 32 bytes as a slip10 key. If they continue to interpret those bytes as root entropies, then going forward they will have zero balances during testing, for any deployment after this commit.