### PR TITLE
Add Fog Local Network and Test Client to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,6 +451,80 @@ commands:
       - store_artifacts:
           path: /tmp/core_dumps
 
+  # A job that runs the fog-local-network script, building things in release mode
+  # This is the only test in the system that tests that change outputs are spendable.
+  # The test ensures this because fog distro is set to only give one tx out per account,
+  # so the test client eventually is forced to spend change.
+  run-fog-local-network-tests-release:
+    steps:
+      - run:
+          name: fog_local_network
+          command: |
+            # tell the operating system to remove the file size limit on core dump files
+            ulimit -c unlimited
+            openssl genrsa -out Enclave_private.pem -3 3072
+            export CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+
+            cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../Cargo.toml -- --num 10 --fog-report-url 'insecure-fog://localhost:6200'
+            cargo run mc-util-generate-sample-ledger --release -- --txs 10
+
+            SGX_MODE=SW IAS_MODE=DEV \
+            MC_LOG="trace,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
+            GRAFANA_PASSWORD="... (get this from a team member, optional) \"
+            LOGSTASH_HOST="... (get this from a team member, optional)" \
+            LOG_BRANCH=eran-local \
+            LEDGER_BASE=$(pwd)/ledger \
+            IAS_SPID="..." \
+            IAS_API_KEY="..." \
+            python3 ../tools/fog-local-network/fog_local_network.py --network-type dense5
+
+            sleep 10
+
+            cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+
+            SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \
+            INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+                cargo run -p mc-fog-distribution --release -- \
+                --sample-data-dir . \
+                --peer insecure-mc://localhost:3200/ \
+                --peer insecure-mc://localhost:3201/ \
+                --peer insecure-mc://localhost:3202/ \
+                --peer insecure-mc://localhost:3203/ \
+                --peer insecure-mc://localhost:3204/ \
+                --num-tx-to-send 1
+
+            SGX_MODE=SW IAS_MODE=DEV MC_LOG=trace \
+            INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+            CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
+                cargo run -p mc-fog-test-client -- \
+                --consensus insecure-mc://localhost:3200/ \
+                --consensus insecure-mc://localhost:3201/ \
+                --consensus insecure-mc://localhost:3202/ \
+                --consensus insecure-mc://localhost:3203/ \
+                --consensus insecure-mc://localhost:3204/ \
+                --num-clients 4 \
+                --num-transactions 32 \
+                --consensus-wait 300 \
+                --transfer-amount 20 \
+                --fog-view insecure-fog-view://localhost:8200 \
+                --fog-ledger insecure-fog-ledger://localhost:8200 \
+                --key-dir $(pwd)/fog_keys
+      - run:
+          command: |
+            mkdir -p /tmp/core_dumps
+            cp core.* /tmp/core_dumps
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/core_dumps
+
   post-build:
     steps:
       - record-sccache-cache-stats
@@ -583,6 +657,15 @@ jobs:
     steps:
       - prepare-for-build
       - run-fog-conformance-tests-release
+
+  # Run fog conformance tests on a single container
+  run-fog-local-network-tests:
+    executor: build-executor
+    environment:
+      <<: *default-build-environment
+    steps:
+      - prepare-for-build
+      - run-fog-local-network-tests-release
 
   # Build and lint in debug mode
   build-and-lint-debug:
@@ -729,6 +812,10 @@ workflows:
 
       # run fog conformance tests
       - run-fog-conformance-tests:
+          filters: { branches: { ignore: /^deploy\/.*/ } }
+
+      # run fog local network tests
+      - run-fog-local-network-tests:
           filters: { branches: { ignore: /^deploy\/.*/ } }
 
       # Build everything in debug

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,36 +463,28 @@ commands:
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
             openssl genrsa -out Enclave_private.pem -3 3072
+            export SGX_MODE=SW
+            export IAS_MODE=DEV
             export CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
+            export MC_LOG=debug
 
             cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client --release
-            export FOG_AUTHORITY_ROOT=$(target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+            export FOG_AUTHORITY_ROOT=$(./target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
             ./target/release/sample-keys --num 10 --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
             ./target/release/generate-sample-ledger --txs 10
 
-            SGX_MODE=SW IAS_MODE=DEV \
-            MC_LOG="trace,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
-            GRAFANA_PASSWORD="... (get this from a team member, optional) \"
-            LOGSTASH_HOST="... (get this from a team member, optional)" \
-            LOG_BRANCH=eran-local \
+            MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
             LEDGER_BASE=$(pwd)/ledger \
-            IAS_SPID="..." \
-            IAS_API_KEY="..." \
             python3 tools/fog-local-network/fog_local_network.py --network-type dense5
 
             sleep 10
 
             ./target/release/sample-keys --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
-            SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \
-            INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-                ./target/release/fog-distribution \
+            ./target/release/fog-distribution \
                 --sample-data-dir . \
                 --peer insecure-mc://localhost:3200/ \
                 --peer insecure-mc://localhost:3201/ \
@@ -501,12 +493,7 @@ commands:
                 --peer insecure-mc://localhost:3204/ \
                 --num-tx-to-send 1
 
-            SGX_MODE=SW IAS_MODE=DEV MC_LOG=trace \
-            INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-            CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-                ./target/release/test_client \
+            ./target/release/test_client \
                 --consensus insecure-mc://localhost:3200/ \
                 --consensus insecure-mc://localhost:3201/ \
                 --consensus insecure-mc://localhost:3202/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,8 +468,10 @@ commands:
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
 
-            cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --fog-report-url 'insecure-fog://localhost:6200'
-            cargo run mc-util-generate-sample-ledger --release -- --txs 10
+            cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client --release
+            export FOG_AUTHORITY_ROOT="$(target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)"
+            ./target/release/sample-keys --num 10 --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
+            ./target/release/generate-sample-ledger --txs 10
 
             SGX_MODE=SW IAS_MODE=DEV \
             MC_LOG="trace,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
@@ -479,18 +481,18 @@ commands:
             LEDGER_BASE=$(pwd)/ledger \
             IAS_SPID="..." \
             IAS_API_KEY="..." \
-            python3 ../tools/fog-local-network/fog_local_network.py --network-type dense5
+            python3 tools/fog-local-network/fog_local_network.py --network-type dense5
 
             sleep 10
 
-            cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+            ./target/release/sample-keys --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
             SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \
             INGEST_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
             LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
             VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
             CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-                cargo run -p mc-fog-distribution --release -- \
+                ./target/release/fog-distribution \
                 --sample-data-dir . \
                 --peer insecure-mc://localhost:3200/ \
                 --peer insecure-mc://localhost:3201/ \
@@ -504,7 +506,7 @@ commands:
             LEDGER_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
             VIEW_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
             CONSENSUS_ENCLAVE_PRIVKEY=$(pwd)/../Enclave_private.pem \
-                cargo run -p mc-fog-test-client -- \
+                ./target/release/test_client \
                 --consensus insecure-mc://localhost:3200/ \
                 --consensus insecure-mc://localhost:3201/ \
                 --consensus insecure-mc://localhost:3202/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ commands:
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
 
-            cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../Cargo.toml -- --num 10 --fog-report-url 'insecure-fog://localhost:6200'
+            cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --fog-report-url 'insecure-fog://localhost:6200'
             cargo run mc-util-generate-sample-ledger --release -- --txs 10
 
             SGX_MODE=SW IAS_MODE=DEV \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,7 +469,7 @@ commands:
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
 
             cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client --release
-            export FOG_AUTHORITY_ROOT="$(target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)"
+            export FOG_AUTHORITY_ROOT=$(target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
             ./target/release/sample-keys --num 10 --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
             ./target/release/generate-sample-ledger --txs 10
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -480,7 +480,7 @@ commands:
             LEDGER_BASE=$(pwd)/ledger \
             python3 tools/fog-local-network/fog_local_network.py --network-type dense5 --skip-build &
 
-            sleep 10
+            sleep 20
 
             ./target/release/sample-keys --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
@@ -494,7 +494,7 @@ commands:
                 --peer insecure-mc://localhost:3204/ \
                 --num-tx-to-send 10
 
-            sleep 5
+            sleep 20
 
             ./target/release/test_client \
                 --consensus insecure-mc://localhost:3200/ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,7 +469,7 @@ commands:
             export INGEST_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export LEDGER_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
-            export MC_LOG=debug
+            export MC_LOG=trace
 
             cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client -p mc-fog-ingest-server -p mc-fog-ingest-client -p mc-fog-view-server -p mc-fog-report-server -p mc-fog-ledger-server -p mc-fog-sql-recovery-db --release
             export FOG_AUTHORITY_ROOT=$(./target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,27 +471,30 @@ commands:
             export VIEW_ENCLAVE_PRIVKEY=$(pwd)/Enclave_private.pem
             export MC_LOG=debug
 
-            cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client --release
+            cargo build -p mc-util-keyfile -p mc-util-generate-sample-ledger -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-fog-distribution -p mc-fog-test-client -p mc-fog-ingest-server -p mc-fog-ingest-client -p mc-fog-view-server -p mc-fog-report-server -p mc-fog-ledger-server -p mc-fog-sql-recovery-db --release
             export FOG_AUTHORITY_ROOT=$(./target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
-            ./target/release/sample-keys --num 10 --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
-            ./target/release/generate-sample-ledger --txs 10
+            ./target/release/sample-keys --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+            ./target/release/generate-sample-ledger --txs 100
 
-            MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
+            MC_LOG="info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
             LEDGER_BASE=$(pwd)/ledger \
-            python3 tools/fog-local-network/fog_local_network.py --network-type dense5
+            python3 tools/fog-local-network/fog_local_network.py --network-type dense5 --skip-build &
 
             sleep 10
 
-            ./target/release/sample-keys --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
+            ./target/release/sample-keys --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
             ./target/release/fog-distribution \
                 --sample-data-dir . \
+                --max-threads 1 \
                 --peer insecure-mc://localhost:3200/ \
                 --peer insecure-mc://localhost:3201/ \
                 --peer insecure-mc://localhost:3202/ \
                 --peer insecure-mc://localhost:3203/ \
                 --peer insecure-mc://localhost:3204/ \
-                --num-tx-to-send 1
+                --num-tx-to-send 10
+
+            sleep 5
 
             ./target/release/test_client \
                 --consensus insecure-mc://localhost:3200/ \
@@ -500,7 +503,7 @@ commands:
                 --consensus insecure-mc://localhost:3203/ \
                 --consensus insecure-mc://localhost:3204/ \
                 --num-clients 4 \
-                --num-transactions 32 \
+                --num-transactions 200 \
                 --consensus-wait 300 \
                 --transfer-amount 20 \
                 --fog-view insecure-fog-view://localhost:8200 \

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -517,6 +517,15 @@ fn submit_tx(
                             "Transaction {:?} could not be submitted before tombstone block passed, giving up", counter);
                     return false;
                 }
+                if let ConnectionError::TransactionValidation(
+                    TransactionValidationError::ContainsSpentKeyImage,
+                ) = error
+                {
+                    log::info!(
+                            logger,
+                            "Transaction {:?} contains a spent key image. Moving to next transaction", counter);
+                    return true;
+                }
 
                 log::warn!(
                     logger,

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -507,7 +507,7 @@ fn submit_tx(
                 BLOCK_HEIGHT.fetch_max(block_height, Ordering::SeqCst);
                 return true;
             }
-            Err(RetryError::Operation { error, .. }) => {
+            Err(RetryError::Operation { error, total_delay, tries }) => {
                 if let ConnectionError::TransactionValidation(
                     TransactionValidationError::TombstoneBlockExceeded,
                 ) = error
@@ -520,12 +520,14 @@ fn submit_tx(
 
                 log::warn!(
                     logger,
-                    "Failed to submit transaction {:?} to node {} (attempt {} / {}): {}",
+                    "Failed to submit transaction {:?} to node {} (attempt {} / {}): {}. Total Delay: {:?}. Retry Crate 'tries': {}.",
                     counter,
                     conn,
                     i,
                     max_retries,
-                    error
+                    error,
+                    total_delay,
+                    tries
                 );
                 thread::sleep(retry_sleep_duration);
             }

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -507,7 +507,11 @@ fn submit_tx(
                 BLOCK_HEIGHT.fetch_max(block_height, Ordering::SeqCst);
                 return true;
             }
-            Err(RetryError::Operation { error, total_delay, tries }) => {
+            Err(RetryError::Operation {
+                error,
+                total_delay,
+                tries,
+            }) => {
                 if let ConnectionError::TransactionValidation(
                     TransactionValidationError::TombstoneBlockExceeded,
                 ) = error
@@ -522,8 +526,10 @@ fn submit_tx(
                 ) = error
                 {
                     log::info!(
-                            logger,
-                            "Transaction {:?} contains a spent key image. Moving to next transaction", counter);
+                        logger,
+                        "Transaction {:?} contains a spent key image. Moving to next transaction",
+                        counter
+                    );
                     return true;
                 }
 

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -224,7 +224,7 @@ impl TestClient {
         &self,
         source_client: &mut Client,
         target_client: &mut Client,
-    ) -> Result<(Tx, u64), TestClientError> {
+    ) -> Result<(Tx, u64, u64), TestClientError> {
         self.tx_info.clear();
         let target_address = target_client.get_account_key().default_subaddress();
         log::debug!(
@@ -269,7 +269,7 @@ impl TestClient {
             block_count
         };
         self.tx_info.set_tx_propose_block_count(block_count);
-        Ok((transaction, block_count))
+        Ok((transaction, block_count, fee))
     }
 
     /// Waits for a transaction to be accepted by the network
@@ -496,9 +496,8 @@ impl TestClient {
             },
         )?;
 
-        let fee = source_client_lk.get_fee().unwrap_or(Mob::MINIMUM_FEE);
         let transfer_start = std::time::SystemTime::now();
-        let (transaction, block_count) =
+        let (transaction, block_count, fee) =
             self.transfer(&mut source_client_lk, &mut target_client_lk)?;
 
         let mut span = block_span_builder(&tracer, "test_iteration", block_count)

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -220,6 +220,11 @@ impl TestClient {
     /// to.
     ///
     /// This only builds and submits the transaction, it does not confirm it
+    ///
+    /// Returns:
+    ///  * Tx: the transaction that represents the transfer.
+    ///  * u64: the block count at which the transaction was submitted.
+    ///  * u64: the fee associated with the transaction.
     fn transfer(
         &self,
         source_client: &mut Client,

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -622,10 +622,6 @@ impl TestClient {
 
         let start_time = Instant::now();
         for ti in 0..num_transactions {
-            // FIXME: Should not be needed
-            log::debug!(self.logger, "sleeping");
-            std::thread::sleep(Duration::from_millis(5000));
-
             log::debug!(self.logger, "Transation: {:?}", ti);
 
             let source_index = ti % client_count;
@@ -639,10 +635,6 @@ impl TestClient {
                 target_client,
                 target_index,
             )?;
-
-            // FIXME: Should not be needed
-            log::debug!(self.logger, "sleeping");
-            std::thread::sleep(Duration::from_millis(5000));
 
             // Attempt double spend on the last transaction. This is an expensive test.
             if ti == num_transactions - 1 {

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -65,6 +65,16 @@ pub struct TestClientPolicy {
     pub test_rth_memos: bool,
 }
 
+/// Data associated with a test client transfer.
+struct TransferData {
+    /// The transaction that represents the transfer.
+    transaction: Tx,
+    /// The block count at which the transaction was submitted.
+    block_count: u64,
+    /// The fee associated with the transaction.
+    fee: u64,
+}
+
 impl Default for TestClientPolicy {
     fn default() -> Self {
         Self {
@@ -222,14 +232,11 @@ impl TestClient {
     /// This only builds and submits the transaction, it does not confirm it
     ///
     /// Returns:
-    ///  * Tx: the transaction that represents the transfer.
-    ///  * u64: the block count at which the transaction was submitted.
-    ///  * u64: the fee associated with the transaction.
     fn transfer(
         &self,
         source_client: &mut Client,
         target_client: &mut Client,
-    ) -> Result<(Tx, u64, u64), TestClientError> {
+    ) -> Result<TransferData, TestClientError> {
         self.tx_info.clear();
         let target_address = target_client.get_account_key().default_subaddress();
         log::debug!(
@@ -274,7 +281,11 @@ impl TestClient {
             block_count
         };
         self.tx_info.set_tx_propose_block_count(block_count);
-        Ok((transaction, block_count, fee))
+        Ok(TransferData {
+            transaction,
+            block_count,
+            fee,
+        })
     }
 
     /// Waits for a transaction to be accepted by the network
@@ -502,13 +513,13 @@ impl TestClient {
         )?;
 
         let transfer_start = std::time::SystemTime::now();
-        let (transaction, block_count, fee) =
+        let  transfer_data =
             self.transfer(&mut source_client_lk, &mut target_client_lk)?;
 
-        let mut span = block_span_builder(&tracer, "test_iteration", block_count)
+        let mut span = block_span_builder(&tracer, "test_iteration", transfer_data.block_count)
             .with_start_time(transfer_start)
             .start(&tracer);
-        span.set_attribute(TELEMETRY_BLOCK_INDEX_KEY.i64(block_count as i64));
+        span.set_attribute(TELEMETRY_BLOCK_INDEX_KEY.i64(transfer_data.block_count as i64));
         let _active = mark_span_as_active(span);
 
         let start = Instant::now();
@@ -528,7 +539,7 @@ impl TestClient {
 
         // Wait for key images to land in ledger server
         let transaction_appeared =
-            self.ensure_transaction_is_accepted(&mut source_client_lk, &transaction)?;
+            self.ensure_transaction_is_accepted(&mut source_client_lk, &transfer_data.transaction)?;
 
         counters::TX_CONFIRMED_TIME.observe(start.elapsed().as_secs_f64());
 
@@ -542,7 +553,7 @@ impl TestClient {
             self.ensure_expected_balance_after_block(
                 &mut source_client_lk,
                 transaction_appeared,
-                src_balance - self.policy.transfer_amount - fee,
+                src_balance - self.policy.transfer_amount - transfer_data.fee,
             )
         })?;
 
@@ -558,16 +569,16 @@ impl TestClient {
                 match source_client_lk.get_last_memo() {
                     Ok(Some(memo)) => match memo {
                         MemoType::Destination(memo) => {
-                            if memo.get_total_outlay() != self.policy.transfer_amount + fee {
-                                log::error!(self.logger, "Destination memo had wrong total outlay, found {}, expected {}. Tx Info: {}", memo.get_total_outlay(), self.policy.transfer_amount + fee, self.tx_info);
+                            if memo.get_total_outlay() != self.policy.transfer_amount + transfer_data.fee {
+                                log::error!(self.logger, "Destination memo had wrong total outlay, found {}, expected {}. Tx Info: {}", memo.get_total_outlay(), self.policy.transfer_amount + transfer_data.fee, self.tx_info);
                                 return Err(TestClientError::UnexpectedMemo);
                             }
-                            if memo.get_fee() != fee {
+                            if memo.get_fee() != transfer_data.fee {
                                 log::error!(
                                     self.logger,
                                     "Destination memo had wrong fee, found {}, expected {}. Tx Info: {}",
                                     memo.get_fee(),
-                                    fee,
+                                    transfer_data.fee,
                                     self.tx_info
                                 );
                                 return Err(TestClientError::UnexpectedMemo);
@@ -610,7 +621,7 @@ impl TestClient {
                 }
             }
         }
-        Ok(transaction)
+        Ok(transfer_data.transaction)
     }
 
     /// Run a test that lasts a fixed duration and fails fast on an error

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -513,8 +513,7 @@ impl TestClient {
         )?;
 
         let transfer_start = std::time::SystemTime::now();
-        let  transfer_data =
-            self.transfer(&mut source_client_lk, &mut target_client_lk)?;
+        let transfer_data = self.transfer(&mut source_client_lk, &mut target_client_lk)?;
 
         let mut span = block_span_builder(&tracer, "test_iteration", transfer_data.block_count)
             .with_start_time(transfer_start)
@@ -569,7 +568,9 @@ impl TestClient {
                 match source_client_lk.get_last_memo() {
                     Ok(Some(memo)) => match memo {
                         MemoType::Destination(memo) => {
-                            if memo.get_total_outlay() != self.policy.transfer_amount + transfer_data.fee {
+                            if memo.get_total_outlay()
+                                != self.policy.transfer_amount + transfer_data.fee
+                            {
                                 log::error!(self.logger, "Destination memo had wrong total outlay, found {}, expected {}. Tx Info: {}", memo.get_total_outlay(), self.policy.transfer_amount + transfer_data.fee, self.tx_info);
                                 return Err(TestClientError::UnexpectedMemo);
                             }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -623,6 +623,10 @@ impl TestClient {
 
         let start_time = Instant::now();
         for ti in 0..num_transactions {
+            // FIXME: Should not be needed
+            log::debug!(self.logger, "sleeping");
+            std::thread::sleep(Duration::from_millis(5000));
+
             log::debug!(self.logger, "Transation: {:?}", ti);
 
             let source_index = ti % client_count;
@@ -636,6 +640,10 @@ impl TestClient {
                 target_client,
                 target_index,
             )?;
+
+            // FIXME: Should not be needed
+            log::debug!(self.logger, "sleeping");
+            std::thread::sleep(Duration::from_millis(5000));
 
             // Attempt double spend on the last transaction. This is an expensive test.
             if ti == num_transactions - 1 {

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -23,7 +23,7 @@ In order to use it, the following steps are necessary.
 
 2) Generating a set of sample keys:
     ```
-    cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../Cargo.toml -- --num 1000 --fog-report-url 'insecure-fog://localhost:6200'
+    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 1000
     ```
 
     Some important things to note:
@@ -33,7 +33,7 @@ In order to use it, the following steps are necessary.
 
 3) Bootstrap a ledger:
     ```
-    cargo run --manifest-path ../util/generate-sample-ledger/Cargo.toml --release -- --txs 100
+    cargo run mc-util-generate-sample-ledger --release -- --txs 100
     ```
 
 4) Start a local network, for example:
@@ -58,7 +58,7 @@ In order to use it, the following steps are necessary.
     # Create a set of target keys. They would be identical to the first N keys inside `keys/`. This is needed if you don't
     # want to send to transactions to all 1000 keys created at step 1.
     # Notice the addition of the --output-dir argument
-    cargo run -p mc-util-keyfile --bin sample-keys --release --manifest-path ../Cargo.toml -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
 
     # Run the distribution script. This takes awhile and you should see transactions going through by looking at the logs.
     SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -134,18 +134,17 @@ class FogNetwork(Network):
         result = subprocess.check_output(cmd, shell=True)
 
     def stop(self):
-        if self.fog_ledger:
+        if hasattr(self, "fog_ledger"):
             self.fog_ledger.stop()
 
-        if self.fog_report:
+        if hasattr(self, "fog_report"):
             self.fog_report.stop()
 
-        if self.fog_view:
+        if hasattr(self, "fog_view"):
             self.fog_view.stop()
 
-        if self.fog_ingest:
+        if hasattr(self, "fog_ingest"):
             self.fog_ingest.stop()
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -152,7 +152,7 @@ class Node:
         self.admin_http_gateway_port = admin_http_gateway_port
         self.peers = peers
         self.quorum_set = quorum_set
-        self.minimum_fee = 10_000_000_000
+        self.minimum_fee = 400_000_000
 
         self.consensus_process = None
         self.ledger_distribution_process = None

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -25,8 +25,8 @@ MOBILECOIND_PORT = 4444
 
 # TODO make these command line arguments
 LEDGER_BASE = os.path.abspath(os.getenv('LEDGER_BASE'))
-IAS_API_KEY = os.getenv('IAS_API_KEY')
-IAS_SPID = os.getenv('IAS_SPID')
+IAS_API_KEY = os.getenv('IAS_API_KEY', default='0'*64) # 32 bytes
+IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 MOB_RELEASE = os.getenv('MOB_RELEASE', '1')
 CARGO_FLAGS = '--release'
@@ -433,7 +433,7 @@ class Network:
             )
 
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-slam -p mc-crypto-x509-test-vectors {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors {CARGO_FLAGS}',
             shell=True,
             check=True,
         )


### PR DESCRIPTION
### Motivation
As Chris wrote in the previous PR (#1173): 
This adds fog local network to CI, with fog distro using very few transactions. The point is to get test coverage that ensures that test client is able to spend change outputs.

Fixes #1572 

## In this PR
- Fixes previous issue with Fog Test Client. The local_network.py script used the old network fee of 10,000,000,000. The test client gets the fee from consensus, but when it failed to retrieve the fee it defaulted to the new network fee of 40,000,000.
- This manifested as an incorrect balance because the amount used for the expected balance used the new fee while the actual transaction used the old fee. This occurred because the fee was getting retrieved in two places. I fixed this by reusing the fee from the transaction in the balance check.
- I also had to update the old network fee to the new network fee because the test client would use the new fee if it couldn't get the fee from consensus, Then consensus would reject the transaction because the fee (40,000,000) was too low (< 10,000,000,000).

### Future Work
- Modify the Fog Local network README to describe how to run the network using  `./mob prompt`.