### PR TITLE
Store mint-related transations in LedgerDb

### DIFF
--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -50,6 +50,12 @@ message BlockContents {
 
     // Outputs created in this block.
     repeated external.TxOut outputs = 2;
+
+    /// Set-mint-config transactions in this block.
+    repeated external.SetMintConfigTx set_mint_config_txs = 3;
+
+    /// Mint transactions in this block.
+    repeated external.MintTx mint_txs = 4;
 }
 
 message BlockSignature {

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -146,7 +146,11 @@ mod tests {
                 .map(|block| block.id.clone())
                 .unwrap_or_else(|| BlockID::try_from(&[1u8; 32][..]).unwrap());
 
-            let block_contents = BlockContents::new(vec![key_image.clone()], vec![tx_out.clone()]);
+            let block_contents = BlockContents {
+                key_images: vec![key_image.clone()],
+                outputs: vec![tx_out.clone()],
+                ..Default::default()
+            };
             let block = Block::new(
                 BlockVersion::ONE,
                 &parent_block_id,

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -67,11 +67,13 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
             .map(MintTx::try_from)
             .collect::<Result<_, _>>()?;
 
-        Ok(BlockContents::new(
+        // We purposefully do not ..Default::default() here so that new fields are not
+        // missed.
+        Ok(BlockContents {
             key_images,
             outputs,
             set_mint_config_txs,
             mint_txs,
-        ))
+        })
     }
 }

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -41,13 +41,13 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
     type Error = ConversionError;
 
     fn try_from(source: &blockchain::BlockContents) -> Result<Self, Self::Error> {
-        let key_images: Vec<KeyImage> = source
+        let key_images = source
             .get_key_images()
             .iter()
             .map(KeyImage::try_from)
             .collect::<Result<_, _>>()?;
 
-        let outputs: Vec<TxOut> = source
+        let outputs = source
             .get_outputs()
             .iter()
             .map(TxOut::try_from)

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -14,27 +14,26 @@ impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {
     fn from(source: &mc_transaction_core::BlockContents) -> Self {
         let mut block_contents = blockchain::BlockContents::new();
 
-        let key_images: Vec<external::KeyImage> = source
+        let key_images = source
             .key_images
             .iter()
             .map(external::KeyImage::from)
             .collect();
 
-        let outputs: Vec<external::TxOut> =
-            source.outputs.iter().map(external::TxOut::from).collect();
+        let outputs = source.outputs.iter().map(external::TxOut::from).collect();
 
-        let set_mint_config_txs: Vec<_> = source
+        let set_mint_config_txs = source
             .set_mint_config_txs
             .iter()
             .map(external::SetMintConfigTx::from)
             .collect();
 
-        let mint_txs: Vec<_> = source.mint_txs.iter().map(external::MintTx::from).collect();
+        let mint_txs = source.mint_txs.iter().map(external::MintTx::from).collect();
 
-        block_contents.set_key_images(RepeatedField::from_vec(key_images));
-        block_contents.set_outputs(RepeatedField::from_vec(outputs));
-        block_contents.set_set_mint_config_txs(RepeatedField::from_vec(set_mint_config_txs));
-        block_contents.set_mint_txs(RepeatedField::from_vec(mint_txs));
+        block_contents.set_key_images(key_images);
+        block_contents.set_outputs(outputs);
+        block_contents.set_set_mint_config_txs(set_mint_config_txs);
+        block_contents.set_mint_txs(mint_txs);
         block_contents
     }
 }

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -7,7 +7,6 @@ use mc_transaction_core::{
     tx::TxOut,
     BlockContents,
 };
-use protobuf::RepeatedField;
 use std::convert::TryFrom;
 
 impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -601,7 +601,12 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // key images.
         outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
         key_images.sort();
-        let block_contents = BlockContents::new(key_images, outputs);
+
+        // Right now set-mint-config-txs and mint-txs are not actually created anywhere.
+        let set_mint_config_txs = Vec::new();
+        let mint_txs = Vec::new();
+
+        let block_contents = BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
 
         // Form the block.
         let block = Block::new_with_parent(

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -606,8 +606,15 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let set_mint_config_txs = Vec::new();
         let mint_txs = Vec::new();
 
-        let block_contents = BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
-
+        // We purposefully do not ..Default::default() here so that new block fields
+        // show up as a compilation error until addressed.
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            set_mint_config_txs,
+            mint_txs,
+        };
+        //
         // Form the block.
         let block = Block::new_with_parent(
             config.block_version,

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -267,7 +267,11 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             outputs.extend(tx.prefix.outputs.into_iter());
         }
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         let block = Block::new_with_parent(
             block_version,

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -784,7 +784,7 @@ mod tests {
 
         let mut mock_enclave = MockConsensusEnclave::new();
         let expected_block = Block::new_origin_block(&vec![]);
-        let expected_block_contents = BlockContents::new(vec![], vec![]);
+        let expected_block_contents = BlockContents::default();
         // The enclave does not set the signed_at field.
         let expected_block_signature =
             BlockSignature::new(Ed25519Signature::default(), Ed25519Public::default(), 0);

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -117,7 +117,11 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
 
     let key_images = vec![KeyImage::from(rng.next_u64())];
 
-    let block_contents = BlockContents::new(key_images, random_output(rng));
+    let block_contents = BlockContents {
+        key_images,
+        outputs: random_output(rng),
+        ..Default::default()
+    };
 
     // Fake proofs
     let root_element = TxOutMembershipElement {

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -237,6 +237,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger
@@ -450,6 +451,7 @@ fn three_node_cluster_fencing(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -796,7 +796,11 @@ fn add_block_to_ledger_db(
         })
         .collect();
 
-    let block_contents = BlockContents::new(key_images.to_vec(), outputs.clone());
+    let block_contents = BlockContents {
+        key_images: key_images.to_vec(),
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let num_blocks = ledger_db.num_blocks().expect("failed to get block height");
 

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -13,7 +13,6 @@ use mc_fog_ledger_enclave_api::{KeyImageData, UntrustedKeyImageQueryResponse};
 use mc_ledger_db::{ActiveMintConfig, Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockSignature, TokenId,

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -192,8 +192,4 @@ impl Ledger for MockLedger {
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
         unimplemented!()
     }
-
-    fn update_total_minted(&self, _mint_config: &MintConfig, _amount: u64) -> Result<(), Error> {
-        unimplemented!()
-    }
 }

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -13,7 +13,7 @@ use mc_fog_ledger_enclave_api::{KeyImageData, UntrustedKeyImageQueryResponse};
 use mc_ledger_db::{ActiveMintConfig, Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockSignature, TokenId,
@@ -186,10 +186,6 @@ impl Ledger for MockLedger {
     }
 
     fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
-        unimplemented!()
-    }
-
-    fn set_active_mint_configs(&self, _set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error> {
         unimplemented!()
     }
 

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -43,6 +43,7 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -60,6 +60,7 @@ fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_an
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -60,6 +60,7 @@ fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -47,6 +47,7 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -60,6 +60,7 @@ fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -58,6 +58,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -122,7 +122,11 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
 
     let key_images = vec![KeyImage::from(rng.next_u64())];
 
-    let block_contents = BlockContents::new(key_images, random_output(rng));
+    let block_contents = BlockContents {
+        key_images,
+        outputs: random_output(rng),
+        ..Default::default()
+    };
 
     // Fake proofs
     let root_element = TxOutMembershipElement {

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -189,7 +189,11 @@ fn main() {
             .get_block(num_blocks - 1)
             .expect("Could not get last block");
 
-        let block_contents = BlockContents::new(key_images_to_burn, tx_outs);
+        let block_contents = BlockContents {
+            key_images: key_images_to_burn,
+            outputs: tx_outs,
+            ..Default::default()
+        };
 
         // Fake proofs
         let root_element = TxOutMembershipElement {

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -140,11 +140,18 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
     // Make them into a block, and ingest it. This is done by appending a block to
     // the ledger and having it be polled by ingest.
     let (block, block_contents) = if block_index == 0 {
-        let block_contents = BlockContents::new(vec![], txos.clone());
+        let block_contents = BlockContents {
+            outputs: txos.clone(),
+            ..Default::default()
+        };
         let block = Block::new_origin_block(&txos);
         (block, block_contents)
     } else {
-        let block_contents = BlockContents::new(vec![KeyImage::from(block_index)], txos);
+        let block_contents = BlockContents {
+            key_images: vec![KeyImage::from(block_index)],
+            outputs: txos,
+            ..Default::default()
+        };
         let parent_block = ledger_db
             .get_block(block_index - 1)
             .unwrap_or_else(|err| panic!("Failed getting block {}: {:?}", block_index - 1, err));

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -72,6 +72,12 @@ pub enum Error {
 
     /// Total minted amount cannot decrease: {0} < {1}
     TotalMintedAmountCannotDecrease(u64, u64),
+
+    /// DuplicateMintTx
+    DuplicateMintTx,
+
+    /// DuplicateSetMintConfigTx
+    DuplicateSetMintConfigTx,
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     /// NoOutputs
     NoOutputs,
 
+    /// TooFewOutputs
+    TooFewOutputs,
+
     /// LMDB error, may mean database is opened multiple times in a process.
     BadRslot,
 

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -4,7 +4,7 @@ use crate::{mint_config_store::ActiveMintConfig, Error};
 use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockIndex, BlockSignature, TokenId,
@@ -91,10 +91,6 @@ pub trait Ledger: Send {
         }
         self.get_block(num_blocks - 1)
     }
-
-    /// Set active mint configurations for a given token id, based on a
-    /// set-mint-config transaction.
-    fn set_active_mint_configs(&self, set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error>;
 
     /// Get active mint configurations for a given token id.
     /// Returns an empty array of no mint configurations are active for the

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -4,7 +4,6 @@ use crate::{mint_config_store::ActiveMintConfig, Error};
 use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockIndex, BlockSignature, TokenId,
@@ -96,7 +95,4 @@ pub trait Ledger: Send {
     /// Returns an empty array of no mint configurations are active for the
     /// given token id.
     fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
-
-    /// Update the total minted amount for a given MintConfig.
-    fn update_total_minted(&self, mint_config: &MintConfig, amount: u64) -> Result<(), Error>;
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -52,7 +52,7 @@ pub use mint_tx_store::MintTxStore;
 pub use tx_out_store::TxOutStore;
 
 pub const MAX_LMDB_FILE_SIZE: usize = 2usize.pow(40); // 1 TB
-pub const MAX_LMDB_DATABASES: u32 = 27; // maximum number of databases in the lmdb file
+pub const MAX_LMDB_DATABASES: u32 = 29; // maximum number of databases in the lmdb file
 
 // LMDB Database names.
 pub const COUNTS_DB_NAME: &str = "ledger_db:counts";

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -952,7 +952,12 @@ mod ledger_db_test {
             } else {
                 vec![]
             };
-            let block_contents = BlockContents::new(key_images, outputs.clone());
+
+            let block_contents = BlockContents {
+                key_images,
+                outputs: outputs.clone(),
+                ..Default::default()
+            };
 
             let block = match parent_block {
                 None => Block::new_origin_block(&outputs),
@@ -1001,7 +1006,10 @@ mod ledger_db_test {
 
         let outputs = vec![output];
         let block = Block::new_origin_block(&outputs);
-        let block_contents = BlockContents::new(vec![], outputs);
+        let block_contents = BlockContents {
+            outputs,
+            ..Default::default()
+        };
 
         (block, block_contents)
     }
@@ -1059,7 +1067,11 @@ mod ledger_db_test {
 
         let key_images: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BLOCK_VERSION,
             &origin_block,
@@ -1138,9 +1150,10 @@ mod ledger_db_test {
             })
             .collect();
 
-        let key_images = Vec::new();
-
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BLOCK_VERSION,
             &origin_block,
@@ -1299,7 +1312,11 @@ mod ledger_db_test {
         .unwrap();
         let outputs = vec![tx_out];
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BlockVersion::ONE,
             &origin_block,
@@ -1344,7 +1361,11 @@ mod ledger_db_test {
         .unwrap();
         let outputs = vec![tx_out];
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
         let block = Block::new_with_parent(
             BlockVersion::ONE,
@@ -1381,9 +1402,11 @@ mod ledger_db_test {
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let outputs = Vec::new();
-
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BlockVersion::ONE,
             &origin_block,
@@ -1465,7 +1488,11 @@ mod ledger_db_test {
                 let key_images: Vec<KeyImage> =
                     (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-                let block_contents = BlockContents::new(key_images.clone(), outputs);
+                let block_contents = BlockContents {
+                    key_images,
+                    outputs,
+                    ..Default::default()
+                };
                 last_block = Block::new_with_parent(
                     block_version,
                     &last_block,
@@ -1509,7 +1536,11 @@ mod ledger_db_test {
             let key_images: Vec<KeyImage> =
                 (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-            let block_contents = BlockContents::new(key_images.clone(), outputs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
             assert_eq!(last_block.version, *MAX_BLOCK_VERSION);
 
             // Note: unsafe transmute is being used to skirt the invariant that BlockVersion
@@ -1562,7 +1593,11 @@ mod ledger_db_test {
         .unwrap();
 
         let outputs = vec![tx_out];
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         // Appending a block to a previously written location should fail.
         let mut new_block = Block::new(
@@ -1618,7 +1653,11 @@ mod ledger_db_test {
             )
             .unwrap();
             let outputs = vec![tx_out];
-            BlockContents::new(block_one_key_images.clone(), outputs)
+            BlockContents {
+                key_images: block_one_key_images.clone(),
+                outputs,
+                ..Default::default()
+            };
         };
 
         let block_one = Block::new_with_parent(
@@ -1642,7 +1681,11 @@ mod ledger_db_test {
             )
             .unwrap();
             let outputs = vec![tx_out];
-            BlockContents::new(block_one_key_images.clone(), outputs)
+            BlockContents {
+                key_images: block_one_key_images.clone(),
+                outputs,
+                ..Default::default()
+            };
         };
 
         let block_two = Block::new_with_parent(
@@ -1687,7 +1730,12 @@ mod ledger_db_test {
             .unwrap();
             tx_out.public_key = existing_tx_out.public_key.clone();
             let outputs = vec![tx_out];
-            BlockContents::new(vec![KeyImage::from(rng.next_u64())], outputs)
+            let key_images = vec![KeyImage::from(rng.next_u64())];
+            BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            }
         };
 
         let block_one = Block::new_with_parent(
@@ -1748,7 +1796,12 @@ mod ledger_db_test {
             .unwrap();
 
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let block_contents = BlockContents::new(key_images, vec![tx_out]);
+            let outputs = vec![tx_out];
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             let bytes = [14u8; 32];
             let bad_parent_id = BlockID::try_from(&bytes[..]).unwrap();

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -26,7 +26,7 @@ use mc_common::logger::global_log;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     membership_proofs::Range,
-    mint::{MintConfig, MintTx, SetMintConfigTx},
+    mint::{MintTx, SetMintConfigTx},
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, TokenId, MAX_BLOCK_VERSION,
@@ -417,14 +417,6 @@ impl Ledger for LedgerDB {
         let db_transaction = self.env.begin_ro_txn()?;
         self.mint_config_store
             .get_active_mint_configs(token_id, &db_transaction)
-    }
-
-    fn update_total_minted(&self, mint_config: &MintConfig, amount: u64) -> Result<(), Error> {
-        let mut db_transaction = self.env.begin_rw_txn()?;
-        self.mint_config_store
-            .update_total_minted(mint_config, amount, &mut db_transaction)?;
-        db_transaction.commit()?;
-        Ok(())
     }
 }
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -912,18 +912,17 @@ mod ledger_db_test {
     use super::*;
     use crate::mint_config_store::tests::{
         generate_test_mint_config_tx, generate_test_mint_config_tx_and_signers,
+        generate_test_mint_tx,
     };
     use core::convert::TryFrom;
     use mc_account_keys::AccountKey;
-    use mc_crypto_keys::{Ed25519Pair, RistrettoPrivate, RistrettoPublic, Signer};
-    use mc_crypto_multisig::MultiSig;
+    use mc_crypto_keys::{Ed25519Pair, RistrettoPrivate};
     use mc_transaction_core::{
-        compute_block_id, membership_proofs::compute_implied_merkle_root, mint::MintTxPrefix,
-        BlockVersion,
+        compute_block_id, membership_proofs::compute_implied_merkle_root, BlockVersion,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use rand_core::{CryptoRng, RngCore};
+    use rand_core::RngCore;
     use tempdir::TempDir;
     use test::Bencher;
 
@@ -1013,36 +1012,6 @@ mod ledger_db_test {
         assert_eq!(db.num_blocks().unwrap(), num_blocks as u64);
 
         (blocks, blocks_contents)
-    }
-
-    // Generate a random mint tx
-    pub fn generate_test_mint_tx(
-        token_id: TokenId,
-        signers: &[Ed25519Pair],
-        amount: u64,
-        rng: &mut (impl RngCore + CryptoRng),
-    ) -> MintTx {
-        let mut nonce: Vec<u8> = vec![0u8; 32];
-        rng.fill_bytes(&mut nonce);
-
-        let prefix = MintTxPrefix {
-            token_id: *token_id,
-            amount,
-            view_public_key: RistrettoPublic::from_random(rng),
-            spend_public_key: RistrettoPublic::from_random(rng),
-            nonce,
-            tombstone_block: rng.next_u64(),
-        };
-
-        let message = prefix.hash();
-
-        let signatures = signers
-            .iter()
-            .map(|signer| signer.try_sign(message.as_ref()).unwrap())
-            .collect();
-        let signature = MultiSig::new(signatures);
-
-        MintTx { prefix, signature }
     }
 
     #[test]

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -168,7 +168,7 @@ pub struct LedgerDB {
     set_mint_config_txs_by_block: Database,
 
     /// MintTxs by block.
-    set_mint_txs_by_block: Database,
+    mint_txs_by_block: Database,
 
     /// Location on filesystem.
     path: PathBuf,
@@ -676,7 +676,7 @@ impl LedgerDB {
 
         db_transaction.put(
             self.set_mint_config_txs_by_block,
-            &u64_to_key_bytes(block_index),
+            &block_index_bytes,
             &encode(&set_mint_config_tx_list),
             WriteFlags::empty(),
         )?;
@@ -697,7 +697,7 @@ impl LedgerDB {
 
         db_transaction.put(
             self.mint_txs_by_block,
-            &u64_to_key_bytes(block_index),
+            &block_index_bytes,
             &encode(&mint_tx_list),
             WriteFlags::empty(),
         )?;

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -2066,8 +2066,9 @@ mod ledger_db_test {
 
     #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NoKeyImages")]
-    // Appending a non-origin block should fail if the block contains no key images.
-    fn test_append_block_fails_for_non_origin_blocks_without_key_images() {
+    // Appending a non-origin block should fail if the block contains no key images
+    // and no minting transactions.
+    fn test_append_block_fails_for_non_origin_non_minting_blocks_without_key_images() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let mut ledger_db = create_db();
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1950,4 +1950,7 @@ mod ledger_db_test {
 
         b.iter(|| ledger_db.get_block(rng.next_u64() % n_blocks).unwrap())
     }
+
+    // TODO add test for block with only mint tx, only set mintconfig tx, no
+    // txs, regular txs + mints, etc
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -52,7 +52,7 @@ pub use mint_tx_store::MintTxStore;
 pub use tx_out_store::TxOutStore;
 
 pub const MAX_LMDB_FILE_SIZE: usize = 2usize.pow(40); // 1 TB
-pub const MAX_LMDB_DATABASES: u32 = 29; // maximum number of databases in the lmdb file
+pub const MAX_LMDB_DATABASES: u32 = 27; // maximum number of databases in the lmdb file
 
 // LMDB Database names.
 pub const COUNTS_DB_NAME: &str = "ledger_db:counts";

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1404,7 +1404,6 @@ mod ledger_db_test {
 
         let block_contents = BlockContents {
             key_images,
-            outputs,
             ..Default::default()
         };
         let block = Block::new_with_parent(
@@ -1657,7 +1656,7 @@ mod ledger_db_test {
                 key_images: block_one_key_images.clone(),
                 outputs,
                 ..Default::default()
-            };
+            }
         };
 
         let block_one = Block::new_with_parent(
@@ -1685,7 +1684,7 @@ mod ledger_db_test {
                 key_images: block_one_key_images.clone(),
                 outputs,
                 ..Default::default()
-            };
+            }
         };
 
         let block_two = Block::new_with_parent(

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -232,11 +232,11 @@ impl MintConfigStore {
 
         for active_mint_config in active_mint_configs {
             // See if this mint config has signed the mint tx.
-            if !active_mint_config
+            if active_mint_config
                 .mint_config
                 .signer_set
                 .verify(&message, &mint_tx.signature)
-                .is_ok()
+                .is_err()
             {
                 continue;
             }

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -198,7 +198,7 @@ impl MintConfigStore {
 }
 
 #[cfg(test)]
-mod test {
+pub mod tests {
     use super::*;
     use crate::tx_out_store::tx_out_store_tests::get_env;
     use mc_crypto_keys::Ed25519Pair;

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -134,7 +134,7 @@ impl MintConfigStore {
             self.set_mint_config_txs_by_block,
             &block_index_bytes,
             &encode(&set_mint_config_tx_list),
-            WriteFlags::empty(),
+            WriteFlags::NO_OVERWRITE, // We should not be updating existing blocks
         )?;
 
         // Update active mint configurations.

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -266,7 +266,7 @@ impl MintConfigStore {
         Ok(())
     }
 
-    /// Returns true of the Ledger contains the given set-mint-config-tx nonce.
+    /// Returns true if the Ledger contains the given set-mint-config-tx nonce.
     pub fn contains_set_mint_config_tx_nonce(
         &self,
         nonce: &[u8],

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -242,6 +242,19 @@ impl MintConfigStore {
 
         Ok(())
     }
+
+    /// Returns true of the Ledger contains the given set-mint-config-tx nonce.
+    pub fn contains_set_mint_config_tx_nonce(
+        &self,
+        nonce: &[u8],
+        db_transaction: &impl Transaction,
+    ) -> Result<bool, Error> {
+        match db_transaction.get(self.set_mint_config_tx_by_nonce, &nonce) {
+            Ok(_db_bytes) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(e) => Err(Error::Lmdb(e)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -37,10 +37,8 @@ impl MintTxStore {
     /// Opens an existing MintTxStore.
     pub fn new(env: &Environment) -> Result<Self, Error> {
         Ok(MintTxStore {
-            mint_txs_by_block: env
-                .open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
-            mint_tx_by_nonce: env
-                .open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
+            mint_txs_by_block: env.open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
+            mint_tx_by_nonce: env.open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
         })
     }
 
@@ -103,7 +101,7 @@ impl MintTxStore {
         for mint_tx in mint_txs {
             // Update total minted.
             let active_mint_config =
-                mint_config_store.get_active_mint_config_for_mint_tx(&mint_tx, db_transaction)?;
+                mint_config_store.get_active_mint_config_for_mint_tx(mint_tx, db_transaction)?;
 
             let new_total_minted = active_mint_config.total_minted.checked_add(mint_tx.prefix.amount).expect("shouldn't have failed because get_active_mint_config_for_mint_tx guards against this");
 

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Data access abstraction for mint transactions stored in the ledger.
+//!
+//! This store maintains two LMDB databases:
+//! 1) A mapping of block index -> list of mint transactions included in the
+//! block.    This is used to provide the mint_txs inside BlockContents.
+//! 2) A mapping of hash -> MintTx. This is used to prevent replay attacks.
+
+use crate::{u64_to_key_bytes, Error, MintConfigStore};
+use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
+use mc_transaction_core::mint::MintTx;
+use mc_util_serial::{decode, encode, Message};
+
+// LMDB Database names.
+pub const MINT_TXS_BY_BLOCK_DB_NAME: &str = "mint_tx_store:set_txs_by_block";
+pub const MINT_TX_BY_NONCE_DB_NAME: &str = "mint_tx_store:mint_tx_by_nonce";
+
+/// A list of mint-txs that can be prost-encoded. This is needed since that's
+/// the only way to encode a Vec<MintTx>.
+#[derive(Clone, Message)]
+pub struct MintTxList {
+    #[prost(message, repeated, tag = "1")]
+    pub mint_txs: Vec<MintTx>,
+}
+
+#[derive(Clone)]
+pub struct MintTxStore {
+    /// MintTxs by block.
+    mint_txs_by_block: Database,
+
+    /// MintTx by nonce.
+    mint_tx_by_nonce: Database,
+}
+
+impl MintTxStore {
+    /// Opens an existing MintTxStore.
+    pub fn new(env: &Environment) -> Result<Self, Error> {
+        Ok(MintTxStore {
+            mint_txs_by_block: env
+                .open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
+            mint_tx_by_nonce: env
+                .open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
+        })
+    }
+
+    /// Creates a fresh MintTxStore.
+    pub fn create(env: &Environment) -> Result<(), Error> {
+        env.create_db(Some(MINT_TXS_BY_BLOCK_DB_NAME), DatabaseFlags::empty())?;
+        env.create_db(Some(MINT_TX_BY_NONCE_DB_NAME), DatabaseFlags::empty())?;
+        Ok(())
+    }
+
+    /// Get mint txs in a given block.
+    pub fn get_mint_txs_by_block_index(
+        &self,
+        block_index: u64,
+        db_transaction: &impl Transaction,
+    ) -> Result<Vec<MintTx>, Error> {
+        let mint_txs: MintTxList =
+            decode(db_transaction.get(self.mint_txs_by_block, &u64_to_key_bytes(block_index))?)?;
+        Ok(mint_txs.mint_txs)
+    }
+
+    /// Returns true if the Ledger contains the given mint tx nonce
+    pub fn contains_mint_tx_nonce(
+        &self,
+        nonce: &[u8],
+        db_transaction: &impl Transaction,
+    ) -> Result<bool, Error> {
+        match db_transaction.get(self.mint_tx_by_nonce, &nonce) {
+            Ok(_db_bytes) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(e) => Err(Error::Lmdb(e)),
+        }
+    }
+
+    /// Write mint txs in a given block.
+    pub fn write_mint_txs(
+        &self,
+        block_index: u64,
+        mint_txs: &[MintTx],
+        mint_config_store: &MintConfigStore,
+        db_transaction: &mut RwTransaction,
+    ) -> Result<(), Error> {
+        let block_index_bytes = u64_to_key_bytes(block_index);
+
+        // Store the list of MintTxs.
+        let mint_tx_list = MintTxList {
+            mint_txs: mint_txs.to_vec(),
+        };
+
+        db_transaction.put(
+            self.mint_txs_by_block,
+            &block_index_bytes,
+            &encode(&mint_tx_list),
+            WriteFlags::empty(),
+        )?;
+
+        // For each mint transaction, we need to locate the matching mint configuration
+        // and update the total minted count. We also need to ensure the nonce is
+        // unique.
+        for mint_tx in mint_txs {
+            // Update total minted.
+            let active_mint_config =
+                mint_config_store.get_active_mint_config_for_mint_tx(&mint_tx, db_transaction)?;
+
+            let new_total_minted = active_mint_config.total_minted.checked_add(mint_tx.prefix.amount).expect("shouldn't have failed because get_active_mint_config_for_mint_tx guards against this");
+
+            mint_config_store.update_total_minted(
+                &active_mint_config.mint_config,
+                new_total_minted,
+                db_transaction,
+            )?;
+
+            // Ensure nonce uniqueness
+            db_transaction.put(
+                self.mint_tx_by_nonce,
+                &mint_tx.prefix.nonce,
+                &encode(mint_tx),
+                WriteFlags::NO_OVERWRITE, /* this ensures we do not overwrite a nonce that was
+                                           * already used */
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -5,7 +5,6 @@ use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, TokenId,
@@ -193,10 +192,6 @@ impl Ledger for MockLedger {
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
-        unimplemented!()
-    }
-
-    fn update_total_minted(&self, _mint_config: &MintConfig, _amount: u64) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -243,7 +243,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let origin_block = Block::new_origin_block(&outputs);
-            let block_contents = BlockContents::new(vec![], outputs);
+            let block_contents = BlockContents::new(vec![], outputs, vec![], vec![]);
             block_ids.push(origin_block.id.clone());
             blocks_and_contents.push((origin_block, block_contents));
         } else {
@@ -258,7 +258,10 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let block_contents = BlockContents::new(key_images, outputs);
+            let set_mint_config_txs = vec![];
+            let mint_txs = vec![];
+            let block_contents =
+                BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
 
             let block = Block::new_with_parent(
                 BlockVersion::ONE,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -243,7 +243,10 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let origin_block = Block::new_origin_block(&outputs);
-            let block_contents = BlockContents::new(vec![], outputs, vec![], vec![]);
+            let block_contents = BlockContents {
+                outputs,
+                ..Default::default()
+            };
             block_ids.push(origin_block.id.clone());
             blocks_and_contents.push((origin_block, block_contents));
         } else {
@@ -258,10 +261,11 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let set_mint_config_txs = vec![];
-            let mint_txs = vec![];
-            let block_contents =
-                BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             let block = Block::new_with_parent(
                 BlockVersion::ONE,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -5,7 +5,7 @@ use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, TokenId,
@@ -190,9 +190,6 @@ impl Ledger for MockLedger {
 
     fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
         unimplemented!();
-    }
-    fn set_active_mint_configs(&self, _set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error> {
-        unimplemented!()
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -90,6 +90,9 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
                 );
                 MintConfigStore::create(&env).expect("Failed creating MintConfigStore");
 
+                // TODO create the two new by-block databases and fill them with empty data for
+                // existing blocks!
+
                 let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
                 metadata_store
                     .set_version(&mut db_txn, 2022_02_22)

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -9,9 +9,9 @@ use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
 use mc_common::logger::{log, Logger};
 use mc_ledger_db::{
     key_bytes_to_u64, tx_out_store::TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME, u64_to_key_bytes, Error,
-    LedgerDbMetadataStoreSettings, MetadataStore, MintConfigStore, TxOutStore, TxOutsByBlockValue,
-    BLOCK_NUMBER_BY_TX_OUT_INDEX, COUNTS_DB_NAME, MAX_LMDB_DATABASES, MAX_LMDB_FILE_SIZE,
-    NUM_BLOCKS_KEY, TX_OUTS_BY_BLOCK_DB_NAME,
+    LedgerDbMetadataStoreSettings, MetadataStore, MintConfigStore, MintTxStore, TxOutStore,
+    TxOutsByBlockValue, BLOCK_NUMBER_BY_TX_OUT_INDEX, COUNTS_DB_NAME, MAX_LMDB_DATABASES,
+    MAX_LMDB_FILE_SIZE, NUM_BLOCKS_KEY, TX_OUTS_BY_BLOCK_DB_NAME,
 };
 use mc_util_lmdb::MetadataStoreError;
 use mc_util_serial::decode;
@@ -42,6 +42,7 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
 
         match version.is_compatible_with_latest() {
             Ok(_) => {
+                log::info!(logger, "Ledger db is compatible with latest version");
                 break;
             }
             // Version 2020_06_10 came after 2020_04_27 and introduced the TxOut public key -> index
@@ -89,9 +90,10 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
                     "Ledger db migrating from version 2020_07_07 to 2022_02_22..."
                 );
                 MintConfigStore::create(&env).expect("Failed creating MintConfigStore");
+                MintTxStore::create(&env).expect("Failed creating MintTxStore");
 
-                // TODO create the two new by-block databases and fill them with empty data for
-                // existing blocks!
+                backfill_empty_mint_stores(&env, logger)
+                    .expect("Failed backfilling empty mint stores");
 
                 let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
                 metadata_store
@@ -210,6 +212,38 @@ fn construct_block_number_by_tx_out_index_from_existing_data(
             log::info!(
                 logger,
                 "Constructing block_number_by_tx_out_index: {}% complete",
+                percents
+            );
+        }
+    }
+    Ok(db_txn.commit()?)
+}
+
+/// A utility function for backfilling empty mint tx data for all existing
+/// blocks. This is necessary because we store an empty list of mint txs for
+/// blocks that did not contain any.
+fn backfill_empty_mint_stores(env: &Environment, logger: &Logger) -> Result<(), Error> {
+    // Open pre-existing databases that has data we need.
+    let mint_config_store = MintConfigStore::new(env)?;
+    let mint_tx_store = MintTxStore::new(env)?;
+    let counts_db = env.open_db(Some(COUNTS_DB_NAME))?;
+
+    let mut db_txn = env.begin_rw_txn()?;
+
+    let num_blocks = key_bytes_to_u64(db_txn.get(counts_db, &NUM_BLOCKS_KEY)?);
+
+    let mut percents: u64 = 0;
+    for block_index in 0..num_blocks {
+        mint_config_store.write_set_mint_config_txs(block_index, &[], &mut db_txn)?;
+        mint_tx_store.write_mint_txs(block_index, &[], &mint_config_store, &mut db_txn)?;
+
+        // Throttled logging.
+        let new_percents = block_index * 100 / num_blocks;
+        if new_percents != percents {
+            percents = new_percents;
+            log::info!(
+                logger,
+                "Backfilling empty mint stores: {}% complete",
                 percents
             );
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3629,7 +3629,11 @@ mod test {
             let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
             let key_images = tx_proposal.tx.key_images();
             let outputs = tx_proposal.tx.prefix.outputs.clone();
-            let block_contents = BlockContents::new(key_images, outputs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             // Append to ledger.
             let num_blocks = ledger_db.num_blocks().unwrap();

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -180,7 +180,11 @@ pub fn add_block_to_ledger_db(
         })
         .collect();
 
-    let block_contents = BlockContents::new(key_images.to_vec(), outputs.clone());
+    let block_contents = BlockContents {
+        key_images: key_images.to_vec(),
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let new_block;
     if num_blocks > 0 {
@@ -211,7 +215,11 @@ pub fn add_txos_to_ledger_db(
     outputs: &Vec<TxOut>,
     rng: &mut (impl CryptoRng + RngCore),
 ) -> u64 {
-    let block_contents = BlockContents::new(vec![KeyImage::from(rng.next_u64())], outputs.clone());
+    let block_contents = BlockContents {
+        key_images: vec![KeyImage::from(rng.next_u64())],
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let num_blocks = ledger_db.num_blocks().expect("failed to get block height");
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -224,7 +224,7 @@ mod block_tests {
             key_images,
             outputs,
             ..Default::default()
-        };
+        }
     }
 
     fn get_key_images_and_outputs<RNG: CryptoRng + RngCore>(

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -61,9 +61,11 @@ impl Block {
         let index: BlockIndex = 0;
         let cumulative_txo_count = outputs.len() as u64;
         let root_element = TxOutMembershipElement::default();
-        // The origin block does not contain any key images.
+        // The origin block does not contain any key images, set_mint_config_txs or mint_txs.
         let key_images = Vec::new();
-        let block_contents = BlockContents::new(key_images, outputs.to_vec());
+        let set_mint_config_txs = Vec::new();
+        let mint_txs = Vec::new();
+        let block_contents = BlockContents::new(key_images, outputs.to_vec(), set_mint_config_txs, mint_txs);
         let contents_hash = block_contents.hash();
         let id = compute_block_id(
             version,

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -4,7 +4,6 @@ use crate::{
     tx::{TxOut, TxOutMembershipElement},
     BlockContents, BlockContentsHash, BlockID, BlockVersion,
 };
-use alloc::vec::Vec;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -61,11 +60,13 @@ impl Block {
         let index: BlockIndex = 0;
         let cumulative_txo_count = outputs.len() as u64;
         let root_element = TxOutMembershipElement::default();
-        // The origin block does not contain any key images, set_mint_config_txs or mint_txs.
-        let key_images = Vec::new();
-        let set_mint_config_txs = Vec::new();
-        let mint_txs = Vec::new();
-        let block_contents = BlockContents::new(key_images, outputs.to_vec(), set_mint_config_txs, mint_txs);
+
+        // The origin block does not contain anything but TxOuts.
+        let block_contents = BlockContents {
+            outputs: outputs.to_vec(),
+            ..Default::default()
+        };
+
         let contents_hash = block_contents.hash();
         let id = compute_block_id(
             version,
@@ -219,7 +220,11 @@ mod block_tests {
 
     fn get_block_contents<RNG: CryptoRng + RngCore>(rng: &mut RNG) -> BlockContents {
         let (key_images, outputs) = get_key_images_and_outputs(rng);
-        BlockContents::new(key_images, outputs)
+        BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
     }
 
     fn get_key_images_and_outputs<RNG: CryptoRng + RngCore>(
@@ -281,7 +286,11 @@ mod block_tests {
             output.e_memo = None;
         }
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
         Block::new(
             BLOCK_VERSION,
             &parent_id,

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -1,6 +1,11 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{ring_signature::KeyImage, tx::TxOut, ConvertError};
+use crate::{
+    mint::{MintTx, SetMintConfigTx},
+    ring_signature::KeyImage,
+    tx::TxOut,
+    ConvertError,
+};
 use alloc::{vec, vec::Vec};
 use core::{convert::TryFrom, fmt::Debug};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
@@ -21,13 +26,28 @@ pub struct BlockContents {
     /// Outputs minted by this block.
     #[prost(message, repeated, tag = "2")]
     pub outputs: Vec<TxOut>,
+
+    /// Set-mint-config transactions in this block.
+    #[prost(message, repeated, tag = "3")]
+    pub set_mint_config_txs: Vec<SetMintConfigTx>,
+
+    /// Mint transactions in this block.
+    #[prost(message, repeated, tag = "4")]
+    pub mint_txs: Vec<MintTx>,
 }
 
 impl BlockContents {
-    pub fn new(key_images: Vec<KeyImage>, outputs: Vec<TxOut>) -> Self {
+    pub fn new(
+        key_images: Vec<KeyImage>,
+        outputs: Vec<TxOut>,
+        set_mint_config_txs: Vec<SetMintConfigTx>,
+        mint_txs: Vec<MintTx>,
+    ) -> Self {
         Self {
             key_images,
             outputs,
+            set_mint_config_txs,
+            mint_txs,
         }
     }
 

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -37,20 +37,6 @@ pub struct BlockContents {
 }
 
 impl BlockContents {
-    pub fn new(
-        key_images: Vec<KeyImage>,
-        outputs: Vec<TxOut>,
-        set_mint_config_txs: Vec<SetMintConfigTx>,
-        mint_txs: Vec<MintTx>,
-    ) -> Self {
-        Self {
-            key_images,
-            outputs,
-            set_mint_config_txs,
-            mint_txs,
-        }
-    }
-
     /// The Merlin digest of `self`.
     pub fn hash(&self) -> BlockContentsHash {
         BlockContentsHash(self.digest32::<MerlinTranscript>(b"block_contents"))

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -43,3 +43,9 @@ pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";
 
 /// Domain separator for hashing the confirmation number
 pub const TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG: &str = "mc_tx_out_confirmation_number";
+
+/// Domain separator for hashing SetMintConfigTxPrefixs
+pub const SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_set_mint_config_tx_prefix";
+
+/// Domain separator for hashing MintTxPrefixs
+pub const MINT_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_tx_prefix";

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -2,8 +2,9 @@
 
 //! Minting transaction configuration.
 
+use crate::domain_separators::SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG;
 use alloc::vec::Vec;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Public, Ed25519Signature};
 use mc_crypto_multisig::{MultiSig, SignerSet};
 use mc_util_serial::Message;
@@ -51,6 +52,13 @@ pub struct SetMintConfigTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "4")]
     pub tombstone_block: u64,
+}
+
+impl SetMintConfigTxPrefix {
+    /// Digestible-crate hash of `self` using Merlin
+    pub fn hash(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG.as_bytes())
+    }
 }
 
 /// A set-mint-config transaction coupled with a signature over it.

--- a/transaction/core/src/mint/tx.rs
+++ b/transaction/core/src/mint/tx.rs
@@ -2,8 +2,9 @@
 
 //! Minting transactions.
 
+use crate::domain_separators::MINT_TX_PREFIX_DOMAIN_TAG;
 use alloc::vec::Vec;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Signature, RistrettoPublic};
 use mc_crypto_multisig::MultiSig;
 use mc_util_serial::Message;
@@ -37,6 +38,13 @@ pub struct MintTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "6")]
     pub tombstone_block: u64,
+}
+
+impl MintTxPrefix {
+    /// Digestible-crate hash of `self` using Merlin
+    pub fn hash(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(MINT_TX_PREFIX_DOMAIN_TAG.as_bytes())
+    }
 }
 
 /// A mint transaction coupled with a signature over it.

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -195,7 +195,11 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                 let key_images = tx.key_images();
                 let outputs = tx.prefix.outputs.clone();
 
-                let block_contents = BlockContents::new(key_images, outputs);
+                let block_contents = BlockContents {
+                    key_images,
+                    outputs,
+                    ..Default::default()
+                };
 
                 let block = Block::new(
                     block_version,
@@ -226,7 +230,10 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                     .collect();
 
                 let block = Block::new_origin_block(&outputs);
-                let block_contents = BlockContents::new(Vec::new(), outputs);
+                let block_contents = BlockContents {
+                    outputs,
+                    ..Default::default()
+                };
                 (block, block_contents)
             }
         };
@@ -278,7 +285,11 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
         // Non-origin blocks must have at least one key image.
         let key_images = vec![KeyImage::from(block_index as u64)];
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         // Fake proofs
         let root_element = TxOutMembershipElement {

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -88,7 +88,11 @@ pub fn bootstrap_ledger(
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let block_contents = BlockContents::new(key_images, outputs.clone());
+        let block_contents = BlockContents {
+            key_images,
+            outputs: outputs.clone(),
+            ..Default::default()
+        };
 
         let block = match previous_block {
             Some(parent) => {


### PR DESCRIPTION
### Motivation

Previous PRs introduced two new transaction types: `MintTx` and `SetMintConfigTx`. These new transactions need to make their way into `BlockContents`.

### In this PR
* Modifying `LedgerDb` to store the new transaction types, and include them inside `BlockContents`.
* Code for tracking how much an active mint configuration has minted so far.

### TODOs
* [x] Ledger migration code for backfilling the LMDB databases.
* [ ] tests in ledger/db/src/mint_tx_store.rs

### Future Work
* Implement tx validation for the two new transaction types
* Add support for SCPing on them
