### PR TITLE
Sam/fog distro

### DIFF
--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -424,7 +424,7 @@ fn worker_thread_entry(
 /// Builds and submits a transaction to a given FogAccount.
 ///
 /// If a transaction submit errors, then we get and use a new FogResolver
-/// to build and submit transactions. In this case, we return this new 
+/// to build and submit transactions. In this case, we return this new
 /// FogResolver to the caller so that it can be used in subsequent transactions.
 fn build_and_submit_transaction(
     txs_created: usize,


### PR DESCRIPTION
### Motivation
As described in #1382, we want to debit each Fog Account with a TxOut prior to running the "slam" phase, which involves multiple threads and introduces race conditions in which a Fog Account might not be debited. This is bad because we have tests that fail if one or more of these Fog accounts has zero balance after the script is run.

### In this PR
* Debits each Fog account with one TxOut prior to the "slam" phase.

Fixes #1382.

### Tested
I ran a local fog network and ran the script with sensible defaults. The script ran with no errors, and the logs suggest that the accounts were debited as expected prior to the slam phase.