### PR TITLE
s/MINIMUM_FEE/MOB_MINIMUM_FEE/

### DIFF
--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -7,7 +7,7 @@ use mc_connection::{
     Result as ConnectionResult, UserTxConnection,
 };
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{constants::MINIMUM_FEE, tx::Tx, Block, BlockID, BlockIndex};
+use mc_transaction_core::{constants::MOB_MINIMUM_FEE, tx::Tx, Block, BlockID, BlockIndex};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
     cmp::{min, Ordering},
@@ -116,7 +116,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
     fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
-            minimum_fee: MINIMUM_FEE,
+            minimum_fee: MOB_MINIMUM_FEE,
         })
     }
 }

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use mc_common::ResponderId;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_sgx_compat::sync::Mutex;
-use mc_transaction_core::{constants::MINIMUM_FEE, tx::TokenId};
+use mc_transaction_core::{constants::MOB_MINIMUM_FEE, tx::TokenId};
 use serde::{Deserialize, Serialize};
 
 /// State managed by `FeeMap`.
@@ -27,7 +27,7 @@ struct FeeMapInner {
 impl Default for FeeMapInner {
     fn default() -> Self {
         let mut map = BTreeMap::new();
-        map.insert(TokenId::MOB, MINIMUM_FEE);
+        map.insert(TokenId::MOB, MOB_MINIMUM_FEE);
 
         let cached_digest = calc_digest_for_map(&map);
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -23,7 +23,7 @@ use mc_crypto_keys::{
 use mc_crypto_rand::McRng;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
+    constants::MOB_MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
     tx::{TokenId, Tx, TxOut, TxOutMembershipProof},
@@ -52,7 +52,7 @@ impl Default for ConsensusServiceMockEnclave {
         let signing_keypair = Arc::new(Ed25519Pair::from_random(&mut csprng));
         let minimum_fees = Arc::new(Mutex::new(BTreeMap::from_iter(vec![(
             TokenId::MOB,
-            MINIMUM_FEE,
+            MOB_MINIMUM_FEE,
         )])));
 
         Self {
@@ -240,7 +240,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
                 tx,
                 parent_block.index + 1,
                 proofs,
-                MINIMUM_FEE,
+                MOB_MINIMUM_FEE,
                 &mut rng,
             )?;
 

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -18,7 +18,7 @@ use mc_fog_report_connection::{Error as ReportConnError, GrpcFogReportConnection
 use mc_fog_report_validation::FogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
+    constants::MOB_MINIMUM_FEE,
     get_tx_out_shared_secret,
     onetime_keys::{recover_onetime_private_key, view_key_matches_output},
     ring_signature::KeyImage,
@@ -132,7 +132,7 @@ fn main() {
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
             .map(|block_info| block_info.minimum_fee)
             .max()
-            .unwrap_or(MINIMUM_FEE),
+            .unwrap_or(MOB_MINIMUM_FEE),
         Ordering::SeqCst,
     );
 

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -29,7 +29,7 @@ use mc_fog_report_validation::{FogPubkeyResolver, FogResolver};
 use mc_fog_types::BlockCount;
 use mc_fog_view_connection::FogViewGrpcClient;
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
+    constants::MOB_MINIMUM_FEE,
     onetime_keys::*,
     ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutMembershipProof},
@@ -321,7 +321,7 @@ impl Client {
         const TARGET_NUM_INPUTS: usize = 3;
         let inputs = self
             .tx_data
-            .get_transaction_inputs(amount + MINIMUM_FEE, TARGET_NUM_INPUTS)?;
+            .get_transaction_inputs(amount + MOB_MINIMUM_FEE, TARGET_NUM_INPUTS)?;
         let inputs: Vec<(OwnedTxOut, TxOutMembershipProof)> = self.get_proofs(&inputs)?;
         let rings: Vec<Vec<(TxOut, TxOutMembershipProof)>> = self.get_rings(inputs.len(), rng)?;
 
@@ -815,7 +815,7 @@ mod test_build_transaction_helper {
             true,
             &mut rng,
             &logger,
-            MINIMUM_FEE,
+            MOB_MINIMUM_FEE,
         )
         .unwrap();
 

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -15,7 +15,7 @@ use mc_fog_sample_paykit::{AccountKey, Client, ClientBuilder, TransactionStatus,
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_sgx_css::Signature;
 use mc_transaction_core::{
-    constants::{MINIMUM_FEE, RING_SIZE},
+    constants::{MOB_MINIMUM_FEE, RING_SIZE},
     BlockIndex,
 };
 use mc_transaction_std::MemoType;
@@ -73,7 +73,7 @@ impl Default for TestClientPolicy {
             tx_receive_deadline: Duration::from_secs(10),
             double_spend_wait: Duration::from_secs(10),
             polling_wait: Duration::from_millis(50),
-            transfer_amount: MINIMUM_FEE,
+            transfer_amount: MOB_MINIMUM_FEE,
             test_rth_memos: false,
         }
     }
@@ -240,7 +240,7 @@ impl TestClient {
         assert!(target_address.fog_report_url().is_some());
 
         // Get the current fee from consensus
-        let fee = source_client.get_fee().unwrap_or(MINIMUM_FEE);
+        let fee = source_client.get_fee().unwrap_or(MOB_MINIMUM_FEE);
 
         // Scope for build operation
         let transaction = {
@@ -490,7 +490,7 @@ impl TestClient {
             },
         )?;
 
-        let fee = source_client_lk.get_fee().unwrap_or(MINIMUM_FEE);
+        let fee = source_client_lk.get_fee().unwrap_or(MOB_MINIMUM_FEE);
         let transfer_start = std::time::SystemTime::now();
         let (transaction, block_count) =
             self.transfer(&mut source_client_lk, &mut target_client_lk)?;

--- a/mobilecoind/clients/python/cli/send_payment.py
+++ b/mobilecoind/clients/python/cli/send_payment.py
@@ -106,14 +106,14 @@ if __name__ == '__main__':
         balance_picoMOB = mobilecoind.get_balance(sender_monitor_id, subaddress_index=args.sender_subaddress).balance
 
         # send as much as possible after accounting for the fee
-        value_to_send_picoMOB = balance_picoMOB - mobilecoin.MINIMUM_FEE
+        value_to_send_picoMOB = balance_picoMOB - mobilecoin.MOB_MINIMUM_FEE
 
         if value_to_send_picoMOB <= 0:
             print(
                 "\nSender's balance is too low to cover fee. ({} < {})\n"
                 .format(
                     mobilecoin.display_as_MOB(balance_picoMOB),
-                    mobilecoin.display_as_MOB(mobilecoin.MINIMUM_FEE)
+                    mobilecoin.display_as_MOB(mobilecoin.MOB_MINIMUM_FEE)
                 )
             )
             sys.exit(0)

--- a/mobilecoind/clients/python/lib/mobilecoin/client.py
+++ b/mobilecoind/clients/python/lib/mobilecoin/client.py
@@ -22,7 +22,7 @@ LEDGER_SYNC_INTERVAL_SECONDS = 0.5
 DEFAULT_SUBADDRESS_INDEX = 0
 
 # see transaction/core/src/constants.rs
-MINIMUM_FEE = 10_000_000_000
+MOB_MINIMUM_FEE = 10_000_000_000
 
 
 def parse_tx_status(status) -> str:

--- a/mobilecoind/clients/python/mailchimp/allocate_mobilecoins.py
+++ b/mobilecoind/clients/python/mailchimp/allocate_mobilecoins.py
@@ -42,7 +42,7 @@ def allocate_MOB(mailchimp_member_record, amount_picoMOB):
 
     # abort if sender's balance is too low
     sender_balance_picoMOB = mobilecoind.get_balance(sender_monitor_id).balance
-    if sender_balance_picoMOB < (amount_picoMOB + mobilecoin.MINIMUM_FEE):
+    if sender_balance_picoMOB < (amount_picoMOB + mobilecoin.MOB_MINIMUM_FEE):
         print(
             "# sender's balance is too low ({})... aborting!"
             .format(mobilecoin.display_as_MOB(sender_balance_picoMOB))

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -404,7 +404,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
     /// * `inputs` - UTXOs that will be spent by the transaction.
     /// * `receiver` - The single receiver of the transaction's outputs.
     /// * `fee` - Transaction fee in picoMOB. If zero, defaults to the highest
-    ///   fee set by configured consensus nodes, or the hard-coded MINIMUM_FEE.
+    ///   fee set by configured consensus nodes, or the hard-coded
+    ///   MOB_MINIMUM_FEE.
     pub fn generate_tx_from_tx_list(
         &self,
         account_key: &AccountKey,
@@ -956,7 +957,7 @@ mod test {
     use mc_connection::{HardcodedCredentialsProvider, ThickClient};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_fog_report_validation::MockFogPubkeyResolver;
-    use mc_transaction_core::constants::{MILLIMOB_TO_PICOMOB, MINIMUM_FEE};
+    use mc_transaction_core::constants::{MILLIMOB_TO_PICOMOB, MOB_MINIMUM_FEE};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -1074,7 +1075,7 @@ mod test {
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
-                >::select_utxos_for_optimization(1000, &utxos, 2, MINIMUM_FEE)
+                >::select_utxos_for_optimization(1000, &utxos, 2, MOB_MINIMUM_FEE)
                 .unwrap();
 
             assert_eq!(selected_utxos, vec![utxos[0].clone(), utxos[4].clone()]);
@@ -1095,7 +1096,7 @@ mod test {
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
-                >::select_utxos_for_optimization(1000, &utxos, 3, MINIMUM_FEE)
+                >::select_utxos_for_optimization(1000, &utxos, 3, MOB_MINIMUM_FEE)
                 .unwrap();
 
             assert_eq!(
@@ -1113,23 +1114,23 @@ mod test {
         {
             let mut utxos = generate_utxos(6);
 
-            utxos[0].value = MINIMUM_FEE / 10;
-            utxos[1].value = MINIMUM_FEE / 10;
-            utxos[2].value = MINIMUM_FEE / 10;
-            utxos[3].value = MINIMUM_FEE / 10;
-            utxos[4].value = 200 * MINIMUM_FEE;
-            utxos[5].value = MINIMUM_FEE / 10;
+            utxos[0].value = MOB_MINIMUM_FEE / 10;
+            utxos[1].value = MOB_MINIMUM_FEE / 10;
+            utxos[2].value = MOB_MINIMUM_FEE / 10;
+            utxos[3].value = MOB_MINIMUM_FEE / 10;
+            utxos[4].value = 200 * MOB_MINIMUM_FEE;
+            utxos[5].value = MOB_MINIMUM_FEE / 10;
 
             assert!(
                 utxos[0].value + utxos[1].value + utxos[2].value + utxos[3].value + utxos[5].value
-                    < MINIMUM_FEE
+                    < MOB_MINIMUM_FEE
             );
 
             let result =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
-                >::select_utxos_for_optimization(1000, &utxos, 100, MINIMUM_FEE);
+                >::select_utxos_for_optimization(1000, &utxos, 100, MOB_MINIMUM_FEE);
             assert!(result.is_err());
         }
 
@@ -1138,14 +1139,14 @@ mod test {
         {
             let mut utxos = generate_utxos(2);
 
-            utxos[0].value = MINIMUM_FEE;
+            utxos[0].value = MOB_MINIMUM_FEE;
             utxos[1].value = 2000 * MILLIMOB_TO_PICOMOB;
 
             let result =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
-                >::select_utxos_for_optimization(1000, &utxos, 100, MINIMUM_FEE);
+                >::select_utxos_for_optimization(1000, &utxos, 100, MOB_MINIMUM_FEE);
             assert!(result.is_err());
         }
 
@@ -1153,16 +1154,16 @@ mod test {
         {
             let mut utxos = generate_utxos(4);
 
-            utxos[0].value = MINIMUM_FEE;
-            utxos[1].value = 208 * MINIMUM_FEE;
-            utxos[2].value = MINIMUM_FEE / 10;
-            utxos[3].value = MINIMUM_FEE / 5;
+            utxos[0].value = MOB_MINIMUM_FEE;
+            utxos[1].value = 208 * MOB_MINIMUM_FEE;
+            utxos[2].value = MOB_MINIMUM_FEE / 10;
+            utxos[3].value = MOB_MINIMUM_FEE / 5;
 
             let selected_utxos =
                 TransactionsManager::<
                     ThickClient<HardcodedCredentialsProvider>,
                     MockFogPubkeyResolver,
-                >::select_utxos_for_optimization(1000, &utxos, 3, MINIMUM_FEE)
+                >::select_utxos_for_optimization(1000, &utxos, 3, MOB_MINIMUM_FEE)
                 .unwrap();
             // Since we're limited to 3 inputs, the lowest input (of value 1) is going to
             // get excluded.
@@ -1184,13 +1185,15 @@ mod test {
         let result = TransactionsManager::<
             ThickClient<HardcodedCredentialsProvider>,
             MockFogPubkeyResolver,
-        >::select_utxos_for_optimization(1000, &[], 100, MINIMUM_FEE);
+        >::select_utxos_for_optimization(1000, &[], 100, MOB_MINIMUM_FEE);
         assert!(result.is_err());
 
         let result = TransactionsManager::<
             ThickClient<HardcodedCredentialsProvider>,
             MockFogPubkeyResolver,
-        >::select_utxos_for_optimization(1000, &utxos[0..1], 100, MINIMUM_FEE);
+        >::select_utxos_for_optimization(
+            1000, &utxos[0..1], 100, MOB_MINIMUM_FEE
+        );
         assert!(result.is_err());
 
         // A set of 2 utxos succeeds when max inputs is 2, but fails when it is 3 (since
@@ -1198,13 +1201,17 @@ mod test {
         let result = TransactionsManager::<
             ThickClient<HardcodedCredentialsProvider>,
             MockFogPubkeyResolver,
-        >::select_utxos_for_optimization(1000, &utxos[0..2], 2, MINIMUM_FEE);
+        >::select_utxos_for_optimization(
+            1000, &utxos[0..2], 2, MOB_MINIMUM_FEE
+        );
         assert!(result.is_ok());
 
         let result = TransactionsManager::<
             ThickClient<HardcodedCredentialsProvider>,
             MockFogPubkeyResolver,
-        >::select_utxos_for_optimization(1000, &utxos[0..2], 3, MINIMUM_FEE);
+        >::select_utxos_for_optimization(
+            1000, &utxos[0..2], 3, MOB_MINIMUM_FEE
+        );
         assert!(result.is_err());
     }
 }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1922,7 +1922,7 @@ mod test {
     use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogPubkeyResolver};
     use mc_fog_report_validation_test_utils::MockFogResolver;
     use mc_transaction_core::{
-        constants::{MAX_INPUTS, MINIMUM_FEE, RING_SIZE},
+        constants::{MAX_INPUTS, MOB_MINIMUM_FEE, RING_SIZE},
         fog_hint::FogHint,
         get_tx_out_shared_secret,
         onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
@@ -3413,7 +3413,7 @@ mod test {
 
             let change_value = test_utils::DEFAULT_PER_RECIPIENT_AMOUNT
                 - outlays.iter().map(|outlay| outlay.value).sum::<u64>()
-                - MINIMUM_FEE;
+                - MOB_MINIMUM_FEE;
 
             for (account_key, expected_value) in &[
                 (&receiver1, outlays[0].value),
@@ -3441,8 +3441,8 @@ mod test {
             }
 
             // Santity test fee
-            assert_eq!(tx_proposal.get_fee(), MINIMUM_FEE);
-            assert_eq!(tx_proposal.get_tx().get_prefix().fee, MINIMUM_FEE);
+            assert_eq!(tx_proposal.get_fee(), MOB_MINIMUM_FEE);
+            assert_eq!(tx_proposal.get_tx().get_prefix().fee, MOB_MINIMUM_FEE);
 
             // Sanity test tombstone block
             let num_blocks = ledger_db.num_blocks().unwrap();
@@ -3713,7 +3713,7 @@ mod test {
             tx_proposal.outlays[0].value,
             // Each UTXO we have has PER_RECIPIENT_AMOUNT coins. We will be merging MAX_INPUTS of
             // those into a single output, minus the fee.
-            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - MINIMUM_FEE,
+            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - MOB_MINIMUM_FEE,
         );
 
         assert_eq!(tx_proposal.outlay_index_to_tx_out_index.len(), 1);
@@ -3728,8 +3728,8 @@ mod test {
         assert_eq!(value, tx_proposal.outlays[0].value);
 
         // Santity test fee
-        assert_eq!(tx_proposal.fee(), MINIMUM_FEE);
-        assert_eq!(tx_proposal.tx.prefix.fee, MINIMUM_FEE);
+        assert_eq!(tx_proposal.fee(), MOB_MINIMUM_FEE);
+        assert_eq!(tx_proposal.tx.prefix.fee, MOB_MINIMUM_FEE);
 
         // Sanity test tombstone block
         let num_blocks = ledger_db.num_blocks().unwrap();
@@ -3788,7 +3788,7 @@ mod test {
         ));
         let receiver = AccountKey::random(&mut rng);
         request.set_receiver((&receiver.default_subaddress()).into());
-        request.set_fee(MINIMUM_FEE);
+        request.set_fee(MOB_MINIMUM_FEE);
 
         let response = client.generate_tx_from_tx_out_list(&request).unwrap();
         let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
@@ -3797,7 +3797,7 @@ mod test {
         assert_eq!(tx_proposal.tx.prefix.outputs.len(), 1);
 
         // It should equal the sum of the inputs minus the fee
-        let expected_value = tx_utxos.iter().map(|utxo| utxo.value).sum::<u64>() - MINIMUM_FEE;
+        let expected_value = tx_utxos.iter().map(|utxo| utxo.value).sum::<u64>() - MOB_MINIMUM_FEE;
 
         let tx_out = &tx_proposal.tx.prefix.outputs[0];
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
@@ -4257,7 +4257,7 @@ mod test {
 
         // Add a few utxos to our recipient, such that all of them are required to
         // create the test transaction.
-        for amount in &[10, 20, MINIMUM_FEE] {
+        for amount in &[10, 20, MOB_MINIMUM_FEE] {
             add_block_to_ledger_db(
                 &mut ledger_db,
                 &[sender.default_subaddress()],
@@ -4343,7 +4343,7 @@ mod test {
         };
 
         // Trying with a higher limit should work.
-        request.set_max_input_utxo_value(MINIMUM_FEE);
+        request.set_max_input_utxo_value(MOB_MINIMUM_FEE);
         let response = client.send_payment(&request).unwrap();
 
         let selected_utxos: Vec<UnspentTxOut> = response

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -31,7 +31,7 @@ pub const MICROMOB_TO_PICOMOB: u64 = 1_000_000;
 pub const MILLIMOB_TO_PICOMOB: u64 = 1_000_000_000;
 
 /// Minimum allowed fee, denominated in picoMOB.
-pub const MINIMUM_FEE: u64 = 400 * MICROMOB_TO_PICOMOB;
+pub const MOB_MINIMUM_FEE: u64 = 400 * MICROMOB_TO_PICOMOB;
 
 lazy_static! {
     // Blinding for the implicit fee outputs.

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -574,7 +574,7 @@ derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
 #[cfg(test)]
 mod tests {
     use crate::{
-        constants::MINIMUM_FEE,
+        constants::MOB_MINIMUM_FEE,
         encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         get_tx_out_shared_secret,
         memo::MemoPayload,
@@ -627,7 +627,7 @@ mod tests {
         let prefix = TxPrefix {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
-            fee: MINIMUM_FEE,
+            fee: MOB_MINIMUM_FEE,
             tombstone_block: 23,
         };
 
@@ -685,7 +685,7 @@ mod tests {
         let prefix = TxPrefix {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
-            fee: MINIMUM_FEE,
+            fee: MOB_MINIMUM_FEE,
             tombstone_block: 23,
         };
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -398,7 +398,7 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::{
-        constants::{MINIMUM_FEE, RING_SIZE},
+        constants::{MOB_MINIMUM_FEE, RING_SIZE},
         tx::{Tx, TxOutMembershipHash, TxOutMembershipProof},
         validation::{
             error::TransactionValidationError,
@@ -916,26 +916,28 @@ mod tests {
 
         {
             // Off by one fee gets rejected
-            let fee = MINIMUM_FEE - 1;
+            let fee = MOB_MINIMUM_FEE - 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
             assert_eq!(
-                validate_transaction_fee(&tx, MINIMUM_FEE),
+                validate_transaction_fee(&tx, MOB_MINIMUM_FEE),
                 Err(TransactionValidationError::TxFeeError)
             );
         }
 
         {
             // Exact fee amount is okay
-            let (tx, _ledger) =
-                create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - MINIMUM_FEE, MINIMUM_FEE);
-            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
+            let (tx, _ledger) = create_test_tx_with_amount(
+                INITIALIZE_LEDGER_AMOUNT - MOB_MINIMUM_FEE,
+                MOB_MINIMUM_FEE,
+            );
+            assert_eq!(validate_transaction_fee(&tx, MOB_MINIMUM_FEE), Ok(()));
         }
 
         {
             // Overpaying fees is okay
-            let fee = MINIMUM_FEE + 1;
+            let fee = MOB_MINIMUM_FEE + 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
-            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
+            assert_eq!(validate_transaction_fee(&tx, MOB_MINIMUM_FEE), Ok(()));
         }
     }
 

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -7,7 +7,7 @@ use mc_crypto_rand::{CryptoRng, RngCore};
 pub use mc_fog_report_validation_test_utils::MockFogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 pub use mc_transaction_core::{
-    constants::MINIMUM_FEE,
+    constants::MOB_MINIMUM_FEE,
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
@@ -54,14 +54,14 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     let shared_secret = get_tx_out_shared_secret(sender.view_private_key(), &tx_out_public_key);
     let (value, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
 
-    assert!(value >= MINIMUM_FEE);
+    assert!(value >= MOB_MINIMUM_FEE);
     create_transaction_with_amount(
         ledger,
         tx_out,
         sender,
         recipient,
-        value - MINIMUM_FEE,
-        MINIMUM_FEE,
+        value - MOB_MINIMUM_FEE,
+        MOB_MINIMUM_FEE,
         tombstone_block,
         rng,
     )

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::ChangeDestination;
 use mc_account_keys::{PublicAddress, ShortAddressHash};
-use mc_transaction_core::{constants::MINIMUM_FEE, MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{constants::MOB_MINIMUM_FEE, MemoContext, MemoPayload, NewMemoError};
 
 /// This memo builder attaches 0x0100 Authenticated Sender Memos to normal
 /// outputs, and 0x0200 Destination Memos to change outputs.
@@ -80,7 +80,7 @@ impl Default for RTHMemoBuilder {
             last_recipient: Default::default(),
             total_outlay: 0,
             num_recipients: 0,
-            fee: MINIMUM_FEE,
+            fee: MOB_MINIMUM_FEE,
         }
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -11,7 +11,7 @@ use mc_account_keys::PublicAddress;
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
+    constants::MOB_MINIMUM_FEE,
     encrypted_fog_hint::EncryptedFogHint,
     fog_hint::FogHint,
     onetime_keys::create_shared_secret,
@@ -87,7 +87,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             input_credentials: Vec::new(),
             outputs_and_shared_secrets: Vec::new(),
             tombstone_block: u64::max_value(),
-            fee: MINIMUM_FEE,
+            fee: MOB_MINIMUM_FEE,
             fog_resolver,
             fog_tombstone_block_limit: u64::max_value(),
             memo_builder: Some(memo_builder),
@@ -597,7 +597,7 @@ pub mod transaction_builder_tests {
         transaction_builder.add_input(input_credentials);
         let (_txout, confirmation) = transaction_builder
             .add_output(
-                value - MINIMUM_FEE,
+                value - MOB_MINIMUM_FEE,
                 &recipient.default_subaddress(),
                 &mut rng,
             )
@@ -665,7 +665,7 @@ pub mod transaction_builder_tests {
         transaction_builder.add_input(input_credentials);
         let (_txout, confirmation) = transaction_builder
             .add_output(
-                value - MINIMUM_FEE,
+                value - MOB_MINIMUM_FEE,
                 &recipient.default_subaddress(),
                 &mut rng,
             )
@@ -743,7 +743,7 @@ pub mod transaction_builder_tests {
 
         let (_txout, _confirmation) = transaction_builder
             .add_output_with_fog_hint_address(
-                value - MINIMUM_FEE,
+                value - MOB_MINIMUM_FEE,
                 &recipient.default_subaddress(),
                 &fog_hint_address,
                 |_| Ok(Default::default()),
@@ -808,7 +808,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
 
             let (_txout, _confirmation) = transaction_builder
-                .add_output(value - MINIMUM_FEE, &recipient_address, &mut rng)
+                .add_output(value - MOB_MINIMUM_FEE, &recipient_address, &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -831,7 +831,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
 
             let (_txout, _confirmation) = transaction_builder
-                .add_output(value - MINIMUM_FEE, &recipient_address, &mut rng)
+                .add_output(value - MOB_MINIMUM_FEE, &recipient_address, &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -881,7 +881,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -936,7 +936,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 assert_eq!(memo, MemoPayload::default());
@@ -1028,7 +1028,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1083,7 +1083,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1127,7 +1127,7 @@ pub mod transaction_builder_tests {
                             "lookup based on address hash failed"
                         );
                         assert_eq!(memo.get_num_recipients(), 1);
-                        assert_eq!(memo.get_fee(), MINIMUM_FEE);
+                        assert_eq!(memo.get_fee(), MOB_MINIMUM_FEE);
                         assert_eq!(
                             memo.get_total_outlay(),
                             value - change_value,
@@ -1151,14 +1151,14 @@ pub mod transaction_builder_tests {
                 TransactionBuilder::new(fog_resolver.clone(), memo_builder);
 
             transaction_builder.set_tombstone_block(2000);
-            transaction_builder.set_fee(MINIMUM_FEE * 4).unwrap();
+            transaction_builder.set_fee(MOB_MINIMUM_FEE * 4).unwrap();
 
             let input_credentials = get_input_credentials(&sender, value, &fog_resolver, &mut rng);
             transaction_builder.add_input(input_credentials);
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE * 4,
+                    value - change_value - MOB_MINIMUM_FEE * 4,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1213,7 +1213,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE * 4);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE * 4);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1257,7 +1257,7 @@ pub mod transaction_builder_tests {
                             "lookup based on address hash failed"
                         );
                         assert_eq!(memo.get_num_recipients(), 1);
-                        assert_eq!(memo.get_fee(), MINIMUM_FEE * 4);
+                        assert_eq!(memo.get_fee(), MOB_MINIMUM_FEE * 4);
                         assert_eq!(
                             memo.get_total_outlay(),
                             value - change_value,
@@ -1288,7 +1288,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1343,7 +1343,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1388,7 +1388,7 @@ pub mod transaction_builder_tests {
                             "lookup based on address hash failed"
                         );
                         assert_eq!(memo.get_num_recipients(), 1);
-                        assert_eq!(memo.get_fee(), MINIMUM_FEE);
+                        assert_eq!(memo.get_fee(), MOB_MINIMUM_FEE);
                         assert_eq!(
                             memo.get_total_outlay(),
                             value - change_value,
@@ -1418,7 +1418,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1473,7 +1473,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1536,7 +1536,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1591,7 +1591,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1621,7 +1621,7 @@ pub mod transaction_builder_tests {
                             "lookup based on address hash failed"
                         );
                         assert_eq!(memo.get_num_recipients(), 1);
-                        assert_eq!(memo.get_fee(), MINIMUM_FEE);
+                        assert_eq!(memo.get_fee(), MOB_MINIMUM_FEE);
                         assert_eq!(
                             memo.get_total_outlay(),
                             value - change_value,
@@ -1678,7 +1678,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
 
             let (_txout, _confirmation) = transaction_builder
-                .add_output(value - change_value - MINIMUM_FEE, &bob_address, &mut rng)
+                .add_output(value - change_value - MOB_MINIMUM_FEE, &bob_address, &mut rng)
                 .unwrap();
 
             transaction_builder
@@ -1730,7 +1730,7 @@ pub mod transaction_builder_tests {
                     &RistrettoPublic::try_from(&output.public_key).unwrap(),
                 );
                 let (tx_out_value, _) = output.amount.get_value(&ss).unwrap();
-                assert_eq!(tx_out_value, value - change_value - MINIMUM_FEE);
+                assert_eq!(tx_out_value, value - change_value - MOB_MINIMUM_FEE);
 
                 let memo = output.e_memo.clone().unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
@@ -1774,7 +1774,7 @@ pub mod transaction_builder_tests {
                             "lookup based on address hash failed"
                         );
                         assert_eq!(memo.get_num_recipients(), 1);
-                        assert_eq!(memo.get_fee(), MINIMUM_FEE);
+                        assert_eq!(memo.get_fee(), MOB_MINIMUM_FEE);
                         assert_eq!(
                             memo.get_total_outlay(),
                             value - change_value,
@@ -1830,7 +1830,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output(
-                    value - change_value - MINIMUM_FEE,
+                    value - change_value - MOB_MINIMUM_FEE,
                     &recipient_address,
                     &mut rng,
                 )
@@ -1841,13 +1841,13 @@ pub mod transaction_builder_tests {
                 .unwrap();
 
             assert!(
-                transaction_builder.set_fee(MINIMUM_FEE * 4).is_err(),
+                transaction_builder.set_fee(MOB_MINIMUM_FEE * 4).is_err(),
                 "setting fee after change output should be rejected"
             );
 
             assert!(
                 transaction_builder
-                    .add_output(MINIMUM_FEE, &recipient_address, &mut rng,)
+                    .add_output(MOB_MINIMUM_FEE, &recipient_address, &mut rng,)
                     .is_err(),
                 "Adding another output after chnage output should be rejected"
             );


### PR DESCRIPTION
### Motivation

The `MINIMUM_FEE` constant actually refers to MOB minimum fee. If we add different tokens, this will get confusing pretty quickly.

### In this PR
* Rename all instances of `MINIMUM_FEE` to `MOB_MINIMUM_FEE`.

### Future Work
* Look for `minimum_fee` and rename that where appropriate.
* Change the [LastBlockInfoResponse](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/consensus/api/proto/consensus_common.proto#L24) API to include the new fee map. 


