### PR TITLE
Make Fog Overseer disabled on start up

### DIFF
--- a/fog/overseer/server/src/service.rs
+++ b/fog/overseer/server/src/service.rs
@@ -61,7 +61,7 @@ where
             logger,
             overseer_worker: None,
             recovery_db,
-            is_enabled: Arc::new(AtomicBool::new(true)),
+            is_enabled: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -107,6 +107,7 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
             .unwrap();
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
+    client.post("/enable").dispatch();
 
     // Give overseer time to perform its logic.
     std::thread::sleep(Duration::from_secs(10));

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -126,6 +126,7 @@ fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_an
             .unwrap();
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
+    client.post("/enable").dispatch();
 
     // Add 11 test blocks.
     for _ in 0..11 {

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -133,6 +133,7 @@ fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_
             .unwrap();
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
+    client.post("/enable").dispatch();
 
     // Add 11 test blocks.
     for _ in 0..11 {

--- a/fog/overseer/server/tests/one_active_node.rs
+++ b/fog/overseer/server/tests/one_active_node.rs
@@ -111,7 +111,7 @@ fn one_active_node_cluster_state_does_not_change(logger: Logger) {
     let overseer_state = OverseerState { overseer_service };
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
-    let _req = client.post("/arm");
+    let _req = client.post("/enable").dispatch();
 
     // Give Overseer time to perform logic
     std::thread::sleep(Duration::from_millis(5000));

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -111,6 +111,7 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
             .unwrap();
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
+    client.post("/enable").dispatch();
 
     // Give overseer time to perform its logic.
     std::thread::sleep(Duration::from_secs(10));

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -133,7 +133,7 @@ fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_
             .unwrap();
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
-    let _req = client.post("/arm");
+    let _req = client.post("/enable").dispatch();
 
     // Retire the current active node.
     node0.retire().unwrap();

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -132,7 +132,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
     let overseer_state = OverseerState { overseer_service };
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
     let client = Client::new(rocket).expect("valid rocket instance");
-    let _req = client.post("/arm");
+    let _req = client.post("/enable").dispatch();
 
     // Retire the current active node.
     node0.retire().unwrap();
@@ -144,7 +144,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
     }
     // Process the next block to make sure that the node gets retired
     // Give Overseer time to perform logic
-    std::thread::sleep(Duration::from_secs(25));
+    std::thread::sleep(Duration::from_secs(60));
 
     // Fog Overseer should have activated any node.
     assert!(node0.is_active() || node1.is_active() || node2.is_active());


### PR DESCRIPTION
### Motivation

Previously, Fog Overseer started up in the "enabled" state, which means that it monitors the Fog Ingest cluster for incorrect state. This was an issue because Overseer was started right when Fog Ingest started, and the ingest nodes didn't have time to activate. In this state, where no active nodes exist, Overseer initiated automatic failover, which is not desirable because ingest node was in the process of activating.

### In this PR
* Starts Fog Overseer in the disabled state. The new deployment flow will involve activating Overseer after the Fog Ingest cluster has reached the active state.
