### PR TITLE
Include the merkle tree root element in consensus enclave form_block

### DIFF
--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     /// Invalid membership proof provided by local system
     InvalidLocalMembershipProof,
 
+    /// Invalid membership root element provided by local system
+    InvalidLocalMembershipRootElement,
+
     /// Form block error: {0}
     FormBlock(String),
 

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -28,7 +28,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Public, RistrettoPublic, 
 use mc_sgx_report_cache_api::ReportableEnclave;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{Tx, TxHash, TxOutMembershipProof},
+    tx::{Tx, TxHash, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockSignature, TokenId,
 };
 use serde::{Deserialize, Serialize};
@@ -301,6 +301,7 @@ pub trait ConsensusEnclave: ReportableEnclave {
         &self,
         parent_block: &Block,
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)>;
 }
 

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -11,7 +11,10 @@ use mc_attest_enclave_api::{
     ClientAuthRequest, ClientSession, EnclaveMessage, PeerAuthRequest, PeerAuthResponse,
     PeerSession,
 };
-use mc_transaction_core::{tx::TxOutMembershipProof, Block, TokenId};
+use mc_transaction_core::{
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
+    Block, TokenId,
+};
 use serde::{Deserialize, Serialize};
 
 /// An enumeration of API calls and their arguments for use across serialization
@@ -131,6 +134,7 @@ pub enum EnclaveCall {
     FormBlock(
         Block,
         Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>,
+        TxOutMembershipElement,
     ),
 
     /// The [ConsensusEnclave::get_minimum_fee()] method.

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -47,7 +47,7 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
     ring_signature::{KeyImage, Scalar},
-    tx::{Tx, TxOut, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, TokenId, BLOCK_VERSION,
 };
@@ -422,6 +422,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         &self,
         parent_block: &Block,
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        _root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         // This implicitly converts Vec<Result<(Tx Vec<TxOutMembershipProof>),_>> into
         // Result<Vec<(Tx, Vec<TxOutMembershipProof>)>, _>, and terminates the
@@ -861,9 +862,14 @@ mod tests {
 
         // Form block
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+        let root_element = ledger.get_root_tx_out_membership_element().unwrap();
 
         let (block, block_contents, signature) = enclave
-            .form_block(&parent_block, &well_formed_encrypted_txs_with_proofs)
+            .form_block(
+                &parent_block,
+                &well_formed_encrypted_txs_with_proofs,
+                &root_element,
+            )
             .unwrap();
 
         // Verify signature.
@@ -991,9 +997,13 @@ mod tests {
 
         // Form block
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+        let root_element = ledger.get_root_tx_out_membership_element().unwrap();
 
-        let form_block_result =
-            enclave.form_block(&parent_block, &well_formed_encrypted_txs_with_proofs);
+        let form_block_result = enclave.form_block(
+            &parent_block,
+            &well_formed_encrypted_txs_with_proofs,
+            &root_element,
+        );
         let expected_duplicate_key_image = new_transactions[0].key_images()[0];
 
         // Check
@@ -1085,9 +1095,13 @@ mod tests {
 
         // Form block
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+        let root_element = ledger.get_root_tx_out_membership_element().unwrap();
 
-        let form_block_result =
-            enclave.form_block(&parent_block, &well_formed_encrypted_txs_with_proofs);
+        let form_block_result = enclave.form_block(
+            &parent_block,
+            &well_formed_encrypted_txs_with_proofs,
+            &root_element,
+        );
         let expected_duplicate_output_public_key = new_transactions[0].output_public_keys()[0];
 
         // Check
@@ -1174,9 +1188,13 @@ mod tests {
 
         // Form block
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+        let root_element = ledger.get_root_tx_out_membership_element().unwrap();
 
-        let form_block_result =
-            enclave.form_block(&parent_block, &well_formed_encrypted_txs_with_proofs);
+        let form_block_result = enclave.form_block(
+            &parent_block,
+            &well_formed_encrypted_txs_with_proofs,
+            &root_element,
+        );
 
         // Check
         let expected = Err(Error::MalformedTx(

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -26,7 +26,7 @@ use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
     ring_signature::KeyImage,
     tokens::Mob,
-    tx::{Tx, TxOut, TxOutMembershipProof},
+    tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, Token, TokenId, BLOCK_VERSION,
 };
@@ -210,6 +210,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         &self,
         parent_block: &Block,
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        _root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let transactions_with_proofs: Vec<(Tx, Vec<TxOutMembershipProof>)> =
             encrypted_txs_with_proofs

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -14,7 +14,8 @@ use mc_consensus_enclave_api::{
 use mc_crypto_keys::{Ed25519Public, X25519Public};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as SgxReportResult};
 use mc_transaction_core::{
-    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
+    Block, BlockContents, BlockSignature, TokenId,
 };
 
 use mockall::*;
@@ -78,7 +79,8 @@ mock! {
             &self,
             parent_block: &Block,
             encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
-         ) -> ConsensusEnclaveResult<(Block, BlockContents, BlockSignature)>;
+            root_element: &TxOutMembershipElement,
+        ) -> ConsensusEnclaveResult<(Block, BlockContents, BlockSignature)>;
     }
 
     impl ReportableEnclave for ConsensusEnclave {

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -22,7 +22,8 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_sgx_types::{sgx_enclave_id_t, sgx_status_t, *};
 use mc_sgx_urts::SgxEnclave;
 use mc_transaction_core::{
-    tx::TxOutMembershipProof, Block, BlockContents, BlockSignature, TokenId,
+    tx::{TxOutMembershipElement, TxOutMembershipProof},
+    Block, BlockContents, BlockSignature, TokenId,
 };
 use std::{path, result::Result as StdResult, sync::Arc};
 
@@ -250,10 +251,12 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         &self,
         parent_block: &Block,
         encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::FormBlock(
             parent_block.clone(),
             encrypted_txs_with_proofs.to_vec(),
+            root_element.clone(),
         ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -97,8 +97,8 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
                 .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
 
-        EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs) => {
-            serialize(&ENCLAVE.form_block(&parent_block, &encrypted_txs_with_proofs))
+        EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs, root_element) => {
+            serialize(&ENCLAVE.form_block(&parent_block, &encrypted_txs_with_proofs, &root_element))
                 .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
     };

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -292,9 +292,11 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
             })
             .collect::<Result<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>, TxManagerError>>()?;
 
-        let (block, block_contents, mut signature) = self
-            .enclave
-            .form_block(parent_block, &encrypted_txs_with_proofs)?;
+        let root_element = self.untrusted.get_root_tx_out_membership_element()?;
+
+        let (block, block_contents, mut signature) =
+            self.enclave
+                .form_block(parent_block, &encrypted_txs_with_proofs, &root_element)?;
 
         // The enclave cannot provide a timestamp, so this happens in untrusted.
         signature.set_signed_at(chrono::Utc::now().timestamp() as u64);

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -368,7 +368,10 @@ mod tests {
     };
     use mc_crypto_keys::{Ed25519Public, Ed25519Signature};
     use mc_ledger_db::Ledger;
-    use mc_transaction_core::validation::TransactionValidationError;
+    use mc_transaction_core::{
+        membership_proofs::Range, tx::TxOutMembershipElement,
+        validation::TransactionValidationError,
+    };
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey,
     };
@@ -769,6 +772,15 @@ mod tests {
             .expect_get_tx_out_proof_of_memberships()
             .times(tx_hashes.len())
             .return_const(Ok(highest_index_proofs));
+
+        // Should get root txout membership element once per block.
+        mock_untrusted
+            .expect_get_root_tx_out_membership_element()
+            .times(1)
+            .return_const(Ok(TxOutMembershipElement::new(
+                Range::new(0, 1).unwrap(),
+                [1; 32],
+            )));
 
         let mut mock_enclave = MockConsensusEnclave::new();
         let expected_block = Block::new_origin_block(&vec![]);

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -2,7 +2,7 @@
 
 use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
-    tx::{TxHash, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationResult,
 };
 use std::sync::Arc;
@@ -44,4 +44,8 @@ pub trait UntrustedInterfaces: Send + Sync {
         &self,
         indexes: &[u64],
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>>;
+
+    fn get_root_tx_out_membership_element(
+        &self,
+    ) -> TransactionValidationResult<TxOutMembershipElement>;
 }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -28,7 +28,7 @@ use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TxHash, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
     validation::{validate_tombstone, TransactionValidationError, TransactionValidationResult},
 };
 use std::{collections::HashSet, iter::FromIterator, sync::Arc};
@@ -167,6 +167,14 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>> {
         self.ledger
             .get_tx_out_proof_of_memberships(indexes)
+            .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
+    }
+
+    fn get_root_tx_out_membership_element(
+        &self,
+    ) -> TransactionValidationResult<TxOutMembershipElement> {
+        self.ledger
+            .get_root_tx_out_membership_element()
             .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
     }
 }


### PR DESCRIPTION
### Motivation

Our blocks contain the [`root_element`](https://github.com/mobilecoinfoundation/mobilecoin/blob/95d2ceff8a3a08704f981f99ef9455185c2c128b/transaction/core/src/blockchain/block.rs#L45) (Root hash of the membership proofs provided by the untrusted). At the moment, when a block is formed using `form_block`, this value is calculated from the proofs-of-membership passed alongside the transactions (see [here](https://github.com/mobilecoinfoundation/mobilecoin/blob/95d2ceff8a3a08704f981f99ef9455185c2c128b/consensus/enclave/impl/src/lib.rs#L463)). This is great when the block contains transactions that are coupled with membership proofs, however we are about to enter a world where a block might only contain minting transactions or configuration change transactions and no regular Txs.

When that will happen, we will not have a value to put inside `root_element`. The change in this PR adds an explicit `root_element` argument to `form_block` that in the future will be used when one cannot be obtained from the txs+proofs-of-membership.

This passed k8 deployment:
https://deploybot.development-eu1.mobilecoin.com/blue/organizations/jenkins/mobilecoin-internal/detail/deploy%2Feran/57/pipeline/689


### In this PR
* Changing `form_block` to accept a new `root_element` argument
* Add a sanity check that the passed `root_element` equals to the one calculated from the proofs.
* Add a test for root_element != calculated root element
