### PR TITLE
Add function to calculate the `crc32` from Compressed Commitment data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,6 +2087,7 @@ dependencies = [
  "aes-gcm",
  "cbindgen",
  "cmake",
+ "crc",
  "displaydoc",
  "libc",
  "mc-account-keys",

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -14,6 +14,7 @@ aes-gcm = "0.9.2"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.22.1"
+crc = "1.8.1"
 rand_core = { version = "0.6", features = ["std"] }
 sha2 = "0.9.5"
 slip10_ed25519 = "0.1.3"

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -43,8 +43,22 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 
 /// # Preconditions
 ///
+/// * `tx_out_commitment` - must be a valid CompressedCommitment
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_tx_out_reconstruct_commitment(
+  const McBuffer* MC_NONNULL tx_out_commitment,
+  uint32_t* MC_NONNULL out_crc32
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/// # Preconditions
+///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
-bool mc_tx_out_matches_any_subaddress(
+bool mc_tx_out_commitment_crc32(
   const McTxOutAmount* MC_NONNULL tx_out_amount,
   const McBuffer* MC_NONNULL tx_out_public_key,
   const McBuffer* MC_NONNULL view_private_key,

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -48,9 +48,9 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_tx_out_reconstruct_commitment(
+bool mc_tx_out_commitment_crc32(
   const McBuffer* MC_NONNULL tx_out_commitment,
-  uint32_t* MC_NONNULL out_crc32
+  uint32_t* MC_NONNULL out_crc32,
   McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1, 2);
@@ -58,7 +58,7 @@ MC_ATTRIBUTE_NONNULL(1, 2);
 /// # Preconditions
 ///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
-bool mc_tx_out_commitment_crc32(
+bool mc_tx_out_matches_any_subaddress(
   const McTxOutAmount* MC_NONNULL tx_out_amount,
   const McBuffer* MC_NONNULL tx_out_public_key,
   const McBuffer* MC_NONNULL view_private_key,

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -593,6 +593,15 @@ bool mc_tx_out_reconstruct_commitment(FfiRefPtr<McTxOutAmount> tx_out_amount,
  *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  */
+bool mc_tx_out_commitment_crc32(FfiRefPtr<McBuffer> tx_out_commitment,
+                                FfiMutPtr<uint32_t> out_crc32,
+                                FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+ */
 bool mc_tx_out_matches_any_subaddress(FfiRefPtr<McTxOutAmount> tx_out_amount,
                                       FfiRefPtr<McBuffer> tx_out_public_key,
                                       FfiRefPtr<McBuffer> view_private_key,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -12,6 +12,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, CompressedCommitment,
 };
+use crc::crc32;
 use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_ffi::*;
 
@@ -50,6 +51,22 @@ pub extern "C" fn mc_tx_out_reconstruct_commitment(
             .expect("out_tx_out_commitment length is insufficient");
 
         out_tx_out_commitment.copy_from_slice(&amount.commitment.to_bytes());
+        Ok(())
+    })
+}
+
+/// # Preconditions
+///
+/// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+#[no_mangle]
+pub extern "C" fn mc_tx_out_commitment_crc32(
+    tx_out_commitment: FfiRefPtr<McBuffer>,
+    out_crc32: FfiMutPtr<u32>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
+) -> bool {
+    ffi_boundary_with_error(out_error, || {
+        let commitment = CompressedCommitment::try_from_ffi(&tx_out_commitment)?;
+        *out_crc32.into_mut() = crc32::checksum_ieee(&commitment.to_bytes());
         Ok(())
     })
 }


### PR DESCRIPTION
Soundtrack of this PR: [Duke Hugh - IFZ Shuffle](https://www.youtube.com/watch?v=__8L_E9ije0)

### Motivation

The iOS SDK needs a way to calculate the crc32 checksum from Compressed Commitment data

### In this PR
* New function `mc_tx_out_commitment_crc32` in transaction.rs

### Future Work
* Will adjust base repository after figuring out which commit/branch this should be merged into (assuming v1.2.0) is incorrect.

