### PR TITLE
Add function to calculate the `crc32` from Compressed Commitment data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,7 @@ dependencies = [
  "aes-gcm",
  "cbindgen",
  "cmake",
+ "crc",
  "displaydoc",
  "libc",
  "mc-account-keys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bulletproofs-og"
 version = "3.0.0-pre.0"
 source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=675330c754f28876dbf94fc303fe73666cf8f8f4#675330c754f28876dbf94fc303fe73666cf8f8f4"
@@ -736,6 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
 ]
 
 [[package]]
@@ -2302,7 +2317,7 @@ dependencies = [
  "aes-gcm",
  "cbindgen",
  "cmake",
- "crc",
+ "crc 1.8.1",
  "displaydoc",
  "libc",
  "mc-account-keys",
@@ -2578,7 +2593,7 @@ version = "1.2.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
- "crc",
+ "crc 2.1.0",
  "curve25519-dalek",
  "datatest",
  "displaydoc",
@@ -4216,7 +4231,7 @@ name = "mc-fog-types"
 version = "1.2.0-pre0"
 dependencies = [
  "blake2",
- "crc",
+ "crc 2.1.0",
  "displaydoc",
  "mc-crypto-keys",
  "mc-fog-kex-rng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,12 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bulletproofs-og"
 version = "3.0.0-pre.0"
 source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=675330c754f28876dbf94fc303fe73666cf8f8f4#675330c754f28876dbf94fc303fe73666cf8f8f4"
@@ -742,15 +736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
 ]
 
 [[package]]
@@ -2317,7 +2302,7 @@ dependencies = [
  "aes-gcm",
  "cbindgen",
  "cmake",
- "crc 1.8.1",
+ "crc",
  "displaydoc",
  "libc",
  "mc-account-keys",
@@ -2593,7 +2578,7 @@ version = "1.2.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
- "crc 2.1.0",
+ "crc",
  "curve25519-dalek",
  "datatest",
  "displaydoc",
@@ -4231,7 +4216,7 @@ name = "mc-fog-types"
 version = "1.2.0-pre0"
 dependencies = [
  "blake2",
- "crc 2.1.0",
+ "crc",
  "displaydoc",
  "mc-crypto-keys",
  "mc-fog-kex-rng",

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -14,7 +14,7 @@ aes-gcm = "0.9.4"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.22.1"
-crc = "1.8.1"
+crc = "2.1.0"
 rand_core = { version = "0.6", features = ["std"] }
 sha2 = "0.9.8"
 slip10_ed25519 = "0.1.3"

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -14,6 +14,7 @@ aes-gcm = "0.9.4"
 displaydoc = "0.2"
 libc = "0.2"
 protobuf = "2.22.1"
+crc = "1.8.1"
 rand_core = { version = "0.6", features = ["std"] }
 sha2 = "0.9.8"
 slip10_ed25519 = "0.1.3"

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -54,6 +54,20 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 
 /// # Preconditions
 ///
+/// * `tx_out_commitment` - must be a valid CompressedCommitment
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_tx_out_commitment_crc32(
+  const McBuffer* MC_NONNULL tx_out_commitment,
+  uint32_t* MC_NONNULL out_crc32,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/// # Preconditions
+///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `subaddress_spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
 bool mc_tx_out_matches_subaddress(

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -610,6 +610,19 @@ bool mc_tx_out_reconstruct_commitment(FfiRefPtr<McTxOutAmount> tx_out_amount,
 /**
  * # Preconditions
  *
+ * * `tx_out_commitment` - must be a valid CompressedCommitment
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_tx_out_commitment_crc32(FfiRefPtr<McBuffer> tx_out_commitment,
+                                FfiMutPtr<uint32_t> out_crc32,
+                                FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  */
 bool mc_tx_out_matches_any_subaddress(FfiRefPtr<McTxOutAmount> tx_out_amount,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -2,7 +2,7 @@
 
 use crate::{common::*, fog::McFogResolver, keys::McPublicAddress, LibMcError};
 use core::convert::TryFrom;
-use crc::crc32;
+use crc::Crc;
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::{ReprBytes, RistrettoPrivate, RistrettoPublic};
 use mc_fog_report_validation::FogResolver;
@@ -70,7 +70,7 @@ pub extern "C" fn mc_tx_out_commitment_crc32(
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
         let commitment = CompressedCommitment::try_from_ffi(&tx_out_commitment)?;
-        *out_crc32.into_mut() = crc32::checksum_ieee(&commitment.to_bytes());
+        *out_crc32.into_mut() = Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment.to_bytes());
         Ok(())
     })
 }

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -70,7 +70,8 @@ pub extern "C" fn mc_tx_out_commitment_crc32(
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
         let commitment = CompressedCommitment::try_from_ffi(&tx_out_commitment)?;
-        *out_crc32.into_mut() = Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment.to_bytes());
++        *out_crc32.into_mut() =
++            Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment.to_bytes());
         Ok(())
     })
 }

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -2,6 +2,7 @@
 
 use crate::{common::*, fog::McFogResolver, keys::McPublicAddress, LibMcError};
 use core::convert::TryFrom;
+use crc::crc32;
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::{ReprBytes, RistrettoPrivate, RistrettoPublic};
 use mc_fog_report_validation::FogResolver;
@@ -12,7 +13,6 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, CompressedCommitment,
 };
-use crc::crc32;
 use mc_transaction_std::{InputCredentials, NoMemoBuilder, TransactionBuilder};
 use mc_util_ffi::*;
 

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -70,8 +70,8 @@ pub extern "C" fn mc_tx_out_commitment_crc32(
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
         let commitment = CompressedCommitment::try_from_ffi(&tx_out_commitment)?;
-+        *out_crc32.into_mut() =
-+            Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment.to_bytes());
+        *out_crc32.into_mut() =
+            Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment.to_bytes());
         Ok(())
     })
 }


### PR DESCRIPTION
Soundtrack of this PR: [Duke Hugh - 2017 Heatwave](https://www.youtube.com/watch?v=-MB4UzSsHmM&list=RD__8L_E9ije0&index=2)

### Motivation

The iOS SDK needs a way to calculate the crc32 checksum from Compressed Commitment data

### In this PR
* New function `mc_tx_out_commitment_crc32` in transaction.rs

### Future Work
* Unit tests for functions in /libmobilecoin