### PR TITLE
replaced serde_cbor with minicbor-ser library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5264,9 +5264,9 @@ dependencies = [
 name = "mc-util-serial"
 version = "1.2.0-pre0"
 dependencies = [
+ "minicbor-ser",
  "prost",
  "serde",
- "serde_cbor",
 ]
 
 [[package]]
@@ -5451,6 +5451,22 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4377ac4fab63e0c3821e7bfff783599292fde1c88d50887131e13d7f7eac70e9"
+dependencies = [
+ "minicbor",
+ "serde",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -456,12 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "half"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,9 +1226,9 @@ dependencies = [
 name = "mc-util-serial"
 version = "1.2.0-pre0"
 dependencies = [
+ "minicbor-ser",
  "prost",
  "serde",
- "serde_cbor",
 ]
 
 [[package]]
@@ -1253,6 +1247,22 @@ dependencies = [
  "keccak",
  "rand_core",
  "zeroize",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4377ac4fab63e0c3821e7bfff783599292fde1c88d50887131e13d7f7eac70e9"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -1519,15 +1529,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -1863,3 +1864,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -500,12 +500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "half"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,9 +1355,9 @@ dependencies = [
 name = "mc-util-serial"
 version = "1.2.0-pre0"
 dependencies = [
+ "minicbor-ser",
  "prost",
  "serde",
- "serde_cbor",
 ]
 
 [[package]]
@@ -1390,6 +1384,22 @@ dependencies = [
  "keccak",
  "rand_core",
  "zeroize",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4377ac4fab63e0c3821e7bfff783599292fde1c88d50887131e13d7f7eac70e9"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -1650,15 +1660,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -2004,3 +2005,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -501,12 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "half"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,9 +1346,9 @@ dependencies = [
 name = "mc-util-serial"
 version = "1.2.0-pre0"
 dependencies = [
+ "minicbor-ser",
  "prost",
  "serde",
- "serde_cbor",
 ]
 
 [[package]]
@@ -1381,6 +1375,22 @@ dependencies = [
  "keccak",
  "rand_core",
  "zeroize",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4377ac4fab63e0c3821e7bfff783599292fde1c88d50887131e13d7f7eac70e9"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -1640,15 +1650,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -1985,3 +1986,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -501,12 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "half"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,9 +1374,9 @@ dependencies = [
 name = "mc-util-serial"
 version = "1.2.0-pre0"
 dependencies = [
+ "minicbor-ser",
  "prost",
  "serde",
- "serde_cbor",
 ]
 
 [[package]]
@@ -1409,6 +1403,22 @@ dependencies = [
  "keccak",
  "rand_core",
  "zeroize",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48222b0b93eea4181f796ff574ad31a6ef635a6a6d9953b5cebffe44e1b70c59"
+
+[[package]]
+name = "minicbor-ser"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4377ac4fab63e0c3821e7bfff783599292fde1c88d50887131e13d7f7eac70e9"
+dependencies = [
+ "minicbor",
+ "serde",
 ]
 
 [[package]]
@@ -1669,15 +1679,6 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.1"
-source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -2023,3 +2024,8 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "git+https://github.com/mobilecoinofficial/cbor?rev=4c886a7c1d523aae1ec4aa7386f402cb2f4341b5#4c886a7c1d523aae1ec4aa7386f402cb2f4341b5"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 # because rmp-ser../../alloc doesn't build against ser../../std,
 # so if anything else in your build plan will activate ser../../std, then mcseri../../std is
 # required.
-std = [ "serde/std", "serde_cbor/std" ]
+std = [ "serde/std" ]
 
 [dependencies]
 prost = { version = "0.9", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"] }
+minicbor-ser = { version = "0.1.2", default-features = false }

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 # because rmp-ser../../alloc doesn't build against ser../../std,
 # so if anything else in your build plan will activate ser../../std, then mcseri../../std is
 # required.
-std = [ "serde/std" ]
+std = [ "serde/std", "minicbor-ser/std" ]
 
 [dependencies]
 prost = { version = "0.9", default-features = false, features = ["prost-derive"] }

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -8,13 +8,14 @@ use alloc::vec::Vec;
 pub extern crate prost;
 
 pub use prost::{DecodeError, EncodeError, Message};
+use minicbor_ser as cbor;
 
-// We put a new-type around serde_cbor::Error in `mod decode` and `mod encode`,
+// We put a new-type around minicbor_ser::error::Error in `mod decode` and `mod encode`,
 // because this keeps us compatible with how rmp-serde was exporting its errors,
 // and avoids unnecessary code changes.
 pub mod decode {
     #[derive(Debug)]
-    pub struct Error(serde_cbor::Error);
+    pub struct Error(minicbor_ser::error::Error);
 
     impl core::fmt::Display for Error {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -22,8 +23,8 @@ pub mod decode {
         }
     }
 
-    impl From<serde_cbor::Error> for Error {
-        fn from(src: serde_cbor::Error) -> Self {
+    impl From<minicbor_ser::error::Error> for Error {
+        fn from(src: minicbor_ser::error::Error) -> Self {
             Self(src)
         }
     }
@@ -31,7 +32,7 @@ pub mod decode {
 
 pub mod encode {
     #[derive(Debug)]
-    pub struct Error(serde_cbor::Error);
+    pub struct Error(minicbor_ser::error::Error);
 
     impl core::fmt::Display for Error {
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -39,8 +40,8 @@ pub mod encode {
         }
     }
 
-    impl From<serde_cbor::Error> for Error {
-        fn from(src: serde_cbor::Error) -> Self {
+    impl From<minicbor_ser::error::Error> for Error {
+        fn from(src: minicbor_ser::error::Error) -> Self {
             Self(src)
         }
     }
@@ -55,7 +56,7 @@ pub fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>, encode::Error>
 where
     T: serde::ser::Serialize + Sized,
 {
-    Ok(serde_cbor::to_vec(value)?)
+    Ok(cbor::to_vec(value)?)
 }
 
 // Forward mc_util_serial::deserialize to bincode::deserialize
@@ -63,7 +64,7 @@ pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T, decode::Error>
 where
     T: serde::de::Deserialize<'a>,
 {
-    Ok(serde_cbor::from_slice(bytes)?)
+    Ok(cbor::from_slice(bytes)?)
 }
 
 pub fn encode<T: Message>(value: &T) -> Vec<u8> {

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -59,7 +59,6 @@ where
     Ok(cbor::to_vec(value)?)
 }
 
-// Forward mc_util_serial::deserialize to bincode::deserialize
 pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T, decode::Error>
 where
     T: serde::de::Deserialize<'a>,


### PR DESCRIPTION
### Motivation

serde_cbor is not maintained anymore, so we replaced it with another library compatible with serde.

### In this PR
* < Additions, removals, fixes, features >

https://github.com/mobilecoinfoundation/mobilecoin/issues/1260


