### PR TITLE
Rename misleading Ed25519SignatureError -> SignatureError

### DIFF
--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use displaydoc::Display;
 use mc_attest_core::SgxError;
 use mc_attest_enclave_api::Error as AttestEnclaveError;
-use mc_crypto_keys::Ed25519SignatureError;
+use mc_crypto_keys::SignatureError;
 use mc_crypto_message_cipher::CipherError as MessageCipherError;
 use mc_sgx_compat::sync::PoisonError;
 use mc_transaction_core::validation::TransactionValidationError;
@@ -108,8 +108,8 @@ impl From<AttestEnclaveError> for Error {
     }
 }
 
-impl From<Ed25519SignatureError> for Error {
-    fn from(_src: Ed25519SignatureError) -> Error {
+impl From<SignatureError> for Error {
+    fn from(_src: SignatureError) -> Error {
         Error::Signature
     }
 }

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -3,7 +3,7 @@
 //! This module implements the common keys traits for the Ed25519 digital
 //! signature scheme.
 
-pub use ed25519::signature::Error as Ed25519SignatureError;
+pub use ed25519::signature::Error as SignatureError;
 
 use alloc::vec;
 
@@ -12,10 +12,7 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 use digest::generic_array::typenum::{U32, U64};
 use ed25519::{
-    signature::{
-        DigestSigner, DigestVerifier, Error as SignatureError, Signature as SignatureTrait, Signer,
-        Verifier,
-    },
+    signature::{DigestSigner, DigestVerifier, Signature as SignatureTrait, Signer, Verifier},
     Signature,
 };
 use ed25519_dalek::{
@@ -30,7 +27,6 @@ use mc_util_repr_bytes::{
 };
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use signature::Error;
 use zeroize::Zeroize;
 
 // ASN.1 DER Signature Bytes -- this is a set of nested TLVs describing
@@ -409,7 +405,7 @@ impl Default for Ed25519Signature {
 }
 
 impl SignatureTrait for Ed25519Signature {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, SignatureError> {
         Ok(Self(Signature::from_bytes(bytes)?))
     }
 }
@@ -421,9 +417,9 @@ impl AsRef<[u8]> for Ed25519Signature {
 }
 
 impl<'a> TryFrom<&'a [u8]> for Ed25519Signature {
-    type Error = Ed25519SignatureError;
+    type Error = SignatureError;
 
-    fn try_from(bytes: &'a [u8]) -> Result<Self, Error> {
+    fn try_from(bytes: &'a [u8]) -> Result<Self, SignatureError> {
         Ok(Self(Signature::try_from(bytes)?))
     }
 }

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -56,9 +56,7 @@ mod traits;
 mod x25519;
 
 pub use crate::{
-    ed25519::{
-        Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, Ed25519SignatureError,
-    },
+    ed25519::{Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, SignatureError},
     ristretto::*,
     traits::*,
     x25519::*,

--- a/fog/sig/report/src/ed25519.rs
+++ b/fog/sig/report/src/ed25519.rs
@@ -5,12 +5,12 @@
 
 use crate::{Signer, Verifier};
 use mc_crypto_digestible_signature::{DigestibleSigner, DigestibleVerifier};
-use mc_crypto_keys::{Ed25519Pair, Ed25519Public, Ed25519Signature, Ed25519SignatureError};
+use mc_crypto_keys::{Ed25519Pair, Ed25519Public, Ed25519Signature, SignatureError};
 use mc_fog_report_types::Report;
 
 impl Signer for Ed25519Pair {
     type Sig = Ed25519Signature;
-    type Error = Ed25519SignatureError;
+    type Error = SignatureError;
 
     fn sign_reports(&self, reports: &[Report]) -> Result<Self::Sig, Self::Error> {
         self.try_sign_digestible(super::context(), &reports)
@@ -19,7 +19,7 @@ impl Signer for Ed25519Pair {
 
 impl Verifier for Ed25519Public {
     type Sig = Ed25519Signature;
-    type Error = Ed25519SignatureError;
+    type Error = SignatureError;
 
     fn verify_reports(&self, reports: &[Report], sig: &Self::Sig) -> Result<(), Self::Error> {
         self.verify_digestible(super::context(), &reports, sig)

--- a/transaction/core/src/blockchain/block_signature.rs
+++ b/transaction/core/src/blockchain/block_signature.rs
@@ -4,7 +4,7 @@ use crate::Block;
 use core::fmt::{Display, Formatter, Result as FmtResult};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{
-    Ed25519Pair, Ed25519Public, Ed25519Signature, Ed25519SignatureError, Signer, Verifier,
+    Ed25519Pair, Ed25519Public, Ed25519Signature, SignatureError, Signer, Verifier,
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -51,7 +51,7 @@ impl BlockSignature {
     pub fn from_block_and_keypair(
         block: &Block,
         keypair: &Ed25519Pair,
-    ) -> Result<Self, Ed25519SignatureError> {
+    ) -> Result<Self, SignatureError> {
         let digest = block.digest32::<MerlinTranscript>(b"block-sig");
         let signature = keypair.try_sign(&digest)?;
 
@@ -85,7 +85,7 @@ impl BlockSignature {
     }
 
     /// Verify that this signature is over a given block.
-    pub fn verify(&self, block: &Block) -> Result<(), Ed25519SignatureError> {
+    pub fn verify(&self, block: &Block) -> Result<(), SignatureError> {
         let digest = block.digest32::<MerlinTranscript>(b"block-sig");
 
         self.signer.verify(&digest, &self.signature)


### PR DESCRIPTION
It is literally just reexporting `signature::Error`