### PR TITLE
Add jitter to most retry iterators

### DIFF
--- a/connection/src/sync.rs
+++ b/connection/src/sync.rs
@@ -148,7 +148,9 @@ macro_rules! impl_sync_connection_retry {
             stringify!($func),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter, || $crate::_retry_wrapper!($obj.$func()))
+        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+            $crate::_retry_wrapper!($obj.$func())
+        })
     }};
     ($obj:expr, $logger:expr, $func:ident, $iter:expr, $arg1:expr) => {{
         $crate::_trace_time!(
@@ -158,7 +160,9 @@ macro_rules! impl_sync_connection_retry {
             stringify!($arg1),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter, || $crate::_retry_wrapper!($obj.$func($arg1)))
+        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+            $crate::_retry_wrapper!($obj.$func($arg1))
+        })
     }};
     ($obj:expr, $logger:expr, $func:ident, $iter:expr, $arg1:expr, $arg2:expr) => {{
         $crate::_trace_time!(
@@ -169,7 +173,9 @@ macro_rules! impl_sync_connection_retry {
             stringify!($arg2),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter, || $crate::_retry_wrapper!($obj.$func($arg1, $arg2)))
+        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+            $crate::_retry_wrapper!($obj.$func($arg1, $arg2))
+        })
     }};
 }
 

--- a/connection/src/sync.rs
+++ b/connection/src/sync.rs
@@ -148,7 +148,7 @@ macro_rules! impl_sync_connection_retry {
             stringify!($func),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+        $crate::_retry::retry($iter.into_iter().map($crate::_retry::delay::jitter), || {
             $crate::_retry_wrapper!($obj.$func())
         })
     }};
@@ -160,7 +160,7 @@ macro_rules! impl_sync_connection_retry {
             stringify!($arg1),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+        $crate::_retry::retry($iter.into_iter().map($crate::_retry::delay::jitter), || {
             $crate::_retry_wrapper!($obj.$func($arg1))
         })
     }};
@@ -173,7 +173,7 @@ macro_rules! impl_sync_connection_retry {
             stringify!($arg2),
             stringify!($iter)
         );
-        $crate::_retry::retry($iter.map($crate::_retry::delay::jitter), || {
+        $crate::_retry::retry($iter.into_iter().map($crate::_retry::delay::jitter), || {
             $crate::_retry_wrapper!($obj.$func($arg1, $arg2))
         })
     }};

--- a/fog/ingest/client/src/lib.rs
+++ b/fog/ingest/client/src/lib.rs
@@ -223,7 +223,9 @@ impl FogIngestGrpcClient {
     // policy, which is then used to implement retries for all the grpc calls
     fn get_retries(&self) -> Box<dyn Iterator<Item = Duration>> {
         Box::new(
-            retry::delay::Fixed::from_millis(100).take(self.retry_duration.as_secs() as usize * 10),
+            retry::delay::Fixed::from_millis(100)
+                .take(self.retry_duration.as_secs() as usize * 10)
+                .map(retry::delay::jitter),
         )
     }
 }

--- a/fog/ledger/server/src/db_fetcher.rs
+++ b/fog/ledger/server/src/db_fetcher.rs
@@ -271,7 +271,7 @@ impl<DB: Ledger, E: LedgerEnclaveProxy + Clone + Send + Sync + 'static> DbFetche
     fn add_records_to_enclave(&mut self, block_index: u64, records: Vec<KeyImageData>) {
         let num_records = records.len();
 
-        let _info = retry(delay::Fixed::from_millis(5000), || {
+        let _info = retry(delay::Fixed::from_millis(5000).map(delay::jitter), || {
             trace_time!(
                 self.logger,
                 "Added {} records into the enclave",

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -240,7 +240,7 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
                 AdminApiClient::new(ch)
             };
 
-            let info = retry(delay::Fixed::from_millis(5000), || {
+            let info = retry(delay::Fixed::from_millis(5000).map(delay::jitter), || {
                 ingest_server.assert_not_stopped();
 
                 match admin_client.get_info(&Empty::default()) {

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -153,7 +153,8 @@ impl SqlRecoveryDb {
     fn get_retries(&self) -> Box<dyn Iterator<Item = Duration>> {
         Box::new(
             delay::Fixed::from_millis(self.config.postgres_retry_millis)
-                .take(self.config.postgres_retry_count),
+                .take(self.config.postgres_retry_count)
+                .map(delay::jitter),
         )
     }
 

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -17,7 +17,7 @@ use mc_consensus_scp::{
 };
 use mc_transaction_core::BlockIndex;
 use mc_util_uri::ConnectionUri;
-use retry::delay::Fibonacci;
+use retry::delay::{Fibonacci,jitter};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -148,7 +148,7 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
 
     fn get_retry_iterator() -> Box<dyn Iterator<Item = Duration>> {
         // Start at 50ms, make 10 attempts (total would be 7150ms)
-        Box::new(Fibonacci::from_millis(50).take(10))
+        Box::new(Fibonacci::from_millis(50).take(10).map(jitter))
     }
 }
 

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -17,7 +17,7 @@ use mc_consensus_scp::{
 };
 use mc_transaction_core::BlockIndex;
 use mc_util_uri::ConnectionUri;
-use retry::delay::{Fibonacci,jitter};
+use retry::delay::{jitter, Fibonacci};
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,

--- a/peers/src/threaded_broadcaster_retry.rs
+++ b/peers/src/threaded_broadcaster_retry.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use retry::delay::Fibonacci;
+use retry::delay::{Fibonacci,jitter};
 use std::time::{Duration, Instant};
 
 /// Default number of attempts to make at delivering each message.
@@ -51,7 +51,8 @@ impl RetryPolicy for FibonacciRetryPolicy {
                 // The `retry` crate does not touch the delay iterator for it's first attempt,
                 // so if we want to have `max_attempts` attempts we need the iterator to return
                 // that number minus one.
-                .take(self.max_attempts - 1),
+                .take(self.max_attempts - 1)
+                .map(jitter),
         )
     }
 

--- a/peers/src/threaded_broadcaster_retry.rs
+++ b/peers/src/threaded_broadcaster_retry.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use retry::delay::{Fibonacci,jitter};
+use retry::delay::{jitter, Fibonacci};
 use std::time::{Duration, Instant};
 
 /// Default number of attempts to make at delivering each message.


### PR DESCRIPTION
### Motivation

When we have multiple instances of a program that includes retries, there is a risk of having many retries synchronize, creating a kind of thundering herd problem when attempting to recover from transient errors. 

### In this PR
* Add a `.map(delay::jitter)` call to all call sites that create a delay iterator for `retry` calls with a remote connection.
