### PR TITLE
Added a new configuration entry to auto assign the @eng group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,25 +5,33 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
-  assignees:
-    - "@eng"
+  reviewers:
+    - "eng"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  reviewers:
+    - "eng"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  reviewers:
+    - "eng"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  reviewers:
+    - "eng"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  reviewers:
+    - "eng"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
+  assignees:
+    - "@eng"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,32 +6,32 @@ updates:
     interval: daily
   open-pull-requests-limit: 25
   reviewers:
-    - "eng"
+    - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
   reviewers:
-    - "eng"
+    - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
   reviewers:
-    - "eng"
+    - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
   reviewers:
-    - "eng"
+    - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
     interval: daily
   open-pull-requests-limit: 5
   reviewers:
-    - "eng"
+    - "mobilecoinfoundation/eng"


### PR DESCRIPTION
### Motivation

 The motivation for the changes in this PR is to have the `@eng` group auto-assigned by the `dependabot`

< Ticket status, e.g. "fixes #issue number" > 
fixed ticket #1407 

