### PR TITLE
derive the traits necessary for implementing scp Value

### DIFF
--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -9,7 +9,11 @@ use alloc::vec;
 
 use crate::traits::*;
 use alloc::vec::Vec;
-use core::convert::TryFrom;
+use core::{
+    cmp::Ordering,
+    convert::TryFrom,
+    hash::{Hash, Hasher},
+};
 use digest::generic_array::typenum::{U32, U64};
 use ed25519::{
     signature::{DigestSigner, DigestVerifier, Signature as SignatureTrait, Signer, Verifier},
@@ -394,6 +398,24 @@ impl Eq for Ed25519Signature {}
 impl PartialEq for Ed25519Signature {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
+    }
+}
+
+impl PartialOrd for Ed25519Signature {
+    fn partial_cmp(&self, other: &Ed25519Signature) -> Option<Ordering> {
+        self.to_bytes().partial_cmp(&other.to_bytes())
+    }
+}
+
+impl Ord for Ed25519Signature {
+    fn cmp(&self, other: &Ed25519Signature) -> Ordering {
+        self.to_bytes().cmp(&other.to_bytes())
+    }
+}
+
+impl Hash for Ed25519Signature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state)
     }
 }
 

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -14,6 +14,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::hash::Hash;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{PublicKey, Signature, SignatureError, Verifier};
 use prost::Message;
@@ -23,16 +24,39 @@ use serde::{Deserialize, Serialize};
 pub const MAX_SIGNATURES: usize = 10;
 
 /// A multi-signature: a collection of one or more signatures.
-#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
+#[derive(
+    Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
+)]
 pub struct MultiSig<
-    S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Signature,
+    S: Clone
+        + Default
+        + Digestible
+        + Eq
+        + Hash
+        + Message
+        + Ord
+        + PartialEq
+        + PartialOrd
+        + Serialize
+        + Signature,
 > {
     #[prost(message, repeated, tag = "1")]
     signatures: Vec<S>,
 }
 
-impl<S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Signature>
-    MultiSig<S>
+impl<
+        S: Clone
+            + Default
+            + Digestible
+            + Eq
+            + Hash
+            + Message
+            + Ord
+            + PartialEq
+            + PartialOrd
+            + Serialize
+            + Signature,
+    > MultiSig<S>
 {
     /// Construct a new multi-signature from a collection of signatures.
     pub fn new(signatures: Vec<S>) -> Self {
@@ -41,7 +65,9 @@ impl<S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Si
 }
 
 /// A set of M-out-of-N public keys.
-#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
+#[derive(
+    Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
+)]
 #[serde(bound = "")]
 pub struct SignerSet<P: Default + PublicKey + Message> {
     /// List of potential signers.
@@ -62,7 +88,17 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
     /// Verify a message against a multi-signature, returning the list of
     /// signers that signed it.
     pub fn verify<
-        S: Clone + Default + Digestible + Eq + Message + PartialEq + Serialize + Signature,
+        S: Clone
+            + Default
+            + Digestible
+            + Eq
+            + Hash
+            + Message
+            + Ord
+            + PartialEq
+            + PartialOrd
+            + Serialize
+            + Signature,
     >(
         &self,
         message: &[u8],


### PR DESCRIPTION
The new objects in `mc-crypto-multisig` are going to end up inside SCP transactions. As such, they need to implement all the traits requires by [`mc-consensus-scp::Value`](https://github.com/mobilecoinfoundation/mobilecoin/blob/0bbca35d7eba7db7a38ccd6dc1591c70fd3c62d5/consensus/scp/src/core_types.rs#L59).

This PR adds the necessary implementations.