### PR TITLE
Add function to calculate the `crc32` from Compressed Commitment data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "aes-gcm",
  "cbindgen",
  "cmake",
+ "crc",
  "displaydoc",
  "libc",
  "mc-account-keys",

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -14,6 +14,7 @@ aes-gcm = "0.9.2"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.22.1"
+crc = "1.8.1"
 rand_core = { version = "0.6", features = ["std"] }
 sha2 = "0.9.5"
 slip10_ed25519 = "0.1.3"

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -38,6 +38,20 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 
 /// # Preconditions
 ///
+/// * `tx_out_commitment` - must be a valid CompressedCommitment
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_tx_out_commitment_crc32(
+  const McBuffer* MC_NONNULL tx_out_commitment,
+  uint32_t* MC_NONNULL out_crc32,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/// # Preconditions
+///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `subaddress_spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
 bool mc_tx_out_matches_subaddress(

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -583,6 +583,15 @@ bool mc_slip10_account_private_keys_from_mnemonic(FfiStr mnemonic,
  *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  */
+bool mc_tx_out_commitment_crc32(FfiRefPtr<McBuffer> tx_out_commitment,
+                                FfiMutPtr<uint32_t> out_crc32,
+                                FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+ */
 bool mc_tx_out_matches_any_subaddress(FfiRefPtr<McTxOutAmount> tx_out_amount,
                                       FfiRefPtr<McBuffer> tx_out_public_key,
                                       FfiRefPtr<McBuffer> view_private_key,


### PR DESCRIPTION
Soundtrack of this PR: [Duke Hugh - 2017 Heatwave](https://www.youtube.com/watch?v=-MB4UzSsHmM&list=RD__8L_E9ije0&index=2)

### Motivation

The iOS SDK needs a way to calculate the crc32 checksum from Compressed Commitment data

### In this PR
* New function `mc_tx_out_commitment_crc32` in transaction.rs


