### PR TITLE
More fixups from discussion with jason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4149,6 +4149,7 @@ version = "1.2.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
+ "hex_fmt",
  "lazy_static",
  "mc-account-keys",
  "mc-common",

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -415,7 +415,7 @@ impl<CP: CredentialsProvider> BlockchainConnection for ThickClient<CP> {
 }
 
 impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
-    fn propose_tx(&mut self, tx: &Tx) -> Result<BlockIndex> {
+    fn propose_tx(&mut self, tx: &Tx) -> Result<u64> {
         trace_time!(self.logger, "ThickClient::propose_tx");
 
         if !self.is_attested() {

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -105,7 +105,7 @@ pub trait UserTxConnection: Connection {
     /// Propose a transaction over the encrypted channel.
     /// Returns the number of blocks in the ledger at the time the call was
     /// received.
-    fn propose_tx(&mut self, tx: &Tx) -> Result<BlockIndex>;
+    fn propose_tx(&mut self, tx: &Tx) -> Result<u64>;
 }
 
 // Retryable connections: these traits exist to allow SyncConnection to extend

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -32,6 +32,7 @@ mc-fog-sample-paykit = { path = "../sample-paykit" }
 # third-party
 displaydoc = "0.2"
 grpcio = "0.9"
+hex_fmt = "0.3"
 lazy_static = "1.4"
 more-asserts = "0.2"
 once_cell = "1.8"

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -79,10 +79,10 @@ fn main() {
         config.fog_view,
         logger.clone(),
     )
-    .consensus_sigstruct(maybe_load_css(config.consensus_enclave_css.as_ref()))
-    .fog_ingest_sigstruct(maybe_load_css(config.ingest_enclave_css.as_ref()))
-    .fog_ledger_sigstruct(maybe_load_css(config.ledger_enclave_css.as_ref()))
-    .fog_view_sigstruct(maybe_load_css(config.view_enclave_css.as_ref()));
+    .consensus_sigstruct(maybe_load_css(&config.consensus_enclave_css))
+    .fog_ingest_sigstruct(maybe_load_css(&config.ingest_enclave_css))
+    .fog_ledger_sigstruct(maybe_load_css(&config.ledger_enclave_css))
+    .fog_view_sigstruct(maybe_load_css(&config.view_enclave_css));
 
     // Run continuously or run as a fixed length test, according to config
     if config.continuous {
@@ -110,6 +110,8 @@ fn main() {
     }
 }
 
-fn maybe_load_css(maybe_file: Option<&String>) -> Option<CssSignature> {
-    maybe_file.map(|x| load_css_file(x).expect("Could not load css file"))
+fn maybe_load_css(maybe_file: &Option<String>) -> Option<CssSignature> {
+    maybe_file
+        .as_ref()
+        .map(|x| load_css_file(x).expect("Could not load css file"))
 }

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -56,11 +56,14 @@ pub struct TestClientConfig {
     pub fog_view: FogViewUri,
 
     /// Seconds to wait for a transaction to clear, before it has exceeded
+    /// deadline. The healthy status will be set false if we exceed this
     /// deadline.
     #[structopt(long, env, default_value = "5", parse(try_from_str=parse_duration_in_seconds))]
     pub consensus_wait: Duration,
 
     /// Seconds to wait for ledger sync on fog
+    /// This affects the double-spend test but not the continuous mode of
+    /// operation.
     #[structopt(long, env, default_value = "5", parse(try_from_str=parse_duration_in_seconds))]
     pub ledger_sync_wait: Duration,
 

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -5,7 +5,7 @@
 use mc_common::logger::{log, Logger};
 use mc_fog_sample_paykit::AccountKey;
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
-use mc_util_parse::{load_css_file, parse_duration_in_seconds, CssSignature};
+use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{AdminUri, ConsensusClientUri};
 use serde::Serialize;
 use std::{path::PathBuf, time::Duration};
@@ -80,24 +80,20 @@ pub struct TestClientConfig {
     pub transfer_amount: u64,
 
     /// Consensus enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env, parse(try_from_str=load_css_file))]
-    #[serde(skip_serializing)]
-    pub consensus_enclave_css: Option<CssSignature>,
+    #[structopt(long, env)]
+    pub consensus_enclave_css: Option<String>,
 
     /// Fog ingest enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "INGEST_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
-    #[serde(skip_serializing)]
-    pub fog_ingest_enclave_css: Option<CssSignature>,
+    #[structopt(long)]
+    pub ingest_enclave_css: Option<String>,
 
     /// Fog ledger enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "LEDGER_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
-    #[serde(skip_serializing)]
-    pub fog_ledger_enclave_css: Option<CssSignature>,
+    #[structopt(long)]
+    pub ledger_enclave_css: Option<String>,
 
     /// Fog view enclave CSS file (overriding the build-time CSS)
-    #[structopt(long, env = "VIEW_ENCLAVE_CSS", parse(try_from_str=load_css_file))]
-    #[serde(skip_serializing)]
-    pub fog_view_enclave_css: Option<CssSignature>,
+    #[structopt(long)]
+    pub view_enclave_css: Option<String>,
 
     /// Whether to turn off memos, for backwards compatibility
     #[structopt(long, env)]

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -87,15 +87,15 @@ pub struct TestClientConfig {
     pub consensus_enclave_css: Option<String>,
 
     /// Fog ingest enclave CSS file (overriding the build-time CSS)
-    #[structopt(long)]
+    #[structopt(long, env)]
     pub ingest_enclave_css: Option<String>,
 
     /// Fog ledger enclave CSS file (overriding the build-time CSS)
-    #[structopt(long)]
+    #[structopt(long, env)]
     pub ledger_enclave_css: Option<String>,
 
     /// Fog view enclave CSS file (overriding the build-time CSS)
-    #[structopt(long)]
+    #[structopt(long, env)]
     pub view_enclave_css: Option<String>,
 
     /// Whether to turn off memos, for backwards compatibility

--- a/fog/test-client/src/counters.rs
+++ b/fog/test-client/src/counters.rs
@@ -2,7 +2,7 @@
 
 //! Prometheus metrics, interesting when the test runs continuously
 
-use mc_util_metrics::{register_histogram, Histogram, IntCounter, OpMetrics};
+use mc_util_metrics::{register_histogram, Histogram, IntCounter, IntGauge, OpMetrics};
 
 // Histogram buckets used for reporting the TX_CONFIRMED_TIME and
 // TX_RECEIVED_TIME to prometheus
@@ -16,9 +16,26 @@ const TX_TIME_BUCKETS: &[f64] = &[
     16.0, 18.0, 20.0,
 ];
 
+// Histogram buckets used for reporting the TX_BUILD_TIME and
+// TX_SEND_TIME to prometheus
+//
+// The resolution in grafana can be improved by adding more buckets, but this
+// increases storage costs. We may wish to tune the buckets over time as we
+// collect more data and have more of an idea of how long it usually takes and
+// where it is interesting to get more resolution.
+const TX_TIME_BUCKETS_SHORT: &[f64] = &[0.2, 0.5, 0.7, 1.0, 1.2, 1.5, 1.7, 2.0, 2.5, 3.0];
+
 lazy_static::lazy_static! {
     /// Counter group
     pub static ref OP_COUNTERS: OpMetrics = OpMetrics::new_and_registered("fog_test_client");
+
+    /// Time in seconds that it takes for the source client to build a transaction (including fog interactions)
+    pub static ref TX_BUILD_TIME: Histogram =
+        register_histogram!("fog_test_client_tx_build_time", "Time for source client to build a transaction, including fog interactions", TX_TIME_BUCKETS_SHORT.to_vec()).unwrap();
+
+    /// Time in seconds that it takes for the source client to send a transaction
+    pub static ref TX_SEND_TIME: Histogram =
+        register_histogram!("fog_test_client_tx_send_time", "Time for source client to send a built transaction", TX_TIME_BUCKETS_SHORT.to_vec()).unwrap();
 
     /// Time in seconds that it takes for the source client to observe that a submitted transaction landed in the blockchain (timer starts immediately after submission)
     pub static ref TX_CONFIRMED_TIME: Histogram =
@@ -80,6 +97,6 @@ lazy_static::lazy_static! {
     /// The IS_HEALTHY status is false (0) if ANY of the clients failed their most recent transfers.
     /// It is (1) if NO client has failed their most recent transfer.
     /// This is updated after every transfer attempt.
-    pub static ref IS_HEATHY: IntCounter = OP_COUNTERS.counter("is_healthy");
+    pub static ref IS_HEALTHY: IntGauge = OP_COUNTERS.gauge("is_healthy");
 
 }

--- a/fog/test-client/src/counters.rs
+++ b/fog/test-client/src/counters.rs
@@ -94,9 +94,8 @@ lazy_static::lazy_static! {
     /// Number of times that the test failed because a confirm tx operation failed
     pub static ref CONFIRM_TX_ERROR_COUNT: IntCounter = OP_COUNTERS.counter("confirm_tx_error_count");
 
-    /// The IS_HEALTHY status is false (0) if ANY of the clients failed their most recent transfers.
+    /// The LAST_POLLING_SUCCESSFUL status is false (0) if ANY of the clients failed their most recent transfers.
     /// It is (1) if NO client has failed their most recent transfer.
     /// This is updated after every transfer attempt.
-    pub static ref IS_HEALTHY: IntGauge = OP_COUNTERS.gauge("is_healthy");
-
+    pub static ref LAST_POLLING_SUCCESSFUL: IntGauge = OP_COUNTERS.gauge("last_polling_successful");
 }

--- a/fog/test-client/src/counters.rs
+++ b/fog/test-client/src/counters.rs
@@ -76,4 +76,10 @@ lazy_static::lazy_static! {
 
     /// Number of times that the test failed because a confirm tx operation failed
     pub static ref CONFIRM_TX_ERROR_COUNT: IntCounter = OP_COUNTERS.counter("confirm_tx_error_count");
+
+    /// The IS_HEALTHY status is false (0) if ANY of the clients failed their most recent transfers.
+    /// It is (1) if NO client has failed their most recent transfer.
+    /// This is updated after every transfer attempt.
+    pub static ref IS_HEATHY: IntCounter = OP_COUNTERS.counter("is_healthy");
+
 }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -1017,7 +1017,7 @@ impl HealthyTracker {
         // * the failure happened at least num_clients ago
         // then set ourselves healthy again
         if self.have_failure.load(Ordering::SeqCst)
-            && self.last_failure.load(Ordering::SeqCst) + self.num_clients >= counter
+            && self.last_failure.load(Ordering::SeqCst) + self.num_clients <= counter
         {
             counters::IS_HEALTHY.set(1);
         }
@@ -1027,6 +1027,7 @@ impl HealthyTracker {
     pub fn announce_failure(&self) {
         self.last_failure
             .store(self.counter.load(Ordering::SeqCst), Ordering::SeqCst);
+        // Store have_failure only after writing to last_failure
         self.have_failure.store(true, Ordering::SeqCst);
         counters::IS_HEALTHY.set(0);
     }


### PR DESCRIPTION
* it is helpful to have the `--ingest-enclave-css` arguments
  in the admin server json blob, so we can't use `Option<Signature>`
  in structopt with `serde(skip_serializing)`, we have to go back to `Option<String>`.
  But this is still nicer after we get load_css_file from another crate.
* It is confusing to have the flag be `--fog-ingest-enclave-css`
  and the env be `INGEST_ENCLAVE_CSS`, they should match
* We want to have a really easy metric to alert on, so we use
  `IS_HEALTHY`, which is 1 when things are working and 0 when any
  of the accounts failed its last transfer. (This means that
  the "time window" after we which we consider ourselves healthy
  is determined by num_clients * transfer_period.)

    * When a transfer fails, but the tx was accepted to the chain,
      log the block and the public keys of its TxOuts for further
      investiation
    * More timings collected around building and sending of txs
    * Fixups to previous commit
