### PR TITLE
Downgrade a noisy log that is not currently actionable

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -195,7 +195,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             self.untrusted.is_valid(context)?;
             Ok(())
         } else {
-            log::error!(
+            log::warn!(
                 self.logger,
                 "attempting to validate non-existent tx hash {:?}",
                 tx_hash


### PR DESCRIPTION
### Motivation

Being `error!`, this log message finds its way to Sentry, but there is nothing to do about it. Its useful for debugging so I want to keep it, and I am not 100% sure why we're seeing it but still no need to have it ship to Sentry.

### In this PR
* `error!` -> `warn!`

### Future Work
* Investigate the cause of this (it is likely fine)