### PR TITLE
Allow configurating Digestible to omit fields equal to zero

### DIFF
--- a/crypto/digestible/README.md
+++ b/crypto/digestible/README.md
@@ -500,7 +500,7 @@ struct Thing {
 }
 ```
 
-This feature makes it easy to add integer fields in a backwards-compatible way without having to wrap them in an `Option<>`. This removes the ambiguity of `None` vs `Some(0)`.
+This feature makes it easy to add integer fields in a backwards-compatible way without having to wrap them in an `Option<>`. This removes the ambiguity of `None` vs `Some(0)`. It mimics the Protobuf behavior, where fields set to zero are omitted.
 
 
 References

--- a/crypto/digestible/README.md
+++ b/crypto/digestible/README.md
@@ -489,6 +489,20 @@ New enum possibilities may be added to an existing rust enum without breaking th
 for the other possibilities. Note that enum names cannot be changed and old enums cannot be
 removed. The index of the enum possibility within the list does become part of the hash.
 
+
+It is also possible to skip digesting of integer fields when they are equal to zero. This is done by using the #[digestible(omit_on_zero)] directive on specific struct fields where this behavior is desired, for exampe:
+
+```
+#[derive(Digestible)]
+struct Thing {
+    #[digestible(omit_on_zero)]
+    field: i32,
+}
+```
+
+This feature makes it easy to add integer fields in a backwards-compatible way without having to wrap them in an `Option<>`. This removes the ambiguity of `None` vs `Some(0)`.
+
+
 References
 ----------
 

--- a/crypto/digestible/README.md
+++ b/crypto/digestible/README.md
@@ -490,17 +490,18 @@ for the other possibilities. Note that enum names cannot be changed and old enum
 removed. The index of the enum possibility within the list does become part of the hash.
 
 
-It is also possible to skip digesting of integer fields when they are equal to zero. This is done by using the #[digestible(omit_on_zero)] directive on specific struct fields where this behavior is desired, for exampe:
+It is also possible to skip digesting fields when they are equal to a given value. This is done by using the #[digestible(omit_on=VAL)] directive on specific struct fields where this behavior is desired, for exampe:
 
 ```
 #[derive(Digestible)]
 struct Thing {
-    #[digestible(omit_on_zero)]
+    #[digestible(omit_on=0)]
     field: i32,
 }
 ```
 
-This feature makes it easy to add integer fields in a backwards-compatible way without having to wrap them in an `Option<>`. This removes the ambiguity of `None` vs `Some(0)`. It mimics the Protobuf behavior, where fields set to zero are omitted.
+This feature makes it easy to add fields in a backwards-compatible way without having to wrap them in an `Option<>`.
+For example, for integer fields this can remove the ambiguity of `None` vs `Some(0)`. It mimics the Protobuf behavior, where fields set to zero are omitted.
 
 
 References

--- a/crypto/digestible/README.md
+++ b/crypto/digestible/README.md
@@ -490,12 +490,12 @@ for the other possibilities. Note that enum names cannot be changed and old enum
 removed. The index of the enum possibility within the list does become part of the hash.
 
 
-It is also possible to skip digesting fields when they are equal to a given value. This is done by using the #[digestible(omit_on=VAL)] directive on specific struct fields where this behavior is desired, for exampe:
+It is also possible to skip digesting fields when they are equal to a given value. This is done by using the #[digestible(omit_when = VAL)] directive on specific struct fields where this behavior is desired, for exampe:
 
 ```
 #[derive(Digestible)]
 struct Thing {
-    #[digestible(omit_on=0)]
+    #[digestible(omit_when = 0)]
     field: i32,
 }
 ```

--- a/crypto/digestible/derive/README.md
+++ b/crypto/digestible/derive/README.md
@@ -99,12 +99,12 @@ struct FooV2 {
 
 expands to the same codegen as we had for `struct Foo` earlier.
 
-It is possible to skip digesting individual struct fields if they are equal to zero. This is done by using the #[digestible(omit_on_zero)] directive, for exampe:
+It is possible to skip digesting individual struct fields if they are equal to a specific value. This is done by using the #[digestible(omit_when = VAL)] directive, for exampe:
 
 ```
 #[derive(Digestible)]
 struct Thing {
-    #[digestible(omit_on_zero)]
+    #[digestible(omit_when = 0)]
     field: i32,
 }
 ```

--- a/crypto/digestible/derive/README.md
+++ b/crypto/digestible/derive/README.md
@@ -99,6 +99,16 @@ struct FooV2 {
 
 expands to the same codegen as we had for `struct Foo` earlier.
 
+It is possible to skip digesting individual struct fields if they are equal to zero. This is done by using the #[digestible(omit_on_zero)] directive, for exampe:
+
+```
+#[derive(Digestible)]
+struct Thing {
+    #[digestible(omit_on_zero)]
+    field: i32,
+}
+```
+
 Future improvements
 -------------------
 

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -108,7 +108,7 @@ struct FieldAttributeConfig {
     /// something. This is a backwards compatibility tool that allows adding
     /// new fields without affecting the hash of existing objects that do
     /// not have the field set.
-    pub omit_on: Option<Lit>,
+    pub omit_when: Option<Lit>,
 }
 
 impl FieldAttributeConfig {
@@ -120,11 +120,11 @@ impl FieldAttributeConfig {
             }
             NestedMeta::Meta(meta) => match meta {
                 Meta::NameValue(mnv) => {
-                    if mnv.path.is_ident("omit_on") {
-                        if self.omit_on.is_none() {
-                            self.omit_on = Some(mnv.lit.clone());
+                    if mnv.path.is_ident("omit_when") {
+                        if self.omit_when.is_none() {
+                            self.omit_when = Some(mnv.lit.clone());
                         } else {
-                            return Err("omit_on cannot appear twice as an attribute");
+                            return Err("omit_when cannot appear twice as an attribute");
                         }
                     } else {
                         return Err("unexpected digestible feature attribute");
@@ -230,9 +230,9 @@ fn try_digestible_struct(
                     // Read any #[digestible(...)]` attributes on this field and parse them
                     let attr_config = FieldAttributeConfig::try_from(&field.attrs[..])?;
 
-                    if let Some(omit_on) = attr_config.omit_on {
+                    if let Some(omit_when) = attr_config.omit_when {
                         Ok(quote! {
-                            if self.#field_ident != #omit_on {
+                            if self.#field_ident != #omit_when {
                                 self.#field_ident.append_to_transcript_allow_omit(stringify!(#field_ident).as_bytes(), transcript);
                             }
                         })

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -228,7 +228,9 @@ fn try_digestible_struct(
 
                     if attr_config.omit_on_zero {
                         Ok(quote! {
-                            self.#field_ident.append_to_transcript_omit_on_zero(stringify!(#field_ident).as_bytes(), transcript);
+                            if self.#field_ident != 0 {
+                                self.#field_ident.append_to_transcript_allow_omit(stringify!(#field_ident).as_bytes(), transcript);
+                            }
                         })
                     } else {
                         Ok(quote! {

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -100,10 +100,15 @@ impl TryFrom<&[Attribute]> for AttributeConfig {
     }
 }
 
-/// TODO document
+/// Configuration options for individual fields inside a struct.
+/// They are set using the #[digestible(..)] directive.
 #[derive(Default, Clone, Debug)]
 struct FieldAttributeConfig {
-    /// TODO
+    /// Allows skipping the hashing of a field if it's value is equal to 0.
+    /// This is a backwards compatibility tool that allows adding new integer
+    /// fields without affecting the hash of existing objects that do not
+    /// have the field set.print! Using this on a field type that cannot be
+    /// compared to 0 will result in a compile error.
     pub omit_on_zero: bool,
 }
 

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -36,6 +36,17 @@ struct ThingV4 {
     c: Vec<bool>,
 }
 
+// A new field that is skipped when set to the type's default value
+#[derive(Digestible)]
+#[digestible(name = "Thing")]
+struct ThingV5 {
+    a: Option<u64>,
+    b: Option<u64>,
+    c: Vec<bool>,
+    #[digestible(omit_on_zero)]
+    d: i32,
+}
+
 // Test vectors for a few instances of the Thing struct, and versions of it
 #[test]
 fn thing_struct() {
@@ -154,6 +165,28 @@ fn struct_schema_evolution() {
             a: Some(14),
             b: Some(99),
             c: Default::default()
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_eq!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV5 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV5 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 1,
         }
         .digest32::<MerlinTranscript>(b"test")
     );

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -43,7 +43,7 @@ struct ThingV5 {
     a: Option<u64>,
     b: Option<u64>,
     c: Vec<bool>,
-    #[digestible(omit_on = 0)]
+    #[digestible(omit_when = 0)]
     d: i32,
 }
 

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -43,7 +43,7 @@ struct ThingV5 {
     a: Option<u64>,
     b: Option<u64>,
     c: Vec<bool>,
-    #[digestible(omit_on_zero)]
+    #[digestible(omit_on = 0)]
     d: i32,
 }
 

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -82,16 +82,6 @@ pub trait Digestible {
     ) {
         self.append_to_transcript(context, transcript)
     }
-
-    /// TODO
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        self.append_to_transcript(context, transcript)
-    }
 }
 
 /// A trait implemented by protocol transcript objects.
@@ -258,17 +248,6 @@ impl Digestible for u16 {
         // Note: encoding of the size of the uint is implicit in merlin's framing
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
     }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
-    }
 }
 
 impl Digestible for u32 {
@@ -279,17 +258,6 @@ impl Digestible for u32 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
-    }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
     }
 }
 
@@ -302,17 +270,6 @@ impl Digestible for u64 {
     ) {
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
     }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
-    }
 }
 
 impl Digestible for i8 {
@@ -323,17 +280,6 @@ impl Digestible for i8 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
-    }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
     }
 }
 
@@ -346,17 +292,6 @@ impl Digestible for i16 {
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
     }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
-    }
 }
 
 impl Digestible for i32 {
@@ -367,17 +302,6 @@ impl Digestible for i32 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
-    }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
     }
 }
 
@@ -390,17 +314,6 @@ impl Digestible for i64 {
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
     }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
-    }
 }
 
 impl Digestible for usize {
@@ -412,17 +325,6 @@ impl Digestible for usize {
     ) {
         (*self as u64).append_to_transcript(context, transcript);
     }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
-    }
 }
 
 impl Digestible for isize {
@@ -433,17 +335,6 @@ impl Digestible for isize {
         transcript: &mut DT,
     ) {
         (*self as i64).append_to_transcript(context, transcript);
-    }
-
-    #[inline]
-    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
-        &self,
-        context: &'static [u8],
-        transcript: &mut DT,
-    ) {
-        if *self != 0 {
-            self.append_to_transcript(context, transcript)
-        }
     }
 }
 

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -82,6 +82,16 @@ pub trait Digestible {
     ) {
         self.append_to_transcript(context, transcript)
     }
+
+    /// TODO
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        self.append_to_transcript(context, transcript)
+    }
 }
 
 /// A trait implemented by protocol transcript objects.
@@ -248,6 +258,17 @@ impl Digestible for u16 {
         // Note: encoding of the size of the uint is implicit in merlin's framing
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
     }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
+    }
 }
 
 impl Digestible for u32 {
@@ -258,6 +279,17 @@ impl Digestible for u32 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+    }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
     }
 }
 
@@ -270,6 +302,17 @@ impl Digestible for u64 {
     ) {
         transcript.append_primitive(context, b"uint", &self.to_le_bytes())
     }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
+    }
 }
 
 impl Digestible for i8 {
@@ -280,6 +323,17 @@ impl Digestible for i8 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
+    }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
     }
 }
 
@@ -292,6 +346,17 @@ impl Digestible for i16 {
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
     }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
+    }
 }
 
 impl Digestible for i32 {
@@ -302,6 +367,17 @@ impl Digestible for i32 {
         transcript: &mut DT,
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
+    }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
     }
 }
 
@@ -314,6 +390,17 @@ impl Digestible for i64 {
     ) {
         transcript.append_primitive(context, b"int", &self.to_le_bytes())
     }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
+    }
 }
 
 impl Digestible for usize {
@@ -325,6 +412,17 @@ impl Digestible for usize {
     ) {
         (*self as u64).append_to_transcript(context, transcript);
     }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
+    }
 }
 
 impl Digestible for isize {
@@ -335,6 +433,17 @@ impl Digestible for isize {
         transcript: &mut DT,
     ) {
         (*self as i64).append_to_transcript(context, transcript);
+    }
+
+    #[inline]
+    fn append_to_transcript_omit_on_zero<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        if *self != 0 {
+            self.append_to_transcript(context, transcript)
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

We'd like to support adding integer fields to existing `Digestible` structs such that existing hashes are not affected when the new fields are set to zero. This plays nicely with structs that are also backed by Protobuf, since integer fields default to zero when not explicitly set to something else.

### In this PR
* Add support for a `#[digestible(omit_on_zero)]` directive that can be applied to struct fields, resulting in the field not being digested if it is set to zero.
