### PR TITLE
Potential approach for extending SCP that involves the enclave

### DIFF
--- a/consensus/api/proto/consensus_client.proto
+++ b/consensus/api/proto/consensus_client.proto
@@ -10,8 +10,15 @@ package consensus_client;
 
 option go_package = "mobilecoin/api";
 
+message MintRequest {
+    uint64 amount = 1;
+}
+
 service ConsensusClientAPI {
     /// This API call is made with an encrypted payload for the enclave,
     /// indicating a new value to be acted upon.
     rpc ClientTxPropose(attest.Message) returns (consensus_common.ProposeTxResponse);
+
+    // TODO
+    rpc ClientMintTxPropose(MintRequest) returns (consensus_common.ProposeTxResponse);
 }

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -209,12 +209,36 @@ mod well_formed_tx_context_tests {
 /// to gather data required for the in-enclave well-formedness test that takes
 /// place in `tx_is_well_formed`.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub struct TxContext {
+pub struct MobTxContext {
     pub locally_encrypted_tx: LocallyEncryptedTx,
     pub tx_hash: TxHash,
     pub highest_indices: Vec<u64>,
     pub key_images: Vec<KeyImage>,
     pub output_public_keys: Vec<CompressedRistrettoPublic>,
+}
+
+// TODO
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum TxContext {
+    MobTx(MobTxContext),
+
+    #[allow(dead_code)]
+    SomethingElse,
+}
+
+impl TxContext {
+    pub fn locally_encrypted_tx(&self) -> &LocallyEncryptedTx {
+        match self {
+            TxContext::MobTx(tx) => &tx.locally_encrypted_tx,
+            TxContext::SomethingElse => todo!(),
+        }
+    }
+    pub fn tx_hash(&self) -> &TxHash {
+        match self {
+            TxContext::MobTx(tx) => &tx.tx_hash,
+            TxContext::SomethingElse => todo!(),
+        }
+    }
 }
 
 pub type SealedBlockSigningKey = Vec<u8>;

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -100,6 +100,9 @@ pub enum EnclaveCall {
     /// client.
     ClientTxPropose(EnclaveMessage<ClientSession>),
 
+    // TODO
+    ClientMintTxPropose(u64),
+
     /// The [ConsensusEnclave::client_discard_message()] method.
     ///
     /// Decrypts an incoming message and discard the data.
@@ -116,6 +119,9 @@ pub enum EnclaveCall {
     /// Provide the missing proofs required to check if a given sealed
     /// transaction is well-formed.
     TxIsWellFormed(LocallyEncryptedTx, u64, Vec<TxOutMembershipProof>),
+
+    // TODO
+    TxIsMintTxWellFormed(LocallyEncryptedTx, u64),
 
     /// The [ConsensusEnclave::txs_for_peer()] method.
     ///

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -144,18 +144,18 @@ impl SgxConsensusEnclave {
 
     fn encrypt_well_formed_tx<R: RngCore + CryptoRng>(
         &self,
-        well_formed_tx: &WellFormedTx,
+        well_formed_tx: WellFormedTx,
         rng: &mut R,
     ) -> Result<WellFormedEncryptedTx> {
         // TODO maybe there's a more efficient way to do this that avoids this copy?
 
         let prost_well_formed_tx = match well_formed_tx {
             WellFormedTx::MobTx(tx) => ProstWellFormedTx {
-                mob_tx: Some(tx.clone()),
+                mob_tx: Some(tx),
                 ..Default::default()
             },
             WellFormedTx::MintTx(mint_tx) => ProstWellFormedTx {
-                mint_tx: Some(mint_tx.clone()),
+                mint_tx: Some(mint_tx),
                 ..Default::default()
             },
         };
@@ -475,7 +475,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Convert into a well formed encrypted transaction + context.
         let well_formed_tx_context = WellFormedTxContext::from(&tx);
         let well_formed_tx = WellFormedTx::from(tx);
-        let well_formed_encrypted_tx = self.encrypt_well_formed_tx(&well_formed_tx, &mut csprng)?;
+        let well_formed_encrypted_tx = self.encrypt_well_formed_tx(well_formed_tx, &mut csprng)?;
 
         Ok((well_formed_encrypted_tx, well_formed_tx_context))
     }
@@ -501,7 +501,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Convert into a well formed encrypted transaction + context.
         let well_formed_tx_context = WellFormedTxContext::from(&tx);
         let well_formed_tx = WellFormedTx::from(tx);
-        let well_formed_encrypted_tx = self.encrypt_well_formed_tx(&well_formed_tx, &mut csprng)?;
+        let well_formed_encrypted_tx = self.encrypt_well_formed_tx(well_formed_tx, &mut csprng)?;
 
         Ok((well_formed_encrypted_tx, well_formed_tx_context))
     }
@@ -585,8 +585,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                     WellFormedTx::MobTx(mob_tx) => Ok((mob_tx, proofs.clone())),
                     WellFormedTx::MintTx(mint_tx) => {
                         // This is where we should do something with the mint transactions.
-                        // We likely need to collect them into a separate list since the handling of MobTxs
-                        // and MintTxs is different.
+                        // We likely need to collect them into a separate list since the handling of
+                        // MobTxs and MintTxs is different.
                         panic!("todo {:?}", mint_tx);
                     }
                 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -37,8 +37,8 @@ use mc_common::{
     ResponderId,
 };
 use mc_consensus_enclave_api::{
-    ConsensusEnclave, Error, FeePublicKey, LocallyEncryptedTx, Result, SealedBlockSigningKey,
-    TxContext, WellFormedEncryptedTx, WellFormedTxContext,
+    ConsensusEnclave, Error, FeePublicKey, LocallyEncryptedTx, MobTxContext, Result,
+    SealedBlockSigningKey, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
 };
 use mc_crypto_ake_enclave::AkeEnclaveState;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
@@ -316,13 +316,13 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let key_images: Vec<KeyImage> = tx.key_images();
         let output_public_keys = tx.output_public_keys();
 
-        Ok(TxContext {
+        Ok(TxContext::MobTx(MobTxContext {
             locally_encrypted_tx,
             tx_hash,
             highest_indices,
             key_images,
             output_public_keys,
-        })
+        }))
     }
 
     fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>> {
@@ -348,13 +348,13 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 let key_images: Vec<KeyImage> = tx.key_images();
                 let output_public_keys = tx.output_public_keys();
 
-                Ok(TxContext {
+                Ok(TxContext::MobTx(MobTxContext {
                     locally_encrypted_tx,
                     tx_hash,
                     highest_indices,
                     key_images,
                     output_public_keys,
-                })
+                }))
             })
             .collect()
     }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -7,8 +7,8 @@ mod mock_consensus_enclave;
 pub use mock_consensus_enclave::MockConsensusEnclave;
 
 pub use mc_consensus_enclave_api::{
-    ConsensusEnclave, ConsensusEnclaveProxy, Error, FeePublicKey, LocallyEncryptedTx, Result,
-    SealedBlockSigningKey, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
+    ConsensusEnclave, ConsensusEnclaveProxy, Error, FeePublicKey, LocallyEncryptedTx, MobTxContext,
+    Result, SealedBlockSigningKey, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
 };
 
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
@@ -67,13 +67,13 @@ impl ConsensusServiceMockEnclave {
         let key_images: Vec<KeyImage> = tx.key_images();
         let output_public_keys = tx.output_public_keys();
 
-        TxContext {
+        TxContext::MobTx(MobTxContext {
             locally_encrypted_tx,
             tx_hash,
             highest_indices,
             key_images,
             output_public_keys,
-        }
+        })
     }
 }
 
@@ -179,7 +179,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
     }
 
     fn client_tx_propose(&self, _msg: EnclaveMessage<ClientSession>) -> Result<TxContext> {
-        Ok(TxContext::default())
+        Ok(TxContext::MobTx(MobTxContext::default()))
     }
 
     fn peer_tx_propose(&self, _msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>> {

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -56,6 +56,8 @@ mock! {
 
         fn client_tx_propose(&self, msg: EnclaveMessage<ClientSession>) -> ConsensusEnclaveResult<TxContext>;
 
+        fn client_mint_tx_propose(&self, amount: u64) -> ConsensusEnclaveResult<TxContext>;
+
         fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> ConsensusEnclaveResult<Vec<TxContext>>;
 
         fn tx_is_well_formed(
@@ -63,6 +65,12 @@ mock! {
             locally_encrypted_tx: LocallyEncryptedTx,
             block_index: u64,
             proofs: Vec<TxOutMembershipProof>,
+        ) -> ConsensusEnclaveResult<(WellFormedEncryptedTx, WellFormedTxContext)>;
+
+        fn tx_is_mint_tx_well_formed(
+            &self,
+            locally_encrypted_tx: LocallyEncryptedTx,
+            block_index: u64,
         ) -> ConsensusEnclaveResult<(WellFormedEncryptedTx, WellFormedTxContext)>;
 
         fn txs_for_peer(

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -208,12 +208,9 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
     }
 
     fn client_mint_tx_propose(&self, amount: u64) -> Result<TxContext> {
-        println!("> client_mint_tx_propose");
         let inbuf = mc_util_serial::serialize(&EnclaveCall::ClientMintTxPropose(amount))?;
         let outbuf = self.enclave_call(&inbuf)?;
-        let ret = mc_util_serial::deserialize(&outbuf[..])?;
-        println!("< client_mint_tx_propose");
-        ret
+        mc_util_serial::deserialize(&outbuf[..])?
     }
 
     fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>> {
@@ -242,15 +239,12 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         locally_encrypted_tx: LocallyEncryptedTx,
         block_index: u64,
     ) -> Result<(WellFormedEncryptedTx, WellFormedTxContext)> {
-        println!("> tx_is_mint_tx_well_formed");
         let inbuf = mc_util_serial::serialize(&EnclaveCall::TxIsMintTxWellFormed(
             locally_encrypted_tx,
             block_index,
         ))?;
         let outbuf = self.enclave_call(&inbuf)?;
-        let ret = mc_util_serial::deserialize(&outbuf[..])?;
-        println!("< tx_is_mint_tx_well_formed");
-        ret
+        mc_util_serial::deserialize(&outbuf[..])?
     }
 
     fn txs_for_peer(
@@ -264,11 +258,8 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
             aad.to_vec(),
             peer.clone(),
         ))?;
-        println!("> txs_for_peer");
         let outbuf = self.enclave_call(&inbuf)?;
-        let ret = mc_util_serial::deserialize(&outbuf[..])?;
-        println!("< txs_for_peer");
-        ret
+        mc_util_serial::deserialize(&outbuf[..])?
     }
 
     fn form_block(
@@ -280,11 +271,8 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
             parent_block.clone(),
             txs_with_proofs.to_vec(),
         ))?;
-        println!("> form_block");
         let outbuf = self.enclave_call(&inbuf)?;
-        let ret = mc_util_serial::deserialize(&outbuf[..])?;
-        println!("< form_block");
-        ret
+        mc_util_serial::deserialize(&outbuf[..])?
     }
 }
 

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -91,11 +91,17 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         // Transactions
         EnclaveCall::ClientTxPropose(msg) => serialize(&ENCLAVE.client_tx_propose(msg))
             .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
+        EnclaveCall::ClientMintTxPropose(msg) => serialize(&ENCLAVE.client_mint_tx_propose(msg))
+            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
         EnclaveCall::PeerTxPropose(msg) => {
             serialize(&ENCLAVE.peer_tx_propose(msg)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         EnclaveCall::TxIsWellFormed(locally_encrypted_tx, block_index, proofs) => {
             serialize(&ENCLAVE.tx_is_well_formed(locally_encrypted_tx, block_index, proofs))
+                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
+        }
+        EnclaveCall::TxIsMintTxWellFormed(locally_encrypted_tx, block_index) => {
+            serialize(&ENCLAVE.tx_is_mint_tx_well_formed(locally_encrypted_tx, block_index))
                 .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         EnclaveCall::TxsForPeer(txs, aad, peer) => {

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -149,7 +149,7 @@ impl PeerApiService {
 
         // Handle each transaction.
         for tx_context in tx_contexts {
-            let tx_hash = tx_context.tx_hash().clone();
+            let tx_hash = *tx_context.tx_hash();
 
             match self.tx_manager.insert(tx_context) {
                 Ok(tx_hash) => {

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -149,7 +149,7 @@ impl PeerApiService {
 
         // Handle each transaction.
         for tx_context in tx_contexts {
-            let tx_hash = tx_context.tx_hash;
+            let tx_hash = tx_context.tx_hash().clone();
 
             match self.tx_manager.insert(tx_context) {
                 Ok(tx_hash) => {

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -94,7 +94,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
                 // The enclave part of the well-formed check.
                 let (well_formed_encrypted_tx, well_formed_tx_context) =
                     self.enclave.tx_is_well_formed(
-                        mob_tx_context.locally_encrypted_tx.clone(),
+                        mob_tx_context.locally_encrypted_tx,
                         current_block_index,
                         highest_index_proofs,
                     )?;
@@ -107,13 +107,11 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
 
             TxContext::MintTx(mint_tx_context) => {
                 // TODO untrusted checks
-                println!("IS MINT WELL FORMED?");
                 let (well_formed_encrypted_tx, well_formed_tx_context) =
                     self.enclave.tx_is_mint_tx_well_formed(
-                        mint_tx_context.locally_encrypted_tx.clone(),
+                        mint_tx_context.locally_encrypted_tx,
                         1, // TODO current_block_index,
                     )?;
-                println!("IT IS");
 
                 Ok(CacheEntry {
                     encrypted_tx: well_formed_encrypted_tx,
@@ -166,19 +164,16 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     /// Insert a transaction into the cache. The transaction must be
     /// well-formed.
     fn insert(&self, tx_context: TxContext) -> TxManagerResult<TxHash> {
-        let tx_hash = tx_context.tx_hash().clone();
-
         {
             let cache = self.lock_cache();
-            if let Some(entry) = cache.get(&tx_hash) {
+            if let Some(entry) = cache.get(tx_context.tx_hash()) {
                 // The transaction is well-formed and is in the cache.
                 return Ok(*entry.context.tx_hash());
             }
         }
 
-        println!("IS_WELL_FORMED");
+        let tx_hash = *tx_context.tx_hash();
         let new_entry = self.is_well_formed(tx_context)?;
-        println!("AND INTO THE CACHE");
 
         {
             let mut cache = self.lock_cache();
@@ -247,9 +242,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
 
         if let Some(context) = context_opt {
             let _timer = counters::VALIDATE_TX_TIME.start_timer();
-            println!("UNTRUSTED IS_VALID?");
             self.untrusted.is_valid(context)?;
-            println!("UNTRUSTED IS_VALID!");
             Ok(())
         } else {
             log::warn!(
@@ -274,7 +267,6 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             .collect::<Vec<_>>();
 
         // Perform the combine operation.
-        println!("COMBINING");
         Ok(self
             .untrusted
             .combine(&tx_contexts, MAX_TRANSACTIONS_PER_BLOCK))
@@ -320,7 +312,6 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             })
             .collect::<Result<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>, TxManagerError>>()?;
 
-        println!("FORMING BLOCK: {:?}", tx_hashes);
         let (block, block_contents, mut signature) = self
             .enclave
             .form_block(parent_block, &encrypted_txs_with_proofs)?;
@@ -346,14 +337,15 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     ) -> TxManagerResult<EnclaveMessage<PeerSession>> {
         // Split `tx_hashes` into a list of found hashes and missing ones. This allows
         // us to return an error with the entire list of missing hashes.
+        let cache = self.lock_cache();
+
         let (encrypted_txs, not_found) = {
-            let cache = self.lock_cache();
             tx_hashes
                 .iter()
                 .map(|tx_hash| {
                     cache.get(tx_hash).map_or_else(
-                        || (*tx_hash, None),
-                        |entry| (*tx_hash, Some(entry.encrypted_tx().clone())),
+                        || (tx_hash, None),
+                        |entry| (tx_hash, Some(entry.encrypted_tx())),
                     )
                 })
                 .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some())
@@ -361,19 +353,19 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
 
         // If we are missing any hashes, return error.
         if !not_found.is_empty() {
-            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
+            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| *tx_hash).collect();
             return Err(TxManagerError::NotInCache(not_found_tx_hashes));
         }
 
         // Proceed with producing encrypted txs for the given peer.
         let encrypted_txs: Vec<_> = encrypted_txs
             .into_iter()
-            .map(|(_, result)| result.unwrap())
+            .map(|(_, result)| result.unwrap().clone())
             .collect();
 
-        println!("TXS FOR PEER?");
+        drop(cache);
+
         let ret = self.enclave.txs_for_peer(&encrypted_txs, aad, peer)?;
-        println!("TXS FOR PEER!");
         Ok(ret)
     }
 

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -105,6 +105,38 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
     fn lock_cache(&self) -> MutexGuard<HashMap<TxHash, CacheEntry>> {
         self.cache.lock().expect("Lock poisoned")
     }
+
+    /// A utility method for resolving a list of TxHashes into CacheEntries that
+    /// errors if any hashes are missing.
+    fn get_cache_entries<'a, 'b, I>(
+        cache: &'a MutexGuard<HashMap<TxHash, CacheEntry>>,
+        tx_hashes: I,
+    ) -> Result<Vec<&'a CacheEntry>, TxManagerError>
+    where
+        I: Iterator<Item = &'b TxHash>,
+    {
+        // Split `tx_hashes` into a list of found hashes and missing ones. This allows
+        // us to return an error with the entire list of missing hashes.
+        let (entries, not_found) = tx_hashes
+            .map(|tx_hash| {
+                cache
+                    .get(tx_hash)
+                    .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
+            })
+            .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
+
+        // If we are missing any hashes, return error.
+        if !not_found.is_empty() {
+            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
+            return Err(TxManagerError::NotInCache(not_found_tx_hashes));
+        }
+
+        // Otherwise, return the found entries.
+        Ok(entries
+            .into_iter()
+            .map(|(_tx_hash, entry)| entry.unwrap())
+            .collect())
+    }
 }
 
 impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
@@ -208,38 +240,18 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     fn combine(&self, tx_hashes: &[TxHash]) -> TxManagerResult<Vec<TxHash>> {
         let tx_hashes: HashSet<&TxHash> = tx_hashes.iter().clone().collect(); // Dedup
 
-        let tx_contexts: TxManagerResult<Vec<Arc<WellFormedTxContext>>> = {
-            let cache = self.lock_cache();
+        let cache = self.lock_cache();
+        let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter().copied())?;
 
-            // Split `tx_hashes` into a list of found hashes and missing ones. This allows
-            // us to return an error with the entire list of missing hashes.
-            let (entries, not_found) = tx_hashes
-                .iter()
-                .map(|tx_hash| {
-                    cache
-                        .get(tx_hash)
-                        .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
-                })
-                .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
-
-            // If we are missing any hashes, return error.
-            if !not_found.is_empty() {
-                let not_found_tx_hashes =
-                    not_found.into_iter().map(|(tx_hash, _)| *tx_hash).collect();
-                return Err(TxManagerError::NotInCache(not_found_tx_hashes));
-            }
-
-            // Collect tx contexts.
-            Ok(entries
-                .into_iter()
-                .map(|(_tx_hash, entry)| entry.unwrap().context().clone())
-                .collect())
-        };
+        let tx_contexts = cache_entries
+            .iter()
+            .map(|entry| entry.context.clone())
+            .collect::<Vec<_>>();
 
         // Perform the combine operation.
         Ok(self
             .untrusted
-            .combine(&tx_contexts?, MAX_TRANSACTIONS_PER_BLOCK))
+            .combine(&tx_contexts, MAX_TRANSACTIONS_PER_BLOCK))
     }
 
     /// Forms a Block containing the transactions that correspond to the given
@@ -255,29 +267,12 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         parent_block: &Block,
     ) -> TxManagerResult<(Block, BlockContents, BlockSignature)> {
         let cache = self.lock_cache();
-
-        // Split `tx_hashes` into a list of found hashes and missing ones. This allows
-        // us to return an error with the entire list of missing hashes.
-        let (entries, not_found) = tx_hashes
-            .iter()
-            .map(|tx_hash| {
-                cache
-                    .get(tx_hash)
-                    .map_or_else(|| (*tx_hash, None), |entry| (*tx_hash, Some(entry)))
-            })
-            .partition::<Vec<_>, _>(|(_tx_hash, result)| result.is_some());
-
-        // If we are missing any hashes, return error.
-        if !not_found.is_empty() {
-            let not_found_tx_hashes = not_found.into_iter().map(|(tx_hash, _)| tx_hash).collect();
-            return Err(TxManagerError::NotInCache(not_found_tx_hashes));
-        }
+        let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter())?;
 
         // Proceed with forming the block.
-        let encrypted_txs_with_proofs = entries
+        let encrypted_txs_with_proofs = cache_entries
             .into_iter()
-            .map(|(_tx_hash, entry)| {
-                let entry = entry.unwrap();
+            .map(|entry| {
                 // Highest indices proofs must be w.r.t. the current ledger.
                 // Recreating them here is a crude way to ensure that.
                 let highest_index_proofs: Vec<_> = self

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -91,7 +91,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManagerImpl<E
 
         // The enclave part of the well-formed check.
         let (well_formed_encrypted_tx, well_formed_tx_context) = self.enclave.tx_is_well_formed(
-            tx_context.locally_encrypted_tx,
+            tx_context.locally_encrypted_tx().clone(),
             current_block_index,
             highest_index_proofs,
         )?;
@@ -145,11 +145,11 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     /// Insert a transaction into the cache. The transaction must be
     /// well-formed.
     fn insert(&self, tx_context: TxContext) -> TxManagerResult<TxHash> {
-        let tx_hash = tx_context.tx_hash;
+        let tx_hash = tx_context.tx_hash().clone();
 
         {
             let cache = self.lock_cache();
-            if let Some(entry) = cache.get(&tx_context.tx_hash) {
+            if let Some(entry) = cache.get(&tx_hash) {
                 // The transaction is well-formed and is in the cache.
                 return Ok(*entry.context.tx_hash());
             }

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use mc_consensus_enclave::{TxContext, WellFormedTxContext};
+use mc_consensus_enclave::{MobTxContext, WellFormedTxContext};
 use mc_transaction_core::{
     tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
@@ -20,7 +20,7 @@ pub trait UntrustedInterfaces: Send + Sync {
     /// highest index.
     fn well_formed_check(
         &self,
-        tx_context: &TxContext,
+        tx_context: &MobTxContext,
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)>;
 
     /// Checks if a transaction is valid (see definition in validators.rs).

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -53,11 +53,13 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
         &self,
         tx_context: &TxContext,
     ) -> TransactionValidationResult<(u64, Vec<TxOutMembershipProof>)> {
+        match tx_context {
+            TxContext::MobTx(mob_tx_context) =>  {
         // The transaction's membership proofs must reference data contained in the
         // ledger. This check could fail if the local ledger is behind the
         // network's consensus ledger.
         let membership_proofs =
-            self.get_tx_out_proof_of_memberships(&tx_context.highest_indices)?;
+            self.get_tx_out_proof_of_memberships(&mob_tx_context.highest_indices)?;
 
         // Note: It is possible that the proofs above are obtained for a different block
         // index as a new block could be written between getting the proofs and
@@ -68,6 +70,10 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
             .map_err(|e| TransactionValidationError::Ledger(e.to_string()))?;
 
         Ok((num_blocks - 1, membership_proofs))
+            },
+
+            TxContext::SomethingElse => todo!(),
+        }
     }
 
     /// Checks if a transaction is valid (see definition at top of this file).

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -549,6 +549,19 @@ impl ReprBytes for TxOutConfirmationNumber {
 
 derive_prost_message_from_repr_bytes!(TxOutConfirmationNumber);
 
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Message, Digestible)]
+pub struct MintTx {
+    // TODO
+    #[prost(uint64, tag = "1")]
+    pub amount: u64,
+}
+
+impl MintTx {
+    pub fn tx_hash(&self) -> TxHash {
+        TxHash::from(self.digest32::<MerlinTranscript>(b"mobilecoin-mint-tx"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{


### PR DESCRIPTION
A potential approach for making it possible to run consensus on new transaction types that involves the enclave.

Pros:
- Allows for confidential information to be included in the transaction, similar to the existing MOB `Tx`
- Smaller SCP statement sizes might result in better performance for a block that includes this type of transaction

Cons:
- More complicated code flow
- Enclave code might need to change to support new tx types even if they don't necessitate any enclave functionality