### PR TITLE
add another option to test client config

### DIFF
--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -33,8 +33,7 @@ fn main() {
 
     // Set up test client policy taking into account the runtime config values
     let policy = TestClientPolicy {
-        // Don't fail fast when running continuously, we want to keep measuring after the deadline
-        fail_fast_on_deadline: !config.continuous,
+        fail_fast_on_deadline: !config.measure_after_deadline,
         // Don't test RTH memos when passed --no_memos
         test_rth_memos: !config.no_memos,
         tx_submit_deadline: config.consensus_wait,

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -35,6 +35,20 @@ pub struct TestClientConfig {
     #[structopt(long, env)]
     pub continuous: bool,
 
+    /// If not set, the test is terminated if a deadline is passed. We fail
+    /// immediately, then start counting down for the next trial.
+    ///
+    /// If set, then we continue waiting after the deadline until the
+    /// transaction succeeds.
+    /// * The failed status is still reported immediately to prometheus
+    /// * This allows us to alert on transactions taking too long, and still
+    ///   collect accurate timing histograms even if our transactions are taking
+    ///   too long.
+    ///
+    /// This is only intended to be set in the continuous mode of operation.
+    #[structopt(long, env)]
+    pub measure_after_deadline: bool,
+
     /// Account key directory.
     #[structopt(long, env)]
     pub key_dir: PathBuf,


### PR DESCRIPTION
this allows more control over what happens when a transaction
hangs and the test client gets blocked, in the continuous mode