### PR TITLE
Update LastBlockInfoResponse to include the new fee map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,7 @@ name = "mc-connection-test-utils"
 version = "1.2.0-pre0"
 dependencies = [
  "mc-connection",
+ "mc-consensus-enclave-api",
  "mc-ledger-db",
  "mc-transaction-core",
  "mc-util-uri",

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -71,7 +71,7 @@ impl BlockInfo {
     /// Returns the minimum fee for a given token id, or None if no fee was
     /// available OR if it was zero.
     pub fn minimum_fee_or_none(&self, token_id: &TokenId) -> Option<u64> {
-        match self.minimum_fees.get(&token_id) {
+        match self.minimum_fees.get(token_id) {
             None | Some(&0) => None,
             Some(fee) => Some(*fee),
         }

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -67,6 +67,17 @@ pub struct BlockInfo {
     pub minimum_fees: BTreeMap<TokenId, u64>,
 }
 
+impl BlockInfo {
+    /// Returns the minimum fee for a given token id, or None if no fee was
+    /// available OR if it was zero.
+    pub fn minimum_fee_or_none(&self, token_id: &TokenId) -> Option<u64> {
+        match self.minimum_fees.get(&token_id) {
+            None | Some(&0) => None,
+            Some(fee) => Some(*fee),
+        }
+    }
+}
+
 impl Display for BlockInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 [dependencies]
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-connection = { path = "../../connection" }
+mc-consensus-enclave-api = { path = "../../consensus/enclave/api" }
 mc-util-uri = { path = "../../util/uri" }
 mc-transaction-core = { path = "../../transaction/core" }

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -11,8 +11,10 @@ use mc_transaction_core::{tokens::Mob, tx::Tx, Block, BlockID, BlockIndex, Token
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
     cmp::{min, Ordering},
+    collections::BTreeMap,
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
+    iter::FromIterator,
     ops::Range,
     thread,
     time::Duration,
@@ -116,7 +118,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
     fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
-            minimum_fee: Mob::MINIMUM_FEE,
+            minimum_fees: BTreeMap::from_iter([(Mob::ID, Mob::MINIMUM_FEE)]),
         })
     }
 }

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -6,15 +6,14 @@ use mc_connection::{
     BlockInfo, BlockchainConnection, Connection, Error as ConnectionError,
     Result as ConnectionResult, UserTxConnection,
 };
+use mc_consensus_enclave_api::FeeMap;
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{tokens::Mob, tx::Tx, Block, BlockID, BlockIndex, Token};
+use mc_transaction_core::{tx::Tx, Block, BlockID, BlockIndex};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
     cmp::{min, Ordering},
-    collections::BTreeMap,
     fmt::{Display, Formatter, Result as FmtResult},
     hash::{Hash, Hasher},
-    iter::FromIterator,
     ops::Range,
     thread,
     time::Duration,
@@ -118,7 +117,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
     fn fetch_block_info(&mut self) -> ConnectionResult<BlockInfo> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
-            minimum_fees: BTreeMap::from_iter([(Mob::ID, Mob::MINIMUM_FEE)]),
+            minimum_fees: FeeMap::default_map(),
         })
     }
 }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -20,8 +20,12 @@ service BlockchainAPI {
 message LastBlockInfoResponse {
     // Block index
     uint64 index = 1;
-    // Current minimum fee
-    uint64 minimum_fee = 2;
+
+    // Current MOB minimum fee (kept for backwards compatibility)
+    uint64 mob_minimum_fee = 2;
+
+    // A map of token id -> minimum fee
+    map<uint32, uint64> minimum_fees = 3;
 }
 
 // Requests a range [offset, offset+limit) of Blocks.

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -22,7 +22,7 @@ message LastBlockInfoResponse {
     uint64 index = 1;
 
     // Current MOB minimum fee (kept for backwards compatibility)
-    uint64 mob_minimum_fee = 2;
+    uint64 mob_minimum_fee = 2 [deprecated = true];
 
     // A map of token id -> minimum fee
     map<uint32, uint64> minimum_fees = 3;

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -106,7 +106,7 @@ impl FeeMap {
     }
 
     /// Helper method for constructing the default fee map.
-    fn default_map() -> BTreeMap<TokenId, u64> {
+    pub fn default_map() -> BTreeMap<TokenId, u64> {
         let mut map = BTreeMap::new();
         map.insert(Mob::ID, Mob::MINIMUM_FEE);
         map

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -10,11 +10,13 @@ use mc_consensus_api::{
     consensus_common_grpc::BlockchainApi,
     empty::Empty,
 };
+use mc_consensus_enclave::FeeMap;
 use mc_ledger_db::Ledger;
+use mc_transaction_core::{tokens::Mob, Token};
 use mc_util_grpc::{rpc_logger, send_result, Authenticator};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use protobuf::RepeatedField;
-use std::{cmp, convert::From, sync::Arc};
+use std::{cmp, collections::HashMap, convert::From, iter::FromIterator, sync::Arc};
 
 #[derive(Clone)]
 pub struct BlockchainApiService<L: Ledger + Clone> {
@@ -28,26 +30,26 @@ pub struct BlockchainApiService<L: Ledger + Clone> {
     /// results.
     max_page_size: u16,
 
+    /// Minimum fee per token.
+    fee_map: FeeMap,
+
     /// Logger.
     logger: Logger,
-
-    /// Configured MOB minimum-fee
-    minimum_fee: u64,
 }
 
 impl<L: Ledger + Clone> BlockchainApiService<L> {
     pub fn new(
         ledger: L,
         authenticator: Arc<dyn Authenticator + Send + Sync>,
+        fee_map: FeeMap,
         logger: Logger,
-        minimum_fee: u64,
     ) -> Self {
         BlockchainApiService {
             ledger,
             authenticator,
             max_page_size: 2000,
+            fee_map,
             logger,
-            minimum_fee,
         }
     }
 
@@ -62,7 +64,16 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
         let num_blocks = self.ledger.num_blocks()?;
         let mut resp = LastBlockInfoResponse::new();
         resp.set_index(num_blocks - 1);
-        resp.set_minimum_fee(self.minimum_fee);
+        resp.set_mob_minimum_fee(
+            self.fee_map
+                .get_fee_for_token(&Mob::ID)
+                .expect("should always have a fee for MOB"),
+        );
+        resp.set_minimum_fees(HashMap::from_iter(
+            self.fee_map
+                .iter()
+                .map(|(token_id, fee)| (**token_id, *fee)),
+        ));
 
         Ok(resp)
     }
@@ -168,15 +179,16 @@ mod tests {
     use grpcio::{ChannelBuilder, Environment, Error as GrpcError, Server, ServerBuilder};
     use mc_common::{logger::test_with_logger, time::SystemTimeProvider};
     use mc_consensus_api::consensus_common_grpc::{self, BlockchainApiClient};
+    use mc_transaction_core::TokenId;
     use mc_transaction_core_test_utils::{create_ledger, initialize_ledger, AccountKey};
     use mc_util_grpc::{AnonymousAuthenticator, TokenAuthenticator};
     use rand::{rngs::StdRng, SeedableRng};
     use std::{
+        collections::HashMap,
+        iter::FromIterator,
         sync::atomic::{AtomicUsize, Ordering::SeqCst},
         time::Duration,
     };
-
-    const TEST_MINIMUM_FEE: u64 = 100;
 
     fn get_free_port() -> u16 {
         static PORT_NR: AtomicUsize = AtomicUsize::new(0);
@@ -204,23 +216,26 @@ mod tests {
     #[test_with_logger]
     // `get_last_block_info` should returns the last block.
     fn test_get_last_block_info(logger: Logger) {
+        let fee_map =
+            FeeMap::try_from_iter([(Mob::ID, 12345), (TokenId::from(60), 10203040)]).unwrap();
+
         let mut ledger_db = create_ledger();
         let authenticator = Arc::new(AnonymousAuthenticator::default());
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let account_key = AccountKey::random(&mut rng);
         let block_entities = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
-        let minimum_fee = 10_000;
 
         let mut expected_response = LastBlockInfoResponse::new();
         expected_response.set_index(block_entities.last().unwrap().index);
-        expected_response.set_minimum_fee(minimum_fee);
+        expected_response.set_mob_minimum_fee(12345);
+        expected_response.set_minimum_fees(HashMap::from_iter(vec![(0, 12345), (60, 10203040)]));
         assert_eq!(
             block_entities.last().unwrap().index,
             ledger_db.num_blocks().unwrap() - 1
         );
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, minimum_fee);
+            BlockchainApiService::new(ledger_db, authenticator, fee_map, logger);
 
         let block_response = blockchain_api_service.get_last_block_info_helper().unwrap();
         assert_eq!(block_response, expected_response);
@@ -238,7 +253,7 @@ mod tests {
         ));
 
         let blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, TEST_MINIMUM_FEE);
+            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
 
         let (client, _server) = get_client_server(blockchain_api_service);
 
@@ -270,7 +285,7 @@ mod tests {
             .collect();
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, TEST_MINIMUM_FEE);
+            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
 
         {
             // The empty range [0,0) should return an empty collection of Blocks.
@@ -308,7 +323,7 @@ mod tests {
         let _blocks = initialize_ledger(&mut ledger_db, 10, &account_key, &mut rng);
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, TEST_MINIMUM_FEE);
+            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
 
         {
             // The range [0, 1000) requests values that don't exist. The response should
@@ -334,7 +349,7 @@ mod tests {
             .collect();
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, TEST_MINIMUM_FEE);
+            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
         blockchain_api_service.set_max_page_size(5);
 
         // The request exceeds the max_page_size, so only max_page_size items should be
@@ -358,7 +373,7 @@ mod tests {
         ));
 
         let blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, logger, TEST_MINIMUM_FEE);
+            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
 
         let (client, _server) = get_client_server(blockchain_api_service);
 

--- a/consensus/service/src/config.rs
+++ b/consensus/service/src/config.rs
@@ -2,6 +2,7 @@
 
 //! Configuration parameters for the Consensus Service application.
 
+use crate::consensus_service::ConsensusServiceError;
 use mc_attest_core::ProviderId;
 use mc_common::{HashMap, HashSet, NodeID, ResponderId};
 use mc_consensus_enclave::FeeMap;
@@ -13,10 +14,7 @@ use mc_util_uri::{
     AdminUri, ConnectionUri, ConsensusClientUri as ClientUri, ConsensusPeerUri as PeerUri,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap, convert::TryFrom, fmt::Debug, fs, iter::FromIterator, path::PathBuf,
-    str::FromStr, string::String, sync::Arc, time::Duration,
-};
+use std::{fmt::Debug, fs, path::PathBuf, str::FromStr, string::String, sync::Arc, time::Duration};
 use structopt::StructOpt;
 
 #[derive(Clone, Debug, StructOpt)]
@@ -216,18 +214,18 @@ impl Config {
     }
 
     /// Get the configured minimum fee.
-    pub fn fee_map(&self) -> Result<FeeMap, String> {
+    pub fn fee_map(&self) -> Result<FeeMap, ConsensusServiceError> {
         if self.minimum_fee.is_empty() {
             return Ok(FeeMap::default());
         }
 
-        let fee_map = FeeMap::try_from(BTreeMap::from_iter(
+        let fee_map = FeeMap::try_from_iter(
             self.minimum_fee
                 .iter()
                 .cloned()
                 .map(|pair| (pair.0, pair.1)),
-        ))
-        .map_err(|err| format!("Invalid fee configuration: {:?}", err))?;
+        )
+        .map_err(|err| ConsensusServiceError::FeesMisconfigured(err.to_string()))?;
 
         // Must have a fee for MOB (this is enforced by is_valid_map above).
         let mob_fee = fee_map
@@ -235,7 +233,10 @@ impl Config {
             .expect("MOB fee must be specified");
 
         if !self.allow_any_fee && !(10_000..1_000_000_000_000u64).contains(&mob_fee) {
-            return Err(format!("Fee {} picoMOB is out of bounds", mob_fee));
+            return Err(ConsensusServiceError::FeesMisconfigured(format!(
+                "Fee {} picoMOB is out of bounds",
+                mob_fee
+            )));
         }
 
         Ok(fee_map)

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -131,16 +131,7 @@ fn main() {
         get_conns(&config, &logger)
             .par_iter()
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
-            .filter_map(|block_info| {
-                // Cleanup the protobuf default fee
-                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
-                    if fee == &0 {
-                        None
-                    } else {
-                        Some(*fee)
-                    }
-                })
-            })
+            .filter_map(|block_info| block_info.minimum_fee_or_none(&Mob::ID))
             .max()
             .unwrap_or(Mob::MINIMUM_FEE),
         Ordering::SeqCst,

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -131,7 +131,16 @@ fn main() {
         get_conns(&config, &logger)
             .par_iter()
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
-            .map(|block_info| block_info.minimum_fee)
+            .filter_map(|block_info| {
+                // Cleanup the protobuf default fee
+                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
+                    if fee == &0 {
+                        None
+                    } else {
+                        Some(*fee)
+                    }
+                })
+            })
             .max()
             .unwrap_or(Mob::MINIMUM_FEE),
         Ordering::SeqCst,

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -522,9 +522,7 @@ impl Client {
         Ok(self
             .consensus_service_conn
             .fetch_block_info()?
-            .minimum_fees
-            .get(&Mob::ID)
-            .copied()
+            .minimum_fee_or_none(&Mob::ID)
             .unwrap_or(0))
     }
 

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -519,7 +519,13 @@ impl Client {
 
     /// Retrieve the currently configured minimum fee from the consensus service
     pub fn get_fee(&mut self) -> Result<u64> {
-        Ok(self.consensus_service_conn.fetch_block_info()?.minimum_fees.get(&Mob::ID).copied().unwrap_or(0))
+        Ok(self
+            .consensus_service_conn
+            .fetch_block_info()?
+            .minimum_fees
+            .get(&Mob::ID)
+            .copied()
+            .unwrap_or(0))
     }
 
     /// Get the public b58 address for this client

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -519,7 +519,7 @@ impl Client {
 
     /// Retrieve the currently configured minimum fee from the consensus service
     pub fn get_fee(&mut self) -> Result<u64> {
-        Ok(self.consensus_service_conn.fetch_block_info()?.minimum_fee)
+        Ok(self.consensus_service_conn.fetch_block_info()?.minimum_fees.get(&Mob::ID).copied().unwrap_or(0))
     }
 
     /// Get the public b58 address for this client

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -20,8 +20,9 @@ use mc_transaction_core::{
     constants::{MAX_INPUTS, MILLIMOB_TO_PICOMOB, RING_SIZE},
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockIndex,
+    BlockIndex, Token,
 };
 use mc_transaction_std::{ChangeDestination, InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_uri::FogUri;
@@ -146,11 +147,13 @@ fn get_fee<T: BlockchainConnection + UserTxConnection + 'static>(
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
             .filter_map(|block_info| {
                 // Cleanup the protobuf default fee
-                if block_info.minimum_fee == 0 {
-                    None
-                } else {
-                    Some(block_info.minimum_fee)
-                }
+                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
+                    if fee == &0 {
+                        None
+                    } else {
+                        Some(*fee)
+                    }
+                })
             })
             .max()
             .unwrap_or(FALLBACK_FEE)

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -145,16 +145,7 @@ fn get_fee<T: BlockchainConnection + UserTxConnection + 'static>(
             .conns()
             .par_iter()
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
-            .filter_map(|block_info| {
-                // Cleanup the protobuf default fee
-                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
-                    if fee == &0 {
-                        None
-                    } else {
-                        Some(*fee)
-                    }
-                })
-            })
+            .filter_map(|block_info| block_info.minimum_fee_or_none(&Mob::ID))
             .max()
             .unwrap_or(FALLBACK_FEE)
     }

--- a/slam/src/main.rs
+++ b/slam/src/main.rs
@@ -134,16 +134,7 @@ fn main() {
         get_conns(&config, &logger)
             .par_iter()
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
-            .filter_map(|block_info| {
-                // Cleanup the protobuf default fee
-                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
-                    if fee == &0 {
-                        None
-                    } else {
-                        Some(*fee)
-                    }
-                })
-            })
+            .filter_map(|block_info| block_info.minimum_fee_or_none(&Mob::ID))
             .max()
             .unwrap_or(FALLBACK_FEE),
         Ordering::SeqCst,

--- a/slam/src/main.rs
+++ b/slam/src/main.rs
@@ -23,7 +23,9 @@ use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::{recover_onetime_private_key, view_key_matches_output},
     ring_signature::KeyImage,
+    tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
+    Token,
 };
 use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_uri::ConnectionUri;
@@ -134,11 +136,13 @@ fn main() {
             .filter_map(|conn| conn.fetch_block_info(empty()).ok())
             .filter_map(|block_info| {
                 // Cleanup the protobuf default fee
-                if block_info.minimum_fee == 0 {
-                    None
-                } else {
-                    Some(block_info.minimum_fee)
-                }
+                block_info.minimum_fees.get(&Mob::ID).and_then(|fee| {
+                    if fee == &0 {
+                        None
+                    } else {
+                        Some(*fee)
+                    }
+                })
             })
             .max()
             .unwrap_or(FALLBACK_FEE),

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use core::fmt;
+use core::{fmt, hash::Hash, ops::Deref};
 use mc_crypto_digestible::Digestible;
 use serde::{Deserialize, Serialize};
 
 /// Token Id, used to identify different assets on on the blockchain.
 #[derive(
-    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Digestible,
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Digestible, Hash,
 )]
 pub struct TokenId(u32);
 
@@ -24,6 +24,14 @@ impl fmt::Display for TokenId {
 
 impl TokenId {
     pub const MOB: Self = Self(0);
+}
+
+impl Deref for TokenId {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 /// A generic representation of a token.


### PR DESCRIPTION
### Motivation

* Now that we support a mapping of token -> minimum fee, we need to make that information available to clients.

### In this PR
* Update `LastBlockInfoResponse` to contain a new field, `minimum_fees`, that holds the map of token id -> minimum fee.
* Rename the existing `minimum_fee` field to `mob_minimum_fee`. This is a backwards-compatible change (the tag number remains the same), but it makes it easy to catch client code that uses the now-deprecated field
* Update client code to use the new field
* Minor cleanups
