### PR TITLE
try to improve circle ci times by splitting fog ingest to its own job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,23 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --package "mc-fog-*" -j 4 --frozen --no-fail-fast
+            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
+      - run:
+          command: |
+            mkdir -p /tmp/core_dumps
+            cp core.* /tmp/core_dumps
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/core_dumps
+
+  run-fog-ingest-tests:
+    steps:
+      - run:
+          name: Run fog ingest tests (in release mode)
+          command: |
+            # tell the operating system to remove the file size limit on core dump files
+            ulimit -c unlimited
+            cargo test --release --package "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -537,6 +553,21 @@ jobs:
     steps:
       - prepare-for-build
       - run-fog-tests
+      - check-dirty-git
+      - when:
+          condition: { equal: [ << pipeline.git.branch >>, master ] }
+          steps: [ save-sccache-cache ]
+      - post-build
+      - post-fog-test
+
+  # Run fog ingest tests on a single container
+  run-fog-ingest-tests:
+    executor: build-executor
+    environment:
+      <<: *default-build-environment
+    steps:
+      - prepare-for-build
+      - run-fog-ingest-tests
       - check-dirty-git
       - when:
           condition: { equal: [ << pipeline.git.branch >>, master ] }
@@ -690,6 +721,10 @@ workflows:
 
       # Run fog tests on a single container
       - run-fog-tests:
+          filters: { branches: { ignore: /^deploy\/.*/ } }
+
+      # Run fog ingest tests on a single container
+      - run-fog-ingest-tests:
           filters: { branches: { ignore: /^deploy\/.*/ } }
 
       # run fog conformance tests


### PR DESCRIPTION
The run mc-fog-tests job currently takes 40 minutes

This does two things:
* Move fog ingest tests to their own job in circle ci, and make
  the fog tests job exclude fog ingest
* Use `--release` when running the fog ingest tests. This is because
  I think it will make the integration tests that run little fog
  ingest clusters a lot faster, since it will make the ORAM and
  all that much faster. Those integration tests probably make more
  sense to run in release mode anyways since then it will more
  closely resemble what we actually deploy.