### PR TITLE
try to fix build info crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4849,6 +4849,7 @@ dependencies = [
 name = "mc-util-build-info"
 version = "1.2.0-pre0"
 dependencies = [
+ "cargo-emit",
  "json",
 ]
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -14,3 +14,6 @@ path = "src/bin/main.rs"
 
 [dev-dependencies]
 json = "0.12"
+
+[build-dependencies]
+cargo-emit = "0.2"


### PR DESCRIPTION
the build info crate records build info, like environment variables
that configure the build, so that targets can log them and such

however, i notice that oftentimes the info can be wrong, especially
in local testing, e.g. SGX_MODE or IAS_MODE not matching the actual
build.

it turns out the build.rs did not emit cargo's rerun-if-changed
directives, so cargo doesn't regenerate the file if one of these
variables changes

this commit may reduce confusion