### PR TITLE
Make omap_capacity configurable by environment variable

### DIFF
--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -64,8 +64,7 @@ pub struct LedgerServerConfig {
     /// available SGX EPC memory, and then beyond that it will be allocated on
     /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
     /// you will either get killed by OOM killer, or it will start being swapped
-    /// to disk by linux kernel. (Unless / until a kernel-bypass pathway is
-    /// developed.)
-    #[structopt(long, default_value = "1048576")]
+    /// to disk by linux kernel.
+    #[structopt(long, default_value = "1048576", env)]
     pub omap_capacity: u64,
 }

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -57,9 +57,8 @@ pub struct MobileAcctViewConfig {
     /// available SGX EPC memory, and then beyond that it will be allocated on
     /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
     /// you will either get killed by OOM killer, or it will start being swapped
-    /// to disk by linux kernel. (Unless / until a kernel-bypass pathway is
-    /// developed.)
-    #[structopt(long, default_value = "1048576")]
+    /// to disk by linux kernel.
+    #[structopt(long, default_value = "1048576", env)]
     pub omap_capacity: u64,
 
     /// Postgres config


### PR DESCRIPTION
I put this in the PR that we backported to 1.1.3 branch, I think
the ENV configuration is sometimes nicer, and I wouldn't want it
to disappear in 1.2 release.