### PR TITLE
Multisig utility crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.17"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2012,7 +2012,7 @@ dependencies = [
  "http-body 0.4.4",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio 1.16.1",
@@ -2045,7 +2045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http 0.2.1",
- "hyper 0.14.17",
+ "hyper 0.14.16",
  "rustls 0.20.2",
  "tokio 1.16.1",
  "tokio-rustls 0.23.2",
@@ -2253,9 +2253,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libloading"
@@ -6498,7 +6498,7 @@ dependencies = [
  "h2 0.3.11",
  "http 0.2.1",
  "http-body 0.4.4",
- "hyper 0.14.17",
+ "hyper 0.14.16",
  "hyper-rustls 0.23.0",
  "ipnet",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1999,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2012,7 +2012,7 @@ dependencies = [
  "http-body 0.4.4",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio 1.16.1",
@@ -2045,7 +2045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http 0.2.1",
- "hyper 0.14.16",
+ "hyper 0.14.17",
  "rustls 0.20.2",
  "tokio 1.16.1",
  "tokio-rustls 0.23.2",
@@ -2253,9 +2253,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libloading"
@@ -3181,6 +3181,20 @@ dependencies = [
  "rand_core 0.6.3",
  "serde",
  "subtle 2.4.1",
+]
+
+[[package]]
+name = "mc-crypto-multisig"
+version = "1.2.0-pre0"
+dependencies = [
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-serial",
+ "prost",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
+ "serde",
 ]
 
 [[package]]
@@ -6484,7 +6498,7 @@ dependencies = [
  "h2 0.3.11",
  "http 0.2.1",
  "http-body 0.4.4",
- "hyper 0.14.16",
+ "hyper 0.14.17",
  "hyper-rustls 0.23.0",
  "ipnet",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "crypto/digestible/signature",
     "crypto/keys",
     "crypto/message-cipher",
+    "crypto/multisig",
     "crypto/noise",
     "crypto/rand",
     "crypto/x509/test-vectors",

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -8,12 +8,13 @@ description = "MobileCoin multi-signature implementations"
 [dependencies]
 mc-crypto-digestible = { path = "../digestible" }
 mc-crypto-keys = { path = "../keys" }
-mc-util-from-random = { path = "../../util/from-random" }
-mc-util-serial = { path = "../../util/serial", default-features = false }
 
 prost = { version = "0.9", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
+mc-util-from-random = { path = "../../util/from-random" }
+mc-util-serial = { path = "../../util/serial", default-features = false }
+
 rand_core = "0.6"
 rand_hc = "0.3"

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mc-crypto-multisig"
+version = "1.2.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+description = "MobileCoin multi-signature implementations"
+
+[dependencies]
+mc-crypto-digestible = { path = "../digestible" }
+mc-crypto-keys = { path = "../keys" }
+mc-util-from-random = { path = "../../util/from-random" }
+mc-util-serial = { path = "../../util/serial", default-features = false }
+
+prost = { version = "0.9", default-features = false, features = ["prost-derive"] }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+
+[dev-dependencies]
+rand_core = "0.6"
+rand_hc = "0.3"

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -13,6 +13,9 @@ use mc_crypto_keys::{Ed25519SignatureError, PublicKey, Signature, Verifier};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
+/// The maximum number of signatures that can be included in a multi-signature.
+pub const MAX_SIGNATURES: usize = 10;
+
 /// A multi-signature: a collection of one or more signatures.
 #[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
 pub struct MultiSig<
@@ -62,9 +65,11 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
     where
         P: Verifier<S>,
     {
-        // If the signature contains less than the threshold number of signers, there's
-        // no point in trying.
-        if multi_sig.signatures.len() < self.threshold as usize {
+        // If the signature contains less than the threshold number of signers or more
+        // than the hardcoded limit, there's no point in trying.
+        if multi_sig.signatures.len() < self.threshold as usize
+            || multi_sig.signatures.len() > MAX_SIGNATURES
+        {
             return Err(Ed25519SignatureError::new());
         }
 

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -5,7 +5,7 @@
 //! produce a joint signature on a common message. The simplest multi-signature
 //! of a message is just a set of signatures containing one signature over the
 //! message from each member of the signing group. We say that a multi-signature
-//! is a k-of-n threshold signature if only k valid signatures are required from
+//! is a m-of-n threshold signature if only k valid signatures are required from
 //! a signing group of size n.
 
 #![cfg_attr(not(test), no_std)]
@@ -40,7 +40,7 @@ impl<S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Si
     }
 }
 
-/// A set of K-out-of-N public keys.
+/// A set of M-out-of-N public keys.
 #[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
 #[serde(bound = "")]
 pub struct SignerSet<P: Default + PublicKey + Message> {

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Multi-signature implementations.
+
+#![no_std]
+#![deny(missing_docs)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use mc_crypto_digestible::Digestible;
+use mc_crypto_keys::{Ed25519Public, Ed25519Signature, Ed25519SignatureError, Verifier};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+
+/// A multi-signature: a collection of 1 or more Ed25519 signatures.
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
+pub struct MultiSig {
+    #[prost(message, repeated, tag = "1")]
+    signatures: Vec<Ed25519Signature>,
+}
+
+impl MultiSig {
+    /// Construct a new multi-signature from a collection of Ed25519 signatures.
+    pub fn new(signatures: Vec<Ed25519Signature>) -> Self {
+        Self { signatures }
+    }
+}
+
+/*impl Signature for MultiSig {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Ed25519SignatureError> {
+        panic!();
+    }
+}*/
+
+/// A set of M-out-of-N Ed25519 public keys.
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
+pub struct SignerSet {
+    /// List of potential signers.
+    #[prost(message, repeated, tag = "1")]
+    signers: Vec<Ed25519Public>,
+
+    /// Minimum number of signers required.
+    #[prost(uint32, tag = "2")]
+    threshold: u32,
+}
+
+impl SignerSet {
+    /// Construct a new `SignerSet` from a list of public keys and threshold.
+    pub fn new(signers: Vec<Ed25519Public>, threshold: u32) -> Self {
+        Self { signers, threshold }
+    }
+
+    /// Verify a message against a multi-signature, returning the list of
+    /// signers that signed it.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        multi_sig: &MultiSig,
+    ) -> Result<Vec<Ed25519Public>, Ed25519SignatureError> {
+        // If the signature contains less than the threshold number of signers, there's
+        // no point in trying.
+        if multi_sig.signatures.len() < self.threshold as usize {
+            return Err(Ed25519SignatureError::new());
+        }
+
+        let mut matched_signers = Vec::new();
+        let mut potential_signers = self.signers.clone();
+        for signature in multi_sig.signatures.iter() {
+            let matched_signer = potential_signers.iter().find_map(|signer| {
+                signer
+                    .verify(message, signature)
+                    .ok()
+                    .map(|_| signer.clone())
+            });
+            if let Some(matched_signer) = matched_signer {
+                potential_signers.retain(|signer| signer != &matched_signer);
+                matched_signers.push(matched_signer);
+            }
+        }
+
+        if matched_signers.len() < self.threshold as usize {
+            return Err(Ed25519SignatureError::new());
+        }
+
+        Ok(matched_signers)
+    }
+}
+
+/*impl Verifier<MultiSig> for SignerSet {
+    fn verify(&self, message: &[u8], multi_sig: &MultiSig) -> Result<(), Ed25519SignatureError> {
+        self.verify_signers(message, multi_sig).map(|_| ())
+    }
+}*/
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::vec;
+    use mc_crypto_keys::{Ed25519Pair, Signer};
+    use mc_util_from_random::FromRandom;
+    use rand_core::SeedableRng;
+    use rand_hc::Hc128Rng;
+
+    #[test]
+    fn verify_signers_sanity() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let signer1 = Ed25519Pair::from_random(&mut rng);
+        let signer2 = Ed25519Pair::from_random(&mut rng);
+        let signer3 = Ed25519Pair::from_random(&mut rng);
+        let signer4 = Ed25519Pair::from_random(&mut rng);
+
+        let signer_set = SignerSet::new(
+            vec![
+                signer1.public_key(),
+                signer2.public_key(),
+                signer3.public_key(),
+            ],
+            2,
+        );
+        let message = b"this is a test";
+
+        // Try with just one valid signature, we should fail to verify.
+        let multi_sig = MultiSig::new(vec![signer1.try_sign(message.as_ref()).unwrap()]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // With two valid signatures we should succeed to verify and get the correct
+        // keys back.
+        let multi_sig = MultiSig::new(vec![
+            signer1.try_sign(message.as_ref()).unwrap(),
+            signer3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        assert_eq!(
+            signer_set.verify(message.as_ref(), &multi_sig).unwrap(),
+            vec![signer1.public_key(), signer3.public_key()]
+        );
+
+        // With three valid signatures we should succeed to verify and get the correct
+        // keys back.
+        let multi_sig = MultiSig::new(vec![
+            signer1.try_sign(message.as_ref()).unwrap(),
+            signer2.try_sign(message.as_ref()).unwrap(),
+            signer3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        assert_eq!(
+            signer_set.verify(message.as_ref(), &multi_sig).unwrap(),
+            vec![
+                signer1.public_key(),
+                signer2.public_key(),
+                signer3.public_key()
+            ]
+        );
+
+        // Trying to cheat by signing twice with the same signer will not work.
+        let multi_sig = MultiSig::new(vec![
+            signer1.try_sign(message.as_ref()).unwrap(),
+            signer1.try_sign(message.as_ref()).unwrap(),
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Using an unknown signer should not allow us to verify is we are under the
+        // threshold
+        let multi_sig = MultiSig::new(vec![
+            signer1.try_sign(message.as_ref()).unwrap(),
+            signer4.try_sign(message.as_ref()).unwrap(),
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Using an unknown signer does not get in the way of verifiying a valid set.
+        let multi_sig = MultiSig::new(vec![
+            signer1.try_sign(message.as_ref()).unwrap(),
+            signer3.try_sign(message.as_ref()).unwrap(),
+            signer4.try_sign(message.as_ref()).unwrap(),
+        ]);
+        assert_eq!(
+            signer_set.verify(message.as_ref(), &multi_sig).unwrap(),
+            vec![signer1.public_key(), signer3.public_key()]
+        );
+    }
+}

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -1,6 +1,12 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Multi-signature implementations.
+//! Multi-signature implementation: A multi-signature is a protocol that allows
+//! a group of signers, each possessing a distinct private/public keypair, to
+//! produce a joint signature on a common message. The simplest multi-signature
+//! of a message is just a set of signatures containing one signature over the
+//! message from each member of the signing group. We say that a multi-signature
+//! is a k-of-n threshold signature if only k valid signatures are required from
+//! a signing group of size n.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
@@ -34,7 +40,7 @@ impl<S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Si
     }
 }
 
-/// A set of M-out-of-N public keys.
+/// A set of K-out-of-N public keys.
 #[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
 #[serde(bound = "")]
 pub struct SignerSet<P: Default + PublicKey + Message> {

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use mc_crypto_digestible::Digestible;
-use mc_crypto_keys::{Ed25519SignatureError, PublicKey, Signature, Verifier};
+use mc_crypto_keys::{SignatureError, PublicKey, Signature, Verifier};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
@@ -61,7 +61,7 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         &self,
         message: &[u8],
         multi_sig: &MultiSig<S>,
-    ) -> Result<Vec<P>, Ed25519SignatureError>
+    ) -> Result<Vec<P>, SignatureError>
     where
         P: Verifier<S>,
     {
@@ -70,7 +70,7 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         if multi_sig.signatures.len() < self.threshold as usize
             || multi_sig.signatures.len() > MAX_SIGNATURES
         {
-            return Err(Ed25519SignatureError::new());
+            return Err(SignatureError::new());
         }
 
         let mut matched_signers = Vec::new();
@@ -89,7 +89,7 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         }
 
         if matched_signers.len() < self.threshold as usize {
-            return Err(Ed25519SignatureError::new());
+            return Err(SignatureError::new());
         }
 
         Ok(matched_signers)

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use mc_crypto_digestible::Digestible;
-use mc_crypto_keys::{SignatureError, PublicKey, Signature, Verifier};
+use mc_crypto_keys::{PublicKey, Signature, SignatureError, Verifier};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
### Motivation

We are going to want some basic M-out-of-N signature primitives for the upcoming new transaction types.

### In this PR
* A new crate, `mc-crypto-multisig`, which contains primitives for a multisig implementation.