### PR TITLE
add a dep-compare python script

### DIFF
--- a/tools/dep-compare.py
+++ b/tools/dep-compare.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
 import toml
+from collections import defaultdict
 
-# Given a Cargo.lock path, get a dictionary mapping package names to version numbers
+# Given a Cargo.lock path, get a dictionary mapping package names to all version numbers for that package
 def load_cargo_lock_packages(path):
     lock = toml.load(path)
-    return {package['name']: package['version'] for package in lock['package']}
+    result = defaultdict(list)
+    for package in lock['package']:
+        result[package['name']].append(package['version'])
+    return result
 
 root = load_cargo_lock_packages("Cargo.lock")
 consensus = load_cargo_lock_packages("consensus/enclave/trusted/Cargo.lock")

--- a/tools/dep-compare.py
+++ b/tools/dep-compare.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import toml
+
+# Given a Cargo.lock path, get a dictionary mapping package names to version numbers
+def load_cargo_lock_packages(path):
+    lock = toml.load(path)
+    return {package['name']: package['version'] for package in lock['package']}
+
+root = load_cargo_lock_packages("Cargo.lock")
+consensus = load_cargo_lock_packages("consensus/enclave/trusted/Cargo.lock")
+fog_ingest = load_cargo_lock_packages("fog/ingest/enclave/trusted/Cargo.lock")
+fog_ledger = load_cargo_lock_packages("fog/ledger/enclave/trusted/Cargo.lock")
+fog_view = load_cargo_lock_packages("fog/view/enclave/trusted/Cargo.lock")
+
+# Display whenever things differ from the root cargo lock
+for name, version in root.items():
+    if name in consensus and consensus[name] != version:
+        print(f"{name}: root = {version}, consensus = {consensus[name]}")
+    if name in fog_ingest and fog_ingest[name] != version:
+        print(f"{name}: root = {version}, fog_ingest = {fog_ingest[name]}")
+    if name in fog_ledger and fog_ledger[name] != version:
+        print(f"{name}: root = {version}, fog_ledger = {fog_ledger[name]}")
+    if name in fog_view and fog_view[name] != version:
+        print(f"{name}: root = {version}, fog_view = {fog_view[name]}")

--- a/tools/dep-compare.py
+++ b/tools/dep-compare.py
@@ -6,9 +6,9 @@ from collections import defaultdict
 # Given a Cargo.lock path, get a dictionary mapping package names to all version numbers for that package
 def load_cargo_lock_packages(path):
     lock = toml.load(path)
-    result = defaultdict(list)
+    result = defaultdict(set)
     for package in lock['package']:
-        result[package['name']].append(package['version'])
+        result[package['name']].add(package['version'])
     return result
 
 root = load_cargo_lock_packages("Cargo.lock")
@@ -18,12 +18,12 @@ fog_ledger = load_cargo_lock_packages("fog/ledger/enclave/trusted/Cargo.lock")
 fog_view = load_cargo_lock_packages("fog/view/enclave/trusted/Cargo.lock")
 
 # Display whenever things differ from the root cargo lock
-for name, version in root.items():
-    if name in consensus and consensus[name] != version:
-        print(f"{name}: root = {version}, consensus = {consensus[name]}")
-    if name in fog_ingest and fog_ingest[name] != version:
-        print(f"{name}: root = {version}, fog_ingest = {fog_ingest[name]}")
-    if name in fog_ledger and fog_ledger[name] != version:
-        print(f"{name}: root = {version}, fog_ledger = {fog_ledger[name]}")
-    if name in fog_view and fog_view[name] != version:
-        print(f"{name}: root = {version}, fog_view = {fog_view[name]}")
+for name, versions in root.items():
+    if name in consensus and not versions.issuperset(consensus[name]):
+        print(f"{name}: root = {versions}, consensus = {consensus[name]}")
+    if name in fog_ingest and not versions.issuperset(fog_ingest[name]):
+        print(f"{name}: root = {versions}, fog_ingest = {fog_ingest[name]}")
+    if name in fog_ledger and not versions.issuperset(fog_ledger[name]):
+        print(f"{name}: root = {versions}, fog_ledger = {fog_ledger[name]}")
+    if name in fog_view and not versions.issuperset(fog_view[name]):
+        print(f"{name}: root = {versions}, fog_view = {fog_view[name]}")


### PR DESCRIPTION
At current revision it prints things like this

```
➜  mobilecoin git:(dep-compare-tool) ./tools/dep-compare.py
aead: root = {'0.4.1'}, fog_ledger = {'0.4.2'}
aho-corasick: root = {'0.7.10'}, consensus = {'0.7.8'}
aho-corasick: root = {'0.7.10'}, fog_ingest = {'0.7.6'}
aho-corasick: root = {'0.7.10'}, fog_ledger = {'0.7.18'}
aho-corasick: root = {'0.7.10'}, fog_view = {'0.7.6'}
anyhow: root = {'1.0.52'}, consensus = {'1.0.26'}
anyhow: root = {'1.0.52'}, fog_ingest = {'1.0.26'}
anyhow: root = {'1.0.52'}, fog_ledger = {'1.0.26'}
anyhow: root = {'1.0.52'}, fog_view = {'1.0.26'}
atty: root = {'0.2.14'}, fog_ingest = {'0.2.13'}
autocfg: root = {'1.0.0'}, consensus = {'1.0.1'}
autocfg: root = {'1.0.0'}, fog_ingest = {'1.0.1'}
autocfg: root = {'1.0.0'}, fog_ledger = {'1.0.1'}
autocfg: root = {'1.0.0'}, fog_view = {'1.0.1'}
cmake: root = {'0.1.45'}, consensus = {'0.1.43'}
cmake: root = {'0.1.45'}, fog_ingest = {'0.1.43'}
cmake: root = {'0.1.45'}, fog_ledger = {'0.1.43'}
cmake: root = {'0.1.45'}, fog_view = {'0.1.43'}
env_logger: root = {'0.8.3'}, fog_ingest = {'0.8.4'}
env_logger: root = {'0.8.3'}, fog_ledger = {'0.8.4'}
env_logger: root = {'0.8.3'}, fog_view = {'0.8.4'}
generic-array: root = {'0.12.3', '0.14.5'}, consensus = {'0.14.4'}
generic-array: root = {'0.12.3', '0.14.5'}, fog_ingest = {'0.14.4'}
generic-array: root = {'0.12.3', '0.14.5'}, fog_ledger = {'0.14.4'}
generic-array: root = {'0.12.3', '0.14.5'}, fog_view = {'0.14.4'}
getrandom: root = {'0.2.4', '0.1.14'}, consensus = {'0.2.2'}
getrandom: root = {'0.2.4', '0.1.14'}, fog_ingest = {'0.2.2'}
getrandom: root = {'0.2.4', '0.1.14'}, fog_ledger = {'0.2.2'}
getrandom: root = {'0.2.4', '0.1.14'}, fog_view = {'0.2.3'}
half: root = {'1.5.0'}, consensus = {'1.4.1'}
half: root = {'1.5.0'}, fog_ingest = {'1.4.1'}
half: root = {'1.5.0'}, fog_ledger = {'1.4.1'}
half: root = {'1.5.0'}, fog_view = {'1.4.1'}
hermit-abi: root = {'0.1.12'}, consensus = {'0.1.6'}
hermit-abi: root = {'0.1.12'}, fog_ledger = {'0.1.6'}
hermit-abi: root = {'0.1.12'}, fog_view = {'0.1.6'}
itertools: root = {'0.10.3'}, consensus = {'0.10.1'}
itertools: root = {'0.10.3'}, fog_ingest = {'0.10.1'}
itertools: root = {'0.10.3'}, fog_ledger = {'0.10.1'}
itertools: root = {'0.10.3'}, fog_view = {'0.10.1'}
lazycell: root = {'1.2.1'}, consensus = {'1.3.0'}
lazycell: root = {'1.2.1'}, fog_ingest = {'1.3.0'}
lazycell: root = {'1.2.1'}, fog_ledger = {'1.3.0'}
lazycell: root = {'1.2.1'}, fog_view = {'1.3.0'}
libc: root = {'0.2.114'}, consensus = {'0.2.103'}
libc: root = {'0.2.114'}, fog_ingest = {'0.2.103'}
libc: root = {'0.2.114'}, fog_ledger = {'0.2.103'}
libc: root = {'0.2.114'}, fog_view = {'0.2.103'}
log: root = {'0.4.11', '0.3.9'}, consensus = {'0.4.8'}
log: root = {'0.4.11', '0.3.9'}, fog_ingest = {'0.4.8'}
log: root = {'0.4.11', '0.3.9'}, fog_ledger = {'0.4.14'}
log: root = {'0.4.11', '0.3.9'}, fog_view = {'0.4.8'}
memchr: root = {'2.4.1'}, consensus = {'2.3.0'}
memchr: root = {'2.4.1'}, fog_ingest = {'2.2.1'}
memchr: root = {'2.4.1'}, fog_ledger = {'2.4.0'}
memchr: root = {'2.4.1'}, fog_view = {'2.2.1'}
num-integer: root = {'0.1.42'}, fog_ingest = {'0.1.44'}
num-integer: root = {'0.1.42'}, fog_ledger = {'0.1.44'}
num-integer: root = {'0.1.42'}, fog_view = {'0.1.44'}
num-traits: root = {'0.2.14'}, consensus = {'0.2.11'}
ppv-lite86: root = {'0.2.10'}, consensus = {'0.2.15'}
proc-macro2: root = {'1.0.36', '0.4.30'}, consensus = {'1.0.24'}
proc-macro2: root = {'1.0.36', '0.4.30'}, fog_ingest = {'1.0.24'}
proc-macro2: root = {'1.0.36', '0.4.30'}, fog_ledger = {'1.0.27'}
proc-macro2: root = {'1.0.36', '0.4.30'}, fog_view = {'1.0.24'}
quote: root = {'1.0.15', '0.6.13'}, consensus = {'1.0.9'}
quote: root = {'1.0.15', '0.6.13'}, fog_ingest = {'1.0.9'}
quote: root = {'1.0.15', '0.6.13'}, fog_ledger = {'1.0.9'}
quote: root = {'1.0.15', '0.6.13'}, fog_view = {'1.0.9'}
rand_chacha: root = {'0.2.2', '0.3.1'}, fog_ingest = {'0.3.0'}
rand_chacha: root = {'0.2.2', '0.3.1'}, fog_ledger = {'0.3.0'}
rand_chacha: root = {'0.2.2', '0.3.1'}, fog_view = {'0.3.0'}
regex: root = {'1.3.7'}, consensus = {'1.3.4'}
regex: root = {'1.3.7'}, fog_ingest = {'1.3.1'}
regex: root = {'1.3.7'}, fog_ledger = {'1.5.4'}
regex: root = {'1.3.7'}, fog_view = {'1.3.1'}
regex-syntax: root = {'0.6.17'}, consensus = {'0.6.14'}
regex-syntax: root = {'0.6.17'}, fog_ingest = {'0.6.12'}
regex-syntax: root = {'0.6.17'}, fog_ledger = {'0.6.25'}
regex-syntax: root = {'0.6.17'}, fog_view = {'0.6.12'}
rs-libc: root = {'0.2.2'}, fog_ledger = {'0.2.3'}
same-file: root = {'1.0.6'}, fog_ingest = {'1.0.5'}
same-file: root = {'1.0.6'}, fog_ledger = {'1.0.5'}
same-file: root = {'1.0.6'}, fog_view = {'1.0.5'}
serde: root = {'1.0.136'}, consensus = {'1.0.133'}
serde: root = {'1.0.136'}, fog_view = {'1.0.133'}
serde_derive: root = {'1.0.136'}, consensus = {'1.0.133'}
serde_derive: root = {'1.0.136'}, fog_view = {'1.0.133'}
siphasher: root = {'0.3.9'}, consensus = {'0.3.7'}
siphasher: root = {'0.3.9'}, fog_ingest = {'0.3.1'}
siphasher: root = {'0.3.9'}, fog_ledger = {'0.3.1'}
siphasher: root = {'0.3.9'}, fog_view = {'0.3.1'}
smallvec: root = {'1.6.1', '0.6.13'}, consensus = {'1.2.0'}
smallvec: root = {'1.6.1', '0.6.13'}, fog_ingest = {'1.3.0'}
smallvec: root = {'1.6.1', '0.6.13'}, fog_ledger = {'1.2.0'}
smallvec: root = {'1.6.1', '0.6.13'}, fog_view = {'1.2.0'}
syn: root = {'0.15.44', '1.0.86'}, consensus = {'1.0.67'}
syn: root = {'0.15.44', '1.0.86'}, fog_ingest = {'1.0.67'}
syn: root = {'0.15.44', '1.0.86'}, fog_ledger = {'1.0.73'}
syn: root = {'0.15.44', '1.0.86'}, fog_view = {'1.0.67'}
termcolor: root = {'1.1.0'}, fog_ingest = {'1.0.5'}
termcolor: root = {'1.1.0'}, fog_ledger = {'1.0.5'}
termcolor: root = {'1.1.0'}, fog_view = {'1.0.5'}
thread_local: root = {'1.0.1'}, fog_ingest = {'0.3.6'}
thread_local: root = {'1.0.1'}, fog_view = {'0.3.6'}
unicode-normalization: root = {'0.1.17'}, consensus = {'0.1.12'}
unicode-normalization: root = {'0.1.17'}, fog_ingest = {'0.1.12'}
unicode-normalization: root = {'0.1.17'}, fog_ledger = {'0.1.12'}
unicode-normalization: root = {'0.1.17'}, fog_view = {'0.1.12'}
vcpkg: root = {'0.2.8'}, consensus = {'0.2.15'}
vcpkg: root = {'0.2.8'}, fog_ingest = {'0.2.15'}
vcpkg: root = {'0.2.8'}, fog_ledger = {'0.2.15'}
vcpkg: root = {'0.2.8'}, fog_view = {'0.2.15'}
vec_map: root = {'0.8.2'}, consensus = {'0.8.1'}
vec_map: root = {'0.8.2'}, fog_ingest = {'0.8.1'}
vec_map: root = {'0.8.2'}, fog_ledger = {'0.8.1'}
vec_map: root = {'0.8.2'}, fog_view = {'0.8.1'}
version_check: root = {'0.1.5', '0.9.3'}, consensus = {'0.9.2'}
version_check: root = {'0.1.5', '0.9.3'}, fog_ingest = {'0.9.2'}
version_check: root = {'0.1.5', '0.9.3'}, fog_ledger = {'0.9.2'}
version_check: root = {'0.1.5', '0.9.3'}, fog_view = {'0.9.2'}
winapi: root = {'0.2.8', '0.3.9'}, consensus = {'0.3.8'}
winapi: root = {'0.2.8', '0.3.9'}, fog_ingest = {'0.3.8'}
winapi: root = {'0.2.8', '0.3.9'}, fog_ledger = {'0.3.8'}
winapi: root = {'0.2.8', '0.3.9'}, fog_view = {'0.3.8'}
winapi-util: root = {'0.1.5'}, consensus = {'0.1.3'}
winapi-util: root = {'0.1.5'}, fog_ingest = {'0.1.2'}
winapi-util: root = {'0.1.5'}, fog_ledger = {'0.1.2'}
winapi-util: root = {'0.1.5'}, fog_view = {'0.1.2'}
```

I think some of these are dev dependencies, so they aren't as interesting. But I can't see an easy way to filter those out.