### PR TITLE
Simplify target-cpu usage

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,22 +1,7 @@
 [build]
 rustflags = ["-D", "warnings"]
 
-# Using 'cfg` is broken, see https://github.com/rust-lang/cargo/issues/6858
-# [target.'cfg(target_arch = "x86_64")']
-# rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
-
-# ...so instead we list all target triples (Tier 1 64-bit platforms)
-
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
-
-[target.x86_64-pc-windows-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
-
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
-
-[target.x86_64-apple-darwin]
+[target.'cfg(target_arch = "x86_64")']
 rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
 
 [cargo-new]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,9 +1,7 @@
 [build]
-rustflags = ["-D", "warnings"]
-
-# NB: This breaks subtly if we use spaces in the cfg clause.
-[target.'cfg(target_arch="x86_64")']
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
+rustflags = ["-D", "warnings", "-C", "target-cpu=native"]
+# NB: 'cfg(target_feature)' does not work in this context.
+# See https://github.com/rust-lang/cargo/issues/6858
 
 [cargo-new]
 name = "MobileCoin"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,8 @@
 [build]
 rustflags = ["-D", "warnings"]
 
-[target.'cfg(target_arch = "x86_64")']
+# NB: This breaks subtly if we use spaces in the cfg clause.
+[target.'cfg(target_arch="x86_64")']
 rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
 
 [cargo-new]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["-D", "warnings", "-C", "target-cpu=native"]
+rustflags = ["-D", "warnings"]
 # NB: 'cfg(target_feature)' does not work in this context.
 # See https://github.com/rust-lang/cargo/issues/6858
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -608,7 +608,7 @@ jobs:
       <<: *default-build-environment
       OPENSSL_BIN: /usr/local/opt/openssl/bin/openssl
       SCCACHE_CACHE_SIZE: 450M
-      RUSTFLAGS: -D warnings -C target-cpu=penryn
+      RUSTFLAGS: -D warnings -C target-cpu=skylake
       CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/sgx/css/src/valid.css
     steps:
       - prepare-for-build: { os: macos }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ defaults:
     IAS_MODE: DEV
     SGX_MODE: SW
     RUST_BACKTRACE: "1"
+    RUSTFLAGS: -D warnings -C target-cpu=skylake
     SKIP_SLOW_TESTS: "1"
 
 executors:
@@ -608,7 +609,7 @@ jobs:
       <<: *default-build-environment
       OPENSSL_BIN: /usr/local/opt/openssl/bin/openssl
       SCCACHE_CACHE_SIZE: 450M
-      RUSTFLAGS: -D warnings -C target-cpu=skylake
+      RUSTFLAGS: -D warnings -C target-cpu=penryn
       CONSENSUS_ENCLAVE_CSS: /Users/distiller/project/sgx/css/src/valid.css
     steps:
       - prepare-for-build: { os: macos }

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -246,7 +246,14 @@ impl Builder {
 
         cargo_builder
             .target(ENCLAVE_TARGET_TRIPLE)
-            .add_rust_flags(&["-D", "warnings", "-C", &feature_buf]);
+            .add_rust_flags(&[
+                "-D",
+                "warnings",
+                "-C",
+                "target-cpu=skylake",
+                "-C",
+                &feature_buf,
+            ]);
 
         Ok(Self {
             cargo_builder,


### PR DESCRIPTION
Tested: `cargo build -v`, `cargo build --release -v` on my dev machine running Ubuntu.

I verified all the `rustc` commands include `-D warnings -C target-cpu=skylake` 

Fixes #580 