### PR TITLE
Enable sentry error logging for Fog Overseer

### DIFF
--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -13,8 +13,6 @@ use structopt::StructOpt;
 
 fn main() {
     mc_common::setup_panic_handler();
-    // TODO: Enable sentry here.
-    // See https://github.com/mobilecoinfoundation/mobilecoin/blob/master/fog/view/server/src/bin/main.rs#L16.
     let _sentry_guard = sentry::init();
     let config = OverseerConfig::from_args();
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -3,7 +3,10 @@
 //! Starts a Rocket server that allows clients to access Fog Overseer APIs
 //! over HTTP.
 
-use mc_common::logger::{log, o};
+use mc_common::{
+    logger::{log, o},
+    sentry,
+};
 use mc_fog_overseer_server::{config::OverseerConfig, server, service::OverseerService};
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
 use structopt::StructOpt;
@@ -12,6 +15,7 @@ fn main() {
     mc_common::setup_panic_handler();
     // TODO: Enable sentry here.
     // See https://github.com/mobilecoinfoundation/mobilecoin/blob/master/fog/view/server/src/bin/main.rs#L16.
+    let _sentry_guard = sentry::init();
     let config = OverseerConfig::from_args();
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());
 

--- a/fog/overseer/server/src/error.rs
+++ b/fog/overseer/server/src/error.rs
@@ -25,8 +25,11 @@ pub enum OverseerError {
     /// Activating an idle node failed: {0}
     ActivateNode(String),
 
-    /// There are multiple outstanding keys: {0}
-    MultipleOutstandingKeys(String),
+    /// Multiple inactive outstanding keys found: {0}
+    MultipleInactiveOutstandingKeys(String),
+
+    /// There are multiple active Fog Ingest nodes at once: {0}
+    MultipleActiveNodes(String),
 }
 
 impl From<SqlRecoveryDbError> for OverseerError {

--- a/fog/overseer/server/src/worker.rs
+++ b/fog/overseer/server/src/worker.rs
@@ -215,7 +215,7 @@ where
                             log::info!(self.logger, "Automatic failover completed successfully.")
                         }
                         Err(err) => {
-                            log::error!(self.logger, "Automatic failover failed: {:?}", err)
+                            log::error!(self.logger, "Automatic failover failed: {}", err)
                         }
                     };
                 }
@@ -239,14 +239,10 @@ where
                                     .get_ingress_pubkey()
                             })
                             .collect();
-                    log::error!(
-                        self.logger,
-                        "There are multiple active nodes in the Fog Ingest cluster. Active ingress keys: {:?}",
-                        active_node_ingress_pubkeys
-                    );
-                    // TODO: Set up sentry alerts and signal to ops that two
-                    // keys are active at once. This is
-                    // unexpected.
+                    let error_message =
+                        format!("Active ingress keys: {:?}", active_node_ingress_pubkeys);
+                    let error = OverseerError::MultipleActiveNodes(error_message);
+                    log::error!(self.logger, "{}", error);
                 }
             }
         }
@@ -333,9 +329,11 @@ where
                 Ok(())
             }
             _ => {
-                log::error!(self.logger, "Found multiple outstanding keys {:?}. This requires manual intervention. Disabling overseer.", inactive_outstanding_keys);
                 self.is_enabled.store(false, Ordering::SeqCst);
-                Err(OverseerError::MultipleOutstandingKeys("Multiple outstanding keys found. This is unexpected and requires manual intervention. As such, we've disabled overseer. Take action and then enable overseer.".to_string()))
+                let error_message = format!("This is unexpected and requires manual intervention. As such, we've disabled overseer. Take the appropriate action and then re-enable overseer by calling the /enable endpoint. Inactive oustanding keys: {:?}", inactive_outstanding_keys);
+                Err(OverseerError::MultipleInactiveOutstandingKeys(
+                    error_message,
+                ))
             }
         }
     }


### PR DESCRIPTION
### Motivation
There are some scenarios that Fog Overseer may encounter in which we want human operators to be alerted. MobileCoin uses [Sentry](https://sentry.io) to handle alerting, so we need to implement Sentry for Fog Overseer. 

The two scenarios for which we'll notify are when there are multiple inactive outstanding keys found, and when there are multiple active nodes found. For the former, we stop overseer and then send the error log (which in turn Sentry transforms into a PagerDuty alert). For the latter, we don't stop overseer and just send the error log.

While this PR implements Sentry logging for the app, we still need to configure alerting via the Sentry UI. 

### In this PR
* Enables the sentry guard in the Fog Overseer binary
* Cleans up logging messages and how errors encapsulate the messaages.


#1416 