### PR TITLE
In digestible crate, allow that `string` and `bytes` can be omitted

### DIFF
--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -53,6 +53,7 @@ pub struct PublicAddress {
     /// Empty if no fog for this public address, should be parseable as
     /// mc_util_uri::FogUri.
     #[prost(string, tag = "3")]
+    #[digestible(never_omit)]
     fog_report_url: String,
 
     /// The fog report server potentially returns multiple reports when queried.
@@ -60,6 +61,7 @@ pub struct PublicAddress {
     ///
     /// Empty if no fog for this public address.
     #[prost(string, tag = "4")]
+    #[digestible(never_omit)]
     fog_report_id: String,
 
     /// A signature with the user's spend_private_key over the fog authority's
@@ -68,6 +70,7 @@ pub struct PublicAddress {
     /// Empty if no fog for this public address, must be parseable as a
     /// [`SchnorrkelSignature`].
     #[prost(bytes, tag = "5")]
+    #[digestible(never_omit)]
     fog_authority_sig: Vec<u8>,
 }
 

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -463,7 +463,7 @@ impl<'src> TryFrom<&'src VerificationReport> for VerificationReportData {
     Clone, Debug, Default, Deserialize, Digestible, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 #[repr(transparent)]
-pub struct VerificationSignature(Vec<u8>);
+pub struct VerificationSignature(#[digestible(never_omit)] Vec<u8>);
 
 impl AsRef<[u8]> for VerificationSignature {
     fn as_ref(&self) -> &[u8] {
@@ -561,9 +561,11 @@ pub struct VerificationReport {
     /// DER-formatted bytes, from the X-IASReport-Signing-Certificate HTTP
     /// header.
     #[prost(bytes, repeated)]
+    #[digestible(never_omit)]
     pub chain: Vec<Vec<u8>>,
     /// The raw report body JSON, as a byte sequence
     #[prost(string, required)]
+    #[digestible(never_omit)]
     pub http_body: String,
 }
 

--- a/attest/core/src/ias/verify.rs
+++ b/attest/core/src/ias/verify.rs
@@ -561,7 +561,6 @@ pub struct VerificationReport {
     /// DER-formatted bytes, from the X-IASReport-Signing-Certificate HTTP
     /// header.
     #[prost(bytes, repeated)]
-    #[digestible(never_omit)]
     pub chain: Vec<Vec<u8>>,
     /// The raw report body JSON, as a byte sequence
     #[prost(string, required)]

--- a/common/src/responder_id.rs
+++ b/common/src/responder_id.rs
@@ -27,7 +27,7 @@ pub enum ResponderIdParseError {
 #[derive(
     Clone, Default, Debug, Eq, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Hash, Digestible,
 )]
-pub struct ResponderId(pub String);
+pub struct ResponderId(#[digestible(never_omit)] pub String);
 
 impl Display for ResponderId {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -109,6 +109,12 @@ struct FieldAttributeConfig {
     /// new fields without affecting the hash of existing objects that do
     /// not have the field set.
     pub omit_when: Option<Lit>,
+
+    /// Never omit the hashing of a field.
+    /// This is a backwards compatibility tool that allows us to skip omitting
+    /// fields that are now omitted when not set (the behavior for
+    /// &[u8]/Vec<u8>/&str/String has changed over time).
+    pub never_omit: bool,
 }
 
 impl FieldAttributeConfig {
@@ -121,15 +127,32 @@ impl FieldAttributeConfig {
             NestedMeta::Meta(meta) => match meta {
                 Meta::NameValue(mnv) => {
                     if mnv.path.is_ident("omit_when") {
-                        if self.omit_when.is_none() {
-                            self.omit_when = Some(mnv.lit.clone());
-                        } else {
+                        if self.never_omit {
+                            return Err("omit_when cannot be used together with never_omit");
+                        } else if self.omit_when.is_some() {
                             return Err("omit_when cannot appear twice as an attribute");
+                        } else {
+                            self.omit_when = Some(mnv.lit.clone());
                         }
                     } else {
                         return Err("unexpected digestible feature attribute");
                     }
                 }
+
+                Meta::Path(path) => {
+                    if path.is_ident("never_omit") {
+                        if self.omit_when.is_some() {
+                            return Err("never_omit cannot be used together with omit_when");
+                        } else {
+                            self.never_omit = true;
+                        }
+                    } else {
+                        return Err(
+                            "unexpected digestible attribute (unrecognized \"path\" element)",
+                        );
+                    }
+                }
+
                 _ => {
                     return Err("unexpected digestible attribute");
                 }
@@ -230,7 +253,11 @@ fn try_digestible_struct(
                     // Read any #[digestible(...)]` attributes on this field and parse them
                     let attr_config = FieldAttributeConfig::try_from(&field.attrs[..])?;
 
-                    if let Some(omit_when) = attr_config.omit_when {
+                    if attr_config.never_omit {
+                        Ok(quote! {
+                            self.#field_ident.append_to_transcript(stringify!(#field_ident).as_bytes(), transcript);
+                        })
+                    } else if let Some(omit_when) = attr_config.omit_when {
                         Ok(quote! {
                             if self.#field_ident != #omit_when {
                                 self.#field_ident.append_to_transcript_allow_omit(stringify!(#field_ident).as_bytes(), transcript);

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -938,3 +938,34 @@ fn test_never_omit() {
     let obj = TestNeverOmitWithAttribute::default();
     assert_eq!(obj.digest32::<MerlinTranscript>(b"obj"), expected_hash);
 }
+
+// Test never_omit on tuple structs.
+#[test]
+fn test_never_omit_tuple_struct() {
+    // A struct that contains fields that were never omitted in the first version of
+    // this crate, but are omitted in the current version.
+    #[derive(Digestible, Default)]
+    #[digestible(name = "TestStruct")]
+    struct TestNeverOmitWithoutAttribute(String, Vec<u8>);
+
+    #[derive(Digestible, Default)]
+    #[digestible(name = "TestStruct")]
+    struct TestNeverOmitWithAttribute(
+        #[digestible(never_omit)] String,
+        #[digestible(never_omit)] Vec<u8>,
+    );
+
+    // Generated at commit cfa51d26ae943a9055698bb209c2fe06fa7a7cac
+    let expected_hash = [
+        73, 178, 245, 28, 202, 74, 143, 171, 184, 16, 2, 92, 62, 48, 204, 51, 235, 99, 69, 202,
+        202, 17, 100, 127, 188, 235, 87, 170, 31, 109, 241, 23,
+    ];
+
+    // Without the never_omit attribute the hash is expected to change.
+    let obj = TestNeverOmitWithoutAttribute::default();
+    assert_ne!(obj.digest32::<MerlinTranscript>(b"obj"), expected_hash);
+
+    // With the never_omit attribute the hash should not change.
+    let obj = TestNeverOmitWithAttribute::default();
+    assert_eq!(obj.digest32::<MerlinTranscript>(b"obj"), expected_hash);
+}

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -47,6 +47,31 @@ struct ThingV5 {
     d: i32,
 }
 
+// A new bytes field that is skipped when empty
+#[derive(Digestible)]
+#[digestible(name = "Thing")]
+struct ThingV6 {
+    a: Option<u64>,
+    b: Option<u64>,
+    c: Vec<bool>,
+    #[digestible(omit_when = 0)]
+    d: i32,
+    e: Vec<u8>,
+}
+
+// A new string field that is skipped when empty
+#[derive(Digestible)]
+#[digestible(name = "Thing")]
+struct ThingV7 {
+    a: Option<u64>,
+    b: Option<u64>,
+    c: Vec<bool>,
+    #[digestible(omit_when = 0)]
+    d: i32,
+    e: Vec<u8>,
+    f: String,
+}
+
 // Test vectors for a few instances of the Thing struct, and versions of it
 #[test]
 fn thing_struct() {
@@ -187,6 +212,114 @@ fn struct_schema_evolution() {
             b: Some(99),
             c: Default::default(),
             d: 1,
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_eq!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV6 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec![],
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV6 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec![1u8],
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV6 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 1,
+            e: vec![],
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_eq!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV7 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec![],
+            f: "".to_string(),
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV7 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec![],
+            f: "a".to_string(),
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV7 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 4,
+            e: vec![],
+            f: "a".to_string(),
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV2 { a: 14, b: Some(99) }.digest32::<MerlinTranscript>(b"test"),
+        ThingV7 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 4,
+            e: vec![],
+            f: "a".to_string(),
+        }
+        .digest32::<MerlinTranscript>(b"test")
+    );
+
+    assert_ne!(
+        ThingV6 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec!['a' as u8]
+        }
+        .digest32::<MerlinTranscript>(b"test"),
+        ThingV7 {
+            a: Some(14),
+            b: Some(99),
+            c: Default::default(),
+            d: 0,
+            e: vec![],
+            f: "a".to_string(),
         }
         .digest32::<MerlinTranscript>(b"test")
     );

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -902,3 +902,39 @@ fn test_enum_schema_evolution() {
         )
     );
 }
+
+// Test never_omit.
+#[test]
+fn test_never_omit() {
+    // A struct that contains fields that were never omitted in the first version of
+    // this crate, but are omitted in the current version.
+    #[derive(Digestible, Default)]
+    #[digestible(name = "TestStruct")]
+    struct TestNeverOmitWithoutAttribute {
+        pub s: String,
+        pub b: Vec<u8>,
+    }
+
+    #[derive(Digestible, Default)]
+    #[digestible(name = "TestStruct")]
+    struct TestNeverOmitWithAttribute {
+        #[digestible(never_omit)]
+        pub s: String,
+        #[digestible(never_omit)]
+        pub b: Vec<u8>,
+    }
+
+    // Generated at commit cfa51d26ae943a9055698bb209c2fe06fa7a7cac
+    let expected_hash = [
+        40, 122, 9, 96, 111, 71, 243, 177, 157, 236, 85, 85, 130, 17, 214, 71, 245, 79, 97, 169,
+        132, 87, 12, 160, 83, 167, 23, 48, 208, 181, 80, 159,
+    ];
+
+    // Without the never_omit attribute the hash is expected to change.
+    let obj = TestNeverOmitWithoutAttribute::default();
+    assert_ne!(obj.digest32::<MerlinTranscript>(b"obj"), expected_hash);
+
+    // With the never_omit attribute the hash should not change.
+    let obj = TestNeverOmitWithAttribute::default();
+    assert_eq!(obj.digest32::<MerlinTranscript>(b"obj"), expected_hash);
+}

--- a/fog/report/types/src/lib.rs
+++ b/fog/report/types/src/lib.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 pub struct Report {
     /// The fog_report_id of the report
     #[prost(string, tag = "1")]
+    #[digestible(never_omit)]
     pub fog_report_id: String,
     /// The bytes of the verification report
     #[prost(message, required, tag = "2")]

--- a/mobilecoind/src/monitor_store.rs
+++ b/mobilecoind/src/monitor_store.rs
@@ -94,13 +94,19 @@ impl From<&MonitorData> for MonitorId {
         // signature scheme was implemented. This re-implements the original
         // structure in order to maintain a consistent hash in the database.
         //
+        // The never_omit attributes are needed because of a change in the digestible
+        // crate that now omits empty strings/vectors by default.
+        //
         // This should eventually be removed.
         #[derive(Debug, Digestible)]
         struct PublicAddress {
             view_public_key: RistrettoPublic,
             spend_public_key: RistrettoPublic,
+            #[digestible(never_omit)]
             fog_report_url: String,
+            #[digestible(never_omit)]
             fog_report_id: String,
+            #[digestible(never_omit)]
             fog_authority_fingerprint_sig: Vec<u8>,
         }
 

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -42,6 +42,7 @@ pub struct SignatureRctBulletproofs {
     /// struct may derive Default, which is a requirement for serializing
     /// with Prost.
     #[prost(bytes, tag = "3")]
+    #[digestible(never_omit)]
     pub range_proof_bytes: Vec<u8>,
 }
 


### PR DESCRIPTION
In digestible crate, part of the design is to allow that new `optional`
and `repeated` fields can be added to structs corresponding to protobufs,
without changing the hashes of old objects. By making the hash algorithm
similar to protobuf in this regard, we make it easier to evolve the
blockchain without breaking backwards compatibility.

Unfortunately, there are some gaps still in what kinds of schema
evolution digestible allows vs. what protobuf allows. Protobuf allows
that new bytes and string fields can be added to a struct without a
breaking change, but digestible doesn't, because it doesn't currently
omit empty bytes or string fields when omitting them would be allowed.
We didn't think about this when implementing the allow_omit stuff,
because we were focused on containers -- but bytes and strings are
primitives in protobuf.

Currently, NO primitives can be added unless they are Optional in rust.
Wrapping things in Optional<...> also works for Digestible, but it doesn't
always work well for things like prost.

This commit makes it so that strings and byte vectors have the "omit if empty"
behavior and can be added easily to our prosty structures.

I believe that there are currently no string objects in our blockchain.
I believe that there are no byte objects that are
being hashed by digestible that are not either fixed size, or wrapped in
optional.

This commit does not adjust the behavior of integers like u64 and u32,
which could also arguably be omitted if zero. However we have a fine
workaround for that in place which is the `digestible(omit_when = 0)`
which Eran made. Unfortunately it is fairly difficult to make that work
when the value to be omitted is not a literal.

If we decide that it is safe to merge this, this will simplify the changes
needed to support masked token ids.

There are other approaches we could take like
* adding more attributes to digestible, or,
* representing this type using `Option<GenericArray<u8, U4>>`.

But the latter requires a bunch of repr-bytes stuff with `prost` and `serde`
macros which in the long run we would like to reduce.

Dan Burkert was non-committal about supporting custom `prost::Message`
implementations: https://github.com/tokio-rs/prost/pull/421#issuecomment-758867131
and suggested that this is an "at your own risk" undertaking not covered
by semver guarantees. That makes the stuff where `prost::Message` is derived
using a repr-bytes implementation somewhat uncomfortable. Hopefully in the
future prost will just allow us to use things like `Option<[u8; 99]>` using const generics.
Or, we may be able to just move everything over to `Vec<u8>` and then fixup the error handling.

Additionally, we considered it surprising that `Vec<u8>` behaves differently
from `Vec<T>` for digestible crate, around whether it is omitted when empty.
The documentation mentions the behavior of `Vec<T>` but not that of Vec<u8>.
By merging this we would eliminate that footgun.

---

TODOs:
- [ ] grep this repo for all `derive(Digestible)` and look for `String`/`Vec<u8>` fields
- [ ] Do the same in `full-service`