### PR TITLE
Add ingress key DB filter that enables selecting only unexpired keys

### DIFF
--- a/fog/api/proto/ingest.proto
+++ b/fog/api/proto/ingest.proto
@@ -112,6 +112,11 @@ message GetIngressKeyRecordsRequest {
 
     /// If true the response will include ingress keys that have been retired.
     bool should_include_retired_keys = 3;
+
+    /// If true the response will only include ingress keys that are
+    /// unexpired, which are keys with public expiry values are greater than 
+    /// their last scanned block values.
+    bool should_only_include_unexpired_keys = 4;
 }
 
 message GetIngressKeyRecordsResponse {

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -1439,12 +1439,14 @@ where
         start_block_at_least: u64,
         should_include_lost_keys: bool,
         should_include_retired_keys: bool,
+        should_only_include_unexpired_keys: bool,
     ) -> Result<Vec<IngressPublicKeyRecord>, <DB as RecoveryDb>::Error> {
         self.recovery_db.get_ingress_key_records(
             start_block_at_least,
             IngressPublicKeyRecordFilters {
                 should_include_lost_keys,
                 should_include_retired_keys,
+                should_only_include_unexpired_keys,
             },
         )
     }

--- a/fog/ingest/server/src/ingest_service.rs
+++ b/fog/ingest/server/src/ingest_service.rs
@@ -236,6 +236,7 @@ where
                 request.start_block_at_least,
                 request.should_include_lost_keys,
                 request.should_include_retired_keys,
+                request.should_only_include_unexpired_keys,
             )
             .map_err(|err| rpc_precondition_error("get_ingress_key_records", err, logger))?;
 

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -29,6 +29,11 @@ pub struct IngressPublicKeyRecordFilters {
 
     /// If set to true, the query will include ingress keys that are retired.
     pub should_include_retired_keys: bool,
+
+    /// If set to true, the query will only include keys that are unexpired,
+    /// which means that the key's last scanned block is less than the key's
+    /// public expiry.
+    pub should_only_include_unexpired_keys: bool,
 }
 
 /// A generic error type for recovery db operations

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -2752,7 +2752,7 @@ mod tests {
             },
             last_scanned_block: Some(10),
         };
-        assert_eq!(actual[0], expected);
+        assert_eq!(actual, vec![expected]);
     }
 
     #[test_with_logger]
@@ -3064,6 +3064,6 @@ mod tests {
             },
             last_scanned_block: Some(10),
         };
-        assert_eq!(actual[0], expected);
+        assert_eq!(actual, vec![expected]);
     }
 }

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -323,6 +323,9 @@ impl RecoveryDb for SqlRecoveryDb {
         let conn = self.pool.get()?;
 
         use schema::ingress_keys::dsl;
+        let last_scanned_block = diesel::dsl::sql::<diesel::sql_types::BigInt>(
+                    "(SELECT MAX(block_number) FROM ingested_blocks WHERE ingress_keys.ingress_public_key = ingested_blocks.ingress_public_key)"
+                );
         let mut query = dsl::ingress_keys
             .select((
                 dsl::ingress_public_key,
@@ -330,20 +333,23 @@ impl RecoveryDb for SqlRecoveryDb {
                 dsl::pubkey_expiry,
                 dsl::retired,
                 dsl::lost,
-                diesel::dsl::sql::<diesel::sql_types::BigInt>(
-                    "(SELECT MAX(block_number) FROM ingested_blocks WHERE ingress_keys.ingress_public_key = ingested_blocks.ingress_public_key)"
-                ).nullable(),
-
+                last_scanned_block.clone().nullable(),
             ))
             .filter(dsl::start_block.ge(start_block_at_least as i64))
             // Allows for conditional queries, which means additional filter
             // clauses can be added to this query.
             .into_boxed();
 
+        if ingress_public_key_record_filters.should_only_include_unexpired_keys {
+            query = query
+                .filter(last_scanned_block.clone().is_not_null())
+                .filter(dsl::pubkey_expiry.gt(last_scanned_block));
+        }
         if !ingress_public_key_record_filters.should_include_lost_keys {
             // Adds this filter to the existing query (rather than replacing it).
             query = query.filter(dsl::lost.eq(false));
         }
+
         if !ingress_public_key_record_filters.should_include_retired_keys {
             // Adds this filter to the existing query (rather than replacing it).
             query = query.filter(dsl::retired.eq(false));
@@ -2110,7 +2116,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2126,7 +2133,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2152,7 +2160,8 @@ mod tests {
                     0,
                     IngressPublicKeyRecordFilters {
                         should_include_lost_keys: true,
-                        should_include_retired_keys: true
+                        should_include_retired_keys: true,
+                        should_only_include_unexpired_keys: false,
                     }
                 )
                 .unwrap()
@@ -2197,7 +2206,8 @@ mod tests {
                         0,
                         IngressPublicKeyRecordFilters {
                             should_include_lost_keys: true,
-                            should_include_retired_keys: true
+                            should_include_retired_keys: true,
+                            should_only_include_unexpired_keys: false,
                         }
                     )
                     .unwrap()
@@ -2237,7 +2247,8 @@ mod tests {
                     0,
                     IngressPublicKeyRecordFilters {
                         should_include_lost_keys: true,
-                        should_include_retired_keys: true
+                        should_include_retired_keys: true,
+                        should_only_include_unexpired_keys: false,
                     }
                 )
                 .unwrap()
@@ -2275,7 +2286,8 @@ mod tests {
                     0,
                     IngressPublicKeyRecordFilters {
                         should_include_lost_keys: true,
-                        should_include_retired_keys: true
+                        should_include_retired_keys: true,
+                        should_only_include_unexpired_keys: false,
                     }
                 )
                 .unwrap()
@@ -2322,7 +2334,8 @@ mod tests {
                     0,
                     IngressPublicKeyRecordFilters {
                         should_include_lost_keys: true,
-                        should_include_retired_keys: true
+                        should_include_retired_keys: true,
+                        should_only_include_unexpired_keys: false,
                     }
                 )
                 .unwrap()
@@ -2372,7 +2385,8 @@ mod tests {
                         0,
                         IngressPublicKeyRecordFilters {
                             should_include_lost_keys: true,
-                            should_include_retired_keys: true
+                            should_include_retired_keys: true,
+                            should_only_include_unexpired_keys: false,
                         }
                     )
                     .unwrap()
@@ -2408,7 +2422,8 @@ mod tests {
                 400,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2439,7 +2454,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: false,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2455,7 +2471,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2476,7 +2493,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: false
+                    should_include_retired_keys: false,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap()
@@ -2499,7 +2517,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: false,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2515,7 +2534,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: true,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2537,7 +2557,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: false,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap()
@@ -2560,7 +2581,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: false,
-                    should_include_retired_keys: true
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap(),
@@ -2580,7 +2602,8 @@ mod tests {
                     0,
                     IngressPublicKeyRecordFilters {
                         should_include_lost_keys: true,
-                        should_include_retired_keys: true
+                        should_include_retired_keys: true,
+                        should_only_include_unexpired_keys: false,
                     }
                 )
                 .unwrap()
@@ -2617,7 +2640,8 @@ mod tests {
                 0,
                 IngressPublicKeyRecordFilters {
                     should_include_lost_keys: false,
-                    should_include_retired_keys: false
+                    should_include_retired_keys: false,
+                    should_only_include_unexpired_keys: false,
                 }
             )
             .unwrap()
@@ -2627,7 +2651,7 @@ mod tests {
     }
 
     #[test_with_logger]
-    fn test_new_ingress_key_no_blocks_added_accepted_block_count_is_proposed_start_block_when_zero(
+    fn test_get_ingress_key_records_should_only_include_in_use_keys_one_key_lost_one_key_retired_but_last_scanned_less_than_pubkey_expiry(
         logger: Logger,
     ) {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
@@ -2649,6 +2673,90 @@ mod tests {
 
     #[test_with_logger]
     fn test_new_ingress_key_no_blocks_added_accepted_block_count_is_proposed_start_block(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: false,
+                    should_only_include_unexpired_keys: false,
+                }
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 0).unwrap();
+
+        let ingress_key2 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
+        db.new_ingress_key(&ingress_key2, 5).unwrap();
+
+        // Add an ingest invocation and see that we can see it.
+        let invoc_id1 = db
+            .new_ingest_invocation(None, &ingress_key1, &random_kex_rng_pubkey(&mut rng), 123)
+            .unwrap();
+
+        let ranges = db.get_ingestable_ranges().unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].start_block, 123);
+        assert_eq!(ranges[0].decommissioned, false);
+        assert_eq!(ranges[0].last_ingested_block, None);
+
+        // This makes last_scanned_block equal 10.
+        for block_index in 0..11 {
+            let (block, records) = random_block(&mut rng, block_index, 10);
+            db.add_block_data(&invoc_id1, &block, 0, &records).unwrap();
+        }
+
+        db.set_report(
+            &ingress_key1,
+            "",
+            &ReportData {
+                pubkey_expiry: 20,
+                ingest_invocation_id: None,
+                report: Default::default(),
+            },
+        )
+        .unwrap();
+
+        db.retire_ingress_key(&ingress_key1, true).unwrap();
+        db.report_lost_ingress_key(ingress_key2).unwrap();
+
+        let actual = db
+            .get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: true,
+                },
+            )
+            .unwrap();
+
+        let expected = IngressPublicKeyRecord {
+            key: ingress_key1.clone(),
+            status: IngressPublicKeyStatus {
+                start_block: 0,
+                pubkey_expiry: 20,
+                retired: true,
+                lost: false,
+            },
+            last_scanned_block: Some(10),
+        };
+        assert_eq!(actual[0], expected);
+    }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_only_include_in_use_keys_one_key_lost_one_key_retired_and_last_scanned_equal_to_pubkey_expiry(
         logger: Logger,
     ) {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
@@ -2797,5 +2905,165 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(accepted_start_block, ingress_key_status.start_block);
+    }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_only_include_in_use_keys_one_key_lost_one_key_retired_and_last_scanned_greater_than_pubkey_expiry(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: false,
+                    should_only_include_unexpired_keys: false,
+                }
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 0).unwrap();
+
+        let ingress_key2 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
+        db.new_ingress_key(&ingress_key2, 5).unwrap();
+
+        // Add an ingest invocation and see that we can see it.
+        let invoc_id1 = db
+            .new_ingest_invocation(None, &ingress_key1, &random_kex_rng_pubkey(&mut rng), 123)
+            .unwrap();
+
+        let ranges = db.get_ingestable_ranges().unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].id, invoc_id1);
+        assert_eq!(ranges[0].start_block, 123);
+        assert_eq!(ranges[0].decommissioned, false);
+        assert_eq!(ranges[0].last_ingested_block, None);
+
+        // This makes last_scanned_block equal 10.
+        for block_index in 0..11 {
+            let (block, records) = random_block(&mut rng, block_index, 10);
+            db.add_block_data(&invoc_id1, &block, 0, &records).unwrap();
+        }
+
+        db.set_report(
+            &ingress_key1,
+            "",
+            &ReportData {
+                pubkey_expiry: 5,
+                ingest_invocation_id: None,
+                report: Default::default(),
+            },
+        )
+        .unwrap();
+
+        db.retire_ingress_key(&ingress_key1, true).unwrap();
+        db.report_lost_ingress_key(ingress_key2).unwrap();
+
+        let actual = db
+            .get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: true,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(actual.len(), 0);
+    }
+
+    #[test_with_logger]
+    fn test_get_ingress_key_records_should_only_include_in_use_keys_one_key_lost_one_key_retired_and_last_scanned_less_than_pubkey_expiry(
+        logger: Logger,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        // At first, there are no records.
+        assert_eq!(
+            db.get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: false,
+                    should_only_include_unexpired_keys: false,
+                }
+            )
+            .unwrap(),
+            vec![],
+        );
+
+        // Add an ingress key and see that we can retreive it.
+        let ingress_key1 = CompressedRistrettoPublic::from_random(&mut rng);
+        db.new_ingress_key(&ingress_key1, 0).unwrap();
+
+        let ingress_key2 = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
+        db.new_ingress_key(&ingress_key2, 5).unwrap();
+
+        // Add an ingest invocation and see that we can see it.
+        let invoc_id1 = db
+            .new_ingest_invocation(None, &ingress_key1, &random_kex_rng_pubkey(&mut rng), 123)
+            .unwrap();
+
+        let ranges = db.get_ingestable_ranges().unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].id, invoc_id1);
+        assert_eq!(ranges[0].start_block, 123);
+        assert_eq!(ranges[0].decommissioned, false);
+        assert_eq!(ranges[0].last_ingested_block, None);
+
+        // This makes last_scanned_block equal 10.
+        for block_index in 0..11 {
+            let (block, records) = random_block(&mut rng, block_index, 10);
+            db.add_block_data(&invoc_id1, &block, 0, &records).unwrap();
+        }
+
+        db.set_report(
+            &ingress_key1,
+            "",
+            &ReportData {
+                pubkey_expiry: 15,
+                ingest_invocation_id: None,
+                report: Default::default(),
+            },
+        )
+        .unwrap();
+
+        db.retire_ingress_key(&ingress_key1, true).unwrap();
+        db.report_lost_ingress_key(ingress_key2).unwrap();
+
+        let actual = db
+            .get_ingress_key_records(
+                0,
+                IngressPublicKeyRecordFilters {
+                    should_include_lost_keys: false,
+                    should_include_retired_keys: true,
+                    should_only_include_unexpired_keys: true,
+                },
+            )
+            .unwrap();
+
+        let expected = IngressPublicKeyRecord {
+            key: ingress_key1.clone(),
+            status: IngressPublicKeyStatus {
+                start_block: 0,
+                pubkey_expiry: 15,
+                retired: true,
+                lost: false,
+            },
+            last_scanned_block: Some(10),
+        };
+        assert_eq!(actual[0], expected);
     }
 }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -220,6 +220,7 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
             IngressPublicKeyRecordFilters {
                 should_include_lost_keys: true,
                 should_include_retired_keys: true,
+                should_only_include_unexpired_keys: false,
             },
         ) {
             Ok(records) => {


### PR DESCRIPTION
### Motivation
This PR enables us to filter ingress keys based on their expiry status. A key is considered expired if its pubkey_expiry is less than or equal to the key's last scanned block. This prepares for the Fog Overseer implementation (see [sam/fog-overseer](https://github.com/mobilecoinfoundation/mobilecoin/tree/sam/fog-overseer/fog)), which requires us to find any keys that are unexpired, meaning they still have work to do. 

Note that I chose to create a new term "unexpired" to signify the state in which a key's pubkey_expiry is less than or equal to last scanned block because we can't use any existing terms to signify this state. For example, we can't just use "retired" to signify this state because a key can be marked as retired but still have work to do on any blocks (IFF its pubkey_expiry is less than or equal to last scanned block). 

I could have used a term like "active" or "outstanding" to signify this state, but I didn't choose the former because "active" is a concept we already have for Fog ingest servers and "outstanding" seemed less precise than "unexpired." However, I'm open to changing the naming if it's a point of contention. 

### In this PR
* Ingress keys can be queried based on their "unexpired" status. 

Asana [ticket](https://app.asana.com/0/1200353042931237/1201068752634748/f)
### Future Work
* Fog overseer will use this filter when querying the database. It will look for keys that are (a) not lost and (b) unexpired (regardless of whether or not they're marked as "retired"). 


