### PR TITLE
Add master minters configuration to TokensConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,6 +3009,7 @@ dependencies = [
  "mc-consensus-scp",
  "mc-crypto-digestible",
  "mc-crypto-keys",
+ "mc-crypto-multisig",
  "mc-ledger-db",
  "mc-ledger-sync",
  "mc-peers",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -24,6 +24,7 @@ mc-consensus-enclave = { path = "../../consensus/enclave" }
 mc-consensus-scp = { path = "../../consensus/scp" }
 mc-crypto-digestible = { path = "../../crypto/digestible" }
 mc-crypto-keys = { path = "../../crypto/keys" }
+mc-crypto-multisig = { path = "../../crypto/multisig" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-ledger-sync = { path = "../../ledger/sync" }
 mc-peers = { path = "../../peers" }

--- a/consensus/service/src/config/tokens.rs
+++ b/consensus/service/src/config/tokens.rs
@@ -91,8 +91,7 @@ pub struct TokenConfig {
     /// Master minters - if set, controls the set of keys that can sign
     /// set-minting-configuration transactions.
     /// Not supported for MOB
-    #[serde(with = "der_signer_set")]
-    #[serde(default)]
+    #[serde(default, with = "der_signer_set")]
     master_minters: Option<SignerSet<Ed25519Public>>,
 }
 

--- a/consensus/service/src/config/tokens.rs
+++ b/consensus/service/src/config/tokens.rs
@@ -668,12 +668,14 @@ mod tests {
     #[test]
     fn valid_minting_config() {
         // This test code is used to generate the two keys used in the test below.
+        /*
         let key1 = Ed25519Public::try_from(&[3u8; 32][..]).unwrap();
         let key2 = Ed25519Public::try_from(&[123u8; 32][..]).unwrap();
         let key1_hex = hex::encode(&key1.to_der());
         let key2_hex = hex::encode(&key2.to_der());
         println!("{}", key1_hex);
         println!("{}", key2_hex);
+        */
 
         let input_toml: &str = r#"
             [[tokens]]
@@ -692,21 +694,21 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
         let input_json: &str = r#"{
-                    "tokens": [
-                        { "token_id": 0 },
-                        {
-                            "token_id": 1,
-                            "minimum_fee": 1,
-                            "master_minters": {
-                                "signers": [
-                                    "302a300506032b65700321000303030303030303030303030303030303030303030303030303030303030303",
-                                    "302a300506032b65700321007b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b"
-                                ],
-                                "threshold": 1
-                            }
-                        }
-                    ]
-                }"#;
+            "tokens": [
+                { "token_id": 0 },
+                {
+                    "token_id": 1,
+                    "minimum_fee": 1,
+                    "master_minters": {
+                        "signers": [
+                            "302a300506032b65700321000303030303030303030303030303030303030303030303030303030303030303",
+                            "302a300506032b65700321007b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b7b"
+                        ],
+                        "threshold": 1
+                    }
+                }
+            ]
+        }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
         assert_eq!(tokens, tokens2);
 

--- a/consensus/service/src/config/tokens.rs
+++ b/consensus/service/src/config/tokens.rs
@@ -11,8 +11,8 @@ use mc_transaction_core::{tokens::Mob, Token, TokenId};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fs, iter::FromIterator, path::Path};
 
-/// A helper struct for ser/derserializing a SignerSet that uses hex-encoded DER
-/// representation of Ed25519 public keys.
+/// A helper struct for ser/derserializing a SignerSet that uses hex-encoded
+/// DER representation of Ed25519 public keys.
 #[derive(Serialize, Deserialize)]
 struct DerSignerSet {
     signers: Vec<String>,

--- a/consensus/service/src/config/tokens.rs
+++ b/consensus/service/src/config/tokens.rs
@@ -667,15 +667,14 @@ mod tests {
 
     #[test]
     fn valid_minting_config() {
-        // This test code is used to generate the two keys used in the test below.
-        /*
         let key1 = Ed25519Public::try_from(&[3u8; 32][..]).unwrap();
         let key2 = Ed25519Public::try_from(&[123u8; 32][..]).unwrap();
+
+        // This test code is used to generate the two keys used in the test below.
         let key1_hex = hex::encode(&key1.to_der());
         let key2_hex = hex::encode(&key2.to_der());
         println!("{}", key1_hex);
         println!("{}", key2_hex);
-        */
 
         let input_toml: &str = r#"
             [[tokens]]

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -59,6 +59,16 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         Self { signers, threshold }
     }
 
+    /// Get the list of potential signers.
+    pub fn signers(&self) -> &[P] {
+        &self.signers
+    }
+
+    /// Get the threshold.
+    pub fn threshold(&self) -> u32 {
+        self.threshold
+    }
+
     /// Verify a message against a multi-signature, returning the list of
     /// signers that signed it.
     pub fn verify<

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -18,7 +18,7 @@ impl From<u32> for TokenId {
 
 impl fmt::Display for TokenId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{}", self.0)
     }
 }
 


### PR DESCRIPTION
### Motivation

This is a first step in implementing a proof-of-concept minting scheme. It is currently based on https://github.com/mobilecoinfoundation/mobilecoin/pull/1491 (which is still blocked on reviews). It will not get merged to `master` at this point, but instead be the base for a minting feature branch to present a potential approach.

### In this PR
* Adding the option to specify a list of master minter signing keys, which are Ed25519 keys that are hex-encoded DER representation.
