### PR TITLE
DRYs up resolving TxHashes into CacheEntries inside TxManager

### DIFF
--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -308,15 +308,14 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     ) -> TxManagerResult<EnclaveMessage<PeerSession>> {
         // Split `tx_hashes` into a list of found hashes and missing ones. This allows
         // us to return an error with the entire list of missing hashes.
-        let cache = self.lock_cache();
-
         let (encrypted_txs, not_found) = {
+            let cache = self.lock_cache();
             tx_hashes
                 .iter()
                 .map(|tx_hash| {
                     cache.get(tx_hash).map_or_else(
-                        || (tx_hash, None),
-                        |entry| (tx_hash, Some(entry.encrypted_tx())),
+                        || (*tx_hash, None),
+                        |entry| (*tx_hash, Some(entry.encrypted_tx().clone())),
                     )
                 })
                 .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some())
@@ -324,18 +323,15 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
 
         // If we are missing any hashes, return error.
         if !not_found.is_empty() {
-            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| *tx_hash).collect();
+            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
             return Err(TxManagerError::NotInCache(not_found_tx_hashes));
         }
 
         // Proceed with producing encrypted txs for the given peer.
         let encrypted_txs: Vec<_> = encrypted_txs
             .into_iter()
-            .map(|(_, result)| result.unwrap().clone())
+            .map(|(_, result)| result.unwrap())
             .collect();
-
-        // Release the mutex before doing the enclave call.
-        drop(cache);
 
         Ok(self.enclave.txs_for_peer(&encrypted_txs, aad, peer)?)
     }

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -105,6 +105,38 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
     fn lock_cache(&self) -> MutexGuard<HashMap<TxHash, CacheEntry>> {
         self.cache.lock().expect("Lock poisoned")
     }
+
+    /// A utility method for resolving a list of TxHashes into CacheEntries that
+    /// errors if any hashes are missing.
+    fn get_cache_entries<'a, 'b, I>(
+        cache: &'a MutexGuard<HashMap<TxHash, CacheEntry>>,
+        tx_hashes: I,
+    ) -> Result<Vec<&'a CacheEntry>, TxManagerError>
+    where
+        I: Iterator<Item = &'b TxHash>,
+    {
+        // Split `tx_hashes` into a list of found hashes and missing ones. This allows
+        // us to return an error with the entire list of missing hashes.
+        let (entries, not_found) = tx_hashes
+            .map(|tx_hash| {
+                cache
+                    .get(tx_hash)
+                    .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
+            })
+            .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
+
+        // If we are missing any hashes, return error.
+        if !not_found.is_empty() {
+            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
+            return Err(TxManagerError::NotInCache(not_found_tx_hashes));
+        }
+
+        // Otherwise, return the found entries.
+        Ok(entries
+            .into_iter()
+            .map(|(_tx_hash, entry)| entry.unwrap())
+            .collect())
+    }
 }
 
 impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
@@ -208,38 +240,18 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     fn combine(&self, tx_hashes: &[TxHash]) -> TxManagerResult<Vec<TxHash>> {
         let tx_hashes: HashSet<&TxHash> = tx_hashes.iter().clone().collect(); // Dedup
 
-        let tx_contexts: TxManagerResult<Vec<Arc<WellFormedTxContext>>> = {
-            let cache = self.lock_cache();
+        let cache = self.lock_cache();
+        let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter().copied())?;
 
-            // Split `tx_hashes` into a list of found hashes and missing ones. This allows
-            // us to return an error with the entire list of missing hashes.
-            let (entries, not_found) = tx_hashes
-                .iter()
-                .map(|tx_hash| {
-                    cache
-                        .get(tx_hash)
-                        .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
-                })
-                .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
-
-            // If we are missing any hashes, return error.
-            if !not_found.is_empty() {
-                let not_found_tx_hashes =
-                    not_found.into_iter().map(|(tx_hash, _)| *tx_hash).collect();
-                return Err(TxManagerError::NotInCache(not_found_tx_hashes));
-            }
-
-            // Collect tx contexts.
-            Ok(entries
-                .into_iter()
-                .map(|(_tx_hash, entry)| entry.unwrap().context().clone())
-                .collect())
-        };
+        let tx_contexts = cache_entries
+            .iter()
+            .map(|entry| entry.context.clone())
+            .collect::<Vec<_>>();
 
         // Perform the combine operation.
         Ok(self
             .untrusted
-            .combine(&tx_contexts?, MAX_TRANSACTIONS_PER_BLOCK))
+            .combine(&tx_contexts, MAX_TRANSACTIONS_PER_BLOCK))
     }
 
     /// Forms a Block containing the transactions that correspond to the given
@@ -255,29 +267,12 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         parent_block: &Block,
     ) -> TxManagerResult<(Block, BlockContents, BlockSignature)> {
         let cache = self.lock_cache();
-
-        // Split `tx_hashes` into a list of found hashes and missing ones. This allows
-        // us to return an error with the entire list of missing hashes.
-        let (entries, not_found) = tx_hashes
-            .iter()
-            .map(|tx_hash| {
-                cache
-                    .get(tx_hash)
-                    .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
-            })
-            .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
-
-        // If we are missing any hashes, return error.
-        if !not_found.is_empty() {
-            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
-            return Err(TxManagerError::NotInCache(not_found_tx_hashes));
-        }
+        let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter())?;
 
         // Proceed with forming the block.
-        let encrypted_txs_with_proofs = entries
+        let encrypted_txs_with_proofs = cache_entries
             .into_iter()
-            .map(|(_tx_hash, entry)| {
-                let entry = entry.unwrap();
+            .map(|entry| {
                 // Highest indices proofs must be w.r.t. the current ledger.
                 // Recreating them here is a crude way to ensure that.
                 let highest_index_proofs: Vec<_> = self


### PR DESCRIPTION
### Motivation

While doing some research work on extending the type of transactions we can run consensus on I encountered this piece of code that was repeated in two places and was a bit un-ergonomic due to resulting in `Vec<Option<CacheEntry>>` instead of `Vec<CacheEntry>`.

### In this PR
Add a utility method to perform the `TxHash` -> `CacheEntry` resolution and use it in the two places that currently do that.

