### PR TITLE
remove rpc_enclave_err, fix a bunch of error -> rpc conversions

### DIFF
--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -251,14 +251,11 @@ impl ConsensusPeerApi for PeerApiService {
                         Ok(response)
                     }
 
-                    Err(peer_service_error) => match peer_service_error {
-                        PeerServiceError::Enclave(err) => match err {
-                            Error::Attest(_) => {
-                                Err(rpc_permissions_error("peer_tx_propose", err, logger))
-                            }
-                            _ => Err(rpc_internal_error("peer_tx_propose", err, logger)),
-                        },
-                        err => Err(rpc_internal_error("peer_tx_propose", err, logger)),
+                    Err(err) => match err {
+                        PeerServiceError::Enclave(Error::Attest(_)) => {
+                            Err(rpc_permissions_error("peer_tx_propose", err, logger))
+                        }
+                        _ => Err(rpc_internal_error("peer_tx_propose", err, logger)),
                     },
                 };
 

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -251,12 +251,10 @@ impl ConsensusPeerApi for PeerApiService {
                         Ok(response)
                     }
 
-                    Err(err) => match err {
-                        PeerServiceError::Enclave(Error::Attest(_)) => {
-                            Err(rpc_permissions_error("peer_tx_propose", err, logger))
-                        }
-                        _ => Err(rpc_internal_error("peer_tx_propose", err, logger)),
-                    },
+                    Err(err @ PeerServiceError::Enclave(Error::Attest(_))) => {
+                        Err(rpc_permissions_error("peer_tx_propose", err, logger))
+                    }
+                    Err(err) => Err(rpc_internal_error("peer_tx_propose", err, logger)),
                 };
 
             send_result(ctx, sink, result, logger)

--- a/fog/ingest/server/src/ingest_peer_service.rs
+++ b/fog/ingest/server/src/ingest_peer_service.rs
@@ -86,7 +86,7 @@ where
         let (private_key, _) = self
             .controller
             .get_ingress_private_key(peer_session)
-            .map_err(|err| rpc_internal_error("get ingress private key", err, logger))?;
+            .map_err(|err| rpc_internal_error("get_ingress_private_key", err, logger))?;
 
         Ok(private_key.into())
     }

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -215,13 +215,15 @@ where
             .sync_keys_from_remote(&peer_uri)
             .map_err(|err| match err {
                 IngestServiceError::ServerNotIdle => {
-                    rpc_precondition_error("activate", err, logger)
+                    rpc_precondition_error("sync_keys_from_remote", err, logger)
                 }
-                IngestServiceError::Connection(_) => rpc_unavailable_error("activate", err, logger),
+                IngestServiceError::Connection(_) => {
+                    rpc_unavailable_error("sync_keys_from_remote", err, logger)
+                }
                 IngestServiceError::Enclave(EnclaveError::Attest(_)) => {
-                    rpc_permissions_error("activate", err, logger)
+                    rpc_permissions_error("sync_keys_from_remote", err, logger)
                 }
-                _ => rpc_internal_error("activate", err, logger),
+                _ => rpc_internal_error("sync_keys_from_remote", err, logger),
             })
     }
 

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -123,10 +123,7 @@ where
                 IngestServiceError::ServerNotIdle => {
                     rpc_precondition_error("activate", err, logger)
                 }
-                IngestServiceError::Connection(_) => rpc_unavailable_error("activate", err, logger),
-                IngestServiceError::Backup(PeerBackupError::Connection(_)) => {
-                    rpc_unavailable_error("activate", err, logger)
-                }
+                IngestServiceError::Connection(_) |  IngestServiceError::Backup(PeerBackupError::Connection(_))  => rpc_unavailable_error("activate", err, logger),
                 IngestServiceError::Backup(PeerBackupError::CreatingNewIngressKey) => {
                     rpc_unavailable_error("activate", err, logger)
                 }


### PR DESCRIPTION
This commit starts from the idea that `rpc_enclave_err` is wrong.
Usually, an enclave error is a complex enum containing numerous
possible failure modes. Some of these may be SGX errors that are
not retriable and may represent internal errors. However,
attestation errors must be mapped to "permission denied" to trigger
re-attestation on the clients. Deserialization errors might represent
invalid arg, or might represent an error internal to the server
depending on which payload couldn't be deserialized.

Moreover, each enclave error is a separate enum for each enclave API.
It's not possible to have a single blanket function that does the
right thing for each one of these types, particularly because of
dependency issues -- the enclave api crates which export these
errors must build in no_std, but grpcio does not build in no_std.
Instead the server that hosts the enclave must be responsible
for deciding how it will map those errors to rpc statuses.

The `rpc_enclave_err` thing was created during very early days
in the project when we were just trying to get things working
and developers didn't want to spend a lot of time trying to do
correct status codes for these errors. It is very convenient to
have a single function for reporting all "enclave errors" but
unfortunately this is usually a trap for the developer nowadays.

Therefore we attempt to remove `rpc_enclave_err` and then review
what code is broken by that and try to do it more nicely.

* consensus peer api service now matches on the enclave error and
  returns permission_denied or internal error
* ingest peer api service now matches on the enclave error and
  returns permission_denied or internal error

While we were at it, we improved a bunch of other error mappings
in fog ingest, for calls triggered by the fog ingest client, like
activate, new-keys, sync-keys-from-remote, etc.

This is not extremely important now, but may help when we tackle
automated failover for fog ingest and have automated systems calling
these APIs which need to know when to retry etc.