### PR TITLE
expose identify_safe_blocks since it is useful for full-service

### DIFF
--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -755,7 +755,7 @@ fn get_block_contents<TF: TransactionsFetcher + 'static>(
 /// * `ledger` - The local node's ledger.
 /// * `blocks_and_contents` - A sequence of Blocks with their associated
 ///   transactions, in increasing order of block number.
-fn identify_safe_blocks<L: Ledger>(
+pub fn identify_safe_blocks<L: Ledger>(
     ledger: &L,
     blocks_and_contents: &[(Block, BlockContents)],
     logger: &Logger,

--- a/ledger/sync/src/ledger_sync/mod.rs
+++ b/ledger/sync/src/ledger_sync/mod.rs
@@ -4,6 +4,6 @@ mod ledger_sync_service_thread;
 mod ledger_sync_trait;
 
 pub use ledger_sync_error::LedgerSyncError;
-pub use ledger_sync_service::LedgerSyncService;
+pub use ledger_sync_service::{LedgerSyncService, identify_safe_blocks};
 pub use ledger_sync_service_thread::LedgerSyncServiceThread;
 pub use ledger_sync_trait::{LedgerSync, MockLedgerSync};

--- a/ledger/sync/src/ledger_sync/mod.rs
+++ b/ledger/sync/src/ledger_sync/mod.rs
@@ -4,6 +4,6 @@ mod ledger_sync_service_thread;
 mod ledger_sync_trait;
 
 pub use ledger_sync_error::LedgerSyncError;
-pub use ledger_sync_service::{LedgerSyncService, identify_safe_blocks};
+pub use ledger_sync_service::{identify_safe_blocks, LedgerSyncService};
 pub use ledger_sync_service_thread::LedgerSyncServiceThread;
 pub use ledger_sync_trait::{LedgerSync, MockLedgerSync};

--- a/ledger/sync/src/lib.rs
+++ b/ledger/sync/src/lib.rs
@@ -6,7 +6,8 @@ mod reqwest_transactions_fetcher;
 mod transactions_fetcher_trait;
 
 pub use ledger_sync::{
-    LedgerSync, LedgerSyncError, LedgerSyncService, LedgerSyncServiceThread, MockLedgerSync,
+    identify_safe_blocks, LedgerSync, LedgerSyncError, LedgerSyncService, LedgerSyncServiceThread,
+    MockLedgerSync,
 };
 pub use network_state::{NetworkState, PollingNetworkState, SCPNetworkState};
 pub use reqwest_transactions_fetcher::{


### PR DESCRIPTION
### Motivation

The `identify_safe_blocks` function contains useful logic that can be re-used by alternative implementations of ledger syncing and I'd like to make that possible.

### In this PR
* Making `identify_safe_blocks` public.
