### PR TITLE
Tag dependabot PRs with the 'Reduce supply chain attack surface' milestone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 25
+  milestone: 2
   reviewers:
     - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
@@ -12,6 +13,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  milestone: 2
   reviewers:
     - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
@@ -19,6 +21,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  milestone: 2
   reviewers:
     - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
@@ -26,6 +29,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  milestone: 2
   reviewers:
     - "mobilecoinfoundation/eng"
 - package-ecosystem: cargo
@@ -33,5 +37,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  milestone: 2
   reviewers:
     - "mobilecoinfoundation/eng"


### PR DESCRIPTION
This should link the PRs with [the milestone](https://github.com/mobilecoinfoundation/mobilecoin/milestone/2), per [docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#milestone)