### PR TITLE
configure sql connection timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,6 +2909,7 @@ dependencies = [
  "mc-util-logger-macros",
  "mc-util-metered-channel",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-serial",
  "mc-util-uri",
  "mockall",
@@ -3256,6 +3257,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-keyfile",
+ "mc-util-parse",
  "mc-util-uri",
  "mc-watcher",
  "predicates 2.0.3",
@@ -3408,6 +3410,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-serial",
  "mc-util-test-helper",
  "mc-util-uri",
@@ -3585,6 +3588,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-serial",
  "mc-util-test-helper",
  "mc-util-uri",
@@ -3787,6 +3791,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-uri",
  "pem",
  "prost",
@@ -3945,6 +3950,7 @@ dependencies = [
  "mc-fog-types",
  "mc-transaction-core",
  "mc-util-from-random",
+ "mc-util-parse",
  "mc-util-repr-bytes",
  "mc-util-test-helper",
  "pem",
@@ -3952,6 +3958,8 @@ dependencies = [
  "r2d2",
  "rand 0.8.4",
  "rand_core 0.6.3",
+ "serde",
+ "structopt",
  "tempdir",
 ]
 
@@ -3973,6 +3981,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-uri",
  "more-asserts",
  "once_cell",
@@ -4223,6 +4232,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-metered-channel",
  "mc-util-metrics",
+ "mc-util-parse",
  "mc-util-serial",
  "mc-util-test-helper",
  "mc-util-uri",
@@ -4373,6 +4383,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
+ "mc-util-parse",
  "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-uri",
@@ -5029,6 +5040,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-parse"
+version = "1.2.0-pre0"
+dependencies = [
+ "itertools 0.10.1",
+ "mc-sgx-css",
+]
+
+[[package]]
 name = "mc-util-repr-bytes"
 version = "1.2.0-pre0"
 dependencies = [
@@ -5113,6 +5132,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
+ "mc-util-parse",
  "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ members = [
     "util/logger-macros",
     "util/metered-channel",
     "util/metrics",
+    "util/parse",
     "util/repr-bytes",
     "util/serial",
     "util/test-helper",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -29,6 +29,7 @@ mc-sgx-report-cache-untrusted = { path = "../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../transaction/core"}
 mc-transaction-std = { path = "../../transaction/std"}
 mc-util-grpc = { path = "../../util/grpc" }
+mc-util-parse = { path = "../../util/parse" }
 mc-util-metered-channel = { path = "../../util/metered-channel" }
 mc-util-metrics = { path = "../../util/metrics" }
 mc-util-serial = { path = "../../util/serial" }

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -6,11 +6,12 @@ use mc_attest_core::ProviderId;
 use mc_common::{HashMap, HashSet, NodeID, ResponderId};
 use mc_consensus_scp::{QuorumSet, QuorumSetMember};
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair, Ed25519Private};
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{
     AdminUri, ConnectionUri, ConsensusClientUri as ClientUri, ConsensusPeerUri as PeerUri,
 };
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, fs, path::PathBuf, str::FromStr, string::String, sync::Arc, time::Duration};
+use std::{fmt::Debug, fs, path::PathBuf, string::String, sync::Arc, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
@@ -112,11 +113,6 @@ fn keypair_from_base64(private_key: &str) -> Result<Arc<Ed25519Pair>, String> {
     let secret_key = Ed25519Private::try_from_der(privkey_bytes.as_slice())
         .map_err(|err| format!("Could not get Ed25519Private from der {:?}", err))?;
     Ok(Arc::new(Ed25519Pair::from(secret_key)))
-}
-
-/// Converts a string containing number of seconds to a Duration object.
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -48,6 +48,7 @@ mc-common = { path = "../../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-keyfile = { path = "../../../util/keyfile" }
+mc-util-parse = { path = "../../../util/parse" }
 mc-util-uri = { path = "../../../util/uri" }
 
 # fog

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -3,7 +3,8 @@
 //! Configuration parameters for the Fog ingest client
 
 use mc_crypto_keys::CompressedRistrettoPublic;
-use std::{str::FromStr, time::Duration};
+use mc_util_parse::parse_duration_in_seconds;
+use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(Clone, StructOpt)]
@@ -18,10 +19,6 @@ pub struct IngestConfig {
 
     #[structopt(subcommand)]
     pub cmd: IngestConfigCommand,
-}
-
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
 }
 
 fn parse_ristretto_hex(src: &str) -> Result<CompressedRistrettoPublic, String> {

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -39,6 +39,7 @@ mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../../transaction/core" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metrics = { path = "../../../util/metrics" }
+mc-util-parse = { path = "../../../util/parse" }
 mc-util-serial = { path = "../../../util/serial" }
 mc-util-uri = { path = "../../../util/uri" }
 mc-watcher = { path = "../../../watcher" }

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -47,7 +47,7 @@ fn main() {
     // Open databases.
     let recovery_db = SqlRecoveryDb::new_from_url(
         &std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
-        config.postgres_params.clone(),
+        config.postgres_config.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -47,6 +47,7 @@ fn main() {
     // Open databases.
     let recovery_db = SqlRecoveryDb::new_from_url(
         &std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
+        config.postgres_params.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -4,7 +4,7 @@
 
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
-use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
+use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
 use mc_fog_uri::{FogIngestUri, IngestPeerUri};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
@@ -97,7 +97,7 @@ pub struct IngestConfig {
 
     /// Postgres config
     #[structopt(flatten)]
-    pub postgres_params: SqlRecoveryDbParams,
+    pub postgres_config: SqlRecoveryDbConnectionConfig,
 }
 
 #[cfg(test)]

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -4,10 +4,12 @@
 
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
+use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
 use mc_fog_uri::{FogIngestUri, IngestPeerUri};
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
 use serde::Serialize;
-use std::{path::PathBuf, str::FromStr, time::Duration};
+use std::{path::PathBuf, time::Duration};
 use structopt::StructOpt;
 
 /// StructOpt configuration options for an Ingest Server
@@ -92,11 +94,10 @@ pub struct IngestConfig {
     /// State file, defaults to ~/.mc-fog-ingest-state
     #[structopt(long)]
     pub state_file: Option<PathBuf>,
-}
 
-/// Converts a string containing number of seconds to a Duration object.
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
+    /// Postgres config
+    #[structopt(flatten)]
+    pub postgres_params: SqlRecoveryDbParams,
 }
 
 #[cfg(test)]

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -8,7 +8,6 @@ use crate::{
     counters,
     error::{IngestServiceError as Error, PeerBackupError, RestoreStateError, SetPeersError},
     server::IngestServerConfig,
-    SeqDisplay,
 };
 use mc_attest_enclave_api::{EnclaveMessage, PeerAuthRequest, PeerAuthResponse, PeerSession};
 use mc_attest_net::RaClient;
@@ -32,6 +31,7 @@ use mc_fog_uri::IngestPeerUri;
 use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCache};
 use mc_transaction_core::{Block, BlockContents, BlockIndex};
+use mc_util_parse::SeqDisplay;
 use mc_util_uri::ConnectionUri;
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -3,13 +3,14 @@
 //! IngestControllerState represents what the ingest server is currently trying
 //! to do
 
-use crate::{counters, server::IngestServerConfig, SeqDisplay};
+use crate::{counters, server::IngestServerConfig};
 use displaydoc::Display;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::ingest_common::{IngestControllerMode, IngestSummary};
 use mc_fog_recovery_db_iface::IngestInvocationId;
 use mc_fog_uri::IngestPeerUri;
 use mc_transaction_core::BlockIndex;
+use mc_util_parse::SeqDisplay;
 use std::{collections::BTreeSet, fmt::Display};
 
 /// The ingest server is, at any time, in one of two modes:

--- a/fog/ingest/server/src/server.rs
+++ b/fog/ingest/server/src/server.rs
@@ -10,7 +10,6 @@ use crate::{
     ingest_service::IngestService,
     state_file::StateFile,
     worker::{IngestWorker, PeerCheckupWorker, ReportCacheWorker},
-    SeqDisplay,
 };
 use futures::executor::block_on;
 use mc_attest_api::attest_grpc::create_attested_api;
@@ -28,6 +27,7 @@ use mc_fog_recovery_db_iface::{RecoveryDb, ReportDb};
 use mc_fog_uri::{FogIngestUri, IngestPeerUri};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_util_grpc::ConnectionUriGrpcioServer;
+use mc_util_parse::SeqDisplay;
 use mc_util_uri::ConnectionUri;
 use mc_watcher::watcher_db::WatcherDB;
 use std::{collections::BTreeSet, path::PathBuf, sync::Arc, time::Duration};

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -28,6 +28,7 @@ mc-util-encodings = { path = "../../../util/encodings" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metrics = { path = "../../../util/metrics" }
+mc-util-parse = { path = "../../../util/parse" }
 mc-util-serial = { path = "../../../util/serial" }
 mc-util-uri = { path = "../../../util/uri" }
 mc-watcher = { path = "../../../watcher" }

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -5,9 +5,10 @@
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
 use mc_fog_uri::FogLedgerUri;
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
 use serde::Serialize;
-use std::{path::PathBuf, str::FromStr, time::Duration};
+use std::{path::PathBuf, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Clone, Serialize, StructOpt)]
@@ -67,9 +68,4 @@ pub struct LedgerServerConfig {
     /// developed.)
     #[structopt(long, default_value = "1048576")]
     pub omap_capacity: u64,
-}
-
-/// Converts a string containing number of seconds to a Duration object.
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
 }

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -25,6 +25,7 @@ mc-fog-sig-report = { path = "../../sig/report" }
 mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metrics = { path = "../../../util/metrics" }
+mc-util-parse = { path = "../../../util/parse" }
 mc-util-uri = { path = "../../../util/uri" }
 
 displaydoc = "0.2"

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -22,7 +22,7 @@ fn main() {
 
     let db = SqlRecoveryDb::new_from_url(
         &env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
-        config.postgres_params.clone(),
+        config.postgres_config.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -22,6 +22,7 @@ fn main() {
 
     let db = SqlRecoveryDb::new_from_url(
         &env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
+        config.postgres_params.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/report/server/src/config.rs
+++ b/fog/report/server/src/config.rs
@@ -5,6 +5,7 @@
 use displaydoc::Display;
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, KeyError};
 use mc_crypto_x509_utils::{ChainError, X509CertificateChain, X509CertificateIter};
+use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
 use mc_util_uri::{AdminUri, FogUri};
 use pem::PemError;
 use serde::Serialize;
@@ -31,6 +32,10 @@ pub struct Config {
     /// The path to the signing key.
     #[structopt(long, parse(from_os_str))]
     pub signing_key: PathBuf,
+
+    /// Postgres config
+    #[structopt(flatten)]
+    pub postgres_params: SqlRecoveryDbParams,
 }
 
 /// An enumeration of errors which can occur while reading configuration from

--- a/fog/report/server/src/config.rs
+++ b/fog/report/server/src/config.rs
@@ -5,7 +5,7 @@
 use displaydoc::Display;
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, KeyError};
 use mc_crypto_x509_utils::{ChainError, X509CertificateChain, X509CertificateIter};
-use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
+use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
 use mc_util_uri::{AdminUri, FogUri};
 use pem::PemError;
 use serde::Serialize;
@@ -35,7 +35,7 @@ pub struct Config {
 
     /// Postgres config
     #[structopt(flatten)]
-    pub postgres_params: SqlRecoveryDbParams,
+    pub postgres_config: SqlRecoveryDbConnectionConfig,
 }
 
 /// An enumeration of errors which can occur while reading configuration from

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -24,6 +24,7 @@ mc-common = { path = "../../common", features = ["loggers"] }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-util-from-random = { path = "../../util/from-random" }
+mc-util-parse = { path = "../../util/parse" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
 mc-fog-kex-rng = { path = "../kex_rng" }
@@ -39,6 +40,8 @@ prost = "0.9"
 r2d2 = "0.8.9"
 rand = "0.8"
 rand_core = "0.6"
+serde = { version = "1.0", features = ["derive"] }
+structopt = "0.3"
 
 # needed for fog-sql-recovery-db-write-bench
 mc-fog-test-infra = { path = "../test_infra" }

--- a/fog/sql_recovery_db/src/bin/fog_sql_recovery_db_write_bench.rs
+++ b/fog/sql_recovery_db/src/bin/fog_sql_recovery_db_write_bench.rs
@@ -15,7 +15,7 @@ use std::{
 
 fn main() {
     let database_url = env::var("DATABASE_URL").expect("Missing DATABASE_URL environment variable");
-    let db = SqlRecoveryDb::new_from_url(&database_url, create_null_logger())
+    let db = SqlRecoveryDb::new_from_url(&database_url, Default::default(), create_null_logger())
         .expect("failled connecting to database");
     let mut rng = thread_rng();
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -41,6 +41,7 @@ use mc_fog_types::{
 use mc_transaction_core::Block;
 use prost::Message;
 use proto_types::ProtoIngestedBlockData;
+use std::time::Duration;
 
 pub use error::Error;
 
@@ -74,6 +75,9 @@ impl SqlRecoveryDb {
         let manager = ConnectionManager::<PgConnection>::new(database_url);
         let pool = Pool::builder()
             .max_size(1)
+            .idle_timeout(Some(Duration::from_secs(60)))
+            .max_lifetime(Some(Duration::from_secs(120)))
+            .connection_timeout(Duration::from_secs(5))
             .test_on_check_out(true)
             .build(manager)?;
         Ok(Self::new(pool, logger))

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -65,17 +65,20 @@ pub struct SqlRecoveryDbConnectionConfig {
     /// seconds beyond this duration. (https://docs.diesel.rs/diesel/r2d2/struct.Builder.html)
     #[structopt(long, env, default_value = "60", parse(try_from_str=parse_duration_in_seconds))]
     postgres_idle_timeout: Duration,
+
     /// The maximum lifetime of connections in the pool.
     /// If set, connections will be closed after existing for at most 30 seconds
     /// beyond this duration. If a connection reaches its maximum lifetime
     /// while checked out it will be closed when it is returned to the pool. (https://docs.diesel.rs/diesel/r2d2/struct.Builder.html)
     #[structopt(long, env, default_value = "120", parse(try_from_str=parse_duration_in_seconds))]
     postgres_max_lifetime: Duration,
+
     /// Sets the connection timeout used by the pool.
     /// The pool will wait this long for a connection to become available before
     /// returning an error. (https://docs.diesel.rs/diesel/r2d2/struct.Builder.html)
     #[structopt(long, env, default_value = "5", parse(try_from_str=parse_duration_in_seconds))]
     postgres_connection_timeout: Duration,
+
     /// The maximum number of connections managed by the pool.
     #[structopt(long, env, default_value = "1")]
     postgres_max_connections: u32,

--- a/fog/sql_recovery_db/src/test_utils.rs
+++ b/fog/sql_recovery_db/src/test_utils.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::SqlRecoveryDb;
+use crate::{SqlRecoveryDb, SqlRecoveryDbParams};
 use diesel::{prelude::*, PgConnection};
 use diesel_migrations::embed_migrations;
 use mc_common::logger::Logger;
@@ -62,8 +62,12 @@ impl SqlRecoveryDbTestContext {
     }
 
     pub fn get_db_instance(&self) -> SqlRecoveryDb {
-        SqlRecoveryDb::new_from_url(&self.db_url(), self.logger.clone())
-            .expect("failed creating new SqlRecoveryDb")
+        SqlRecoveryDb::new_from_url(
+            &self.db_url(),
+            SqlRecoveryDbParams::default(),
+            self.logger.clone(),
+        )
+        .expect("failed creating new SqlRecoveryDb")
     }
 
     pub fn new_conn(&self) -> PgConnection {

--- a/fog/sql_recovery_db/src/test_utils.rs
+++ b/fog/sql_recovery_db/src/test_utils.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{SqlRecoveryDb, SqlRecoveryDbParams};
+use crate::{SqlRecoveryDb, SqlRecoveryDbConnectionConfig};
 use diesel::{prelude::*, PgConnection};
 use diesel_migrations::embed_migrations;
 use mc_common::logger::Logger;
@@ -64,7 +64,7 @@ impl SqlRecoveryDbTestContext {
     pub fn get_db_instance(&self) -> SqlRecoveryDb {
         SqlRecoveryDb::new_from_url(
             &self.db_url(),
-            SqlRecoveryDbParams::default(),
+            SqlRecoveryDbConnectionConfig::default(),
             self.logger.clone(),
         )
         .expect("failed creating new SqlRecoveryDb")

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -21,6 +21,7 @@ mc-transaction-std = { path = "../../transaction/std" }
 mc-util-grpc = { path = "../../util/grpc" }
 mc-util-keyfile = { path = "../../util/keyfile" }
 mc-util-metrics = { path = "../../util/metrics" }
+mc-util-parse = { path = "../../util/parse" }
 mc-util-uri = { path = "../../util/uri" }
 
 # fog

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -5,14 +5,16 @@
 use mc_common::logger::{log, Logger};
 use mc_fog_sample_paykit::AccountKey;
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
+use mc_util_parse::{load_css_file, parse_duration_in_seconds, CssSignature};
 use mc_util_uri::{AdminUri, ConsensusClientUri};
-
 use serde::Serialize;
-use std::{path::PathBuf, str::FromStr, time::Duration};
+use std::{path::PathBuf, time::Duration};
 use structopt::StructOpt;
 
 /// StructOpt for test-client binary
-#[derive(Debug, StructOpt, Serialize, Clone)]
+///
+/// Serialize is used to create a json summary
+#[derive(Debug, StructOpt, Clone, Serialize)]
 #[structopt(name = "test-client", about = "Test client for Fog infrastructure.")]
 pub struct TestClientConfig {
     /// A URI to host the prometheus data at.
@@ -78,20 +80,24 @@ pub struct TestClientConfig {
     pub transfer_amount: u64,
 
     /// Consensus enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env)]
-    pub consensus_enclave_css: Option<String>,
+    #[structopt(long, env, parse(try_from_str=load_css_file))]
+    #[serde(skip_serializing)]
+    pub consensus_enclave_css: Option<CssSignature>,
 
     /// Fog ingest enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "INGEST_ENCLAVE_CSS")]
-    pub fog_ingest_enclave_css: Option<String>,
+    #[structopt(long, env = "INGEST_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
+    #[serde(skip_serializing)]
+    pub fog_ingest_enclave_css: Option<CssSignature>,
 
     /// Fog ledger enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "LEDGER_ENCLAVE_CSS")]
-    pub fog_ledger_enclave_css: Option<String>,
+    #[structopt(long, env = "LEDGER_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
+    #[serde(skip_serializing)]
+    pub fog_ledger_enclave_css: Option<CssSignature>,
 
     /// Fog view enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "VIEW_ENCLAVE_CSS")]
-    pub fog_view_enclave_css: Option<String>,
+    #[structopt(long, env = "VIEW_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
+    #[serde(skip_serializing)]
+    pub fog_view_enclave_css: Option<CssSignature>,
 
     /// Whether to turn off memos, for backwards compatibility
     #[structopt(long, env)]
@@ -123,8 +129,4 @@ pub struct ConsensusConfig {
     /// Consensus Validator nodes to connect to.
     #[structopt(long = "consensus", env, required = true, min_values = 1)]
     pub consensus_validators: Vec<ConsensusClientUri>,
-}
-
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
 }

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -35,6 +35,7 @@ mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metered-channel = { path = "../../../util/metered-channel" }
 mc-util-metrics = { path = "../../../util/metrics" }
+mc-util-parse = { path = "../../../util/parse" }
 mc-util-serial = { path = "../../../util/serial" }
 mc-util-uri = { path = "../../../util/uri" }
 

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let recovery_db = SqlRecoveryDb::new_from_url(
         &std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
-        config.postgres_params.clone(),
+        config.postgres_config.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -20,6 +20,7 @@ fn main() {
 
     let recovery_db = SqlRecoveryDb::new_from_url(
         &std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable missing"),
+        config.postgres_params.clone(),
         logger.clone(),
     )
     .expect("Failed connecting to database");

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -4,10 +4,12 @@
 
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
+use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
 use mc_fog_uri::FogViewUri;
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
 use serde::Serialize;
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(Clone, Serialize, StructOpt)]
@@ -59,9 +61,8 @@ pub struct MobileAcctViewConfig {
     /// developed.)
     #[structopt(long, default_value = "1048576")]
     pub omap_capacity: u64,
-}
 
-/// Converts a string containing number of seconds to a Duration object.
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
+    /// Postgres config
+    #[structopt(flatten)]
+    pub postgres_params: SqlRecoveryDbParams,
 }

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -4,7 +4,7 @@
 
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
-use mc_fog_sql_recovery_db::SqlRecoveryDbParams;
+use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
 use mc_fog_uri::FogViewUri;
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
@@ -64,5 +64,5 @@ pub struct MobileAcctViewConfig {
 
     /// Postgres config
     #[structopt(flatten)]
-    pub postgres_params: SqlRecoveryDbParams,
+    pub postgres_config: SqlRecoveryDbConnectionConfig,
 }

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -69,6 +69,7 @@ fn get_test_environment(
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Default::default(),
             omap_capacity: view_omap_capacity,
+            postgres_params: Default::default(),
         };
 
         let enclave = SgxViewEnclave::new(

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -61,15 +61,15 @@ fn get_test_environment(
 
     let server = {
         let config = ViewConfig {
-            ias_spid: Default::default(),
-            ias_api_key: Default::default(),
             client_responder_id: ResponderId::from_str(&uri.addr()).unwrap(),
             client_listen_uri: uri.clone(),
-            admin_listen_uri: Default::default(),
             client_auth_token_secret: None,
-            client_auth_token_max_lifetime: Default::default(),
             omap_capacity: view_omap_capacity,
-            postgres_params: Default::default(),
+            ias_spid: Default::default(),
+            ias_api_key: Default::default(),
+            admin_listen_uri: Default::default(),
+            client_auth_token_max_lifetime: Default::default(),
+            postgres_config: Default::default(),
         };
 
         let enclave = SgxViewEnclave::new(

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -36,6 +36,7 @@ mc-transaction-std = { path = "../transaction/std" }
 mc-util-from-random = { path = "../util/from-random" }
 mc-util-grpc = { path = "../util/grpc" }
 mc-util-lmdb = { path = "../util/lmdb" }
+mc-util-parse = { path = "../util/parse" }
 mc-util-repr-bytes = { path = "../util/repr-bytes" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -11,13 +11,14 @@ use mc_fog_report_connection::GrpcFogReportConnection;
 use mc_fog_report_validation::FogResolver;
 use mc_mobilecoind_api::MobilecoindUri;
 use mc_sgx_css::Signature;
+use mc_util_parse::{load_css_file, parse_duration_in_seconds};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
 #[cfg(feature = "ip-check")]
 use reqwest::{
     blocking::Client,
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
 };
-use std::{convert::TryFrom, fs, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -82,10 +83,6 @@ pub struct Config {
     pub fog_ingest_enclave_css: Option<Signature>,
 }
 
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
-}
-
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {
     let quorum_set: QuorumSet<ResponderId> = serde_json::from_str(src)
         .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
@@ -95,14 +92,6 @@ fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, Strin
     }
 
     Ok(quorum_set)
-}
-
-fn load_css_file(filename: &str) -> Result<Signature, String> {
-    let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
-    let signature = Signature::try_from(&bytes[..])
-        .map_err(|err| format!("Failed parsing CSS file '{}': {}", filename, err))?;
-    Ok(signature)
 }
 
 #[derive(Display, Debug)]

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mc-util-parse"
+version = "1.2.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+description = "Helpers for parsing, particularly, for use with structopt and similar"
+readme = "README.md"
+
+[dependencies]
+itertools = "0.10"
+mc-sgx-css = { path = "../../sgx/css" }

--- a/util/parse/README.md
+++ b/util/parse/README.md
@@ -1,0 +1,4 @@
+mc-util-parse
+=============
+
+Utility functions to help with parsing and formatting and such.

--- a/util/parse/src/lib.rs
+++ b/util/parse/src/lib.rs
@@ -1,0 +1,40 @@
+//! Miscellaneous parsing and formatting utilities
+
+#![deny(missing_docs)]
+
+use core::fmt::Display;
+use itertools::Itertools;
+use std::{convert::TryFrom, fs, str::FromStr, time::Duration};
+
+pub use mc_sgx_css::Signature as CssSignature;
+
+/// Parse a number of seconds into a duration
+///
+/// This can be used with structopt
+pub fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
+    Ok(Duration::from_secs(u64::from_str(src)?))
+}
+
+/// Load a CSS file from disk. This represents a signature over an enclave,
+/// and contains attestation parameters like MRENCLAVE and MRSIGNER as well
+/// as other stuff.
+pub fn load_css_file(filename: &str) -> Result<CssSignature, String> {
+    let bytes =
+        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+    let signature = CssSignature::try_from(&bytes[..])
+        .map_err(|err| format!("Failed parsing CSS file '{}': {}", filename, err))?;
+    Ok(signature)
+}
+
+/// Helper to format a sequence as a comma-separated list
+/// (This is used with lists of Ingest peer uris in logs,
+/// because the debug logging of that object is harder to read)
+///
+/// To use this, wrap the value in SeqDisplay( ) then format it
+pub struct SeqDisplay<T: Display, I: Iterator<Item = T> + Clone>(pub I);
+
+impl<T: Display, I: Iterator<Item = T> + Clone> Display for SeqDisplay<T, I> {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(fmt, "[{}]", self.0.clone().format(", "))
+    }
+}

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -26,6 +26,7 @@ mc-transaction-core-test-utils = { path = "../transaction/core/test-utils" }
 mc-util-from-random = { path = "../util/from-random" }
 mc-util-grpc = { path = "../util/grpc" }
 mc-util-lmdb = { path = "../util/lmdb" }
+mc-util-parse = { path = "../util/parse" }
 mc-util-repr-bytes = { path = "../util/repr-bytes" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -2,6 +2,7 @@
 
 //! Configuration parameters for the watcher test utility.
 
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{ConsensusClientUri, WatcherUri};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::PathBuf, str::FromStr, time::Duration};
@@ -131,10 +132,6 @@ impl SourcesConfig {
     pub fn sources(&self) -> &[SourceConfig] {
         &self.sources
     }
-}
-
-fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseIntError> {
-    Ok(Duration::from_secs(u64::from_str(src)?))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
this may help when the server loses connection to the database

---

```
    make sql timeouts configurable in a standard way
    
    this makes the sql config params a struct_opt object,
    which all servers can incorporate into their config objects
    
    this also pays down some tech debt and code duplicaiton where
    lots of "struct opt parsing" type functions are copy pasted
    everywhere, instead they are put in a crate called `mc-util-parse`.
```