### PR TITLE
add get_root_tx_out_membership_element

### DIFF
--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -14,7 +14,7 @@ use mc_ledger_db::{Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TxOut, TxOutMembershipProof},
+    tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockSignature,
 };
 
@@ -177,6 +177,10 @@ impl Ledger for MockLedger {
     }
 
     fn get_block_index_by_tx_out_index(&self, _tx_out_index: u64) -> Result<u64, Error> {
+        unimplemented!()
+    }
+
+    fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
         unimplemented!()
     }
 }

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -5,7 +5,7 @@ use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TxOut, TxOutMembershipProof},
+    tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockIndex, BlockSignature,
 };
 use mockall::*;
@@ -78,4 +78,7 @@ pub trait Ledger: Send {
 
     /// Gets the key images used by transactions in a single block.
     fn get_key_images_by_block(&self, block_number: BlockIndex) -> Result<Vec<KeyImage>, Error>;
+
+    /// Get the tx out root membership element from the tx out Merkle Tree.
+    fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error>;
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1701,7 +1701,7 @@ mod ledger_db_test {
             ledger_db.append_block(block, block_contents, None).unwrap();
         }
 
-        // The root element shoudl be the same for all TxOuts in the ledger.
+        // The root element should be the same for all TxOuts in the ledger.
         let root_element = ledger_db.get_root_tx_out_membership_element().unwrap();
 
         for tx_out_index in 0..ledger_db.num_txos().unwrap() {

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -346,13 +346,13 @@ impl Ledger for LedgerDB {
     /// Get the tx out root membership element from the tx out Merkle Tree.
     fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
         let db_transaction = self.env.begin_ro_txn()?;
-        let num_txos = self.tx_out_store.num_tx_outs(&db_transaction)?;
-        let root_merkle_hash = self.tx_out_store.get_root_merkle_hash(&db_transaction)?;
 
+        let num_txos = self.tx_out_store.num_tx_outs(&db_transaction)?;
         if num_txos == 0 {
             return Err(Error::NoOutputs);
         }
 
+        let root_merkle_hash = self.tx_out_store.get_root_merkle_hash(&db_transaction)?;
         let range = Range::new(
             0,
             // This duplicates the range calculation logic inside get_root_merkle_hash

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -186,6 +186,10 @@ impl Ledger for MockLedger {
             })
             .collect()
     }
+
+    fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
+        unimplemented!();
+    }
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
### Motivation

Our blocks keep track of the root hash of membership proofs that were used when validating transactions: https://github.com/mobilecoinfoundation/mobilecoin/blob/master/transaction/core/src/blockchain/block.rs#L45

In a future version we might introduce new transaction types that go into the blockchain that do not involve verifying any proofs of existing input TxOuts, and as such the enclave will not have a root_element to place inside the block (see [form_block](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/consensus/enclave/impl/src/lib.rs#L471-L473)).

For such cases, where the block only contains new transactions, we still want to provide a root element that captures the state of the ledger at the time the block was formed. This PRs adds a new method to `LedgerDB` that provides the current root hash, in a format that is compatible with what would've ended in the block if valid proofs were provided.

### In this PR
* Add a new method to `LedgerDB`: `get_root_tx_out_membership_element`
