### PR TITLE
remove unused logging macros

### DIFF
--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -32,66 +32,6 @@ pub fn create_null_logger() -> Logger {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "log")] {
-        /// Wrap calls to assert! macros to record an error message before panic
-        #[macro_export]
-        macro_rules! log_assert {
-            ($logger:expr, $cond:expr) => ({
-                if !$cond {
-                    let cond_str = stringify!($cond);
-                    log::crit!($logger, "assert!({}) failed", cond_str);
-                    std::thread::sleep(Duration::from_millis(500));
-                    panic!("assert!({}) failed", cond_str);
-                }
-            });
-            ($logger:expr, $cond:expr,) => ({
-                if !$cond {
-                    let cond_str = stringify!($cond);
-                    log::crit!($logger, "assert!({}) failed", cond_str);
-                    std::thread::sleep(Duration::from_millis(500));
-                    panic!("assert!({}) failed", cond_str);
-                }
-            });
-            ($logger:expr, $cond:expr, $($arg:tt)+) => ({
-                if !$cond {
-                    let m = format!($($arg)+);
-                    let cond_str = stringify!($cond);
-                    log::crit!($logger, "assert!({}) failed, {}", cond_str, m);
-                    std::thread::sleep(Duration::from_millis(500));
-                    panic!("assert!({}) failed, {}", cond_str, m);
-                }
-            })
-        }
-
-        /// Wrap calls to assert_eq! macros to record an error message before panic
-        #[macro_export]
-        macro_rules! log_assert_eq {
-            ($logger:expr, $left:expr, $right:expr) => ({
-                log_assert!($logger, ($left) == ($right));
-            });
-            ($logger:expr, $left:expr, $right:expr,) => ({
-                log_assert!($logger, ($left) == ($right));
-            });
-            ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
-                let m = format!($($arg)+);
-                log_assert!($logger, ($left) == ($right), "{}", m);
-            })
-        }
-
-        /// Wrap calls to assert_ne! macros to record an error message before panic
-        #[macro_export]
-        macro_rules! log_assert_ne {
-            ($logger:expr, $left:expr, $right:expr) => ({
-                log_assert!($logger, ($left) != ($right));
-            });
-            ($logger:expr, $left:expr, $right:expr,) => ({
-                log_assert!($logger, ($left) != ($right));
-            });
-            ($logger:expr, $left:expr, $right:expr, $($arg:tt)+) => ({
-                let m = format!($($arg)+);
-                log_assert!($logger, ($left) != ($right), "{}", m);
-            })
-        }
-
         /// A global logger, for when passing a Logger instance is impractical.
         pub mod global_log {
             pub use slog_scope::{crit, debug, error, info, trace, warn};


### PR DESCRIPTION
these macros, `log_assert`, `log_assert_eq`, etc. are not used
anywhere in the codebase.

these macros are harmful because the panic handler already logs
the panic to the logger, so using these macros means that you
actually log the assert failure twice. I believe that this may
be why no one is actually using this.

Since this is dead code we should delete it.