### PR TITLE
Less aggressive grpc logs

### DIFF
--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -18,12 +18,12 @@
 /// Expose the standard crit! debug! error! etc macros from slog
 /// (those are the ones that accept a Logger instance)
 pub mod log {
-    pub use slog::{crit, debug, error, info, trace, warn};
+    pub use slog::{crit, debug, error, info, log, trace, warn};
 }
 
 /// Expose slog and select useful primitives.
 pub use slog;
-pub use slog::{o, FnValue, Logger, PushFnValue};
+pub use slog::{o, FnValue, Level, Logger, PushFnValue};
 
 /// Create a logger that discards everything.
 pub fn create_null_logger() -> Logger {

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -104,9 +104,7 @@ impl<L: Ledger + Clone, E: LedgerEnclaveProxy> KeyImageService<L, E> {
             EnclaveError::ProstDecode => {
                 rpc_invalid_arg_error(context, "Prost decode failed", &self.logger)
             }
-            EnclaveError::Attest(err) => {
-                rpc_permissions_error(context, err, &self.logger)
-            }
+            EnclaveError::Attest(err) => rpc_permissions_error(context, err, &self.logger),
             other => rpc_internal_error(context, format!("{}", &other), &self.logger),
         }
     }

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -97,11 +97,15 @@ impl<L: Ledger + Clone, E: LedgerEnclaveProxy> KeyImageService<L, E> {
 
     // Helper function that is common
     fn enclave_err_to_rpc_status(&self, context: &str, src: EnclaveError) -> RpcStatus {
-        // Treat prost-decode error as an invalid arg, everything else is an internal
-        // error
+        // Treat prost-decode error as an invalid arg,
+        // treat attest error as permission denied,
+        // everything else is an internal error
         match src {
             EnclaveError::ProstDecode => {
                 rpc_invalid_arg_error(context, "Prost decode failed", &self.logger)
+            }
+            EnclaveError::Attest(err) => {
+                rpc_permissions_error(context, err, &self.logger)
             }
             other => rpc_internal_error(context, format!("{}", &other), &self.logger),
         }


### PR DESCRIPTION
### Motivation

Log messages with the level Error (e.g. `log::error!`) get forwarded to Sentry. The way we handle returning GRPC errors involves logging, and that used the error level for all scenarios, even ones that are common and not actionable. This results in many thousands of events being submitted to Sentry unnecessarily.

### In this PR
* Degrade a bunch of grpc-related log messages to a less severe level, causing them not to go out to Sentry.
* Fix an error handling case to return the correct grpc error code

