### PR TITLE
Fix peer flag accepting mcp URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,7 @@ checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa 0.4.5",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1908,7 +1908,7 @@ checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
  "bytes 0.4.12",
  "fnv",
- "itoa 0.4.5",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1919,7 +1919,7 @@ checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
- "itoa 0.4.5",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1995,7 +1995,7 @@ dependencies = [
  "http-body 0.1.0",
  "httparse",
  "iovec",
- "itoa 0.4.5",
+ "itoa 0.4.8",
  "log 0.4.11",
  "net2",
  "rustc_version",
@@ -2025,7 +2025,7 @@ dependencies = [
  "http 0.2.1",
  "http-body 0.3.1",
  "httparse",
- "itoa 0.4.5",
+ "itoa 0.4.8",
  "log 0.4.11",
  "net2",
  "pin-project 0.4.10",
@@ -6097,12 +6097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7004,7 +6998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.5",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -7570,7 +7564,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
  "time-macros",
 ]

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -114,7 +114,7 @@ impl UriScheme for WatcherScheme {
 
 #[cfg(test)]
 mod consensus_client_uri_tests {
-    use super::{ConnectionUri, ConsensusClientUri as ClientUri, ConsensusPeerUri as PeerUri};
+    use super::{ConnectionUri, ConsensusClientUri as ClientUri};
     use mc_common::ResponderId;
     use std::str::FromStr;
 
@@ -247,15 +247,8 @@ mod consensus_client_uri_tests {
 
     #[test]
     fn test_client_from_peer_should_fail() {
-        let uri = PeerUri::from_str("insecure-mcp://localhost:3223/?consensus-msg-key=MCowBQYDK2VwAyEAUBfht6884a45r0AjFRXgLlnw3yIDllTepWavLrT8Lfk=").unwrap();
-        assert_eq!(uri.addr(), "localhost:3223");
-        assert_eq!(
-            uri.responder_id().unwrap(),
-            ResponderId::from_str("localhost:3223").unwrap()
-        );
-        assert_eq!(uri.use_tls(), false);
-
-        assert!(ClientUri::from_str(&uri.addr()).is_err());
+        assert!(ClientUri::from_str("mcp://localhost:3223/").is_err());
+        assert!(ClientUri::from_str("insecure-mcp://localhost:3223/").is_err());
     }
 
     #[test]

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -106,9 +106,9 @@ impl<Scheme: UriScheme> FromStr for Uri<Scheme> {
             return Err(UriParseError::MissingHost);
         }
 
-        let use_tls = if url.scheme().starts_with(Scheme::SCHEME_SECURE) {
+        let use_tls = if url.scheme() == Scheme::SCHEME_SECURE {
             true
-        } else if url.scheme().starts_with(Scheme::SCHEME_INSECURE) {
+        } else if url.scheme() == Scheme::SCHEME_INSECURE {
             false
         } else {
             return Err(UriParseError::UnknownScheme(


### PR DESCRIPTION
Fixes #828: `--peer` accepts `mcp://` URLs.