### PR TITLE
Fixups/statefilerecovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ version = "1.2.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
+ "displaydoc",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-attest-verifier",

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -30,6 +30,9 @@ mc-sgx-types = { path = "../../../sgx/types" }
 mc-sgx-urts = { path = "../../../sgx/urts" }
 mc-util-serial = { path = "../../../util/serial" }
 
+# third-party
+displaydoc = "0.2"
+
 [dev-dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-crypto-rand = { path = "../../../crypto/rand" }

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -45,6 +45,12 @@ pub enum NewEnclaveError {
     Init(EnclaveError),
 }
 
+impl From<EnclaveError> for NewEnclaveError {
+    fn from(src: EnclaveError) -> Self {
+        Self::Init(src)
+    }
+}
+
 /// A handle to an ingest enclave, on the untrusted side
 #[derive(Clone)]
 pub struct IngestSgxEnclave {
@@ -118,8 +124,7 @@ impl IngestSgxEnclave {
         };
 
         sgx_enclave
-            .enclave_init(params)
-            .map_err(NewEnclaveError::Init)?;
+            .enclave_init(params)?;
 
         Ok(sgx_enclave)
     }

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -119,7 +119,7 @@ impl IngestSgxEnclave {
 
         sgx_enclave
             .enclave_init(params)
-            .map_err(|err| NewEnclaveError::Init(err))?;
+            .map_err(NewEnclaveError::Init)?;
 
         Ok(sgx_enclave)
     }

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -123,8 +123,7 @@ impl IngestSgxEnclave {
             desired_capacity: omap_capacity,
         };
 
-        sgx_enclave
-            .enclave_init(params)?;
+        sgx_enclave.enclave_init(params)?;
 
         Ok(sgx_enclave)
     }

--- a/fog/ingest/enclave/tests/graceful_teardown.rs
+++ b/fog/ingest/enclave/tests/graceful_teardown.rs
@@ -22,6 +22,8 @@ fn ingest_enclave_graceful_teardown(logger: Logger) {
             &ResponderId::from_str("127.0.0.1:3040").unwrap(),
             &None,
             OMAP_CAP,
-        );
+            &logger,
+        )
+        .expect("could not initialize enclave");
     }
 }

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -222,7 +222,7 @@ where
                         break;
                     }
                     Err(err @ RestoreStateError::Connection(_)) => {
-                        log::error!(
+                        log::warn!(
                             logger,
                             "Retry to restore state on connection error: {}",
                             err

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -217,8 +217,6 @@ where
             loop {
                 match result.restore_state_from_summary(summary) {
                     Ok(_) => {
-                        let mut state = result.get_state();
-                        state.set_initialized();
                         break;
                     }
                     Err(err @ RestoreStateError::Connection(_)) => {
@@ -238,15 +236,10 @@ where
                     "Could not restore state from state file ({:?}), {:?}: {}. Starting in idle instead",
                     config.state_file, summary, err
                     );
-                        let mut state = result.get_state();
-                        state.set_partially_initialized();
                         break;
                     }
                 };
             }
-        } else {
-            let mut state = result.get_state();
-            state.set_initialized();
         }
 
         result.write_state_file();

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -304,7 +304,7 @@ impl IngestControllerState {
     fn set_mode(&mut self, mode: IngestMode) {
         log::info!(
             self.logger,
-            "Mode switching from {:?} to {:?}",
+            "Mode switching from {} to {}",
             self.mode,
             mode
         );
@@ -317,7 +317,7 @@ impl IngestControllerState {
     fn set_status(&mut self, status: IngestStatus) {
         log::info!(
             self.logger,
-            "Status switching from {:?} to {:?}",
+            "Status switching from {} to {}",
             self.status,
             status
         );

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -34,23 +34,6 @@ pub enum IngestMode {
     Active,
 }
 
-/// The ingest server may or may not be fully initialized
-///
-/// Uninitialized: Healthy state, can not be set to active. Can be initialized
-/// Partially Initialized: Unhealty state, initialize was atempted but was not
-/// able to fully initialize
-/// Fully Initailized: Healthy state, can be turned
-/// active
-#[derive(Copy, Clone, Display, Debug, PartialEq, Eq)]
-pub enum IngestStatus {
-    /// Uninitialized
-    Uninitialized,
-    /// Partially initialized
-    Partial,
-    /// Fully initialized
-    Full,
-}
-
 /// State controlling the operation of the ingest controller.
 ///
 /// This data is set from the server configuration initially, but then can be
@@ -80,9 +63,6 @@ pub struct IngestControllerState {
     /// Whether the server is idling, actively scanning the blockchain and
     /// publishing reports, or retiring
     mode: IngestMode,
-    /// Whether the server is unintialized, partially initialized, or fully
-    /// initialized
-    status: IngestStatus,
     /// The next block index to scan from
     next_block_index: u64,
     /// The value we add to the current block index to compute the pubkey expiry
@@ -104,7 +84,6 @@ impl IngestControllerState {
         let peers = config.peers.clone();
         let result = Self {
             mode: IngestMode::Idle,
-            status: IngestStatus::Uninitialized,
             next_block_index: 0, // this is set when the server activates, based on DB's
             pubkey_expiry_window: config.pubkey_expiry_window,
             ingest_invocation_id: None,
@@ -125,35 +104,6 @@ impl IngestControllerState {
     /// In this mode, we are consuming blocks, and publishing fog reports
     pub fn is_active(&self) -> bool {
         self.mode == IngestMode::Active
-    }
-
-    /// Move the server to the initialized status
-    /// This is allowed from any mode.
-    pub fn set_initialized(&mut self) {
-        match self.status {
-            IngestStatus::Full => {
-                log::info!(self.logger, "Server was already initialized");
-            }
-            IngestStatus::Uninitialized | IngestStatus::Partial => {
-                log::info!(
-                    self.logger,
-                    "Server moved to initialized from {}",
-                    self.status
-                );
-            }
-        }
-        self.set_status(IngestStatus::Full);
-    }
-
-    /// Move the server to the partially initialized status
-    /// This is allowed from any mode.
-    pub fn set_partially_initialized(&mut self) {
-        log::warn!(
-            self.logger,
-            "Server was {}, moving to partially initialized",
-            self.status
-        );
-        self.set_status(IngestStatus::Partial);
     }
 
     /// Move the server to the active mode.
@@ -304,19 +254,6 @@ impl IngestControllerState {
     fn set_mode(&mut self, mode: IngestMode) {
         log::info!(self.logger, "Mode switching from {} to {}", self.mode, mode);
         self.mode = mode;
-
-        self.update_metrics()
-    }
-
-    /// Sets the current status and update relevant metrics.
-    fn set_status(&mut self, status: IngestStatus) {
-        log::info!(
-            self.logger,
-            "Status switching from {} to {}",
-            self.status,
-            status
-        );
-        self.status = status;
 
         self.update_metrics()
     }

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -302,12 +302,7 @@ impl IngestControllerState {
 
     /// Sets the current mode and update relevant metrics.
     fn set_mode(&mut self, mode: IngestMode) {
-        log::info!(
-            self.logger,
-            "Mode switching from {} to {}",
-            self.mode,
-            mode
-        );
+        log::info!(self.logger, "Mode switching from {} to {}", self.mode, mode);
         self.mode = mode;
 
         self.update_metrics()

--- a/fog/ingest/server/src/state_file.rs
+++ b/fog/ingest/server/src/state_file.rs
@@ -57,4 +57,12 @@ impl StateFile {
         file.write_all(&proto_data)?;
         file.sync_all()
     }
+
+    /// Rename the statefile to "backup". This is done if loading the statefile
+    /// fails, in order to prevent a crash loop.
+    pub fn move_to_bak(&self) -> Result<()> {
+        let bak = self.file_path.with_extension("bak");
+        std::fs::rename(&self.file_path, &bak)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Soundtrack of this PR: [link to song that really fits the mood of this PR](https://www.youtube.com/watch?v=IgFwiCApH7E)

### Motivation

Better state file management to avoid losing a relevant key. Based on this PR by @garbageslam: https://github.com/mobilecoinfoundation/mobilecoin/pull/1085

### In this PR

1. Add functionality to delete the statefile (except instead of deleting, we rename it to .bak, in case it will help debug something.)
2. Delete the statefile if initializing the ingest enclave fails. This is generally going to indicate that we couldn't unseal the private key. (Enclave creation failing is a separate issue, and that could be caused by an SGX daemon not being woken up yet)
3. If we did successfully load a key, don't panic even if restoring from state file failed.
4. Besides this, we generally improved error handling around the creation of the IngestSgxEnclave object
5. Adding a initialization status to state to indicate when partially initialized for future error handling.

This resolve issue #1082

### Future Work
* [Do not handle the case where you have a valid key but overseer has already activated a new node.](https://github.com/mobilecoinfoundation/mobilecoin/issues/1357)
* Do not handle or inspect the initialization status in this PR. Will be dealt with after overseer PR.

