### PR TITLE
 Potential approach for extending SCP that does not involve the enclave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,7 +3028,6 @@ dependencies = [
  "mc-consensus-enclave",
  "mc-consensus-enclave-mock",
  "mc-consensus-scp",
- "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-ledger-db",
  "mc-ledger-sync",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3028,6 +3028,7 @@ dependencies = [
  "mc-consensus-enclave",
  "mc-consensus-enclave-mock",
  "mc-consensus-scp",
+ "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-ledger-db",
  "mc-ledger-sync",

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -44,14 +44,20 @@ pub trait AttestedConnection: Connection {
         func: impl FnOnce(&mut Self) -> StdResult<T, GrpcError>,
     ) -> StdResult<T, Self::Error> {
         if !self.is_attested() {
+            println!("ATTESTING");
             let _verification_report = self.attest()?;
+            println!("ATTESTED");
         }
 
+        println!("FUNCING");
         let result = func(self);
 
         if let Err(GrpcError::RpcFailure(_rpc_status)) = &result {
+            println!("DEATTEST");
             self.deattest();
         }
+
+        println!("OK?");
 
         Ok(result?)
     }

--- a/consensus/api/proto/consensus_client.proto
+++ b/consensus/api/proto/consensus_client.proto
@@ -14,4 +14,15 @@ service ConsensusClientAPI {
     /// This API call is made with an encrypted payload for the enclave,
     /// indicating a new value to be acted upon.
     rpc ClientTxPropose(attest.Message) returns (consensus_common.ProposeTxResponse);
+
+    rpc Mint(MintRequest) returns (MintResponse);
+}
+
+message MintRequest {
+    uint64 amount = 1;
+    uint64 tombstone_block = 2;
+}
+
+message MintResponse {
+    uint64 block_count = 1;
 }

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -27,8 +27,9 @@ use mc_common::ResponderId;
 use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, RistrettoPublic, X25519Public};
 use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
+    mint::MintTx,
     ring_signature::KeyImage,
-    tx::{MintTx, Tx, TxHash, TxOutMembershipElement, TxOutMembershipProof},
+    tx::{Tx, TxHash, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, TokenId,
 };
 use serde::{Deserialize, Serialize};

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -28,7 +28,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, RistrettoPublic, 
 use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{Tx, TxHash, TxOutMembershipProof},
+    tx::{MintTx, Tx, TxHash, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, TokenId,
 };
 use serde::{Deserialize, Serialize};
@@ -300,7 +300,9 @@ pub trait ConsensusEnclave: ReportableEnclave {
     fn form_block(
         &self,
         parent_block: &Block,
-        txs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        root_element: &TxOutMembershipElement,
+        mint_txs: &[MintTx],
     ) -> Result<(Block, BlockContents, BlockSignature)>;
 }
 

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -11,7 +11,10 @@ use mc_attest_enclave_api::{
     ClientAuthRequest, ClientSession, EnclaveMessage, PeerAuthRequest, PeerAuthResponse,
     PeerSession,
 };
-use mc_transaction_core::{tx::TxOutMembershipProof, Block, TokenId};
+use mc_transaction_core::{
+    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    Block, TokenId,
+};
 use serde::{Deserialize, Serialize};
 
 /// An enumeration of API calls and their arguments for use across serialization
@@ -131,6 +134,8 @@ pub enum EnclaveCall {
     FormBlock(
         Block,
         Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>,
+        TxOutMembershipElement,
+        Vec<MintTx>,
     ),
 
     /// The [ConsensusEnclave::get_minimum_fee()] method.

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -12,7 +12,8 @@ use mc_attest_enclave_api::{
     PeerSession,
 };
 use mc_transaction_core::{
-    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    mint::MintTx,
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
     Block, TokenId,
 };
 use serde::{Deserialize, Serialize};

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -46,8 +46,9 @@ use mc_sgx_compat::sync::Mutex;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
+    mint::MintTx,
     ring_signature::{KeyImage, Scalar},
-    tx::{MintTx, Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, TokenId, BLOCK_VERSION,
 };

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -26,7 +26,7 @@ use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
     tokens::Mob,
-    tx::{Tx, TxOut, TxOutMembershipProof, MintTx, TxOutMembershipElement},
+    tx::{MintTx, Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, Token, TokenId, BLOCK_VERSION,
 };
@@ -212,7 +212,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
         _root_element: &TxOutMembershipElement,
         _mint_txs: &[MintTx],
-     ) -> Result<(Block, BlockContents, BlockSignature)> {
+    ) -> Result<(Block, BlockContents, BlockSignature)> {
         let transactions_with_proofs: Vec<(Tx, Vec<TxOutMembershipProof>)> =
             encrypted_txs_with_proofs
                 .iter()

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -24,9 +24,10 @@ use mc_crypto_rand::McRng;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
+    mint::MintTx,
     ring_signature::KeyImage,
     tokens::Mob,
-    tx::{MintTx, Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, Token, TokenId, BLOCK_VERSION,
 };

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -26,7 +26,7 @@ use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
     tokens::Mob,
-    tx::{Tx, TxOut, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipProof, MintTx, TxOutMembershipElement},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, Token, TokenId, BLOCK_VERSION,
 };
@@ -210,7 +210,9 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         &self,
         parent_block: &Block,
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
-    ) -> Result<(Block, BlockContents, BlockSignature)> {
+        _root_element: &TxOutMembershipElement,
+        _mint_txs: &[MintTx],
+     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let transactions_with_proofs: Vec<(Tx, Vec<TxOutMembershipProof>)> =
             encrypted_txs_with_proofs
                 .iter()

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -14,7 +14,8 @@ use mc_consensus_enclave_api::{
 use mc_crypto_keys::{Ed25519Public, X25519Public};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as SgxReportResult};
 use mc_transaction_core::{
-    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
+    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    Block, BlockContents, BlockSignature, TokenId,
 };
 
 use mockall::*;
@@ -78,7 +79,9 @@ mock! {
             &self,
             parent_block: &Block,
             txs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
-        ) -> ConsensusEnclaveResult<(Block, BlockContents, BlockSignature)>;
+            root_element: &TxOutMembershipElement,
+            mint_txs: &[MintTx],
+         ) -> ConsensusEnclaveResult<(Block, BlockContents, BlockSignature)>;
     }
 
     impl ReportableEnclave for ConsensusEnclave {

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -14,7 +14,8 @@ use mc_consensus_enclave_api::{
 use mc_crypto_keys::{Ed25519Public, X25519Public};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as SgxReportResult};
 use mc_transaction_core::{
-    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    mint::MintTx,
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, TokenId,
 };
 

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -22,7 +22,8 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_sgx_types::{sgx_enclave_id_t, sgx_status_t, *};
 use mc_sgx_urts::SgxEnclave;
 use mc_transaction_core::{
-    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
+    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    Block, BlockContents, BlockSignature, TokenId,
 };
 use std::{path, result::Result as StdResult, sync::Arc};
 
@@ -250,10 +251,14 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         &self,
         parent_block: &Block,
         txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        root_element: &TxOutMembershipElement,
+        mint_txs: &[MintTx],
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::FormBlock(
             parent_block.clone(),
             txs_with_proofs.to_vec(),
+            root_element.clone(),
+            mint_txs.to_vec(),
         ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -22,7 +22,8 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_sgx_types::{sgx_enclave_id_t, sgx_status_t, *};
 use mc_sgx_urts::SgxEnclave;
 use mc_transaction_core::{
-    tx::{MintTx, TxOutMembershipElement, TxOutMembershipProof},
+    mint::MintTx,
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, TokenId,
 };
 use std::{path, result::Result as StdResult, sync::Arc};

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -97,9 +97,14 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
                 .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
 
-        EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs) => {
-            serialize(&ENCLAVE.form_block(&parent_block, &encrypted_txs_with_proofs))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
+        EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs, root_element, mint_txs) => {
+            serialize(&ENCLAVE.form_block(
+                &parent_block,
+                &encrypted_txs_with_proofs,
+                &root_element,
+                &mint_txs,
+            ))
+            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
     };
 

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -22,6 +22,7 @@ mc-connection = { path = "../../connection" }
 mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-enclave = { path = "../../consensus/enclave" }
 mc-consensus-scp = { path = "../../consensus/scp" }
+mc-crypto-digestible = { path = "../../crypto/digestible" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-ledger-sync = { path = "../../ledger/sync" }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -179,6 +179,7 @@ mod client_api_tests {
     use mc_consensus_enclave::TxContext;
     use mc_consensus_enclave_mock::MockConsensusEnclave;
     use mc_ledger_db::MockLedger;
+    use mc_peers::ConsensusValue;
     use mc_transaction_core::{
         ring_signature::KeyImage, tx::TxHash, validation::TransactionValidationError,
     };
@@ -219,7 +220,9 @@ mod client_api_tests {
 
         // Arc<dyn Fn(TxHash, Option<&NodeID>, Option<&ResponderId>) + Sync + Send>
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {
                 // TODO: store inputs for inspection.
             },
         );
@@ -283,7 +286,9 @@ mod client_api_tests {
         }
 
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {},
         );
 
         let mut ledger = MockLedger::new();
@@ -353,7 +358,9 @@ mod client_api_tests {
             .return_const(Ok(tx_context));
 
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {},
         );
 
         let num_blocks = 5;
@@ -412,7 +419,9 @@ mod client_api_tests {
         let is_serving_fn = Arc::new(|| -> bool { false }); // Not serving
 
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {},
         );
 
         let authenticator = AnonymousAuthenticator::default();
@@ -458,7 +467,9 @@ mod client_api_tests {
         let is_serving_fn = Arc::new(|| -> bool { true });
 
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {},
         );
 
         let authenticator = AnonymousAuthenticator::default();
@@ -504,7 +515,9 @@ mod client_api_tests {
         let is_serving_fn = Arc::new(|| -> bool { true }); // Not serving
 
         let scp_client_value_sender = Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {},
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {},
         );
 
         let authenticator = TokenAuthenticator::new(

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -19,7 +19,7 @@ use mc_consensus_api::{
 use mc_consensus_enclave::ConsensusEnclave;
 use mc_ledger_db::Ledger;
 use mc_peers::ConsensusValue;
-use mc_transaction_core::tx::MintTx;
+use mc_transaction_core::mint::MintTx;
 use mc_util_grpc::{rpc_logger, send_result, Authenticator};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use std::sync::Arc;

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -10,13 +10,15 @@ use crate::{
 };
 use grpcio::{RpcContext, RpcStatus, UnarySink};
 use mc_attest_api::attest::Message;
-use mc_common::logger::Logger;
+use mc_common::logger::{log, Logger};
 use mc_consensus_api::{
+    consensus_client::{MintRequest, MintResponse},
     consensus_client_grpc::ConsensusClientApi,
     consensus_common::{ProposeTxResponse, ProposeTxResult},
 };
 use mc_consensus_enclave::ConsensusEnclave;
 use mc_ledger_db::Ledger;
+use mc_peers::{ConsensusValue, MintTx};
 use mc_util_grpc::{rpc_logger, send_result, Authenticator};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use std::sync::Arc;
@@ -88,7 +90,7 @@ impl ClientApiService {
         self.tx_manager.validate(&tx_hash)?;
 
         // The transaction can be considered by the network.
-        (*self.propose_tx_callback)(tx_hash, None, None);
+        (*self.propose_tx_callback)(ConsensusValue::TxHash(tx_hash), None, None);
         counters::ADD_TX.inc();
         Ok(response)
     }
@@ -136,6 +138,20 @@ impl ConsensusClientApi for ClientApiService {
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             send_result(ctx, sink, result, logger)
         });
+    }
+
+    fn mint(&mut self, ctx: RpcContext, req: MintRequest, sink: UnarySink<MintResponse>) {
+        log::info!(self.logger, "MINT REQ {:?}", req);
+
+        let mint_tx = MintTx {
+            amount: req.amount,
+            tombstone_block: req.tombstone_block,
+        };
+        (*self.propose_tx_callback)(ConsensusValue::Mint(mint_tx), None, None);
+
+        let mut resp = MintResponse::new();
+        resp.set_block_count(self.ledger.num_blocks().unwrap());
+        send_result(ctx, sink, Ok(resp), &self.logger);
     }
 }
 

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -18,7 +18,8 @@ use mc_consensus_api::{
 };
 use mc_consensus_enclave::ConsensusEnclave;
 use mc_ledger_db::Ledger;
-use mc_peers::{ConsensusValue, MintTx};
+use mc_peers::ConsensusValue;
+use mc_transaction_core::tx::MintTx;
 use mc_util_grpc::{rpc_logger, send_result, Authenticator};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use std::sync::Arc;

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -418,8 +418,8 @@ mod tests {
     };
     use mc_crypto_keys::{Ed25519Pair, Ed25519Private};
     use mc_ledger_db::MockLedger;
-    use mc_peers;
-    use mc_transaction_core::{tx::TxHash, Block};
+    use mc_peers::{self, ConsensusValue};
+    use mc_transaction_core::Block;
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
     use std::sync::Arc;
@@ -445,9 +445,11 @@ mod tests {
 
     // Does nothing.
     fn get_scp_client_value_sender(
-    ) -> Arc<dyn Fn(TxHash, Option<&NodeID>, Option<&ResponderId>) + Sync + Send> {
+    ) -> Arc<dyn Fn(ConsensusValue, Option<&NodeID>, Option<&ResponderId>) + Sync + Send> {
         Arc::new(
-            |_tx_hash: TxHash, _node_id: Option<&NodeID>, _responder_id: Option<&ResponderId>| {
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {
                 // Do nothing.
             },
         )

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -27,7 +27,7 @@ use mc_consensus_api::{
 };
 use mc_consensus_enclave::{ConsensusEnclave, Error};
 use mc_ledger_db::Ledger;
-use mc_peers::TxProposeAAD;
+use mc_peers::{ConsensusValue, TxProposeAAD};
 use mc_transaction_core::tx::TxHash;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, rpc_permissions_error, send_result,
@@ -155,7 +155,7 @@ impl PeerApiService {
                 Ok(tx_hash) => {
                     // Submit for consideration in next SCP slot.
                     (*self.scp_client_value_sender)(
-                        tx_hash,
+                        ConsensusValue::TxHash(tx_hash),
                         origin_node.as_ref(),
                         relayed_by.as_ref(),
                     );

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -103,7 +103,7 @@ impl ByzantineLedger {
                 node_id.clone(),
                 quorum_set,
                 Arc::new(move |scp_value| match scp_value {
-                    ConsensusValue::TxHash(tx_hash) => tx_manager_validate.validate(&tx_hash),
+                    ConsensusValue::TxHash(tx_hash) => tx_manager_validate.validate(tx_hash),
                     ConsensusValue::Mint(_) => Ok(()), // TODO
                 }),
                 Arc::new(move |scp_values| {
@@ -111,10 +111,10 @@ impl ByzantineLedger {
                     let mut mint_txs = Vec::new();
 
                     // TODO avoid copies
-                    for value in scp_values.into_iter() {
+                    for value in scp_values.iter() {
                         match value {
                             ConsensusValue::TxHash(tx_hash) => tx_hashes.push(*tx_hash),
-                            ConsensusValue::Mint(mint_tx) => mint_txs.push(mint_tx.clone()),
+                            ConsensusValue::Mint(mint_tx) => mint_txs.push(*mint_tx),
                         }
                     }
                     let tx_hashes = tx_manager_combine.combine(&tx_hashes[..])?;
@@ -541,19 +541,22 @@ mod tests {
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_zero,
             ))
-            .unwrap();
+            .unwrap()
+            .into();
 
         let hash_tx_one = tx_manager
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_one,
             ))
-            .unwrap();
+            .unwrap()
+            .into();
 
         let hash_tx_two = tx_manager
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_two,
             ))
-            .unwrap();
+            .unwrap()
+            .into();
 
         byzantine_ledger.push_values(
             vec![hash_tx_zero, hash_tx_one, hash_tx_two],

--- a/consensus/service/src/byzantine_ledger/pending_values.rs
+++ b/consensus/service/src/byzantine_ledger/pending_values.rs
@@ -2,7 +2,7 @@
 
 //! A utility object for keeping track of pending transaction hashes.
 
-use crate::{tx_manager::TxManager};
+use crate::tx_manager::TxManager;
 use mc_peers::ConsensusValue;
 use std::{
     collections::{hash_map::Entry::Vacant, HashMap},
@@ -78,6 +78,13 @@ impl<TXM: TxManager> PendingValues<TXM> {
                         false
                     }
                 }
+
+                // TODO
+                ConsensusValue::Mint(_) => {
+                    entry.insert(timestamp);
+                    self.pending_values.push(value);
+                    true
+                }
             }
         } else {
             false
@@ -116,6 +123,9 @@ impl<TXM: TxManager> PendingValues<TXM> {
         let tx_manager = self.tx_manager.clone();
         self.retain(|value| match value {
             ConsensusValue::TxHash(tx_hash) => tx_manager.validate(tx_hash).is_ok(),
+
+            // TODO
+            ConsensusValue::Mint(_) => true,
         });
     }
 }

--- a/consensus/service/src/byzantine_ledger/pending_values.rs
+++ b/consensus/service/src/byzantine_ledger/pending_values.rs
@@ -2,8 +2,8 @@
 
 //! A utility object for keeping track of pending transaction hashes.
 
-use crate::tx_manager::TxManager;
-use mc_transaction_core::tx::TxHash;
+use crate::{tx_manager::TxManager};
+use mc_peers::ConsensusValue;
 use std::{
     collections::{hash_map::Entry::Vacant, HashMap},
     sync::Arc,
@@ -31,8 +31,8 @@ pub struct PendingValues<TXM: TxManager> {
     /// ByzantineLedger. We skip tracking processing times for relayed
     /// values since we want to track the time from when the network first
     /// saw a value, and not when a specific node saw it.
-    pending_values: Vec<TxHash>,
-    pending_values_map: HashMap<TxHash, Option<Instant>>,
+    pending_values: Vec<ConsensusValue>,
+    pending_values_map: HashMap<ConsensusValue, Option<Instant>>,
 }
 
 impl<TXM: TxManager> PendingValues<TXM> {
@@ -64,16 +64,20 @@ impl<TXM: TxManager> PendingValues<TXM> {
     /// Try and add a pending value, associated with a given timestamp, to the
     /// list. Returns `true` if the value is valid and not already on the
     /// list, false otherwise.
-    pub fn push(&mut self, tx_hash: TxHash, timestamp: Option<Instant>) -> bool {
-        if let Vacant(entry) = self.pending_values_map.entry(tx_hash) {
-            // A new transaction.
-            if self.tx_manager.validate(&tx_hash).is_ok() {
-                // The transaction is well-formed and valid.
-                entry.insert(timestamp);
-                self.pending_values.push(tx_hash);
-                true
-            } else {
-                false
+    pub fn push(&mut self, value: ConsensusValue, timestamp: Option<Instant>) -> bool {
+        if let Vacant(entry) = self.pending_values_map.entry(value) {
+            match value {
+                ConsensusValue::TxHash(tx_hash) => {
+                    // A new transaction.
+                    if self.tx_manager.validate(&tx_hash).is_ok() {
+                        // The transaction is well-formed and valid.
+                        entry.insert(timestamp);
+                        self.pending_values.push(value);
+                        true
+                    } else {
+                        false
+                    }
+                }
             }
         } else {
             false
@@ -81,19 +85,19 @@ impl<TXM: TxManager> PendingValues<TXM> {
     }
 
     /// Iterate over the list of pending values.
-    pub fn iter(&self) -> impl Iterator<Item = &TxHash> {
+    pub fn iter(&self) -> impl Iterator<Item = &ConsensusValue> {
         self.pending_values.iter()
     }
 
     /// Try and get the timestamp associated with a given value.
-    pub fn get_timestamp_for_value(&self, tx_hash: &TxHash) -> Option<Instant> {
+    pub fn get_timestamp_for_value(&self, tx_hash: &ConsensusValue) -> Option<Instant> {
         self.pending_values_map.get(tx_hash).cloned().flatten()
     }
 
     /// Retains only the values specified by the predicate.
     pub fn retain<F>(&mut self, predicate: F)
     where
-        F: Fn(&TxHash) -> bool,
+        F: Fn(&ConsensusValue) -> bool,
     {
         self.pending_values_map
             .retain(|tx_hash, _| predicate(tx_hash));
@@ -110,7 +114,9 @@ impl<TXM: TxManager> PendingValues<TXM> {
     /// Clear any pending values that are no longer valid.
     pub fn clear_invalid_values(&mut self) {
         let tx_manager = self.tx_manager.clone();
-        self.retain(|tx_hash| tx_manager.validate(tx_hash).is_ok());
+        self.retain(|value| match value {
+            ConsensusValue::TxHash(tx_hash) => tx_manager.validate(tx_hash).is_ok(),
+        });
     }
 }
 

--- a/consensus/service/src/byzantine_ledger/task_message.rs
+++ b/consensus/service/src/byzantine_ledger/task_message.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use mc_common::ResponderId;
-use mc_peers::VerifiedConsensusMsg;
-use mc_transaction_core::tx::TxHash;
+use mc_peers::{ConsensusValue, VerifiedConsensusMsg};
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -10,7 +9,7 @@ pub enum TaskMessage {
     /// A tuple of (timestamp, list of client-submitted values). The timestamp
     /// refers to when the list was added to the queue, and is used to
     /// tracking how long it takes to process each value.
-    Values(Option<Instant>, Vec<TxHash>),
+    Values(Option<Instant>, Vec<ConsensusValue>),
 
     /// SCP Statement.
     ConsensusMsg(VerifiedConsensusMsg, ResponderId),

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -583,8 +583,12 @@ impl<
             self.tx_manager.remove_expired(index)
         };
 
+        let current_slot_index = self.current_slot_index;
         self.pending_values.retain(|value| match value {
             ConsensusValue::TxHash(tx_hash) => !purged_hashes.contains(tx_hash),
+
+            // TODO not tested
+            ConsensusValue::Mint(mint_tx) => mint_tx.tombstone_block >= current_slot_index,
         });
 
         // Drop pending values that are no longer considered valid.
@@ -640,6 +644,8 @@ impl<
                         Some(tx_hash)
                     }
                 }
+
+                ConsensusValue::Mint(_) => None,
             })
             .collect();
 

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -21,8 +21,8 @@ use mc_crypto_keys::Ed25519Pair;
 use mc_ledger_db::Ledger;
 use mc_ledger_sync::{LedgerSync, NetworkState, SCPNetworkState};
 use mc_peers::{
-    Broadcast, ConsensusConnection, ConsensusMsg, Error as PeerError, RetryableConsensusConnection,
-    VerifiedConsensusMsg,
+    Broadcast, ConsensusConnection, ConsensusMsg, ConsensusValue, Error as PeerError,
+    RetryableConsensusConnection, VerifiedConsensusMsg,
 };
 use mc_transaction_core::tx::TxHash;
 use mc_util_metered_channel::Receiver;
@@ -48,7 +48,7 @@ pub struct ByzantineLedgerWorker<
     PC: BlockchainConnection + ConsensusConnection + 'static,
     TXM: TxManager,
 > {
-    scp_node: Box<dyn ScpNode<TxHash>>,
+    scp_node: Box<dyn ScpNode<ConsensusValue>>,
     msg_signer_key: Arc<Ed25519Pair>,
 
     connection_manager: ConnectionManager<PC>,
@@ -121,7 +121,7 @@ impl<
     ///   by this node.
     /// * `logger` - Logger instance.
     pub fn new(
-        scp_node: Box<dyn ScpNode<TxHash>>,
+        scp_node: Box<dyn ScpNode<ConsensusValue>>,
         msg_signer_key: Arc<Ed25519Pair>,
         ledger: L,
         ledger_sync_service: LS,
@@ -509,13 +509,14 @@ impl<
         }
     }
 
-    fn complete_current_slot(&mut self, externalized: Vec<TxHash>) {
+    fn complete_current_slot(&mut self, externalized: Vec<ConsensusValue>) {
         let tracer = tracer!();
 
         let span = start_block_span(&tracer, "complete_current_slot", self.current_slot_index);
         let _active = mark_span_as_active(span);
 
         // Update pending value processing time metrics.
+        // TODO: need to rename tx_hash here
         for tx_hash in externalized.iter() {
             if let Some(timestamp) = self.pending_values.get_timestamp_for_value(tx_hash) {
                 let duration = Instant::now().saturating_duration_since(timestamp);
@@ -582,8 +583,9 @@ impl<
             self.tx_manager.remove_expired(index)
         };
 
-        self.pending_values
-            .retain(|tx_hash| !purged_hashes.contains(tx_hash));
+        self.pending_values.retain(|value| match value {
+            ConsensusValue::TxHash(tx_hash) => !purged_hashes.contains(tx_hash),
+        });
 
         // Drop pending values that are no longer considered valid.
         self.pending_values.clear_invalid_values();
@@ -623,14 +625,22 @@ impl<
 
     fn fetch_missing_txs(
         &mut self,
-        scp_msg: &Msg<TxHash>,
+        scp_msg: &Msg<ConsensusValue>,
         from_responder_id: &ResponderId,
     ) -> bool {
         // Hashes of transactions that are not currently cached.
         let missing_hashes: Vec<TxHash> = scp_msg
             .values()
             .into_iter()
-            .filter(|tx_hash| !self.tx_manager.contains(tx_hash))
+            .filter_map(|value| match value {
+                ConsensusValue::TxHash(tx_hash) => {
+                    if self.tx_manager.contains(&tx_hash) {
+                        None
+                    } else {
+                        Some(tx_hash)
+                    }
+                }
+            })
             .collect();
 
         // Don't attempt to issue any RPC calls if we know we're going to fail.
@@ -722,7 +732,7 @@ impl<
     }
 
     /// Broadcast a consensus message issued by this node.
-    fn issue_consensus_message(&mut self, msg: Msg<TxHash>) -> Result<(), &'static str> {
+    fn issue_consensus_message(&mut self, msg: Msg<ConsensusValue>) -> Result<(), &'static str> {
         let consensus_msg =
             ConsensusMsg::from_scp_msg(&self.ledger, msg, self.msg_signer_key.as_ref())
                 .map_err(|_| "Failed creating ConsensusMsg")?;

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -28,7 +28,7 @@ use mc_consensus_api::{consensus_client_grpc, consensus_common_grpc, consensus_p
 use mc_consensus_enclave::{ConsensusEnclave, Error as ConsensusEnclaveError};
 use mc_crypto_keys::DistinguishedEncoding;
 use mc_ledger_db::{Error as LedgerDbError, Ledger, LedgerDB};
-use mc_peers::{PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
+use mc_peers::{ConsensusValue, PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
 use mc_sgx_report_cache_untrusted::{Error as ReportCacheError, ReportCacheThread};
 use mc_transaction_core::tx::TxHash;
 use mc_util_grpc::{
@@ -641,9 +641,9 @@ impl<
                 None
             };
             byzantine_ledger.upgrade().and_then(|ledger| {
-                ledger
-                    .get()
-                    .map(|ledger| ledger.push_values(vec![tx_hash], timestamp))
+                ledger.get().map(|ledger| {
+                    ledger.push_values(vec![ConsensusValue::TxHash(tx_hash)], timestamp)
+                })
             });
         })
     }

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -295,9 +295,14 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             })
             .collect::<Result<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>, TxManagerError>>()?;
 
-        let (block, block_contents, mut signature) = self
-            .enclave
-            .form_block(parent_block, &encrypted_txs_with_proofs)?;
+        let root_element = self.untrusted.get_root_tx_out_membership_element()?;
+
+        let (block, block_contents, mut signature) = self.enclave.form_block(
+            parent_block,
+            &encrypted_txs_with_proofs,
+            &root_element,
+            &mint_txs,
+        )?;
 
         // TODO
         log::info!(self.logger, "MINT TXS: {:?}", mint_txs);

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -16,6 +16,7 @@ use mc_common::{
 use mc_consensus_enclave::{
     ConsensusEnclave, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
 };
+use mc_peers::ConsensusValue;
 use mc_transaction_core::{
     constants::MAX_TRANSACTIONS_PER_BLOCK,
     tx::{TxHash, TxOutMembershipProof},
@@ -263,9 +264,17 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
     /// * `parent_block` - The last block written to the ledger.
     fn tx_hashes_to_block(
         &self,
-        tx_hashes: &[TxHash],
+        values: &[ConsensusValue],
         parent_block: &Block,
     ) -> TxManagerResult<(Block, BlockContents, BlockSignature)> {
+        // TODO
+        let tx_hashes: Vec<TxHash> = values
+            .into_iter()
+            .filter_map(|value| match value {
+                ConsensusValue::TxHash(tx_hash) => Some(*tx_hash), // TODO how to avoid this copy
+            })
+            .collect();
+
         let cache = self.lock_cache();
         let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter())?;
 

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -4,6 +4,7 @@ use crate::tx_manager::TxManagerResult;
 use mc_attest_enclave_api::{EnclaveMessage, PeerSession};
 use mc_common::HashSet;
 use mc_consensus_enclave::{TxContext, WellFormedEncryptedTx};
+use mc_peers::ConsensusValue;
 use mc_transaction_core::{tx::TxHash, Block, BlockContents, BlockSignature};
 
 #[cfg(test)]
@@ -36,9 +37,10 @@ pub trait TxManager: Send {
 
     /// Forms a Block containing the transactions that correspond to the given
     /// hashes.
+    // TODO rename
     fn tx_hashes_to_block(
         &self,
-        tx_hashes: &[TxHash],
+        value: &[ConsensusValue],
         parent_block: &Block,
     ) -> TxManagerResult<(Block, BlockContents, BlockSignature)>;
 

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -2,7 +2,7 @@
 
 use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
-    tx::{TxHash, TxOutMembershipProof, TxOutMembershipElement},
+    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationResult,
 };
 use std::sync::Arc;
@@ -45,5 +45,7 @@ pub trait UntrustedInterfaces: Send + Sync {
         indexes: &[u64],
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>>;
 
-    fn get_root_tx_out_membership_element(&self) -> TransactionValidationResult<TxOutMembershipElement>;
+    fn get_root_tx_out_membership_element(
+        &self,
+    ) -> TransactionValidationResult<TxOutMembershipElement>;
 }

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -2,7 +2,7 @@
 
 use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
-    tx::{TxHash, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipProof, TxOutMembershipElement},
     validation::TransactionValidationResult,
 };
 use std::sync::Arc;
@@ -44,4 +44,6 @@ pub trait UntrustedInterfaces: Send + Sync {
         &self,
         indexes: &[u64],
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>>;
+
+    fn get_root_tx_out_membership_element(&self) -> TransactionValidationResult<TxOutMembershipElement>;
 }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -28,7 +28,7 @@ use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TxHash, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
     validation::{validate_tombstone, TransactionValidationError, TransactionValidationResult},
 };
 use std::{collections::HashSet, iter::FromIterator, sync::Arc};
@@ -167,6 +167,14 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>> {
         self.ledger
             .get_tx_out_proof_of_memberships(indexes)
+            .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
+    }
+
+    fn get_root_tx_out_membership_element(
+        &self,
+    ) -> TransactionValidationResult<TxOutMembershipElement> {
+        self.ledger
+            .get_root_tx_out_membership_element()
             .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
     }
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -353,6 +353,7 @@ impl Ledger for LedgerDB {
         }
 
         let root_merkle_hash = self.tx_out_store.get_root_merkle_hash(&db_transaction)?;
+
         let range = Range::new(
             0,
             // This duplicates the range calculation logic inside get_root_merkle_hash

--- a/peers/src/connection.rs
+++ b/peers/src/connection.rs
@@ -347,7 +347,7 @@ impl<Enclave: ConsensusEnclave + Clone + Send + Sync> ConsensusConnection
     }
 
     fn fetch_latest_msg(&mut self) -> Result<Option<ConsensusMsg>> {
-        let response = self.log_attested_call("gte_latest_msg", |this| {
+        let response = self.log_attested_call("get_latest_msg", |this| {
             this.consensus_api_client.get_latest_msg(&Empty::new())
         })?;
         if response.get_payload().is_empty() {

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -13,6 +13,15 @@ use mc_transaction_core::{tx::TxHash, BlockID};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
 
+/// TODO
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
+)]
+pub struct MintTx {
+    pub amount: u64,
+    pub tombstone_block: u64,
+}
+
 // TODO
 #[derive(
     Clone,
@@ -31,6 +40,9 @@ use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
 pub enum ConsensusValue {
     /// TxHash({0})
     TxHash(TxHash),
+
+    /// Mint({0:?})
+    Mint(MintTx),
 }
 
 /// A consensus message holds the data that is exchanged by consensus service

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -9,18 +9,12 @@ use mc_consensus_scp::Msg;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Pair, Ed25519Signature, KeyError, Signer, Verifier};
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{tx::TxHash, BlockID};
+use mc_transaction_core::{
+    tx::{MintTx, TxHash},
+    BlockID,
+};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
-
-/// TODO
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
-)]
-pub struct MintTx {
-    pub amount: u64,
-    pub tombstone_block: u64,
-}
 
 // TODO
 #[derive(

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -9,10 +9,7 @@ use mc_consensus_scp::Msg;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Pair, Ed25519Signature, KeyError, Signer, Verifier};
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{
-    tx::{MintTx, TxHash},
-    BlockID,
-};
+use mc_transaction_core::{mint::MintTx, tx::TxHash, BlockID};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
 

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -39,6 +39,18 @@ pub enum ConsensusValue {
     Mint(MintTx),
 }
 
+impl From<TxHash> for ConsensusValue {
+    fn from(tx_hash: TxHash) -> Self {
+        Self::TxHash(tx_hash)
+    }
+}
+
+impl From<MintTx> for ConsensusValue {
+    fn from(mint_tx: MintTx) -> Self {
+        Self::Mint(mint_tx)
+    }
+}
+
 /// A consensus message holds the data that is exchanged by consensus service
 /// nodes as part of the process of reaching agreement on the contents of the
 /// next block.
@@ -227,7 +239,7 @@ mod tests {
                 local_quorum_set,
                 num_blocks as u64,
                 Topic::Commit(CommitPayload {
-                    B: Ballot::new(100, &[hash_tx]),
+                    B: Ballot::new(100, &[ConsensusValue::TxHash(hash_tx)]),
                     PN: 77,
                     CN: 55,
                     HN: 66,
@@ -276,11 +288,11 @@ mod tests {
         assert_eq!(msg.scp_msg.quorum_set, m);
 
         let ser = mc_util_serial::serialize(&msg.scp_msg.topic).unwrap();
-        let m: Topic<TxHash> = mc_util_serial::deserialize(&ser).unwrap();
+        let m: Topic<ConsensusValue> = mc_util_serial::deserialize(&ser).unwrap();
         assert_eq!(msg.scp_msg.topic, m);
 
         let ser = mc_util_serial::serialize(&msg.scp_msg).unwrap();
-        let m: Msg<TxHash> = mc_util_serial::deserialize(&ser).unwrap();
+        let m: Msg<ConsensusValue> = mc_util_serial::deserialize(&ser).unwrap();
         assert_eq!(msg.scp_msg, m);
 
         let ser = mc_util_serial::serialize(&msg.prev_block_id).unwrap();

--- a/peers/src/lib.rs
+++ b/peers/src/lib.rs
@@ -16,7 +16,9 @@ mod traits;
 pub use crate::{
     broadcast::{Broadcast, MockBroadcast},
     connection::PeerConnection,
-    consensus_msg::{ConsensusMsg, ConsensusMsgError, TxProposeAAD, VerifiedConsensusMsg, ConsensusValue},
+    consensus_msg::{
+        ConsensusMsg, ConsensusMsgError, ConsensusValue, MintTx, TxProposeAAD, VerifiedConsensusMsg,
+    },
     error::{Error, Result},
     threaded_broadcaster::ThreadedBroadcaster,
     threaded_broadcaster_retry::{

--- a/peers/src/lib.rs
+++ b/peers/src/lib.rs
@@ -16,7 +16,7 @@ mod traits;
 pub use crate::{
     broadcast::{Broadcast, MockBroadcast},
     connection::PeerConnection,
-    consensus_msg::{ConsensusMsg, ConsensusMsgError, TxProposeAAD, VerifiedConsensusMsg},
+    consensus_msg::{ConsensusMsg, ConsensusMsgError, TxProposeAAD, VerifiedConsensusMsg, ConsensusValue},
     error::{Error, Result},
     threaded_broadcaster::ThreadedBroadcaster,
     threaded_broadcaster_retry::{

--- a/peers/src/lib.rs
+++ b/peers/src/lib.rs
@@ -17,7 +17,7 @@ pub use crate::{
     broadcast::{Broadcast, MockBroadcast},
     connection::PeerConnection,
     consensus_msg::{
-        ConsensusMsg, ConsensusMsgError, ConsensusValue, MintTx, TxProposeAAD, VerifiedConsensusMsg,
+        ConsensusMsg, ConsensusMsgError, ConsensusValue, TxProposeAAD, VerifiedConsensusMsg,
     },
     error::{Error, Result},
     threaded_broadcaster::ThreadedBroadcaster,

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod constants;
 pub mod encrypted_fog_hint;
 pub mod fog_hint;
 pub mod membership_proofs;
+pub mod mint;
 pub mod onetime_keys;
 pub mod range_proofs;
 pub mod ring_signature;

--- a/transaction/core/src/mint.rs
+++ b/transaction/core/src/mint.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use mc_crypto_digestible::Digestible;
+use serde::{Deserialize, Serialize};
+
+/// TODO
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
+)]
+pub struct MintTx {
+    pub amount: u64,
+    pub tombstone_block: u64,
+}

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -26,6 +26,15 @@ use crate::{
     CompressedCommitment, NewMemoError, NewTxError,
 };
 
+/// TODO
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
+)]
+pub struct MintTx {
+    pub amount: u64,
+    pub tombstone_block: u64,
+}
+
 /// Transaction hash length, in bytes.
 pub const TX_HASH_LEN: usize = 32;
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -26,15 +26,6 @@ use crate::{
     CompressedCommitment, NewMemoError, NewTxError,
 };
 
-/// TODO
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
-)]
-pub struct MintTx {
-    pub amount: u64,
-    pub tombstone_block: u64,
-}
-
 /// Transaction hash length, in bytes.
 pub const TX_HASH_LEN: usize = 32;
 


### PR DESCRIPTION
A potential approach for making it possible to run consensus on new transaction types that does not involve the enclave.

Pros:
- Relatively simple code change
- Ability to extend consensus functionality without requiring enclave changes

Cons:
- No support for confidential information - all transaction data is visible to untrusted (imo this is fine for many type of transactions we might consider adding)
- SCP statements will be bigger when new transaction types implemented using this mechanism are used