### PR TITLE
Introduce new `Token` trait and use it for specify constants relating to a given token.

### DIFF
--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -7,7 +7,7 @@ use mc_connection::{
     Result as ConnectionResult, UserTxConnection,
 };
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{constants::MINIMUM_FEE, tx::Tx, Block, BlockID, BlockIndex};
+use mc_transaction_core::{tokens::Mob, tx::Tx, Block, BlockID, BlockIndex, Token};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
     cmp::{min, Ordering},
@@ -116,7 +116,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
     fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
-            minimum_fee: MINIMUM_FEE,
+            minimum_fee: Mob::MINIMUM_FEE,
         })
     }
 }

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use mc_common::ResponderId;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_sgx_compat::sync::Mutex;
-use mc_transaction_core::{constants::MINIMUM_FEE, TokenId};
+use mc_transaction_core::{tokens::Mob, Token, TokenId};
 use serde::{Deserialize, Serialize};
 
 /// State managed by `FeeMap`.
@@ -27,7 +27,7 @@ struct FeeMapInner {
 impl Default for FeeMapInner {
     fn default() -> Self {
         let mut map = BTreeMap::new();
-        map.insert(TokenId::MOB, MINIMUM_FEE);
+        map.insert(Mob::ID, Mob::MINIMUM_FEE);
 
         let cached_digest = calc_digest_for_map(&map);
 
@@ -108,8 +108,8 @@ impl FeeMap {
         }
 
         // Must have a minimum fee for MOB.
-        if !minimum_fees.contains_key(&TokenId::MOB) {
-            return Err(Error::MissingFee(TokenId::MOB));
+        if !minimum_fees.contains_key(&Mob::ID) {
+            return Err(Error::MissingFee(Mob::ID));
         }
 
         // All good.
@@ -151,19 +151,19 @@ mod test {
     #[test]
     fn different_fee_maps_result_in_different_responder_ids() {
         let fee_map1 = FeeMap::try_from(BTreeMap::from_iter(vec![
-            (TokenId::MOB, 100),
+            (Mob::ID, 100),
             (TokenId::from(2), 200),
         ]))
         .unwrap();
 
         let fee_map2 = FeeMap::try_from(BTreeMap::from_iter(vec![
-            (TokenId::MOB, 100),
+            (Mob::ID, 100),
             (TokenId::from(2), 300),
         ]))
         .unwrap();
 
         let fee_map3 = FeeMap::try_from(BTreeMap::from_iter(vec![
-            (TokenId::MOB, 100),
+            (Mob::ID, 100),
             (TokenId::from(3), 300),
         ]))
         .unwrap();
@@ -200,23 +200,23 @@ mod test {
         // Missing MOB is not allowed
         assert_eq!(
             FeeMap::is_valid_map(&BTreeMap::default()),
-            Err(Error::MissingFee(TokenId::MOB)),
+            Err(Error::MissingFee(Mob::ID)),
         );
 
         assert_eq!(
             FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(test_token_id, 100)])),
-            Err(Error::MissingFee(TokenId::MOB)),
+            Err(Error::MissingFee(Mob::ID)),
         );
 
         // All fees must be >0
         assert_eq!(
-            FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(TokenId::MOB, 0)])),
-            Err(Error::InvalidFee(TokenId::MOB, 0)),
+            FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(Mob::ID, 0)])),
+            Err(Error::InvalidFee(Mob::ID, 0)),
         );
 
         assert_eq!(
             FeeMap::is_valid_map(&BTreeMap::from_iter(vec![
-                (TokenId::MOB, 10),
+                (Mob::ID, 10),
                 (test_token_id, 0)
             ])),
             Err(Error::InvalidFee(test_token_id, 0)),

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use mc_common::ResponderId;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_sgx_compat::sync::Mutex;
-use mc_transaction_core::{constants::MINIMUM_FEE, tx::TokenId};
+use mc_transaction_core::{constants::MINIMUM_FEE, TokenId};
 use serde::{Deserialize, Serialize};
 
 /// State managed by `FeeMap`.

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -28,8 +28,8 @@ use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, RistrettoPublic, 
 use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TokenId, Tx, TxHash, TxOutMembershipProof},
-    Block, BlockContents, BlockSignature,
+    tx::{Tx, TxHash, TxOutMembershipProof},
+    Block, BlockContents, BlockSignature, TokenId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -9,10 +9,7 @@ use mc_attest_enclave_api::{
     ClientAuthRequest, ClientSession, EnclaveMessage, PeerAuthRequest, PeerAuthResponse,
     PeerSession,
 };
-use mc_transaction_core::{
-    tx::{TokenId, TxOutMembershipProof},
-    Block,
-};
+use mc_transaction_core::{tx::TxOutMembershipProof, Block, TokenId};
 use serde::{Deserialize, Serialize};
 
 /// An enumeration of API calls and their arguments for use across serialization

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -53,9 +53,9 @@ use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
     onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
     ring_signature::{KeyImage, Scalar},
-    tx::{TokenId, Tx, TxOut, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
-    Amount, Block, BlockContents, BlockSignature, MemoPayload, BLOCK_VERSION,
+    Amount, Block, BlockContents, BlockSignature, MemoPayload, TokenId, BLOCK_VERSION,
 };
 use prost::Message;
 use rand_core::{CryptoRng, RngCore};

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -23,12 +23,12 @@ use mc_crypto_keys::{
 use mc_crypto_rand::McRng;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
-    Block, BlockContents, BlockSignature, TokenId, BLOCK_VERSION,
+    Block, BlockContents, BlockSignature, Token, TokenId, BLOCK_VERSION,
 };
 use mc_util_from_random::FromRandom;
 use rand_core::SeedableRng;
@@ -52,7 +52,7 @@ impl Default for ConsensusServiceMockEnclave {
         let signing_keypair = Arc::new(Ed25519Pair::from_random(&mut csprng));
         let minimum_fees = Arc::new(Mutex::new(BTreeMap::from_iter(vec![(
             TokenId::MOB,
-            MINIMUM_FEE,
+            Mob::MINIMUM_FEE,
         )])));
 
         Self {
@@ -240,7 +240,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
                 tx,
                 parent_block.index + 1,
                 proofs,
-                MINIMUM_FEE,
+                Mob::MINIMUM_FEE,
                 &mut rng,
             )?;
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -26,9 +26,9 @@ use mc_transaction_core::{
     constants::MINIMUM_FEE,
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
-    tx::{TokenId, Tx, TxOut, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
-    Block, BlockContents, BlockSignature, BLOCK_VERSION,
+    Block, BlockContents, BlockSignature, TokenId, BLOCK_VERSION,
 };
 use mc_util_from_random::FromRandom;
 use rand_core::SeedableRng;

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -14,8 +14,7 @@ use mc_consensus_enclave_api::{
 use mc_crypto_keys::{Ed25519Public, X25519Public};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as SgxReportResult};
 use mc_transaction_core::{
-    tx::{TokenId, TxOutMembershipProof},
-    Block, BlockContents, BlockSignature,
+    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
 };
 use std::collections::BTreeMap;
 

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -22,8 +22,7 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_sgx_types::{sgx_enclave_id_t, sgx_status_t, *};
 use mc_sgx_urts::SgxEnclave;
 use mc_transaction_core::{
-    tx::{TokenId, TxOutMembershipProof},
-    Block, BlockContents, BlockSignature,
+    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
 };
 use std::{collections::BTreeMap, path, result::Result as StdResult, sync::Arc};
 

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -7,7 +7,7 @@ use mc_common::{HashMap, HashSet, NodeID, ResponderId};
 use mc_consensus_enclave::FeeMap;
 use mc_consensus_scp::{QuorumSet, QuorumSetMember};
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair, Ed25519Private};
-use mc_transaction_core::tx::TokenId;
+use mc_transaction_core::TokenId;
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::{
     AdminUri, ConnectionUri, ConsensusClientUri as ClientUri, ConsensusPeerUri as PeerUri,

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -30,7 +30,7 @@ use mc_crypto_keys::DistinguishedEncoding;
 use mc_ledger_db::{Error as LedgerDbError, Ledger, LedgerDB};
 use mc_peers::{PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCacheThread};
-use mc_transaction_core::tx::{TokenId, TxHash};
+use mc_transaction_core::{tx::TxHash, TokenId};
 use mc_util_grpc::{
     AdminServer, AnonymousAuthenticator, Authenticator, BuildInfoService,
     ConnectionUriGrpcioServer, GetConfigJsonFn, HealthCheckStatus, HealthService,

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -18,12 +18,13 @@ use mc_fog_report_connection::{Error as ReportConnError, GrpcFogReportConnection
 use mc_fog_report_validation::FogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
     get_tx_out_shared_secret,
     onetime_keys::{recover_onetime_private_key, view_key_matches_output},
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
+    Token,
 };
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
 use mc_util_uri::FogUri;
@@ -132,7 +133,7 @@ fn main() {
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
             .map(|block_info| block_info.minimum_fee)
             .max()
-            .unwrap_or(MINIMUM_FEE),
+            .unwrap_or(Mob::MINIMUM_FEE),
         Ordering::SeqCst,
     );
 

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -29,11 +29,11 @@ use mc_fog_report_validation::{FogPubkeyResolver, FogResolver};
 use mc_fog_types::BlockCount;
 use mc_fog_view_connection::FogViewGrpcClient;
 use mc_transaction_core::{
-    constants::MINIMUM_FEE,
     onetime_keys::*,
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
-    BlockIndex,
+    BlockIndex, Token,
 };
 use mc_transaction_std::{
     ChangeDestination, InputCredentials, MemoType, NoMemoBuilder, RTHMemoBuilder,
@@ -321,7 +321,7 @@ impl Client {
         const TARGET_NUM_INPUTS: usize = 3;
         let inputs = self
             .tx_data
-            .get_transaction_inputs(amount + MINIMUM_FEE, TARGET_NUM_INPUTS)?;
+            .get_transaction_inputs(amount + Mob::MINIMUM_FEE, TARGET_NUM_INPUTS)?;
         let inputs: Vec<(OwnedTxOut, TxOutMembershipProof)> = self.get_proofs(&inputs)?;
         let rings: Vec<Vec<(TxOut, TxOutMembershipProof)>> = self.get_rings(inputs.len(), rng)?;
 
@@ -815,7 +815,7 @@ mod test_build_transaction_helper {
             true,
             &mut rng,
             &logger,
-            MINIMUM_FEE,
+            Mob::MINIMUM_FEE,
         )
         .unwrap();
 

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -14,10 +14,7 @@ use mc_crypto_rand::McRng;
 use mc_fog_sample_paykit::{AccountKey, Client, ClientBuilder, TransactionStatus, Tx};
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_sgx_css::Signature;
-use mc_transaction_core::{
-    constants::{MINIMUM_FEE, RING_SIZE},
-    BlockIndex,
-};
+use mc_transaction_core::{constants::RING_SIZE, tokens::Mob, BlockIndex, Token};
 use mc_transaction_std::MemoType;
 use mc_util_telemetry::{
     block_span_builder, mark_span_as_active, telemetry_static_key, tracer, Context, Key, Span,
@@ -73,7 +70,7 @@ impl Default for TestClientPolicy {
             tx_receive_deadline: Duration::from_secs(10),
             double_spend_wait: Duration::from_secs(10),
             polling_wait: Duration::from_millis(50),
-            transfer_amount: MINIMUM_FEE,
+            transfer_amount: Mob::MINIMUM_FEE,
             test_rth_memos: false,
         }
     }
@@ -240,7 +237,7 @@ impl TestClient {
         assert!(target_address.fog_report_url().is_some());
 
         // Get the current fee from consensus
-        let fee = source_client.get_fee().unwrap_or(MINIMUM_FEE);
+        let fee = source_client.get_fee().unwrap_or(Mob::MINIMUM_FEE);
 
         // Scope for build operation
         let transaction = {
@@ -490,7 +487,7 @@ impl TestClient {
             },
         )?;
 
-        let fee = source_client_lk.get_fee().unwrap_or(MINIMUM_FEE);
+        let fee = source_client_lk.get_fee().unwrap_or(Mob::MINIMUM_FEE);
         let transfer_start = std::time::SystemTime::now();
         let (transaction, block_count) =
             self.transfer(&mut source_client_lk, &mut target_client_lk)?;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1922,12 +1922,13 @@ mod test {
     use mc_fog_report_validation::{FullyValidatedFogPubkey, MockFogPubkeyResolver};
     use mc_fog_report_validation_test_utils::MockFogResolver;
     use mc_transaction_core::{
-        constants::{MAX_INPUTS, MINIMUM_FEE, RING_SIZE},
+        constants::{MAX_INPUTS, RING_SIZE},
         fog_hint::FogHint,
         get_tx_out_shared_secret,
         onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
+        tokens::Mob,
         tx::{Tx, TxOut},
-        Block, BlockContents, BLOCK_VERSION,
+        Block, BlockContents, Token, BLOCK_VERSION,
     };
     use mc_transaction_std::{NoMemoBuilder, TransactionBuilder};
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
@@ -3413,7 +3414,7 @@ mod test {
 
             let change_value = test_utils::DEFAULT_PER_RECIPIENT_AMOUNT
                 - outlays.iter().map(|outlay| outlay.value).sum::<u64>()
-                - MINIMUM_FEE;
+                - Mob::MINIMUM_FEE;
 
             for (account_key, expected_value) in &[
                 (&receiver1, outlays[0].value),
@@ -3441,8 +3442,8 @@ mod test {
             }
 
             // Santity test fee
-            assert_eq!(tx_proposal.get_fee(), MINIMUM_FEE);
-            assert_eq!(tx_proposal.get_tx().get_prefix().fee, MINIMUM_FEE);
+            assert_eq!(tx_proposal.get_fee(), Mob::MINIMUM_FEE);
+            assert_eq!(tx_proposal.get_tx().get_prefix().fee, Mob::MINIMUM_FEE);
 
             // Sanity test tombstone block
             let num_blocks = ledger_db.num_blocks().unwrap();
@@ -3713,7 +3714,7 @@ mod test {
             tx_proposal.outlays[0].value,
             // Each UTXO we have has PER_RECIPIENT_AMOUNT coins. We will be merging MAX_INPUTS of
             // those into a single output, minus the fee.
-            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - MINIMUM_FEE,
+            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - Mob::MINIMUM_FEE,
         );
 
         assert_eq!(tx_proposal.outlay_index_to_tx_out_index.len(), 1);
@@ -3728,8 +3729,8 @@ mod test {
         assert_eq!(value, tx_proposal.outlays[0].value);
 
         // Santity test fee
-        assert_eq!(tx_proposal.fee(), MINIMUM_FEE);
-        assert_eq!(tx_proposal.tx.prefix.fee, MINIMUM_FEE);
+        assert_eq!(tx_proposal.fee(), Mob::MINIMUM_FEE);
+        assert_eq!(tx_proposal.tx.prefix.fee, Mob::MINIMUM_FEE);
 
         // Sanity test tombstone block
         let num_blocks = ledger_db.num_blocks().unwrap();
@@ -3788,7 +3789,7 @@ mod test {
         ));
         let receiver = AccountKey::random(&mut rng);
         request.set_receiver((&receiver.default_subaddress()).into());
-        request.set_fee(MINIMUM_FEE);
+        request.set_fee(Mob::MINIMUM_FEE);
 
         let response = client.generate_tx_from_tx_out_list(&request).unwrap();
         let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
@@ -3797,7 +3798,7 @@ mod test {
         assert_eq!(tx_proposal.tx.prefix.outputs.len(), 1);
 
         // It should equal the sum of the inputs minus the fee
-        let expected_value = tx_utxos.iter().map(|utxo| utxo.value).sum::<u64>() - MINIMUM_FEE;
+        let expected_value = tx_utxos.iter().map(|utxo| utxo.value).sum::<u64>() - Mob::MINIMUM_FEE;
 
         let tx_out = &tx_proposal.tx.prefix.outputs[0];
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
@@ -4257,7 +4258,7 @@ mod test {
 
         // Add a few utxos to our recipient, such that all of them are required to
         // create the test transaction.
-        for amount in &[10, 20, MINIMUM_FEE] {
+        for amount in &[10, 20, Mob::MINIMUM_FEE] {
             add_block_to_ledger_db(
                 &mut ledger_db,
                 &[sender.default_subaddress()],
@@ -4343,7 +4344,7 @@ mod test {
         };
 
         // Trying with a higher limit should work.
-        request.set_max_input_utxo_value(MINIMUM_FEE);
+        request.set_max_input_utxo_value(Mob::MINIMUM_FEE);
         let response = client.send_payment(&request).unwrap();
 
         let selected_utxos: Vec<UnspentTxOut> = response

--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -30,9 +30,6 @@ pub const MICROMOB_TO_PICOMOB: u64 = 1_000_000;
 /// one milliMOB = 1e9 picoMOB
 pub const MILLIMOB_TO_PICOMOB: u64 = 1_000_000_000;
 
-/// Minimum allowed fee, denominated in picoMOB.
-pub const MINIMUM_FEE: u64 = 400 * MICROMOB_TO_PICOMOB;
-
 lazy_static! {
     // Blinding for the implicit fee outputs.
     pub static ref FEE_BLINDING: Scalar = Scalar::zero();

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -19,6 +19,7 @@ mod amount;
 mod blockchain;
 mod domain_separators;
 mod memo;
+mod token;
 mod tx_error;
 
 pub mod constants;
@@ -37,6 +38,7 @@ pub mod proptest_fixtures;
 pub use amount::{get_value_mask, Amount, AmountError, Commitment, CompressedCommitment};
 pub use blockchain::*;
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
+pub use token::{tokens, Token, TokenId};
 pub use tx::MemoContext;
 pub use tx_error::{NewMemoError, NewTxError};
 

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2018-2021 The MobileCoin Foundation
+
+use core::fmt;
+use mc_crypto_digestible::Digestible;
+use serde::{Deserialize, Serialize};
+
+/// Token Id, used to identify different assets on on the blockchain.
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Digestible,
+)]
+pub struct TokenId(u32);
+
+impl From<u32> for TokenId {
+    fn from(src: u32) -> Self {
+        Self(src)
+    }
+}
+
+impl fmt::Display for TokenId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl TokenId {
+    pub const MOB: Self = Self(0);
+}
+
+/// A generic representation of a token.
+pub trait Token {
+    /// Token Id.
+    const ID: TokenId;
+
+    /// Mininum fee for this token.
+    const MINIMUM_FEE: u64;
+}
+
+pub mod tokens {
+    use super::*;
+    use crate::constants::MICROMOB_TO_PICOMOB;
+
+    /// The MOB token.
+    pub struct Mob;
+    impl Token for Mob {
+        /// Token Id.
+        const ID: TokenId = TokenId::MOB;
+
+        /// Minimum fee, deominated in picoMOB.
+        const MINIMUM_FEE: u64 = 400 * MICROMOB_TO_PICOMOB;
+    }
+}

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -98,28 +98,6 @@ impl fmt::Debug for TxHash {
     }
 }
 
-/// Token Id, used to identify different assets on on the blockchain.
-#[derive(
-    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Digestible,
-)]
-pub struct TokenId(u32);
-
-impl From<u32> for TokenId {
-    fn from(src: u32) -> Self {
-        Self(src)
-    }
-}
-
-impl fmt::Display for TokenId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl TokenId {
-    pub const MOB: Self = Self(0);
-}
-
 /// A CryptoNote-style transaction.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Message, Digestible)]
 pub struct Tx {

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -552,14 +552,14 @@ derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
 #[cfg(test)]
 mod tests {
     use crate::{
-        constants::MINIMUM_FEE,
         encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         get_tx_out_shared_secret,
         memo::MemoPayload,
         ring_signature::SignatureRctBulletproofs,
         subaddress_matches_tx_out,
+        tokens::Mob,
         tx::{Tx, TxIn, TxOut, TxPrefix},
-        Amount,
+        Amount, Token,
     };
     use alloc::vec::Vec;
     use mc_account_keys::{AccountKey, CHANGE_SUBADDRESS_INDEX, DEFAULT_SUBADDRESS_INDEX};
@@ -605,7 +605,7 @@ mod tests {
         let prefix = TxPrefix {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
-            fee: MINIMUM_FEE,
+            fee: Mob::MINIMUM_FEE,
             tombstone_block: 23,
         };
 
@@ -663,7 +663,7 @@ mod tests {
         let prefix = TxPrefix {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
-            fee: MINIMUM_FEE,
+            fee: Mob::MINIMUM_FEE,
             tombstone_block: 23,
         };
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -398,7 +398,8 @@ mod tests {
     use alloc::vec::Vec;
 
     use crate::{
-        constants::{MINIMUM_FEE, RING_SIZE},
+        constants::RING_SIZE,
+        tokens::Mob,
         tx::{Tx, TxOutMembershipHash, TxOutMembershipProof},
         validation::{
             error::TransactionValidationError,
@@ -410,6 +411,7 @@ mod tests {
                 validate_tombstone, validate_transaction_fee, MAX_TOMBSTONE_BLOCKS,
             },
         },
+        Token,
     };
 
     use crate::{
@@ -916,26 +918,28 @@ mod tests {
 
         {
             // Off by one fee gets rejected
-            let fee = MINIMUM_FEE - 1;
+            let fee = Mob::MINIMUM_FEE - 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
             assert_eq!(
-                validate_transaction_fee(&tx, MINIMUM_FEE),
+                validate_transaction_fee(&tx, Mob::MINIMUM_FEE),
                 Err(TransactionValidationError::TxFeeError)
             );
         }
 
         {
             // Exact fee amount is okay
-            let (tx, _ledger) =
-                create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - MINIMUM_FEE, MINIMUM_FEE);
-            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
+            let (tx, _ledger) = create_test_tx_with_amount(
+                INITIALIZE_LEDGER_AMOUNT - Mob::MINIMUM_FEE,
+                Mob::MINIMUM_FEE,
+            );
+            assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
         }
 
         {
             // Overpaying fees is okay
-            let fee = MINIMUM_FEE + 1;
+            let fee = Mob::MINIMUM_FEE + 1;
             let (tx, _ledger) = create_test_tx_with_amount(INITIALIZE_LEDGER_AMOUNT - fee, fee);
-            assert_eq!(validate_transaction_fee(&tx, MINIMUM_FEE), Ok(()));
+            assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
         }
     }
 

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -6,15 +6,15 @@ use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_crypto_rand::{CryptoRng, RngCore};
 pub use mc_fog_report_validation_test_utils::MockFogResolver;
 use mc_ledger_db::{Ledger, LedgerDB};
+use mc_transaction_core::{constants::RING_SIZE, membership_proofs::Range, BlockContents};
 pub use mc_transaction_core::{
-    constants::MINIMUM_FEE,
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
-    Block, BlockID, BlockIndex, BLOCK_VERSION,
+    Block, BlockID, BlockIndex, Token, BLOCK_VERSION,
 };
-use mc_transaction_core::{constants::RING_SIZE, membership_proofs::Range, BlockContents};
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
 use mc_util_from_random::FromRandom;
 use rand::{seq::SliceRandom, Rng};
@@ -54,14 +54,14 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     let shared_secret = get_tx_out_shared_secret(sender.view_private_key(), &tx_out_public_key);
     let (value, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
 
-    assert!(value >= MINIMUM_FEE);
+    assert!(value >= Mob::MINIMUM_FEE);
     create_transaction_with_amount(
         ledger,
         tx_out,
         sender,
         recipient,
-        value - MINIMUM_FEE,
-        MINIMUM_FEE,
+        value - Mob::MINIMUM_FEE,
+        Mob::MINIMUM_FEE,
         tombstone_block,
         rng,
     )

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::ChangeDestination;
 use mc_account_keys::{PublicAddress, ShortAddressHash};
-use mc_transaction_core::{constants::MINIMUM_FEE, MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{tokens::Mob, MemoContext, MemoPayload, NewMemoError, Token};
 
 /// This memo builder attaches 0x0100 Authenticated Sender Memos to normal
 /// outputs, and 0x0200 Destination Memos to change outputs.
@@ -80,7 +80,7 @@ impl Default for RTHMemoBuilder {
             last_recipient: Default::default(),
             total_outlay: 0,
             num_recipients: 0,
-            fee: MINIMUM_FEE,
+            fee: Mob::MINIMUM_FEE,
         }
     }
 }


### PR DESCRIPTION
### Motivation

The `MINIMUM_FEE` constant we use everywhere does not make sense in a multi-token world. This PR proposes to deprecate it in favor of a new trait, `Token`, that will hold useful information about arbitrary tokens.
Right now this is limited to a `TokenId` and the minimum fee.

In the future this can be extended to support human-readable names, an `Amount<T: Token>` trait, a `TransactionBuilder<T: Token>` that contains token-specific logic, etc.

### In this PR
* Moving `TokenId` into a new `token.rs` file
* Introducing the `Token` trait
* Replacing `MINIMUM_FEE` with `Mob::MINIMUM_FEE`.
