### PR TITLE
provide correct GIT_COMMIT when mobilecoin is a submodule of another repository

### DIFF
--- a/util/build/info/src/lib.rs
+++ b/util/build/info/src/lib.rs
@@ -11,8 +11,9 @@ use core::fmt::{Result, Write};
 pub fn write_report(output: &mut dyn Write) -> Result {
     write!(
         output,
-        r##"{{ "GIT_COMMIT": "{}", "PROFILE": "{}", "DEBUG": "{}", "OPT_LEVEL": "{}", "DEBUG_ASSERTIONS": "{}", "TARGET_ARCH": "{}", "TARGET_OS": "{}", "TARGET_FEATURE": "{}", "RUSTFLAGS": "{}", "SGX_MODE": "{}", "IAS_MODE": "{}" }}"##,
+        r##"{{ "GIT_COMMIT": "{}", "MOBILECOIN_GIT_COMMIT": "{}", "PROFILE": "{}", "DEBUG": "{}", "OPT_LEVEL": "{}", "DEBUG_ASSERTIONS": "{}", "TARGET_ARCH": "{}", "TARGET_OS": "{}", "TARGET_FEATURE": "{}", "RUSTFLAGS": "{}", "SGX_MODE": "{}", "IAS_MODE": "{}" }}"##,
         git_commit(),
+        mobilecoin_git_commit(),
         profile(),
         debug(),
         opt_level(),


### PR DESCRIPTION
We ran into an issue where `mc-util-build-info` would pick the wrong value for GIT_COMMIT when `mobilecoin` is being included as a submodule in another repository. Since the build script runs inside the crate's directory, `git describe` would grab the commit id of the `mobilecoin` submodule, wheer the expected behavior was that it would grab the commit id of the root repo. 
This PR addresses that with a hack that looks for the top-most git repository and grabs the commit id from there. It also adds `MOBILECOIN_GIT_COMMIT` for getting the commit of the actual `mobilecoin` repository, since that information might come in handy.