### PR TITLE
Elevate watcher log level for sync errors

### DIFF
--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -149,7 +149,7 @@ impl WatcherSyncThread {
 
             // For now, ignore origin block, as it does not have a signature.
             let syncing_done = watcher
-                .sync_blocks(1, config.max_block_height)
+                .sync_blocks(1, config.max_block_height, false)
                 .expect("Could not sync signatures");
             if syncing_done {
                 log::info!(logger, "sync_signatures indicates we're done");

--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -110,6 +110,7 @@ impl Watcher {
         &self,
         start: u64,
         max_block_height: Option<u64>,
+        log_sync_failures: bool,
     ) -> Result<bool, WatcherError> {
         log::info!(
             self.logger,
@@ -194,12 +195,21 @@ impl Watcher {
                     }
 
                     Err(err) => {
-                        log::debug!(
-                            self.logger,
-                            "Could not sync block {} for url ({:?})",
-                            block_index,
-                            err
-                        );
+                        if log_sync_failures {
+                            log::error!(
+                                self.logger,
+                                "Could not sync block {} for url ({:?})",
+                                block_index,
+                                err
+                            );
+                        } else {
+                            log::debug!(
+                                self.logger,
+                                "Could not sync block {} for url ({:?})",
+                                block_index,
+                                err
+                            );
+                        }
                     }
                 }
             }
@@ -355,7 +365,7 @@ impl WatcherSyncThread {
                     lowest_next_block_to_sync + MAX_BLOCKS_PER_SYNC_ITERATION as u64,
                 );
                 watcher
-                    .sync_blocks(lowest_next_block_to_sync, Some(max_blocks))
+                    .sync_blocks(lowest_next_block_to_sync, Some(max_blocks), true)
                     .expect("Could not sync blocks");
             } else if !stop_requested.load(Ordering::SeqCst) {
                 log::trace!(


### PR DESCRIPTION
These logs do
indeed exist, but the log level was below that of what the log
shipper was able to pickup. Has been raised to "error"

Soundtrack of this PR: [link to song that really fits the mood of this PR]()

### Motivation
In the 2021-12-25 mainnet outage, no watcher logs were found indicating trouble syncing attestation signatures. The only indication was that watcher info messages stating it was 1000 blocks behind.

### In this PR
* Proper logging statements to log node having difficult + the underlying cause existed, but the log level was debug and thus was not being shipped. Simple elevation of log level provides these log statements 

### Future Work
* Make the watcher sync nodes independently so they don't get stuck if one node can't sync
* Create Prometheus logging that give per-node sync stats in order to develop an idea of performance/error trends among nodes
