### PR TITLE
DRY up enclave dispatch calls.

### DIFF
--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -32,7 +32,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         deserialize(inbuf).or(Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER))?;
 
     // And actually do it
-    let outdata = match call_details {
+    match call_details {
         // Utility methods
         EnclaveCall::EnclaveInit(peer_self_id, client_self_id, sealed_key, blockchain_config) => {
             serialize(&ENCLAVE.enclave_init(
@@ -41,74 +41,43 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
                 &sealed_key,
                 blockchain_config,
             ))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-        EnclaveCall::GetMinimumFee(token_id) => serialize(&ENCLAVE.get_minimum_fee(&token_id))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
+        EnclaveCall::GetMinimumFee(token_id) => serialize(&ENCLAVE.get_minimum_fee(&token_id)),
         // Node-to-Node Attestation
-        EnclaveCall::PeerInit(node_id) => {
-            serialize(&ENCLAVE.peer_init(&node_id)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-        EnclaveCall::PeerAccept(auth_msg) => {
-            serialize(&ENCLAVE.peer_accept(auth_msg)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::PeerInit(node_id) => serialize(&ENCLAVE.peer_init(&node_id)),
+        EnclaveCall::PeerAccept(auth_msg) => serialize(&ENCLAVE.peer_accept(auth_msg)),
         EnclaveCall::PeerConnect(node_id, auth_msg) => {
             serialize(&ENCLAVE.peer_connect(&node_id, auth_msg))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-        EnclaveCall::PeerClose(session_id) => serialize(&ENCLAVE.peer_close(&session_id))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
+        EnclaveCall::PeerClose(session_id) => serialize(&ENCLAVE.peer_close(&session_id)),
         // Node-to-Client Attestation
-        EnclaveCall::ClientAccept(auth_msg) => serialize(&ENCLAVE.client_accept(auth_msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::ClientClose(channel_id) => serialize(&ENCLAVE.client_close(channel_id))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::ClientDiscardMessage(msg) => serialize(&ENCLAVE.client_discard_message(msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
+        EnclaveCall::ClientAccept(auth_msg) => serialize(&ENCLAVE.client_accept(auth_msg)),
+        EnclaveCall::ClientClose(channel_id) => serialize(&ENCLAVE.client_close(channel_id)),
+        EnclaveCall::ClientDiscardMessage(msg) => serialize(&ENCLAVE.client_discard_message(msg)),
         // Report Caching
-        EnclaveCall::GetIdentity => {
-            serialize(&ENCLAVE.get_identity()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-        EnclaveCall::GetSigner => {
-            serialize(&ENCLAVE.get_signer()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-        EnclaveCall::GetFeeRecipient => {
-            serialize(&ENCLAVE.get_fee_recipient()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-        EnclaveCall::NewEreport(qe_info) => {
-            serialize(&ENCLAVE.new_ereport(qe_info)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::GetIdentity => serialize(&ENCLAVE.get_identity()),
+        EnclaveCall::GetSigner => serialize(&ENCLAVE.get_signer()),
+        EnclaveCall::GetFeeRecipient => serialize(&ENCLAVE.get_fee_recipient()),
+        EnclaveCall::NewEreport(qe_info) => serialize(&ENCLAVE.new_ereport(qe_info)),
         EnclaveCall::VerifyQuote(quote, qe_report) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::GetReport => {
-            serialize(&ENCLAVE.get_ias_report()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
+        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
         // Transactions
-        EnclaveCall::ClientTxPropose(msg) => serialize(&ENCLAVE.client_tx_propose(msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::PeerTxPropose(msg) => {
-            serialize(&ENCLAVE.peer_tx_propose(msg)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::ClientTxPropose(msg) => serialize(&ENCLAVE.client_tx_propose(msg)),
+        EnclaveCall::PeerTxPropose(msg) => serialize(&ENCLAVE.peer_tx_propose(msg)),
         EnclaveCall::TxIsWellFormed(locally_encrypted_tx, block_index, proofs) => {
             serialize(&ENCLAVE.tx_is_well_formed(locally_encrypted_tx, block_index, proofs))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         EnclaveCall::TxsForPeer(txs, aad, peer) => {
             serialize(&ENCLAVE.txs_for_peer(&txs, &aad, &peer))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-
         EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs, root_element) => {
             serialize(&ENCLAVE.form_block(&parent_block, &encrypted_txs_with_proofs, &root_element))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-    };
-
-    Ok(outdata)
+    }
+    .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }
 
 /// The entry point implementation for consensus_enclave_api

--- a/fog/ingest/enclave/trusted/src/lib.rs
+++ b/fog/ingest/enclave/trusted/src/lib.rs
@@ -34,84 +34,37 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         deserialize(inbuf).or(Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER))?;
 
     // And actually do it
-    let outdata = match call_details {
+    match call_details {
         // Utility methods
-        EnclaveCall::EnclaveInit(params) => {
-            serialize(&ENCLAVE.enclave_init(params)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::NewKeys => {
-            serialize(&ENCLAVE.new_keys()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::NewEgressKey => {
-            serialize(&ENCLAVE.new_egress_key()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
+        EnclaveCall::EnclaveInit(params) => serialize(&ENCLAVE.enclave_init(params)),
+        EnclaveCall::NewKeys => serialize(&ENCLAVE.new_keys()),
+        EnclaveCall::NewEgressKey => serialize(&ENCLAVE.new_egress_key()),
         // Public Key for Fog Hints
-        EnclaveCall::GetIngressPubkey => {
-            serialize(&ENCLAVE.get_ingress_pubkey()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
+        EnclaveCall::GetIngressPubkey => serialize(&ENCLAVE.get_ingress_pubkey()),
         EnclaveCall::GetSealedIngressPrivateKey => {
             serialize(&ENCLAVE.get_sealed_ingress_private_key())
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-
         EnclaveCall::GetIngressPrivateKey(peer_session) => {
             serialize(&ENCLAVE.get_ingress_private_key(peer_session))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-
-        EnclaveCall::SetIngressPrivateKey(msg) => serialize(&ENCLAVE.set_ingress_private_key(msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-
+        EnclaveCall::SetIngressPrivateKey(msg) => serialize(&ENCLAVE.set_ingress_private_key(msg)),
         // Public key for rng's
-        EnclaveCall::GetKexRngPubkey => {
-            serialize(&ENCLAVE.get_kex_rng_pubkey()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::IngestTxs(chunk) => {
-            serialize(&ENCLAVE.ingest_txs(chunk)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
+        EnclaveCall::GetKexRngPubkey => serialize(&ENCLAVE.get_kex_rng_pubkey()),
+        EnclaveCall::IngestTxs(chunk) => serialize(&ENCLAVE.ingest_txs(chunk)),
         // Report Caching
-        EnclaveCall::GetIdentity => {
-            serialize(&ENCLAVE.get_identity()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::NewEreport(qe_info) => {
-            serialize(&ENCLAVE.new_ereport(qe_info)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
+        EnclaveCall::GetIdentity => serialize(&ENCLAVE.get_identity()),
+        EnclaveCall::NewEreport(qe_info) => serialize(&ENCLAVE.new_ereport(qe_info)),
         EnclaveCall::VerifyQuote(quote, qe_report) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-
-        EnclaveCall::GetReport => {
-            serialize(&ENCLAVE.get_ias_report()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::PeerInit(peer_id) => {
-            serialize(&ENCLAVE.peer_init(&peer_id)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::PeerAccept(req) => {
-            serialize(&ENCLAVE.peer_accept(req)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-
-        EnclaveCall::PeerConnect(peer_id, msg) => serialize(&ENCLAVE.peer_connect(&peer_id, msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-
-        EnclaveCall::PeerClose(session_id) => serialize(&ENCLAVE.peer_close(&session_id))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-    };
-
-    Ok(outdata)
+        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
+        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
+        EnclaveCall::PeerInit(peer_id) => serialize(&ENCLAVE.peer_init(&peer_id)),
+        EnclaveCall::PeerAccept(req) => serialize(&ENCLAVE.peer_accept(req)),
+        EnclaveCall::PeerConnect(peer_id, msg) => serialize(&ENCLAVE.peer_connect(&peer_id, msg)),
+        EnclaveCall::PeerClose(session_id) => serialize(&ENCLAVE.peer_close(&session_id)),
+    }
+    .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }
 
 /// The entry point implementation for ingest_enclave_api

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -34,52 +34,35 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         deserialize(inbuf).or(Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER))?;
 
     // And actually do it
-    let outdata = match call_details {
+    match call_details {
         // Utility methods
         EnclaveCall::EnclaveInit(self_id, desired_capacity) => {
             serialize(&ENCLAVE.enclave_init(&self_id, desired_capacity))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         // Node-to-Client Attestation
-        EnclaveCall::ClientAccept(auth_msg) => serialize(&ENCLAVE.client_accept(auth_msg))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::ClientClose(channel_id) => serialize(&ENCLAVE.client_close(channel_id))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
+        EnclaveCall::ClientAccept(auth_msg) => serialize(&ENCLAVE.client_accept(auth_msg)),
+        EnclaveCall::ClientClose(channel_id) => serialize(&ENCLAVE.client_close(channel_id)),
         // Report Caching
-        EnclaveCall::GetIdentity => {
-            serialize(&ENCLAVE.get_identity()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
-        EnclaveCall::NewEreport(qe_info) => {
-            serialize(&ENCLAVE.new_ereport(qe_info)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::GetIdentity => serialize(&ENCLAVE.get_identity()),
+        EnclaveCall::NewEreport(qe_info) => serialize(&ENCLAVE.new_ereport(qe_info)),
         EnclaveCall::VerifyQuote(quote, qe_report) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-        EnclaveCall::GetReport => {
-            serialize(&ENCLAVE.get_ias_report()).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
+        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
         // Outputs
-        EnclaveCall::GetOutputs(msg) => {
-            serialize(&ENCLAVE.get_outputs(msg)).or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
-        }
+        EnclaveCall::GetOutputs(msg) => serialize(&ENCLAVE.get_outputs(msg)),
         EnclaveCall::GetOutputsData(resp, client) => {
             serialize(&ENCLAVE.get_outputs_data(resp, client))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         // Check Key image
         EnclaveCall::CheckKeyImages(req, untrusted_keyimagequery_response) => {
             serialize(&ENCLAVE.check_key_images(req, untrusted_keyimagequery_response))
-                .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?
         }
         // Add Key Image Data
-        EnclaveCall::AddKeyImageData(records) => serialize(&ENCLAVE.add_key_image_data(records))
-            .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?,
-    };
-
-    Ok(outdata)
+        EnclaveCall::AddKeyImageData(records) => serialize(&ENCLAVE.add_key_image_data(records)),
+    }
+    .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }
 
 /// The entry point implementation for ledger_enclave_api


### PR DESCRIPTION
### Motivation

Flagged in [our TOB audit report](https://github.com/trailofbits/publications/blob/master/reviews/Mobilecoin.pdf) (page 32).

### In this PR
* Consolidate `.or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))?` statements in the various `ecall_dispatcher` methods, and remove an unnecessary variable.