### PR TITLE
Keep Fog Overseer Server alive when started via binary

### DIFF
--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -41,5 +41,6 @@ fn main() {
             .port(config.overseer_listen_port)
             .unwrap();
 
-    server::initialize_rocket_server(rocket_config, overseer_state);
+    let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
+    rocket.launch();
 }

--- a/fog/overseer/server/src/server.rs
+++ b/fog/overseer/server/src/server.rs
@@ -55,6 +55,7 @@ where
 }
 
 /// Returns an instance of a Rocket server.
+#[must_use = "Use with a Client or call launch"]
 pub fn initialize_rocket_server(
     rocket_config: rocket::Config,
     state: OverseerState<SqlRecoveryDb>,


### PR DESCRIPTION
### Motivation
Currently, the fog overseer shuts down soon after being started because the server's `rocket` instance is not kept in scope. This issue was surfaced locally using a local network and on the CD deployment. Fixing this should make overseer run successfully on CD.

Contributes to #1482.

### In this PR
* Keeps the `rocket` instance in scope and calls launch.
