### PR TITLE
Refactor some rct bulletproofs code for performance

### DIFF
--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -292,15 +292,23 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     };
 
     if check_value_is_preserved {
-        let sum_of_output_commitments: RistrettoPoint = output_values_and_blindings
+        let sum_of_output_values: u64 = output_values_and_blindings
             .iter()
-            .map(|(value, blinding)| GENERATORS.commit(Scalar::from(*value), *blinding))
+            .map(|(value, _)| value)
             .sum();
 
-        let sum_of_pseudo_output_commitments: RistrettoPoint = pseudo_output_values_and_blindings
+        let sum_of_output_commitments =
+            GENERATORS.commit(Scalar::from(sum_of_output_values), sum_of_output_blindings);
+
+        let sum_of_pseudo_output_values: u64 = pseudo_output_values_and_blindings
             .iter()
-            .map(|(value, blinding)| GENERATORS.commit(Scalar::from(*value), *blinding))
+            .map(|(value, _)| value)
             .sum();
+
+        let sum_of_pseudo_output_commitments = GENERATORS.commit(
+            Scalar::from(sum_of_pseudo_output_values),
+            sum_of_pseudo_output_blindings,
+        );
 
         // The implicit fee output.
         let fee_commitment = GENERATORS.commit(Scalar::from(fee), *FEE_BLINDING);


### PR DESCRIPTION
When we sign rct bulletproofs, we always use the `check_balance = true`
flag in prod, because that is the only public API that is exposed.

If there are `n` inputs and `m` outputs, this code causes us to do
at least `2n - 1 + 2m - 1` elliptic curve operations, since we
do one such operation to form n + m pedersen commitments, and then
add all of them together.

Since we have the values and blindings, we can add them together
in a more efficient way, just adding the underlying numbers together
and only converting to a commitment at the very end. That way we only
do 2 elliptic curve operations ever.

This may save many elliptic curve operations when there are many inputs.
Since elliptic curve operations are generally the bottleneck, this may
reduce the work that a mobile device needs to do to build a transaction.

It is likely not very noticeable because there are way more such
operations in bulletproofs, but it is still probably worth it to
minimize elliptic curve ops when its easy to do so.

For example, on fast Intel hardware, these ops take about .1 millis.
On ARM arch, it might be more like 1 millisecond to do an elliptic
curve operation. If we remove 20 elliptic curve operations, it might
translate to like .02 seconds savings. So probably still not noticeable
but it's an easy win.