### PR TITLE
Minting transaction validation

### DIFF
--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -50,6 +50,12 @@ message BlockContents {
 
     // Outputs created in this block.
     repeated external.TxOut outputs = 2;
+
+    /// Set-mint-config transactions in this block.
+    repeated external.SetMintConfigTx set_mint_config_txs = 3;
+
+    /// Mint transactions in this block.
+    repeated external.MintTx mint_txs = 4;
 }
 
 message BlockSignature {

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -146,7 +146,11 @@ mod tests {
                 .map(|block| block.id.clone())
                 .unwrap_or_else(|| BlockID::try_from(&[1u8; 32][..]).unwrap());
 
-            let block_contents = BlockContents::new(vec![key_image.clone()], vec![tx_out.clone()]);
+            let block_contents = BlockContents {
+                key_images: vec![key_image.clone()],
+                outputs: vec![tx_out.clone()],
+                ..Default::default()
+            };
             let block = Block::new(
                 BlockVersion::ONE,
                 &parent_block_id,

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -67,11 +67,13 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
             .map(MintTx::try_from)
             .collect::<Result<_, _>>()?;
 
-        Ok(BlockContents::new(
+        // We purposefully do not ..Default::default() here so that new fields are not
+        // missed.
+        Ok(BlockContents {
             key_images,
             outputs,
             set_mint_config_txs,
             mint_txs,
-        ))
+        })
     }
 }

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -41,13 +41,13 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
     type Error = ConversionError;
 
     fn try_from(source: &blockchain::BlockContents) -> Result<Self, Self::Error> {
-        let key_images: Vec<KeyImage> = source
+        let key_images = source
             .get_key_images()
             .iter()
             .map(KeyImage::try_from)
             .collect::<Result<_, _>>()?;
 
-        let outputs: Vec<TxOut> = source
+        let outputs = source
             .get_outputs()
             .iter()
             .map(TxOut::try_from)

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -14,27 +14,26 @@ impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {
     fn from(source: &mc_transaction_core::BlockContents) -> Self {
         let mut block_contents = blockchain::BlockContents::new();
 
-        let key_images: Vec<external::KeyImage> = source
+        let key_images = source
             .key_images
             .iter()
             .map(external::KeyImage::from)
             .collect();
 
-        let outputs: Vec<external::TxOut> =
-            source.outputs.iter().map(external::TxOut::from).collect();
+        let outputs = source.outputs.iter().map(external::TxOut::from).collect();
 
-        let set_mint_config_txs: Vec<_> = source
+        let set_mint_config_txs = source
             .set_mint_config_txs
             .iter()
             .map(external::SetMintConfigTx::from)
             .collect();
 
-        let mint_txs: Vec<_> = source.mint_txs.iter().map(external::MintTx::from).collect();
+        let mint_txs = source.mint_txs.iter().map(external::MintTx::from).collect();
 
-        block_contents.set_key_images(RepeatedField::from_vec(key_images));
-        block_contents.set_outputs(RepeatedField::from_vec(outputs));
-        block_contents.set_set_mint_config_txs(RepeatedField::from_vec(set_mint_config_txs));
-        block_contents.set_mint_txs(RepeatedField::from_vec(mint_txs));
+        block_contents.set_key_images(key_images);
+        block_contents.set_outputs(outputs);
+        block_contents.set_set_mint_config_txs(set_mint_config_txs);
+        block_contents.set_mint_txs(mint_txs);
         block_contents
     }
 }

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -7,7 +7,6 @@ use mc_transaction_core::{
     tx::TxOut,
     BlockContents,
 };
-use protobuf::RepeatedField;
 use std::convert::TryFrom;
 
 impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -601,7 +601,12 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // key images.
         outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
         key_images.sort();
-        let block_contents = BlockContents::new(key_images, outputs);
+
+        // Right now set-mint-config-txs and mint-txs are not actually created anywhere.
+        let set_mint_config_txs = Vec::new();
+        let mint_txs = Vec::new();
+
+        let block_contents = BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
 
         // Form the block.
         let block = Block::new_with_parent(

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -606,8 +606,15 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let set_mint_config_txs = Vec::new();
         let mint_txs = Vec::new();
 
-        let block_contents = BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
-
+        // We purposefully do not ..Default::default() here so that new block fields
+        // show up as a compilation error until addressed.
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            set_mint_config_txs,
+            mint_txs,
+        };
+        //
         // Form the block.
         let block = Block::new_with_parent(
             config.block_version,

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -267,7 +267,11 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             outputs.extend(tx.prefix.outputs.into_iter());
         }
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         let block = Block::new_with_parent(
             block_version,

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -784,7 +784,7 @@ mod tests {
 
         let mut mock_enclave = MockConsensusEnclave::new();
         let expected_block = Block::new_origin_block(&vec![]);
-        let expected_block_contents = BlockContents::new(vec![], vec![]);
+        let expected_block_contents = BlockContents::default();
         // The enclave does not set the signed_at field.
         let expected_block_signature =
             BlockSignature::new(Ed25519Signature::default(), Ed25519Public::default(), 0);

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -117,7 +117,11 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
 
     let key_images = vec![KeyImage::from(rng.next_u64())];
 
-    let block_contents = BlockContents::new(key_images, random_output(rng));
+    let block_contents = BlockContents {
+        key_images,
+        outputs: random_output(rng),
+        ..Default::default()
+    };
 
     // Fake proofs
     let root_element = TxOutMembershipElement {

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -237,6 +237,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger
@@ -450,6 +451,7 @@ fn three_node_cluster_fencing(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -796,7 +796,11 @@ fn add_block_to_ledger_db(
         })
         .collect();
 
-    let block_contents = BlockContents::new(key_images.to_vec(), outputs.clone());
+    let block_contents = BlockContents {
+        key_images: key_images.to_vec(),
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let num_blocks = ledger_db.num_blocks().expect("failed to get block height");
 

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -13,7 +13,6 @@ use mc_fog_ledger_enclave_api::{KeyImageData, UntrustedKeyImageQueryResponse};
 use mc_ledger_db::{ActiveMintConfig, Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockSignature, TokenId,

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -15,7 +15,7 @@ use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResu
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-    Block, BlockContents, BlockData, BlockSignature, TokenId,
+    Block, BlockContents, BlockData, BlockIndex, BlockSignature, TokenId,
 };
 
 #[derive(Default, Clone)]
@@ -189,6 +189,14 @@ impl Ledger for MockLedger {
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
+        unimplemented!()
+    }
+
+    fn check_set_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
+        unimplemented!()
+    }
+
+    fn check_mint_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }
 }

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -192,8 +192,4 @@ impl Ledger for MockLedger {
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
         unimplemented!()
     }
-
-    fn update_total_minted(&self, _mint_config: &MintConfig, _amount: u64) -> Result<(), Error> {
-        unimplemented!()
-    }
 }

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -13,7 +13,7 @@ use mc_fog_ledger_enclave_api::{KeyImageData, UntrustedKeyImageQueryResponse};
 use mc_ledger_db::{ActiveMintConfig, Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockSignature, TokenId,
@@ -186,10 +186,6 @@ impl Ledger for MockLedger {
     }
 
     fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
-        unimplemented!()
-    }
-
-    fn set_active_mint_configs(&self, _set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error> {
         unimplemented!()
     }
 

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -43,6 +43,7 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -60,6 +60,7 @@ fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_an
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -60,6 +60,7 @@ fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -47,6 +47,7 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -60,6 +60,7 @@ fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -58,6 +58,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
     let origin_contents = BlockContents {
         key_images: Default::default(),
         outputs: origin_txo.clone(),
+        ..Default::default()
     };
     let origin_block = Block::new_origin_block(&origin_txo);
     ledger

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -122,7 +122,11 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
 
     let key_images = vec![KeyImage::from(rng.next_u64())];
 
-    let block_contents = BlockContents::new(key_images, random_output(rng));
+    let block_contents = BlockContents {
+        key_images,
+        outputs: random_output(rng),
+        ..Default::default()
+    };
 
     // Fake proofs
     let root_element = TxOutMembershipElement {

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -189,7 +189,11 @@ fn main() {
             .get_block(num_blocks - 1)
             .expect("Could not get last block");
 
-        let block_contents = BlockContents::new(key_images_to_burn, tx_outs);
+        let block_contents = BlockContents {
+            key_images: key_images_to_burn,
+            outputs: tx_outs,
+            ..Default::default()
+        };
 
         // Fake proofs
         let root_element = TxOutMembershipElement {

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -140,11 +140,18 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
     // Make them into a block, and ingest it. This is done by appending a block to
     // the ledger and having it be polled by ingest.
     let (block, block_contents) = if block_index == 0 {
-        let block_contents = BlockContents::new(vec![], txos.clone());
+        let block_contents = BlockContents {
+            outputs: txos.clone(),
+            ..Default::default()
+        };
         let block = Block::new_origin_block(&txos);
         (block, block_contents)
     } else {
-        let block_contents = BlockContents::new(vec![KeyImage::from(block_index)], txos);
+        let block_contents = BlockContents {
+            key_images: vec![KeyImage::from(block_index)],
+            outputs: txos,
+            ..Default::default()
+        };
         let parent_block = ledger_db
             .get_block(block_index - 1)
             .unwrap_or_else(|err| panic!("Failed getting block {}: {:?}", block_index - 1, err));

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -72,6 +72,12 @@ pub enum Error {
 
     /// Total minted amount cannot decrease: {0} < {1}
     TotalMintedAmountCannotDecrease(u64, u64),
+
+    /// DuplicateMintTx
+    DuplicateMintTx,
+
+    /// DuplicateSetMintConfigTx
+    DuplicateSetMintConfigTx,
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     /// NoOutputs
     NoOutputs,
 
+    /// TooFewOutputs
+    TooFewOutputs,
+
     /// LMDB error, may mean database is opened multiple times in a process.
     BadRslot,
 

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -4,7 +4,7 @@ use crate::{mint_config_store::ActiveMintConfig, Error};
 use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockIndex, BlockSignature, TokenId,
@@ -91,10 +91,6 @@ pub trait Ledger: Send {
         }
         self.get_block(num_blocks - 1)
     }
-
-    /// Set active mint configurations for a given token id, based on a
-    /// set-mint-config transaction.
-    fn set_active_mint_configs(&self, set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error>;
 
     /// Get active mint configurations for a given token id.
     /// Returns an empty array of no mint configurations are active for the

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -92,7 +92,7 @@ pub trait Ledger: Send {
     }
 
     /// Get active mint configurations for a given token id.
-    /// Returns an empty array of no mint configurations are active for the
+    /// Returns an empty array if no mint configurations are active for the
     /// given token id.
     fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
 

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -4,7 +4,6 @@ use crate::{mint_config_store::ActiveMintConfig, Error};
 use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockIndex, BlockSignature, TokenId,
@@ -96,7 +95,4 @@ pub trait Ledger: Send {
     /// Returns an empty array of no mint configurations are active for the
     /// given token id.
     fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
-
-    /// Update the total minted amount for a given MintConfig.
-    fn update_total_minted(&self, mint_config: &MintConfig, amount: u64) -> Result<(), Error>;
 }

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -95,4 +95,14 @@ pub trait Ledger: Send {
     /// Returns an empty array of no mint configurations are active for the
     /// given token id.
     fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
+
+    /// Checks if the ledger contains a given SetMintConfigTx nonce.
+    /// If so, returns the index of the block in which it entered the ledger.
+    /// Ok(None) is returned when the nonce is not in the ledger.
+    fn check_set_mint_config_tx_nonce(&self, nonce: &[u8]) -> Result<Option<BlockIndex>, Error>;
+
+    /// Checks if the ledger contains a given MintTx nonce.
+    /// If so, returns the index of the block in which it entered the ledger.
+    /// Ok(None) is returned when the nonce is not in the ledger.
+    fn check_mint_tx_nonce(&self, nonce: &[u8]) -> Result<Option<BlockIndex>, Error>;
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -52,7 +52,7 @@ pub use mint_tx_store::MintTxStore;
 pub use tx_out_store::TxOutStore;
 
 pub const MAX_LMDB_FILE_SIZE: usize = 2usize.pow(40); // 1 TB
-pub const MAX_LMDB_DATABASES: u32 = 27; // maximum number of databases in the lmdb file
+pub const MAX_LMDB_DATABASES: u32 = 29; // maximum number of databases in the lmdb file
 
 // LMDB Database names.
 pub const COUNTS_DB_NAME: &str = "ledger_db:counts";

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -952,7 +952,12 @@ mod ledger_db_test {
             } else {
                 vec![]
             };
-            let block_contents = BlockContents::new(key_images, outputs.clone());
+
+            let block_contents = BlockContents {
+                key_images,
+                outputs: outputs.clone(),
+                ..Default::default()
+            };
 
             let block = match parent_block {
                 None => Block::new_origin_block(&outputs),
@@ -1001,7 +1006,10 @@ mod ledger_db_test {
 
         let outputs = vec![output];
         let block = Block::new_origin_block(&outputs);
-        let block_contents = BlockContents::new(vec![], outputs);
+        let block_contents = BlockContents {
+            outputs,
+            ..Default::default()
+        };
 
         (block, block_contents)
     }
@@ -1059,7 +1067,11 @@ mod ledger_db_test {
 
         let key_images: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BLOCK_VERSION,
             &origin_block,
@@ -1138,9 +1150,10 @@ mod ledger_db_test {
             })
             .collect();
 
-        let key_images = Vec::new();
-
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BLOCK_VERSION,
             &origin_block,
@@ -1299,7 +1312,11 @@ mod ledger_db_test {
         .unwrap();
         let outputs = vec![tx_out];
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BlockVersion::ONE,
             &origin_block,
@@ -1344,7 +1361,11 @@ mod ledger_db_test {
         .unwrap();
         let outputs = vec![tx_out];
 
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images: key_images.clone(),
+            outputs,
+            ..Default::default()
+        };
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
         let block = Block::new_with_parent(
             BlockVersion::ONE,
@@ -1381,9 +1402,11 @@ mod ledger_db_test {
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let outputs = Vec::new();
-
-        let block_contents = BlockContents::new(key_images.clone(), outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
         let block = Block::new_with_parent(
             BlockVersion::ONE,
             &origin_block,
@@ -1465,7 +1488,11 @@ mod ledger_db_test {
                 let key_images: Vec<KeyImage> =
                     (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-                let block_contents = BlockContents::new(key_images.clone(), outputs);
+                let block_contents = BlockContents {
+                    key_images,
+                    outputs,
+                    ..Default::default()
+                };
                 last_block = Block::new_with_parent(
                     block_version,
                     &last_block,
@@ -1509,7 +1536,11 @@ mod ledger_db_test {
             let key_images: Vec<KeyImage> =
                 (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
-            let block_contents = BlockContents::new(key_images.clone(), outputs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
             assert_eq!(last_block.version, *MAX_BLOCK_VERSION);
 
             // Note: unsafe transmute is being used to skirt the invariant that BlockVersion
@@ -1562,7 +1593,11 @@ mod ledger_db_test {
         .unwrap();
 
         let outputs = vec![tx_out];
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         // Appending a block to a previously written location should fail.
         let mut new_block = Block::new(
@@ -1618,7 +1653,11 @@ mod ledger_db_test {
             )
             .unwrap();
             let outputs = vec![tx_out];
-            BlockContents::new(block_one_key_images.clone(), outputs)
+            BlockContents {
+                key_images: block_one_key_images.clone(),
+                outputs,
+                ..Default::default()
+            };
         };
 
         let block_one = Block::new_with_parent(
@@ -1642,7 +1681,11 @@ mod ledger_db_test {
             )
             .unwrap();
             let outputs = vec![tx_out];
-            BlockContents::new(block_one_key_images.clone(), outputs)
+            BlockContents {
+                key_images: block_one_key_images.clone(),
+                outputs,
+                ..Default::default()
+            };
         };
 
         let block_two = Block::new_with_parent(
@@ -1687,7 +1730,12 @@ mod ledger_db_test {
             .unwrap();
             tx_out.public_key = existing_tx_out.public_key.clone();
             let outputs = vec![tx_out];
-            BlockContents::new(vec![KeyImage::from(rng.next_u64())], outputs)
+            let key_images = vec![KeyImage::from(rng.next_u64())];
+            BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            }
         };
 
         let block_one = Block::new_with_parent(
@@ -1748,7 +1796,12 @@ mod ledger_db_test {
             .unwrap();
 
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let block_contents = BlockContents::new(key_images, vec![tx_out]);
+            let outputs = vec![tx_out];
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             let bytes = [14u8; 32];
             let bad_parent_id = BlockID::try_from(&bytes[..]).unwrap();

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -26,7 +26,7 @@ use mc_common::logger::global_log;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     membership_proofs::Range,
-    mint::{MintConfig, MintTx, SetMintConfigTx},
+    mint::{MintTx, SetMintConfigTx},
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, TokenId, MAX_BLOCK_VERSION,
@@ -417,14 +417,6 @@ impl Ledger for LedgerDB {
         let db_transaction = self.env.begin_ro_txn()?;
         self.mint_config_store
             .get_active_mint_configs(token_id, &db_transaction)
-    }
-
-    fn update_total_minted(&self, mint_config: &MintConfig, amount: u64) -> Result<(), Error> {
-        let mut db_transaction = self.env.begin_rw_txn()?;
-        self.mint_config_store
-            .update_total_minted(mint_config, amount, &mut db_transaction)?;
-        db_transaction.commit()?;
-        Ok(())
     }
 }
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -669,15 +669,27 @@ impl LedgerDB {
             }
         }
 
-        // A block must have outputs, unless it has minting-related transactions.
-        let has_minting_txs =
-            !block_contents.set_mint_config_txs.is_empty() || !block_contents.mint_txs.is_empty();
-        if block_contents.outputs.is_empty() && !has_minting_txs {
+        // A block must have outputs, unless it has set-mint-config transactions:
+        // - Origin block had outputs only outputs in it.
+        // - Blocks before minting was introduced always had outputs in them.
+        // - Blocks that have MintTxs in them will also have the minted TxOuts in them.
+        // - Blocks with only SetMintConfigTxs are allowed to not have outputs.
+        let has_set_mint_config_txs = !block_contents.set_mint_config_txs.is_empty();
+        if block_contents.outputs.is_empty() && !has_set_mint_config_txs {
             return Err(Error::NoOutputs);
         }
 
+        // Number of outputs must be >= number of mint transactions because each mint
+        // transaction must produce a single output.
+        if block_contents.outputs.len() < block_contents.mint_txs.len() {
+            return Err(Error::TooFewOutputs);
+        }
+
         // Non-origin blocks must have key images, unless it has minting-related
-        // transactions.
+        // transactions. When we have minting transactions it implies we might've not
+        // spent any pre-existing outputs and as such we will not have key images.
+        let has_minting_txs =
+            !block_contents.set_mint_config_txs.is_empty() || !block_contents.mint_txs.is_empty();
         if block.index != 0 && block_contents.key_images.is_empty() && !has_minting_txs {
             return Err(Error::NoKeyImages);
         }
@@ -877,7 +889,7 @@ mod ledger_db_test {
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use rand_core::RngCore;
+    use rand_core::{CryptoRng, RngCore};
     use tempdir::TempDir;
     use test::Bencher;
 
@@ -967,6 +979,17 @@ mod ledger_db_test {
         assert_eq!(db.num_blocks().unwrap(), num_blocks as u64);
 
         (blocks, blocks_contents)
+    }
+    /// Generate a dummy txout for testing.
+    fn get_test_tx_out(rng: &mut (impl RngCore + CryptoRng)) -> TxOut {
+        let account_key = AccountKey::random(rng);
+        TxOut::new(
+            rng.next_u64(),
+            &account_key.default_subaddress(),
+            &RistrettoPrivate::from_random(rng),
+            Default::default(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -1306,9 +1329,9 @@ mod ledger_db_test {
     }
 
     #[test]
-    // Appending a block with only MintTxs should correctly update each LMDB
+    // Appending a block with MintTxs and outputs should correctly update each LMDB
     // database.
-    fn append_block_with_only_mint_tx() {
+    fn append_block_with_mint_txs_and_outputs() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let mut ledger_db = create_db();
         let token_id1 = TokenId::from(1);
@@ -1359,6 +1382,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1374,9 +1398,9 @@ mod ledger_db_test {
             .unwrap();
 
         assert_eq!(3, ledger_db.num_blocks().unwrap());
+        assert_eq!(2, ledger_db.num_txos().unwrap());
         // The origin block should still be in the ledger:
         assert_eq!(origin_block, ledger_db.get_block(0).unwrap());
-        assert_eq!(1, ledger_db.num_txos().unwrap());
         // The new block should be in the ledger:
         assert_eq!(block2, ledger_db.get_block(2).unwrap());
 
@@ -1415,6 +1439,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1430,9 +1455,9 @@ mod ledger_db_test {
             .unwrap();
 
         assert_eq!(4, ledger_db.num_blocks().unwrap());
+        assert_eq!(3, ledger_db.num_txos().unwrap());
         // The origin block should still be in the ledger:
         assert_eq!(origin_block, ledger_db.get_block(0).unwrap());
-        assert_eq!(1, ledger_db.num_txos().unwrap());
         // Previous blocks should still be in the ledger:
         assert_eq!(block1, ledger_db.get_block(1).unwrap());
         assert_eq!(block2, ledger_db.get_block(2).unwrap());
@@ -1470,6 +1495,7 @@ mod ledger_db_test {
 
         let block_contents4 = BlockContents {
             mint_txs: vec![mint_tx3.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1485,9 +1511,9 @@ mod ledger_db_test {
             .unwrap();
 
         assert_eq!(5, ledger_db.num_blocks().unwrap());
+        assert_eq!(4, ledger_db.num_txos().unwrap());
         // The origin block should still be in the ledger:
         assert_eq!(origin_block, ledger_db.get_block(0).unwrap());
-        assert_eq!(1, ledger_db.num_txos().unwrap());
         // Previous blocks should still be in the ledger:
         assert_eq!(block1, ledger_db.get_block(1).unwrap());
         assert_eq!(block2, ledger_db.get_block(2).unwrap());
@@ -1511,6 +1537,148 @@ mod ledger_db_test {
                 ActiveMintConfig {
                     mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: mint_tx2.prefix.amount,
+                }
+            ]
+        );
+
+        // === Append a fourth block with two MintTxs, tragetting the first active
+        // mint config which should result in the total minted amount
+        // increasing.
+        let mint_tx4 = generate_test_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            100,
+            &mut rng,
+        );
+
+        let mint_tx5 = generate_test_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            200,
+            &mut rng,
+        );
+
+        let block_contents5 = BlockContents {
+            mint_txs: vec![mint_tx4.clone(), mint_tx5.clone()],
+            outputs: vec![get_test_tx_out(&mut rng), get_test_tx_out(&mut rng)],
+            ..Default::default()
+        };
+
+        let block5 = Block::new_with_parent(
+            BLOCK_VERSION,
+            &block4,
+            &Default::default(),
+            &block_contents5,
+        );
+
+        ledger_db
+            .append_block(&block5, &block_contents5, None)
+            .unwrap();
+
+        assert_eq!(6, ledger_db.num_blocks().unwrap());
+        assert_eq!(6, ledger_db.num_txos().unwrap());
+        // The origin block should still be in the ledger:
+        assert_eq!(origin_block, ledger_db.get_block(0).unwrap());
+        // Previous blocks should still be in the ledger:
+        assert_eq!(block1, ledger_db.get_block(1).unwrap());
+        assert_eq!(block2, ledger_db.get_block(2).unwrap());
+        assert_eq!(block3, ledger_db.get_block(3).unwrap());
+        assert_eq!(block4, ledger_db.get_block(4).unwrap());
+
+        assert_eq!(block_contents1, ledger_db.get_block_contents(1).unwrap());
+        assert_eq!(block_contents2, ledger_db.get_block_contents(2).unwrap());
+        assert_eq!(block_contents3, ledger_db.get_block_contents(3).unwrap());
+        assert_eq!(block_contents4, ledger_db.get_block_contents(4).unwrap());
+        // The new block should be in the ledger:
+        assert_eq!(block5, ledger_db.get_block(5).unwrap());
+        assert_eq!(block_contents5, ledger_db.get_block_contents(5).unwrap());
+
+        // The active mint configs should be updated.
+        assert_eq!(
+            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            vec![
+                ActiveMintConfig {
+                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    total_minted: mint_tx1.prefix.amount
+                        + mint_tx3.prefix.amount
+                        + mint_tx4.prefix.amount
+                        + mint_tx5.prefix.amount,
+                },
+                ActiveMintConfig {
+                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    total_minted: mint_tx2.prefix.amount,
+                }
+            ]
+        );
+
+        // === Append a fifth with two MintTxs, tragetting both mint configs which
+        // should result in the total minted amount increasing.
+        let mint_tx6 = generate_test_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            101,
+            &mut rng,
+        );
+
+        let mint_tx7 = generate_test_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[1].private_key())],
+            201,
+            &mut rng,
+        );
+
+        let block_contents6 = BlockContents {
+            mint_txs: vec![mint_tx6.clone(), mint_tx7.clone()],
+            outputs: vec![get_test_tx_out(&mut rng), get_test_tx_out(&mut rng)],
+            ..Default::default()
+        };
+
+        let block6 = Block::new_with_parent(
+            BLOCK_VERSION,
+            &block5,
+            &Default::default(),
+            &block_contents6,
+        );
+
+        ledger_db
+            .append_block(&block6, &block_contents6, None)
+            .unwrap();
+
+        assert_eq!(7, ledger_db.num_blocks().unwrap());
+        assert_eq!(8, ledger_db.num_txos().unwrap());
+        // The origin block should still be in the ledger:
+        assert_eq!(origin_block, ledger_db.get_block(0).unwrap());
+        // Previous blocks should still be in the ledger:
+        assert_eq!(block1, ledger_db.get_block(1).unwrap());
+        assert_eq!(block2, ledger_db.get_block(2).unwrap());
+        assert_eq!(block3, ledger_db.get_block(3).unwrap());
+        assert_eq!(block4, ledger_db.get_block(4).unwrap());
+        assert_eq!(block5, ledger_db.get_block(5).unwrap());
+
+        assert_eq!(block_contents1, ledger_db.get_block_contents(1).unwrap());
+        assert_eq!(block_contents2, ledger_db.get_block_contents(2).unwrap());
+        assert_eq!(block_contents3, ledger_db.get_block_contents(3).unwrap());
+        assert_eq!(block_contents4, ledger_db.get_block_contents(4).unwrap());
+        assert_eq!(block_contents5, ledger_db.get_block_contents(5).unwrap());
+        // The new block should be in the ledger:
+        assert_eq!(block6, ledger_db.get_block(6).unwrap());
+        assert_eq!(block_contents6, ledger_db.get_block_contents(6).unwrap());
+
+        // The active mint configs should be updated.
+        assert_eq!(
+            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            vec![
+                ActiveMintConfig {
+                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    total_minted: mint_tx1.prefix.amount
+                        + mint_tx3.prefix.amount
+                        + mint_tx4.prefix.amount
+                        + mint_tx5.prefix.amount
+                        + mint_tx6.prefix.amount,
+                },
+                ActiveMintConfig {
+                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    total_minted: mint_tx2.prefix.amount + mint_tx7.prefix.amount,
                 }
             ]
         );
@@ -1741,6 +1909,71 @@ mod ledger_db_test {
     }
 
     #[test]
+    #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: TooFewOutputs")]
+    // Appending a block that contains more MintTxs than outputs should
+    // fail.
+    fn test_append_block_fails_if_not_enough_outputs() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let mut ledger_db = create_db();
+        let token_id1 = TokenId::from(1);
+
+        // === Create and append the origin block. ===
+        // The origin block contains a single output belonging to the
+        // `origin_account_key`.
+
+        let origin_account_key = AccountKey::random(&mut rng);
+        let (origin_block, origin_block_contents) =
+            get_origin_block_and_contents(&origin_account_key);
+
+        ledger_db
+            .append_block(&origin_block, &origin_block_contents, None)
+            .unwrap();
+
+        // === Append a block wth a SetMintConfigTx transaction. This is needed since
+        // the MintTx must be matched with an active mint config.
+        let (set_mint_config_tx1, signers1) =
+            generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
+
+        let block_contents1 = BlockContents {
+            set_mint_config_txs: vec![set_mint_config_tx1.clone()],
+            ..Default::default()
+        };
+
+        let block1 = Block::new_with_parent(
+            BLOCK_VERSION,
+            &origin_block,
+            &Default::default(),
+            &block_contents1,
+        );
+
+        ledger_db
+            .append_block(&block1, &block_contents1, None)
+            .unwrap();
+
+        // === Append a block with two MintTxs but only a single TxOut. ===
+        let mint_tx1 = generate_test_mint_tx(token_id1, &signers1, 10, &mut rng);
+        let mint_tx2 = generate_test_mint_tx(token_id1, &signers1, 10, &mut rng);
+
+        let block_contents2 = BlockContents {
+            mint_txs: vec![mint_tx1, mint_tx2],
+            outputs: vec![get_test_tx_out(&mut rng)],
+            ..Default::default()
+        };
+
+        let block2 = Block::new_with_parent(
+            BLOCK_VERSION,
+            &block1,
+            &Default::default(),
+            &block_contents2,
+        );
+
+        // This should fail.
+        ledger_db
+            .append_block(&block2, &block_contents2, None)
+            .unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: DuplicateMintTx")]
     // Appending a block that contains a previously-seen MintTx should
     // fail.
@@ -1787,6 +2020,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1814,6 +2048,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2.clone(), mint_tx1.clone()],
+            outputs: vec![get_test_tx_out(&mut rng), get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1882,6 +2117,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1956,6 +2192,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -1981,6 +2218,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 
@@ -2020,6 +2258,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx3.clone()],
+            outputs: vec![get_test_tx_out(&mut rng)],
             ..Default::default()
         };
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -912,18 +912,17 @@ mod ledger_db_test {
     use super::*;
     use crate::mint_config_store::tests::{
         generate_test_mint_config_tx, generate_test_mint_config_tx_and_signers,
+        generate_test_mint_tx,
     };
     use core::convert::TryFrom;
     use mc_account_keys::AccountKey;
-    use mc_crypto_keys::{Ed25519Pair, RistrettoPrivate, RistrettoPublic, Signer};
-    use mc_crypto_multisig::MultiSig;
+    use mc_crypto_keys::{Ed25519Pair, RistrettoPrivate};
     use mc_transaction_core::{
-        compute_block_id, membership_proofs::compute_implied_merkle_root, mint::MintTxPrefix,
-        BlockVersion,
+        compute_block_id, membership_proofs::compute_implied_merkle_root, BlockVersion,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
-    use rand_core::{CryptoRng, RngCore};
+    use rand_core::RngCore;
     use tempdir::TempDir;
     use test::Bencher;
 
@@ -1013,36 +1012,6 @@ mod ledger_db_test {
         assert_eq!(db.num_blocks().unwrap(), num_blocks as u64);
 
         (blocks, blocks_contents)
-    }
-
-    // Generate a random mint tx
-    pub fn generate_test_mint_tx(
-        token_id: TokenId,
-        signers: &[Ed25519Pair],
-        amount: u64,
-        rng: &mut (impl RngCore + CryptoRng),
-    ) -> MintTx {
-        let mut nonce: Vec<u8> = vec![0u8; 32];
-        rng.fill_bytes(&mut nonce);
-
-        let prefix = MintTxPrefix {
-            token_id: *token_id,
-            amount,
-            view_public_key: RistrettoPublic::from_random(rng),
-            spend_public_key: RistrettoPublic::from_random(rng),
-            nonce,
-            tombstone_block: rng.next_u64(),
-        };
-
-        let message = prefix.hash();
-
-        let signatures = signers
-            .iter()
-            .map(|signer| signer.try_sign(message.as_ref()).unwrap())
-            .collect();
-        let signature = MultiSig::new(signatures);
-
-        MintTx { prefix, signature }
     }
 
     #[test]

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -168,7 +168,7 @@ pub struct LedgerDB {
     set_mint_config_txs_by_block: Database,
 
     /// MintTxs by block.
-    set_mint_txs_by_block: Database,
+    mint_txs_by_block: Database,
 
     /// Location on filesystem.
     path: PathBuf,
@@ -676,7 +676,7 @@ impl LedgerDB {
 
         db_transaction.put(
             self.set_mint_config_txs_by_block,
-            &u64_to_key_bytes(block_index),
+            &block_index_bytes,
             &encode(&set_mint_config_tx_list),
             WriteFlags::empty(),
         )?;
@@ -697,7 +697,7 @@ impl LedgerDB {
 
         db_transaction.put(
             self.mint_txs_by_block,
-            &u64_to_key_bytes(block_index),
+            &block_index_bytes,
             &encode(&mint_tx_list),
             WriteFlags::empty(),
         )?;

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -2087,8 +2087,9 @@ mod ledger_db_test {
 
     #[test]
     #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: NoKeyImages")]
-    // Appending a non-origin block should fail if the block contains no key images.
-    fn test_append_block_fails_for_non_origin_blocks_without_key_images() {
+    // Appending a non-origin block should fail if the block contains no key images
+    // and no minting transactions.
+    fn test_append_block_fails_for_non_origin_non_minting_blocks_without_key_images() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let mut ledger_db = create_db();
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1950,4 +1950,7 @@ mod ledger_db_test {
 
         b.iter(|| ledger_db.get_block(rng.next_u64() % n_blocks).unwrap())
     }
+
+    // TODO add test for block with only mint tx, only set mintconfig tx, no
+    // txs, regular txs + mints, etc
 }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -52,7 +52,7 @@ pub use mint_tx_store::MintTxStore;
 pub use tx_out_store::TxOutStore;
 
 pub const MAX_LMDB_FILE_SIZE: usize = 2usize.pow(40); // 1 TB
-pub const MAX_LMDB_DATABASES: u32 = 29; // maximum number of databases in the lmdb file
+pub const MAX_LMDB_DATABASES: u32 = 27; // maximum number of databases in the lmdb file
 
 // LMDB Database names.
 pub const COUNTS_DB_NAME: &str = "ledger_db:counts";

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1404,7 +1404,6 @@ mod ledger_db_test {
 
         let block_contents = BlockContents {
             key_images,
-            outputs,
             ..Default::default()
         };
         let block = Block::new_with_parent(
@@ -1657,7 +1656,7 @@ mod ledger_db_test {
                 key_images: block_one_key_images.clone(),
                 outputs,
                 ..Default::default()
-            };
+            }
         };
 
         let block_one = Block::new_with_parent(
@@ -1685,7 +1684,7 @@ mod ledger_db_test {
                 key_images: block_one_key_images.clone(),
                 outputs,
                 ..Default::default()
-            };
+            }
         };
 
         let block_two = Block::new_with_parent(

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -232,11 +232,11 @@ impl MintConfigStore {
 
         for active_mint_config in active_mint_configs {
             // See if this mint config has signed the mint tx.
-            if !active_mint_config
+            if active_mint_config
                 .mint_config
                 .signer_set
                 .verify(&message, &mint_tx.signature)
-                .is_ok()
+                .is_err()
             {
                 continue;
             }

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -298,7 +298,7 @@ impl MintConfigStore {
         Ok(())
     }
 
-    pub fn contains_set_mint_config_tx_nonce(
+    pub fn check_set_mint_config_tx_nonce(
         &self,
         nonce: &[u8],
         db_transaction: &impl Transaction,

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -198,7 +198,7 @@ impl MintConfigStore {
 }
 
 #[cfg(test)]
-mod test {
+pub mod tests {
     use super::*;
     use crate::tx_out_store::tx_out_store_tests::get_env;
     use mc_crypto_keys::Ed25519Pair;

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -134,7 +134,7 @@ impl MintConfigStore {
             self.set_mint_config_txs_by_block,
             &block_index_bytes,
             &encode(&set_mint_config_tx_list),
-            WriteFlags::empty(),
+            WriteFlags::NO_OVERWRITE, // We should not be updating existing blocks
         )?;
 
         // Update active mint configurations.

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -161,8 +161,8 @@ impl MintConfigStore {
                 self.block_index_by_set_mint_config_tx_nonce,
                 &set_mint_config_tx.prefix.nonce,
                 &block_index_bytes,
-                WriteFlags::NO_OVERWRITE, /* this ensures we do not overwrite a nonce that was
-                                           * already used */
+                //  ensures we do not overwrite a nonce that was already used
+                WriteFlags::NO_OVERWRITE,
             )?;
 
             db_transaction.put(

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -10,9 +10,10 @@
 //!      2) It enables keeping track of how much was minted using a given
 //! configuration. This is used to enforce the per-configuration mint limit.
 //! 2) A mapping of nonce -> block index of the block containing the
-//! SetMintConfigTx with that nonce. This    is mainly used to prevent replay
-//! attacks. 3) A mapping of block index -> list of SetMintConfigTx objects
-//! included in    the block.
+//! SetMintConfigTx with that nonce. This is mainly used to prevent replay
+//! attacks.
+//! 3) A mapping of block index -> list of SetMintConfigTx objects
+//! included in the block.
 
 use crate::{key_bytes_to_u64, u32_to_key_bytes, u64_to_key_bytes, Error};
 use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -9,24 +9,24 @@
 //! transaction is allowed to mint.
 //!      2) It enables keeping track of how much was minted using a given
 //! configuration. This is used to enforce the per-configuration mint limit.
-//! 2) A mapping of nonce -> SetMintConfigTx object containing the nonce. This
-//!    is mainly used to prevent replay attacks.
-//! 3) A mapping of block index -> list of SetMintConfigTx objects included in
-//!    the block.
+//! 2) A mapping of nonce -> block index of the block containing the
+//! SetMintConfigTx with that nonce. This    is mainly used to prevent replay
+//! attacks. 3) A mapping of block index -> list of SetMintConfigTx objects
+//! included in    the block.
 
-use crate::{u32_to_key_bytes, u64_to_key_bytes, Error};
+use crate::{key_bytes_to_u64, u32_to_key_bytes, u64_to_key_bytes, Error};
 use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
 use mc_transaction_core::{
     mint::{MintConfig, MintTx, SetMintConfigTx},
-    TokenId,
+    BlockIndex, TokenId,
 };
 use mc_util_serial::{decode, encode, Message};
 
 // LMDB Database names.
 pub const ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME: &str =
     "mint_config_store:active_mint_configs_by_token_id";
-pub const SET_MINT_CONFIG_TX_BY_NONCE_DB_NAME: &str =
-    "mint_config_store:set_mint_config_tx_by_nonce_db_name";
+pub const BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME: &str =
+    "mint_config_store:block_index_by_set_mint_config_tx_nonce";
 pub const SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str =
     "mint_config_store:set_mint_config_txs_by_block";
 
@@ -79,8 +79,8 @@ pub struct MintConfigStore {
     /// token id -> Vec<ActiveMintConfig>
     active_mint_configs_by_token_id: Database,
 
-    /// nonce -> SetMintConfigTx
-    set_mint_config_tx_by_nonce: Database,
+    /// nonce -> block index
+    block_index_by_set_mint_config_tx_nonce: Database,
 
     /// block_index -> SetMintConfigTxList
     set_mint_config_txs_by_block: Database,
@@ -92,7 +92,8 @@ impl MintConfigStore {
         Ok(MintConfigStore {
             active_mint_configs_by_token_id: env
                 .open_db(Some(ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME))?,
-            set_mint_config_tx_by_nonce: env.open_db(Some(SET_MINT_CONFIG_TX_BY_NONCE_DB_NAME))?,
+            block_index_by_set_mint_config_tx_nonce: env
+                .open_db(Some(BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME))?,
             set_mint_config_txs_by_block: env
                 .open_db(Some(SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
         })
@@ -105,7 +106,7 @@ impl MintConfigStore {
             DatabaseFlags::empty(),
         )?;
         env.create_db(
-            Some(SET_MINT_CONFIG_TX_BY_NONCE_DB_NAME),
+            Some(BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME),
             DatabaseFlags::empty(),
         )?;
         env.create_db(
@@ -139,8 +140,38 @@ impl MintConfigStore {
 
         // Update active mint configurations.
         for set_mint_config_tx in set_mint_config_txs {
-            self.set_active_mint_configs(set_mint_config_tx, db_transaction)?;
+            // All mint configurations must have the same token id.
+            if set_mint_config_tx
+                .prefix
+                .configs
+                .iter()
+                .any(|mint_config| mint_config.token_id != set_mint_config_tx.prefix.token_id)
+            {
+                return Err(Error::InvalidMintConfig(
+                    "All mint configurations must have the same token id".to_string(),
+                ));
+            }
+
+            // MintConfigs -> ActiveMintConfigs
+            let active_mint_configs = ActiveMintConfigs::from(set_mint_config_tx);
+
+            // Store in database
+            db_transaction.put(
+                self.block_index_by_set_mint_config_tx_nonce,
+                &set_mint_config_tx.prefix.nonce,
+                &block_index_bytes,
+                WriteFlags::NO_OVERWRITE, /* this ensures we do not overwrite a nonce that was
+                                           * already used */
+            )?;
+
+            db_transaction.put(
+                self.active_mint_configs_by_token_id,
+                &u32_to_key_bytes(set_mint_config_tx.prefix.token_id),
+                &encode(&active_mint_configs),
+                WriteFlags::empty(),
+            )?;
         }
+
         Ok(())
     }
 
@@ -266,57 +297,16 @@ impl MintConfigStore {
         Ok(())
     }
 
-    /// Returns true of the Ledger contains the given set-mint-config-tx nonce.
-    pub fn contains_set_mint_config_tx_nonce(
+    pub fn check_set_mint_config_tx_nonce(
         &self,
         nonce: &[u8],
         db_transaction: &impl Transaction,
-    ) -> Result<bool, Error> {
-        match db_transaction.get(self.set_mint_config_tx_by_nonce, &nonce) {
-            Ok(_db_bytes) => Ok(true),
-            Err(lmdb::Error::NotFound) => Ok(false),
+    ) -> Result<Option<BlockIndex>, Error> {
+        match db_transaction.get(self.block_index_by_set_mint_config_tx_nonce, &nonce) {
+            Ok(db_bytes) => Ok(Some(key_bytes_to_u64(db_bytes))),
+            Err(lmdb::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::Lmdb(e)),
         }
-    }
-
-    /// Set mint configurations for a given token.
-    fn set_active_mint_configs(
-        &self,
-        set_mint_config_tx: &SetMintConfigTx,
-        db_transaction: &mut RwTransaction,
-    ) -> Result<(), Error> {
-        // All mint configurations must have the same token id.
-        if set_mint_config_tx
-            .prefix
-            .configs
-            .iter()
-            .any(|mint_config| mint_config.token_id != set_mint_config_tx.prefix.token_id)
-        {
-            return Err(Error::InvalidMintConfig(
-                "All mint configurations must have the same token id".to_string(),
-            ));
-        }
-
-        // MintConfigs -> ActiveMintConfigs
-        let active_mint_configs = ActiveMintConfigs::from(set_mint_config_tx);
-
-        // Store in database
-        db_transaction.put(
-            self.set_mint_config_tx_by_nonce,
-            &set_mint_config_tx.prefix.nonce,
-            &encode(set_mint_config_tx),
-            WriteFlags::NO_OVERWRITE, /* this ensures we do not overwrite a nonce that was
-                                       * already used */
-        )?;
-
-        db_transaction.put(
-            self.active_mint_configs_by_token_id,
-            &u32_to_key_bytes(set_mint_config_tx.prefix.token_id),
-            &encode(&active_mint_configs),
-            WriteFlags::empty(),
-        )?;
-
-        Ok(())
     }
 }
 
@@ -432,7 +422,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -458,7 +448,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_2, &mut db_transaction)
+                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -495,7 +485,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -503,7 +493,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.set_active_mint_configs(&test_tx_1, &mut db_transaction),
+                mint_config_store.write_set_mint_config_txs(
+                    1,
+                    &[test_tx_1.clone()],
+                    &mut db_transaction
+                ),
                 Err(Error::Lmdb(lmdb::Error::KeyExist))
             );
             db_transaction.commit().unwrap();
@@ -513,7 +507,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.set_active_mint_configs(&test_tx_1, &mut db_transaction),
+                mint_config_store.write_set_mint_config_txs(
+                    2,
+                    &[test_tx_1.clone()],
+                    &mut db_transaction
+                ),
                 Err(Error::Lmdb(lmdb::Error::KeyExist))
             );
             db_transaction.commit().unwrap();
@@ -524,7 +522,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_2, &mut db_transaction)
+                .write_set_mint_config_txs(3, &[test_tx_2], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -543,7 +541,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -563,7 +561,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_2, &mut db_transaction)
+                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -601,7 +599,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -621,7 +619,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_2, &mut db_transaction)
+                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -648,7 +646,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -723,7 +721,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -754,7 +752,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -807,7 +805,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -857,7 +855,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -929,7 +927,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1014,7 +1012,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .set_active_mint_configs(&test_tx_1, &mut db_transaction)
+                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1132,6 +1130,95 @@ pub mod tests {
             assert_eq!(
                 active_mint_configs,
                 ActiveMintConfigs::from(&test_tx_2).configs
+            );
+        }
+    }
+
+    #[test]
+    fn check_set_mint_config_tx_nonce_works() {
+        let (mint_config_store, env) = init_mint_config_store();
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let test_tx_1 = generate_test_mint_config_tx(token_id1, &mut rng);
+        let test_tx_2 = generate_test_mint_config_tx(token_id2, &mut rng);
+        let test_tx_3 = generate_test_mint_config_tx(token_id2, &mut rng);
+
+        {
+            let mut db_transaction = env.begin_rw_txn().unwrap();
+            mint_config_store
+                .write_set_mint_config_txs(
+                    0,
+                    &[test_tx_1.clone(), test_tx_2.clone()],
+                    &mut db_transaction,
+                )
+                .unwrap();
+            db_transaction.commit().unwrap();
+        }
+
+        {
+            let db_transaction = env.begin_ro_txn().unwrap();
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
+                Ok(Some(0)),
+            );
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
+                Ok(Some(0)),
+            );
+
+            assert_eq!(
+                mint_config_store.check_set_mint_config_tx_nonce(
+                    &test_tx_2.prefix.nonce[0..test_tx_2.prefix.nonce.len() - 1],
+                    &db_transaction
+                ),
+                Ok(None),
+            );
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
+                Ok(None),
+            );
+
+            assert_eq!(
+                mint_config_store.check_set_mint_config_tx_nonce(&[1, 2, 3], &db_transaction),
+                Ok(None),
+            );
+        }
+
+        {
+            let mut db_transaction = env.begin_rw_txn().unwrap();
+            mint_config_store
+                .write_set_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
+                .unwrap();
+            db_transaction.commit().unwrap();
+        }
+
+        {
+            let db_transaction = env.begin_ro_txn().unwrap();
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
+                Ok(Some(0)),
+            );
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
+                Ok(Some(0)),
+            );
+
+            assert_eq!(
+                mint_config_store
+                    .check_set_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
+                Ok(Some(1)),
             );
         }
     }

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -298,7 +298,7 @@ impl MintConfigStore {
         Ok(())
     }
 
-    pub fn check_set_mint_config_tx_nonce(
+    pub fn contains_set_mint_config_tx_nonce(
         &self,
         nonce: &[u8],
         db_transaction: &impl Transaction,

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -242,6 +242,19 @@ impl MintConfigStore {
 
         Ok(())
     }
+
+    /// Returns true of the Ledger contains the given set-mint-config-tx nonce.
+    pub fn contains_set_mint_config_tx_nonce(
+        &self,
+        nonce: &[u8],
+        db_transaction: &impl Transaction,
+    ) -> Result<bool, Error> {
+        match db_transaction.get(self.set_mint_config_tx_by_nonce, &nonce) {
+            Ok(_db_bytes) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(e) => Err(Error::Lmdb(e)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -37,10 +37,8 @@ impl MintTxStore {
     /// Opens an existing MintTxStore.
     pub fn new(env: &Environment) -> Result<Self, Error> {
         Ok(MintTxStore {
-            mint_txs_by_block: env
-                .open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
-            mint_tx_by_nonce: env
-                .open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
+            mint_txs_by_block: env.open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
+            mint_tx_by_nonce: env.open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
         })
     }
 
@@ -103,7 +101,7 @@ impl MintTxStore {
         for mint_tx in mint_txs {
             // Update total minted.
             let active_mint_config =
-                mint_config_store.get_active_mint_config_for_mint_tx(&mint_tx, db_transaction)?;
+                mint_config_store.get_active_mint_config_for_mint_tx(mint_tx, db_transaction)?;
 
             let new_total_minted = active_mint_config.total_minted.checked_add(mint_tx.prefix.amount).expect("shouldn't have failed because get_active_mint_config_for_mint_tx guards against this");
 

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Data access abstraction for mint transactions stored in the ledger.
+//!
+//! This store maintains two LMDB databases:
+//! 1) A mapping of block index -> list of mint transactions included in the
+//! block.    This is used to provide the mint_txs inside BlockContents.
+//! 2) A mapping of hash -> MintTx. This is used to prevent replay attacks.
+
+use crate::{u64_to_key_bytes, Error, MintConfigStore};
+use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
+use mc_transaction_core::mint::MintTx;
+use mc_util_serial::{decode, encode, Message};
+
+// LMDB Database names.
+pub const MINT_TXS_BY_BLOCK_DB_NAME: &str = "mint_tx_store:set_txs_by_block";
+pub const MINT_TX_BY_NONCE_DB_NAME: &str = "mint_tx_store:mint_tx_by_nonce";
+
+/// A list of mint-txs that can be prost-encoded. This is needed since that's
+/// the only way to encode a Vec<MintTx>.
+#[derive(Clone, Message)]
+pub struct MintTxList {
+    #[prost(message, repeated, tag = "1")]
+    pub mint_txs: Vec<MintTx>,
+}
+
+#[derive(Clone)]
+pub struct MintTxStore {
+    /// MintTxs by block.
+    mint_txs_by_block: Database,
+
+    /// MintTx by nonce.
+    mint_tx_by_nonce: Database,
+}
+
+impl MintTxStore {
+    /// Opens an existing MintTxStore.
+    pub fn new(env: &Environment) -> Result<Self, Error> {
+        Ok(MintTxStore {
+            mint_txs_by_block: env
+                .open_db(Some(MINT_TXS_BY_BLOCK_DB_NAME))?,
+            mint_tx_by_nonce: env
+                .open_db(Some(MINT_TX_BY_NONCE_DB_NAME))?,
+        })
+    }
+
+    /// Creates a fresh MintTxStore.
+    pub fn create(env: &Environment) -> Result<(), Error> {
+        env.create_db(Some(MINT_TXS_BY_BLOCK_DB_NAME), DatabaseFlags::empty())?;
+        env.create_db(Some(MINT_TX_BY_NONCE_DB_NAME), DatabaseFlags::empty())?;
+        Ok(())
+    }
+
+    /// Get mint txs in a given block.
+    pub fn get_mint_txs_by_block_index(
+        &self,
+        block_index: u64,
+        db_transaction: &impl Transaction,
+    ) -> Result<Vec<MintTx>, Error> {
+        let mint_txs: MintTxList =
+            decode(db_transaction.get(self.mint_txs_by_block, &u64_to_key_bytes(block_index))?)?;
+        Ok(mint_txs.mint_txs)
+    }
+
+    /// Returns true if the Ledger contains the given mint tx nonce
+    pub fn contains_mint_tx_nonce(
+        &self,
+        nonce: &[u8],
+        db_transaction: &impl Transaction,
+    ) -> Result<bool, Error> {
+        match db_transaction.get(self.mint_tx_by_nonce, &nonce) {
+            Ok(_db_bytes) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(e) => Err(Error::Lmdb(e)),
+        }
+    }
+
+    /// Write mint txs in a given block.
+    pub fn write_mint_txs(
+        &self,
+        block_index: u64,
+        mint_txs: &[MintTx],
+        mint_config_store: &MintConfigStore,
+        db_transaction: &mut RwTransaction,
+    ) -> Result<(), Error> {
+        let block_index_bytes = u64_to_key_bytes(block_index);
+
+        // Store the list of MintTxs.
+        let mint_tx_list = MintTxList {
+            mint_txs: mint_txs.to_vec(),
+        };
+
+        db_transaction.put(
+            self.mint_txs_by_block,
+            &block_index_bytes,
+            &encode(&mint_tx_list),
+            WriteFlags::empty(),
+        )?;
+
+        // For each mint transaction, we need to locate the matching mint configuration
+        // and update the total minted count. We also need to ensure the nonce is
+        // unique.
+        for mint_tx in mint_txs {
+            // Update total minted.
+            let active_mint_config =
+                mint_config_store.get_active_mint_config_for_mint_tx(&mint_tx, db_transaction)?;
+
+            let new_total_minted = active_mint_config.total_minted.checked_add(mint_tx.prefix.amount).expect("shouldn't have failed because get_active_mint_config_for_mint_tx guards against this");
+
+            mint_config_store.update_total_minted(
+                &active_mint_config.mint_config,
+                new_total_minted,
+                db_transaction,
+            )?;
+
+            // Ensure nonce uniqueness
+            db_transaction.put(
+                self.mint_tx_by_nonce,
+                &mint_tx.prefix.nonce,
+                &encode(mint_tx),
+                WriteFlags::NO_OVERWRITE, /* this ensures we do not overwrite a nonce that was
+                                           * already used */
+            )?;
+        }
+
+        Ok(())
+    }
+}

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -5,7 +5,6 @@ use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
-    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, TokenId,
@@ -193,10 +192,6 @@ impl Ledger for MockLedger {
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
-        unimplemented!()
-    }
-
-    fn update_total_minted(&self, _mint_config: &MintConfig, _amount: u64) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -243,7 +243,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let origin_block = Block::new_origin_block(&outputs);
-            let block_contents = BlockContents::new(vec![], outputs);
+            let block_contents = BlockContents::new(vec![], outputs, vec![], vec![]);
             block_ids.push(origin_block.id.clone());
             blocks_and_contents.push((origin_block, block_contents));
         } else {
@@ -258,7 +258,10 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let block_contents = BlockContents::new(key_images, outputs);
+            let set_mint_config_txs = vec![];
+            let mint_txs = vec![];
+            let block_contents =
+                BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
 
             let block = Block::new_with_parent(
                 BlockVersion::ONE,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -7,7 +7,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-    Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, TokenId,
+    Block, BlockContents, BlockData, BlockID, BlockIndex, BlockSignature, BlockVersion, TokenId,
 };
 use mc_util_from_random::FromRandom;
 use rand::{rngs::StdRng, SeedableRng};
@@ -192,6 +192,14 @@ impl Ledger for MockLedger {
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
+        unimplemented!()
+    }
+
+    fn check_set_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
+        unimplemented!()
+    }
+
+    fn check_mint_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }
 }

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -243,7 +243,10 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let origin_block = Block::new_origin_block(&outputs);
-            let block_contents = BlockContents::new(vec![], outputs, vec![], vec![]);
+            let block_contents = BlockContents {
+                outputs,
+                ..Default::default()
+            };
             block_ids.push(origin_block.id.clone());
             blocks_and_contents.push((origin_block, block_contents));
         } else {
@@ -258,10 +261,11 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
-            let set_mint_config_txs = vec![];
-            let mint_txs = vec![];
-            let block_contents =
-                BlockContents::new(key_images, outputs, set_mint_config_txs, mint_txs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             let block = Block::new_with_parent(
                 BlockVersion::ONE,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -5,7 +5,7 @@ use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
-    mint::{MintConfig, SetMintConfigTx},
+    mint::MintConfig,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
     Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, TokenId,
@@ -190,9 +190,6 @@ impl Ledger for MockLedger {
 
     fn get_root_tx_out_membership_element(&self) -> Result<TxOutMembershipElement, Error> {
         unimplemented!();
-    }
-    fn set_active_mint_configs(&self, _set_mint_config_tx: &SetMintConfigTx) -> Result<(), Error> {
-        unimplemented!()
     }
 
     fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -90,6 +90,9 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
                 );
                 MintConfigStore::create(&env).expect("Failed creating MintConfigStore");
 
+                // TODO create the two new by-block databases and fill them with empty data for
+                // existing blocks!
+
                 let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
                 metadata_store
                     .set_version(&mut db_txn, 2022_02_22)

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -9,9 +9,9 @@ use lmdb::{DatabaseFlags, Environment, Transaction, WriteFlags};
 use mc_common::logger::{log, Logger};
 use mc_ledger_db::{
     key_bytes_to_u64, tx_out_store::TX_OUT_INDEX_BY_PUBLIC_KEY_DB_NAME, u64_to_key_bytes, Error,
-    LedgerDbMetadataStoreSettings, MetadataStore, MintConfigStore, TxOutStore, TxOutsByBlockValue,
-    BLOCK_NUMBER_BY_TX_OUT_INDEX, COUNTS_DB_NAME, MAX_LMDB_DATABASES, MAX_LMDB_FILE_SIZE,
-    NUM_BLOCKS_KEY, TX_OUTS_BY_BLOCK_DB_NAME,
+    LedgerDbMetadataStoreSettings, MetadataStore, MintConfigStore, MintTxStore, TxOutStore,
+    TxOutsByBlockValue, BLOCK_NUMBER_BY_TX_OUT_INDEX, COUNTS_DB_NAME, MAX_LMDB_DATABASES,
+    MAX_LMDB_FILE_SIZE, NUM_BLOCKS_KEY, TX_OUTS_BY_BLOCK_DB_NAME,
 };
 use mc_util_lmdb::MetadataStoreError;
 use mc_util_serial::decode;
@@ -42,6 +42,7 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
 
         match version.is_compatible_with_latest() {
             Ok(_) => {
+                log::info!(logger, "Ledger db is compatible with latest version");
                 break;
             }
             // Version 2020_06_10 came after 2020_04_27 and introduced the TxOut public key -> index
@@ -89,9 +90,10 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
                     "Ledger db migrating from version 2020_07_07 to 2022_02_22..."
                 );
                 MintConfigStore::create(&env).expect("Failed creating MintConfigStore");
+                MintTxStore::create(&env).expect("Failed creating MintTxStore");
 
-                // TODO create the two new by-block databases and fill them with empty data for
-                // existing blocks!
+                backfill_empty_mint_stores(&env, logger)
+                    .expect("Failed backfilling empty mint stores");
 
                 let mut db_txn = env.begin_rw_txn().expect("Failed starting rw transaction");
                 metadata_store
@@ -210,6 +212,38 @@ fn construct_block_number_by_tx_out_index_from_existing_data(
             log::info!(
                 logger,
                 "Constructing block_number_by_tx_out_index: {}% complete",
+                percents
+            );
+        }
+    }
+    Ok(db_txn.commit()?)
+}
+
+/// A utility function for backfilling empty mint tx data for all existing
+/// blocks. This is necessary because we store an empty list of mint txs for
+/// blocks that did not contain any.
+fn backfill_empty_mint_stores(env: &Environment, logger: &Logger) -> Result<(), Error> {
+    // Open pre-existing databases that has data we need.
+    let mint_config_store = MintConfigStore::new(env)?;
+    let mint_tx_store = MintTxStore::new(env)?;
+    let counts_db = env.open_db(Some(COUNTS_DB_NAME))?;
+
+    let mut db_txn = env.begin_rw_txn()?;
+
+    let num_blocks = key_bytes_to_u64(db_txn.get(counts_db, &NUM_BLOCKS_KEY)?);
+
+    let mut percents: u64 = 0;
+    for block_index in 0..num_blocks {
+        mint_config_store.write_set_mint_config_txs(block_index, &[], &mut db_txn)?;
+        mint_tx_store.write_mint_txs(block_index, &[], &mint_config_store, &mut db_txn)?;
+
+        // Throttled logging.
+        let new_percents = block_index * 100 / num_blocks;
+        if new_percents != percents {
+            percents = new_percents;
+            log::info!(
+                logger,
+                "Backfilling empty mint stores: {}% complete",
                 percents
             );
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3629,7 +3629,11 @@ mod test {
             let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
             let key_images = tx_proposal.tx.key_images();
             let outputs = tx_proposal.tx.prefix.outputs.clone();
-            let block_contents = BlockContents::new(key_images, outputs);
+            let block_contents = BlockContents {
+                key_images,
+                outputs,
+                ..Default::default()
+            };
 
             // Append to ledger.
             let num_blocks = ledger_db.num_blocks().unwrap();

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -180,7 +180,11 @@ pub fn add_block_to_ledger_db(
         })
         .collect();
 
-    let block_contents = BlockContents::new(key_images.to_vec(), outputs.clone());
+    let block_contents = BlockContents {
+        key_images: key_images.to_vec(),
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let new_block;
     if num_blocks > 0 {
@@ -211,7 +215,11 @@ pub fn add_txos_to_ledger_db(
     outputs: &Vec<TxOut>,
     rng: &mut (impl CryptoRng + RngCore),
 ) -> u64 {
-    let block_contents = BlockContents::new(vec![KeyImage::from(rng.next_u64())], outputs.clone());
+    let block_contents = BlockContents {
+        key_images: vec![KeyImage::from(rng.next_u64())],
+        outputs: outputs.clone(),
+        ..Default::default()
+    };
 
     let num_blocks = ledger_db.num_blocks().expect("failed to get block height");
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -224,7 +224,7 @@ mod block_tests {
             key_images,
             outputs,
             ..Default::default()
-        };
+        }
     }
 
     fn get_key_images_and_outputs<RNG: CryptoRng + RngCore>(

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -61,9 +61,11 @@ impl Block {
         let index: BlockIndex = 0;
         let cumulative_txo_count = outputs.len() as u64;
         let root_element = TxOutMembershipElement::default();
-        // The origin block does not contain any key images.
+        // The origin block does not contain any key images, set_mint_config_txs or mint_txs.
         let key_images = Vec::new();
-        let block_contents = BlockContents::new(key_images, outputs.to_vec());
+        let set_mint_config_txs = Vec::new();
+        let mint_txs = Vec::new();
+        let block_contents = BlockContents::new(key_images, outputs.to_vec(), set_mint_config_txs, mint_txs);
         let contents_hash = block_contents.hash();
         let id = compute_block_id(
             version,

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -4,7 +4,6 @@ use crate::{
     tx::{TxOut, TxOutMembershipElement},
     BlockContents, BlockContentsHash, BlockID, BlockVersion,
 };
-use alloc::vec::Vec;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -61,11 +60,13 @@ impl Block {
         let index: BlockIndex = 0;
         let cumulative_txo_count = outputs.len() as u64;
         let root_element = TxOutMembershipElement::default();
-        // The origin block does not contain any key images, set_mint_config_txs or mint_txs.
-        let key_images = Vec::new();
-        let set_mint_config_txs = Vec::new();
-        let mint_txs = Vec::new();
-        let block_contents = BlockContents::new(key_images, outputs.to_vec(), set_mint_config_txs, mint_txs);
+
+        // The origin block does not contain anything but TxOuts.
+        let block_contents = BlockContents {
+            outputs: outputs.to_vec(),
+            ..Default::default()
+        };
+
         let contents_hash = block_contents.hash();
         let id = compute_block_id(
             version,
@@ -219,7 +220,11 @@ mod block_tests {
 
     fn get_block_contents<RNG: CryptoRng + RngCore>(rng: &mut RNG) -> BlockContents {
         let (key_images, outputs) = get_key_images_and_outputs(rng);
-        BlockContents::new(key_images, outputs)
+        BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
     }
 
     fn get_key_images_and_outputs<RNG: CryptoRng + RngCore>(
@@ -281,7 +286,11 @@ mod block_tests {
             output.e_memo = None;
         }
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
         Block::new(
             BLOCK_VERSION,
             &parent_id,

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -1,6 +1,11 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{ring_signature::KeyImage, tx::TxOut, ConvertError};
+use crate::{
+    mint::{MintTx, SetMintConfigTx},
+    ring_signature::KeyImage,
+    tx::TxOut,
+    ConvertError,
+};
 use alloc::{vec, vec::Vec};
 use core::{convert::TryFrom, fmt::Debug};
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
@@ -21,13 +26,28 @@ pub struct BlockContents {
     /// Outputs minted by this block.
     #[prost(message, repeated, tag = "2")]
     pub outputs: Vec<TxOut>,
+
+    /// Set-mint-config transactions in this block.
+    #[prost(message, repeated, tag = "3")]
+    pub set_mint_config_txs: Vec<SetMintConfigTx>,
+
+    /// Mint transactions in this block.
+    #[prost(message, repeated, tag = "4")]
+    pub mint_txs: Vec<MintTx>,
 }
 
 impl BlockContents {
-    pub fn new(key_images: Vec<KeyImage>, outputs: Vec<TxOut>) -> Self {
+    pub fn new(
+        key_images: Vec<KeyImage>,
+        outputs: Vec<TxOut>,
+        set_mint_config_txs: Vec<SetMintConfigTx>,
+        mint_txs: Vec<MintTx>,
+    ) -> Self {
         Self {
             key_images,
             outputs,
+            set_mint_config_txs,
+            mint_txs,
         }
     }
 

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -37,20 +37,6 @@ pub struct BlockContents {
 }
 
 impl BlockContents {
-    pub fn new(
-        key_images: Vec<KeyImage>,
-        outputs: Vec<TxOut>,
-        set_mint_config_txs: Vec<SetMintConfigTx>,
-        mint_txs: Vec<MintTx>,
-    ) -> Self {
-        Self {
-            key_images,
-            outputs,
-            set_mint_config_txs,
-            mint_txs,
-        }
-    }
-
     /// The Merlin digest of `self`.
     pub fn hash(&self) -> BlockContentsHash {
         BlockContentsHash(self.digest32::<MerlinTranscript>(b"block_contents"))

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -43,3 +43,9 @@ pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";
 
 /// Domain separator for hashing the confirmation number
 pub const TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG: &str = "mc_tx_out_confirmation_number";
+
+/// Domain separator for hashing SetMintConfigTxPrefixs
+pub const SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_set_mint_config_tx_prefix";
+
+/// Domain separator for hashing MintTxPrefixs
+pub const MINT_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_tx_prefix";

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -2,8 +2,9 @@
 
 //! Minting transaction configuration.
 
+use crate::domain_separators::SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG;
 use alloc::vec::Vec;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Public, Ed25519Signature};
 use mc_crypto_multisig::{MultiSig, SignerSet};
 use mc_util_serial::Message;
@@ -51,6 +52,13 @@ pub struct SetMintConfigTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "4")]
     pub tombstone_block: u64,
+}
+
+impl SetMintConfigTxPrefix {
+    /// Digestible-crate hash of `self` using Merlin
+    pub fn hash(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG.as_bytes())
+    }
 }
 
 /// A set-mint-config transaction coupled with a signature over it.

--- a/transaction/core/src/mint/constants.rs
+++ b/transaction/core/src/mint/constants.rs
@@ -7,4 +7,3 @@ pub const NONCE_MIN_LENGTH: usize = 8;
 
 /// Maximal nonce length.
 pub const NONCE_MAX_LENGTH: usize = 64;
-

--- a/transaction/core/src/mint/constants.rs
+++ b/transaction/core/src/mint/constants.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! MobileCoin minting-related constants.
+
+/// Minimal nonce length.
+pub const NONCE_MIN_LENGTH: usize = 8;
+
+/// Maximal nonce length.
+pub const NONCE_MAX_LENGTH: usize = 64;
+

--- a/transaction/core/src/mint/constants.rs
+++ b/transaction/core/src/mint/constants.rs
@@ -2,8 +2,5 @@
 
 //! MobileCoin minting-related constants.
 
-/// Minimal nonce length.
-pub const NONCE_MIN_LENGTH: usize = 8;
-
-/// Maximal nonce length.
-pub const NONCE_MAX_LENGTH: usize = 64;
+/// Nonce length.
+pub const NONCE_LENGTH: usize = 64;

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -10,4 +10,4 @@ pub mod constants;
 
 pub use config::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
 pub use tx::{MintTx, MintTxPrefix};
-pub use validation::{config::validate_set_mint_config_tx, error::Error as MintValidationError};
+pub use validation::{config::validate_set_mint_config_tx, tx::validate_mint_tx, error::Error as MintValidationError};

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -10,4 +10,6 @@ pub mod constants;
 
 pub use config::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
 pub use tx::{MintTx, MintTxPrefix};
-pub use validation::{config::validate_set_mint_config_tx, tx::validate_mint_tx, error::Error as MintValidationError};
+pub use validation::{
+    config::validate_set_mint_config_tx, error::Error as MintValidationError, tx::validate_mint_tx,
+};

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -4,10 +4,10 @@
 
 mod config;
 mod tx;
-mod validate;
+mod validation;
 
 pub mod constants;
 
 pub use config::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
 pub use tx::{MintTx, MintTxPrefix};
-pub use validate::config::{validate_set_mint_config_tx, Error as ValidateSetMintConfigTxError};
+pub use validation::{config::validate_set_mint_config_tx, error::Error as MintValidationError};

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -4,6 +4,10 @@
 
 mod config;
 mod tx;
+mod validate;
+
+pub mod constants;
 
 pub use config::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
 pub use tx::{MintTx, MintTxPrefix};
+pub use validate::config::{validate_set_mint_config_tx, Error as ValidateSetMintConfigTxError};

--- a/transaction/core/src/mint/tx.rs
+++ b/transaction/core/src/mint/tx.rs
@@ -2,8 +2,9 @@
 
 //! Minting transactions.
 
+use crate::domain_separators::MINT_TX_PREFIX_DOMAIN_TAG;
 use alloc::vec::Vec;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Signature, RistrettoPublic};
 use mc_crypto_multisig::MultiSig;
 use mc_util_serial::Message;
@@ -37,6 +38,13 @@ pub struct MintTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "6")]
     pub tombstone_block: u64,
+}
+
+impl MintTxPrefix {
+    /// Digestible-crate hash of `self` using Merlin
+    pub fn hash(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(MINT_TX_PREFIX_DOMAIN_TAG.as_bytes())
+    }
 }
 
 /// A mint transaction coupled with a signature over it.

--- a/transaction/core/src/mint/validate/config.rs
+++ b/transaction/core/src/mint/validate/config.rs
@@ -42,12 +42,21 @@ pub enum Error {
     Unknown,
 }
 
-/// TODO document
+/// Determines if the transaction is valid, with respect to the provided
+/// context.
+///
+/// # Arguments
+/// * `tx` - A pending transaction.
+/// * `current_block_index` - The index of the current block that is being
+///   built.
+/// * `block_version` - The version of the block that is being built.
+/// * `master_minters` - The set of signers that are allowed to sign
+///   SetMintConfigTx transactions.
 pub fn validate_set_mint_config_tx(
     tx: &SetMintConfigTx,
     current_block_index: u64,
     block_version: BlockVersion,
-    signer_set: &SignerSet<Ed25519Public>,
+    master_minters: &SignerSet<Ed25519Public>,
 ) -> Result<(), Error> {
     validate_block_version(block_version)?;
 
@@ -66,11 +75,12 @@ pub fn validate_set_mint_config_tx(
         },
     )?;
 
-    validate_signature(&tx, signer_set)?;
+    validate_signature(tx, master_minters)?;
 
     Ok(())
 }
 
+/// The current block version being built must support minting.
 fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
     // TODO this should actually be block version THREE!
     if block_version < BlockVersion::TWO || BlockVersion::MAX < block_version {
@@ -80,6 +90,7 @@ fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
     Ok(())
 }
 
+/// The token id being minted must be supported.
 fn validate_token_id(token_id: u32) -> Result<(), Error> {
     if token_id == *TokenId::MOB {
         return Err(Error::TokenId(token_id));
@@ -88,10 +99,12 @@ fn validate_token_id(token_id: u32) -> Result<(), Error> {
     Ok(())
 }
 
+/// The minting configurations must all point to the same token id, and must
+/// have a valid signer set.
 fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> {
     for config in configs {
         if config.token_id != token_id {
-            return Err(Error::TokenId(token_id));
+            return Err(Error::TokenId(config.token_id));
         }
 
         let num_signers = config.signer_set.signers().len();
@@ -103,6 +116,7 @@ fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> 
     Ok(())
 }
 
+/// The nonce must be within the hardcoded lenght limit.
 fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
     if nonce.len() < NONCE_MIN_LENGTH || nonce.len() > NONCE_MAX_LENGTH {
         return Err(Error::NonceLength(nonce.len()));
@@ -111,14 +125,505 @@ fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
+/// The transaction must be properly signed by the master minters set.
 fn validate_signature(
     tx: &SetMintConfigTx,
-    signer_set: &SignerSet<Ed25519Public>,
+    master_minters: &SignerSet<Ed25519Public>,
 ) -> Result<(), Error> {
     let message = tx.prefix.hash();
 
-    signer_set
+    master_minters
         .verify(&message[..], &tx.signature)
         .map_err(|_| Error::Signature)
         .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mint::config::SetMintConfigTxPrefix;
+    use mc_crypto_keys::{Ed25519Pair, Signer};
+    use mc_crypto_multisig::MultiSig;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+    #[test]
+    fn validate_block_version_accepts_valid_block_versions() {
+        assert!(validate_block_version(BlockVersion::TWO).is_ok()); // TODO needs to be three
+        assert!(validate_block_version(BlockVersion::MAX).is_ok()); // TODO needs to be three
+    }
+
+    #[test]
+    fn validate_block_version_rejects_unsupported_block_versions() {
+        assert_eq!(
+            validate_block_version(BlockVersion::ONE),
+            Err(Error::BlockVersion(BlockVersion::ONE))
+        );
+    }
+
+    #[test]
+    fn validate_token_id_accepts_valid_token_ids() {
+        assert!(validate_token_id(1).is_ok());
+        assert!(validate_token_id(10).is_ok());
+    }
+
+    #[test]
+    fn validate_token_id_rejects_invalid_token_ids() {
+        assert_eq!(validate_token_id(0), Err(Error::TokenId(0)));
+    }
+
+    #[test]
+    fn validate_configs_accepts_valid_mint_configs() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let signer_3 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config1 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        let mint_config3 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![signer_2.public_key(), signer_3.public_key()], 1),
+            mint_limit: 15,
+        };
+        let mint_config4 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![signer_2.public_key(), signer_3.public_key()], 2),
+            mint_limit: 15,
+        };
+
+        assert!(validate_configs(
+            token_id,
+            &[mint_config1, mint_config2, mint_config3, mint_config4]
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_configs_rejects_mismatching_token_ids() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config1 = MintConfig {
+            token_id: 123,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: 234,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        assert_eq!(
+            validate_configs(123, &[mint_config1.clone(), mint_config2.clone()]),
+            Err(Error::TokenId(234))
+        );
+
+        assert_eq!(
+            validate_configs(1, &[mint_config1.clone(), mint_config2.clone()]),
+            Err(Error::TokenId(123))
+        );
+    }
+
+    #[test]
+    fn validate_configs_rejects_invalid_signer_sets() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let token_id = 123;
+
+        let mint_config1 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 2), /* threshold > number of
+                                                                         * signers */
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(vec![], 1), // no signers
+            mint_limit: 15,
+        };
+
+        assert_eq!(
+            validate_configs(token_id, &[mint_config1]),
+            Err(Error::SignerSet)
+        );
+        assert_eq!(
+            validate_configs(token_id, &[mint_config2]),
+            Err(Error::SignerSet)
+        );
+    }
+
+    #[test]
+    fn validate_nonce_accepts_valid_nonces() {
+        validate_nonce(&[1u8; NONCE_MIN_LENGTH]).unwrap();
+        validate_nonce(&[1u8; NONCE_MIN_LENGTH + 1]).unwrap();
+        validate_nonce(&[1u8; NONCE_MAX_LENGTH]).unwrap();
+    }
+
+    #[test]
+    fn validate_nonce_rejects_valid_nonces() {
+        assert_eq!(validate_nonce(&[]), Err(Error::NonceLength(0)));
+        assert_eq!(
+            validate_nonce(&[1u8; NONCE_MIN_LENGTH - 1]),
+            Err(Error::NonceLength(NONCE_MIN_LENGTH - 1))
+        );
+        assert_eq!(
+            validate_nonce(&[1u8; NONCE_MAX_LENGTH + 1]),
+            Err(Error::NonceLength(NONCE_MAX_LENGTH + 1))
+        );
+    }
+
+    #[test]
+    fn validate_signature_accepts_valid_signature() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let token_id = 123;
+
+        let mint_config1 = MintConfig {
+            token_id: 123,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: 234,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        let master_minter_1 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_2 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_3 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = SetMintConfigTxPrefix {
+            token_id: token_id,
+            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            tombstone_block: 123,
+        };
+        let message = prefix.hash();
+
+        // Try with 1 out of 3 signers.
+        let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert!(validate_signature(
+            &tx,
+            &SignerSet::new(
+                vec![
+                    master_minter_1.public_key(),
+                    master_minter_2.public_key(),
+                    master_minter_3.public_key()
+                ],
+                1
+            )
+        )
+        .is_ok());
+
+        // Try with 2 out of 3 signers.
+        let signature = MultiSig::new(vec![
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+            master_minter_2.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert!(validate_signature(
+            &tx,
+            &SignerSet::new(
+                vec![
+                    master_minter_1.public_key(),
+                    master_minter_2.public_key(),
+                    master_minter_3.public_key()
+                ],
+                2
+            )
+        )
+        .is_ok());
+
+        // Try with different 2 out of 3 signers.
+        let signature = MultiSig::new(vec![
+            master_minter_3.try_sign(message.as_ref()).unwrap(),
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert!(validate_signature(
+            &tx,
+            &SignerSet::new(
+                vec![
+                    master_minter_1.public_key(),
+                    master_minter_2.public_key(),
+                    master_minter_3.public_key()
+                ],
+                2
+            )
+        )
+        .is_ok());
+
+        // Try with 3 out of 3 signers.
+        let signature = MultiSig::new(vec![
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+            master_minter_2.try_sign(message.as_ref()).unwrap(),
+            master_minter_3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = SetMintConfigTx { prefix, signature };
+        assert!(validate_signature(
+            &tx,
+            &SignerSet::new(
+                vec![
+                    master_minter_1.public_key(),
+                    master_minter_2.public_key(),
+                    master_minter_3.public_key()
+                ],
+                3
+            )
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_signature_rejects_tampered_messages() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let token_id = 123;
+
+        let mint_config1 = MintConfig {
+            token_id: 123,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: 234,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        let master_minter_1 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_2 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_3 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = SetMintConfigTxPrefix {
+            token_id: token_id,
+            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            tombstone_block: 123,
+        };
+        let message = prefix.hash();
+
+        // Tamper with the mint limit.
+        let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
+        let mut tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        tx.prefix.configs[0].mint_limit += 1;
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![
+                        master_minter_1.public_key(),
+                        master_minter_2.public_key(),
+                        master_minter_3.public_key()
+                    ],
+                    1
+                )
+            ),
+            Err(Error::Signature)
+        );
+
+        // Tamper with the tombstone block.
+        let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
+        let mut tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        tx.prefix.tombstone_block += 1;
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![
+                        master_minter_1.public_key(),
+                        master_minter_2.public_key(),
+                        master_minter_3.public_key()
+                    ],
+                    1
+                )
+            ),
+            Err(Error::Signature)
+        );
+    }
+
+    #[test]
+    fn validate_signature_rejects_signers_mismatch() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let token_id = 123;
+
+        let mint_config1 = MintConfig {
+            token_id: 123,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: 234,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        let master_minter_1 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_2 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_3 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = SetMintConfigTxPrefix {
+            token_id: token_id,
+            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            tombstone_block: 123,
+        };
+        let message = prefix.hash();
+
+        // Signing below threshold
+        let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![
+                        master_minter_1.public_key(),
+                        master_minter_2.public_key(),
+                        master_minter_3.public_key()
+                    ],
+                    2
+                )
+            ),
+            Err(Error::Signature)
+        );
+
+        // Signing with unknown signers.
+        let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![master_minter_2.public_key(), master_minter_3.public_key()],
+                    1
+                )
+            ),
+            Err(Error::Signature)
+        );
+
+        // Signing below threshold with one known signers and one unknown.
+        let signature = MultiSig::new(vec![
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+            master_minter_2.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![master_minter_2.public_key(), master_minter_3.public_key()],
+                    2
+                )
+            ),
+            Err(Error::Signature)
+        );
+    }
+
+    #[test]
+    fn validate_signature_rejects_duplicate_signer() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let token_id = 123;
+
+        let mint_config1 = MintConfig {
+            token_id: 123,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: 10,
+        };
+
+        let mint_config2 = MintConfig {
+            token_id: 234,
+            signer_set: SignerSet::new(vec![signer_2.public_key()], 1),
+            mint_limit: 15,
+        };
+
+        let master_minter_1 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_2 = Ed25519Pair::from_random(&mut rng);
+        let master_minter_3 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = SetMintConfigTxPrefix {
+            token_id: token_id,
+            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            tombstone_block: 123,
+        };
+        let message = prefix.hash();
+
+        // Signing below threshold (duplicate isnger not counted twice)
+        let signature = MultiSig::new(vec![
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+            master_minter_1.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = SetMintConfigTx {
+            prefix: prefix.clone(),
+            signature,
+        };
+        assert_eq!(
+            validate_signature(
+                &tx,
+                &SignerSet::new(
+                    vec![
+                        master_minter_1.public_key(),
+                        master_minter_2.public_key(),
+                        master_minter_3.public_key()
+                    ],
+                    2
+                )
+            ),
+            Err(Error::Signature)
+        );
+    }
 }

--- a/transaction/core/src/mint/validate/config.rs
+++ b/transaction/core/src/mint/validate/config.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! SetMintConfigTx transaction validation.
+
+use crate::{
+    mint::{
+        config::{MintConfig, SetMintConfigTx},
+        constants::{NONCE_MAX_LENGTH, NONCE_MIN_LENGTH},
+    },
+    validation::{validate_tombstone, TransactionValidationError},
+    BlockVersion, TokenId,
+};
+use displaydoc::Display;
+use mc_crypto_keys::Ed25519Public;
+use mc_crypto_multisig::SignerSet;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum Error {
+    /// Invalid block version: {0}
+    BlockVersion(BlockVersion),
+
+    /// Invalid token id: {0}
+    TokenId(u32),
+
+    /// Invalid nonce length: {0}
+    NonceLength(usize),
+
+    /// Invalid signer set
+    SignerSet,
+
+    /// Invalid signature
+    Signature,
+
+    /// Number of blocks in ledger exceeds the tombstone block number
+    TombstoneBlockExceeded,
+
+    /// Tombstone block is too far in the future
+    TombstoneBlockTooFar,
+
+    /// Unknown error (should never happen)
+    Unknown,
+}
+
+/// TODO document
+pub fn validate_set_mint_config_tx(
+    tx: &SetMintConfigTx,
+    current_block_index: u64,
+    block_version: BlockVersion,
+    signer_set: &SignerSet<Ed25519Public>,
+) -> Result<(), Error> {
+    validate_block_version(block_version)?;
+
+    validate_token_id(tx.prefix.token_id)?;
+
+    validate_configs(tx.prefix.token_id, &tx.prefix.configs)?;
+
+    validate_nonce(&tx.prefix.nonce)?;
+
+    validate_tombstone(current_block_index, tx.prefix.tombstone_block).map_err(
+        |err| match err {
+            TransactionValidationError::TombstoneBlockExceeded => Error::TombstoneBlockExceeded,
+            TransactionValidationError::TombstoneBlockTooFar => Error::TombstoneBlockTooFar,
+            _ => Error::Unknown, /* This should never happen since validate_tombstone only
+                                  * returns one of the two error types above */
+        },
+    )?;
+
+    validate_signature(&tx, signer_set)?;
+
+    Ok(())
+}
+
+fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
+    // TODO this should actually be block version THREE!
+    if block_version < BlockVersion::TWO || BlockVersion::MAX < block_version {
+        return Err(Error::BlockVersion(block_version));
+    }
+
+    Ok(())
+}
+
+fn validate_token_id(token_id: u32) -> Result<(), Error> {
+    if token_id == *TokenId::MOB {
+        return Err(Error::TokenId(token_id));
+    }
+
+    Ok(())
+}
+
+fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> {
+    for config in configs {
+        if config.token_id != token_id {
+            return Err(Error::TokenId(token_id));
+        }
+
+        let num_signers = config.signer_set.signers().len();
+        if num_signers == 0 || num_signers < config.signer_set.threshold() as usize {
+            return Err(Error::SignerSet);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
+    if nonce.len() < NONCE_MIN_LENGTH || nonce.len() > NONCE_MAX_LENGTH {
+        return Err(Error::NonceLength(nonce.len()));
+    }
+
+    Ok(())
+}
+
+fn validate_signature(
+    tx: &SetMintConfigTx,
+    signer_set: &SignerSet<Ed25519Public>,
+) -> Result<(), Error> {
+    let message = tx.prefix.hash();
+
+    signer_set
+        .verify(&message[..], &tx.signature)
+        .map_err(|_| Error::Signature)
+        .map(|_| ())
+}

--- a/transaction/core/src/mint/validate/mod.rs
+++ b/transaction/core/src/mint/validate/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Minting-related validation code.
+
+pub mod config;

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -35,6 +35,9 @@ pub fn validate_tombstone(
 }
 
 /// The current block version being built must support minting.
+///
+/// # Arguments
+/// * `block_version` - The block version of the block currently being built.
 pub fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
     // TODO this should actually be block version THREE!
     if block_version < BlockVersion::TWO || BlockVersion::MAX < block_version {
@@ -45,6 +48,9 @@ pub fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> 
 }
 
 /// The token id being minted must be supported.
+///
+/// Arguments:
+/// * `token_id` - The token id being minted.
 pub fn validate_token_id(token_id: u32) -> Result<(), Error> {
     if token_id == *TokenId::MOB {
         return Err(Error::TokenId(token_id));
@@ -54,6 +60,9 @@ pub fn validate_token_id(token_id: u32) -> Result<(), Error> {
 }
 
 /// The nonce must be within the hardcoded lenght limit.
+///
+/// # Arguments
+/// `nonce` - The nonce to validate.
 pub fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
     if nonce.len() < NONCE_MIN_LENGTH || nonce.len() > NONCE_MAX_LENGTH {
         return Err(Error::NonceLength(nonce.len()));

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_nonce_rejects_valid_nonces() {
+    fn validate_nonce_rejects_invalid_nonces() {
         assert_eq!(validate_nonce(&[]), Err(Error::NonceLength(0)));
         assert_eq!(
             validate_nonce(&[1u8; NONCE_MIN_LENGTH - 1]),

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Common validation code shared between different mint transaction types.
+
+use crate::{
+    mint::{
+        constants::{NONCE_MAX_LENGTH, NONCE_MIN_LENGTH},
+        validation::error::Error,
+    },
+    validation::{
+        validate_tombstone as transaction_validate_tombstone, TransactionValidationError,
+    },
+    BlockVersion, TokenId,
+};
+
+/// A wrapper around crate::validation::validate_tombstone that maps to our
+/// error type.
+///
+/// # Arguments
+/// * `current_block_index` - The index of the block currently being built.
+/// * `tombstone_block_index` - The block index at which this transaction is no
+///   longer considered valid.
+pub fn validate_tombstone(
+    current_block_index: u64,
+    tombstone_block_index: u64,
+) -> Result<(), Error> {
+    transaction_validate_tombstone(current_block_index, tombstone_block_index).map_err(|err| {
+        match err {
+            TransactionValidationError::TombstoneBlockExceeded => Error::TombstoneBlockExceeded,
+            TransactionValidationError::TombstoneBlockTooFar => Error::TombstoneBlockTooFar,
+            _ => Error::Unknown, /* This should never happen since validate_tombstone only
+                                  * returns one of the two error types above */
+        }
+    })
+}
+
+/// The current block version being built must support minting.
+pub fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
+    // TODO this should actually be block version THREE!
+    if block_version < BlockVersion::TWO || BlockVersion::MAX < block_version {
+        return Err(Error::BlockVersion(block_version));
+    }
+
+    Ok(())
+}
+
+/// The token id being minted must be supported.
+pub fn validate_token_id(token_id: u32) -> Result<(), Error> {
+    if token_id == *TokenId::MOB {
+        return Err(Error::TokenId(token_id));
+    }
+
+    Ok(())
+}
+
+/// The nonce must be within the hardcoded lenght limit.
+pub fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
+    if nonce.len() < NONCE_MIN_LENGTH || nonce.len() > NONCE_MAX_LENGTH {
+        return Err(Error::NonceLength(nonce.len()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_block_version_accepts_valid_block_versions() {
+        assert!(validate_block_version(BlockVersion::TWO).is_ok()); // TODO needs to be three
+        assert!(validate_block_version(BlockVersion::MAX).is_ok()); // TODO needs to be three
+    }
+
+    #[test]
+    fn validate_block_version_rejects_unsupported_block_versions() {
+        assert_eq!(
+            validate_block_version(BlockVersion::ONE),
+            Err(Error::BlockVersion(BlockVersion::ONE))
+        );
+    }
+
+    #[test]
+    fn validate_token_id_accepts_valid_token_ids() {
+        assert!(validate_token_id(1).is_ok());
+        assert!(validate_token_id(10).is_ok());
+    }
+
+    #[test]
+    fn validate_token_id_rejects_invalid_token_ids() {
+        assert_eq!(validate_token_id(0), Err(Error::TokenId(0)));
+    }
+
+    #[test]
+    fn validate_nonce_accepts_valid_nonces() {
+        validate_nonce(&[1u8; NONCE_MIN_LENGTH]).unwrap();
+        validate_nonce(&[1u8; NONCE_MIN_LENGTH + 1]).unwrap();
+        validate_nonce(&[1u8; NONCE_MAX_LENGTH]).unwrap();
+    }
+
+    #[test]
+    fn validate_nonce_rejects_valid_nonces() {
+        assert_eq!(validate_nonce(&[]), Err(Error::NonceLength(0)));
+        assert_eq!(
+            validate_nonce(&[1u8; NONCE_MIN_LENGTH - 1]),
+            Err(Error::NonceLength(NONCE_MIN_LENGTH - 1))
+        );
+        assert_eq!(
+            validate_nonce(&[1u8; NONCE_MAX_LENGTH + 1]),
+            Err(Error::NonceLength(NONCE_MAX_LENGTH + 1))
+        );
+    }
+}

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -3,10 +3,7 @@
 //! Common validation code shared between different mint transaction types.
 
 use crate::{
-    mint::{
-        constants::{NONCE_MAX_LENGTH, NONCE_MIN_LENGTH},
-        validation::error::Error,
-    },
+    mint::{constants::NONCE_LENGTH, validation::error::Error},
     validation::{
         validate_tombstone as transaction_validate_tombstone, TransactionValidationError,
     },
@@ -59,12 +56,12 @@ pub fn validate_token_id(token_id: u32) -> Result<(), Error> {
     Ok(())
 }
 
-/// The nonce must be within the hardcoded lenght limit.
+/// The nonce must be of the correct length.
 ///
 /// # Arguments
 /// `nonce` - The nonce to validate.
 pub fn validate_nonce(nonce: &[u8]) -> Result<(), Error> {
-    if nonce.len() < NONCE_MIN_LENGTH || nonce.len() > NONCE_MAX_LENGTH {
+    if nonce.len() != NONCE_LENGTH {
         return Err(Error::NonceLength(nonce.len()));
     }
 
@@ -102,21 +99,19 @@ mod tests {
 
     #[test]
     fn validate_nonce_accepts_valid_nonces() {
-        validate_nonce(&[1u8; NONCE_MIN_LENGTH]).unwrap();
-        validate_nonce(&[1u8; NONCE_MIN_LENGTH + 1]).unwrap();
-        validate_nonce(&[1u8; NONCE_MAX_LENGTH]).unwrap();
+        validate_nonce(&[1u8; NONCE_LENGTH]).unwrap();
     }
 
     #[test]
     fn validate_nonce_rejects_invalid_nonces() {
         assert_eq!(validate_nonce(&[]), Err(Error::NonceLength(0)));
         assert_eq!(
-            validate_nonce(&[1u8; NONCE_MIN_LENGTH - 1]),
-            Err(Error::NonceLength(NONCE_MIN_LENGTH - 1))
+            validate_nonce(&[1u8; NONCE_LENGTH - 1]),
+            Err(Error::NonceLength(NONCE_LENGTH - 1))
         );
         assert_eq!(
-            validate_nonce(&[1u8; NONCE_MAX_LENGTH + 1]),
-            Err(Error::NonceLength(NONCE_MAX_LENGTH + 1))
+            validate_nonce(&[1u8; NONCE_LENGTH + 1]),
+            Err(Error::NonceLength(NONCE_LENGTH + 1))
         );
     }
 }

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -50,6 +50,10 @@ pub fn validate_set_mint_config_tx(
 
 /// The minting configurations must all point to the same token id, and must
 /// have a valid signer set.
+///
+/// # Arguments
+/// * `token_id` - The token id we are trying to mint.
+/// * `configs` - The minting configurations to validate.
 fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> {
     for config in configs {
         if config.token_id != token_id {
@@ -66,6 +70,10 @@ fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> 
 }
 
 /// The transaction must be properly signed by the master minters set.
+///
+/// # Arguments
+/// * `tx` - A pending transaction that is being validated.
+/// * `signer_set` - The signer set that is permitted to sign the transaction.
 fn validate_signature(
     tx: &SetMintConfigTx,
     master_minters: &SignerSet<Ed25519Public>,

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -506,7 +506,7 @@ mod tests {
         };
         let message = prefix.hash();
 
-        // Signing below threshold (duplicate isnger not counted twice)
+        // Signing below threshold (duplicate singer not counted twice)
         let signature = MultiSig::new(vec![
             master_minter_1.try_sign(message.as_ref()).unwrap(),
             master_minter_1.try_sign(message.as_ref()).unwrap(),

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -89,7 +89,7 @@ fn validate_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mint::{config::SetMintConfigTxPrefix, constants::NONCE_MIN_LENGTH};
+    use crate::mint::{config::SetMintConfigTxPrefix, constants::NONCE_LENGTH};
     use mc_crypto_keys::{Ed25519Pair, Signer};
     use mc_crypto_multisig::MultiSig;
     use mc_util_from_random::FromRandom;
@@ -217,7 +217,7 @@ mod tests {
         let prefix = SetMintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
-            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
         };
         let message = prefix.hash();
@@ -333,7 +333,7 @@ mod tests {
         let prefix = SetMintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
-            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
         };
         let message = prefix.hash();
@@ -410,7 +410,7 @@ mod tests {
         let prefix = SetMintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
-            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
         };
         let message = prefix.hash();
@@ -501,7 +501,7 @@ mod tests {
         let prefix = SetMintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
-            nonce: vec![2u8; NONCE_MIN_LENGTH],
+            nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
         };
         let message = prefix.hash();

--- a/transaction/core/src/mint/validation/error.rs
+++ b/transaction/core/src/mint/validation/error.rs
@@ -31,4 +31,7 @@ pub enum Error {
 
     /// Unknown error (should never happen)
     Unknown,
+
+    /// Amount exceeds mint limit
+    AmountExceedsMintLimit,
 }

--- a/transaction/core/src/mint/validation/error.rs
+++ b/transaction/core/src/mint/validation/error.rs
@@ -1,11 +1,12 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Error type of mint transactions validation.
+//! Error type for mint transactions validation.
 
 use crate::BlockVersion;
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 
+/// Error type for mint transactions validation.
 #[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Error {
     /// Invalid block version: {0}

--- a/transaction/core/src/mint/validation/error.rs
+++ b/transaction/core/src/mint/validation/error.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Error type of mint transactions validation.
+
+use crate::BlockVersion;
+use displaydoc::Display;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum Error {
+    /// Invalid block version: {0}
+    BlockVersion(BlockVersion),
+
+    /// Invalid token id: {0}
+    TokenId(u32),
+
+    /// Invalid nonce length: {0}
+    NonceLength(usize),
+
+    /// Invalid signer set
+    SignerSet,
+
+    /// Invalid signature
+    Signature,
+
+    /// Number of blocks in ledger exceeds the tombstone block number
+    TombstoneBlockExceeded,
+
+    /// Tombstone block is too far in the future
+    TombstoneBlockTooFar,
+
+    /// Unknown error (should never happen)
+    Unknown,
+}

--- a/transaction/core/src/mint/validation/mod.rs
+++ b/transaction/core/src/mint/validation/mod.rs
@@ -3,3 +3,7 @@
 //! Minting-related validation code.
 
 pub mod config;
+pub mod error;
+pub mod tx;
+
+mod common;

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -48,6 +48,11 @@ pub fn validate_mint_tx(
 }
 
 /// Validate the trnasaction against a specific mint config.
+///
+/// # Arguments
+/// * `tx` - A pending transaction that is being validated.
+/// * `mint_config` - The mint config that the transaction is being validated
+///   against.
 pub fn validate_against_mint_config(tx: &MintTx, mint_config: &MintConfig) -> Result<(), Error> {
     // The token id must match.
     if tx.prefix.token_id != mint_config.token_id {
@@ -67,6 +72,10 @@ pub fn validate_against_mint_config(tx: &MintTx, mint_config: &MintConfig) -> Re
 }
 
 /// The transaction must be properly signed by the signer set.
+///
+/// # Arguments
+/// * `tx` - A pending transaction that is being validated.
+/// * `signer_set` - The signer set that is permitted to sign the transaction.
 fn validate_signature(tx: &MintTx, signer_set: &SignerSet<Ed25519Public>) -> Result<(), Error> {
     let message = tx.prefix.hash();
 

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -88,7 +88,7 @@ fn validate_signature(tx: &MintTx, signer_set: &SignerSet<Ed25519Public>) -> Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mint::{constants::NONCE_MIN_LENGTH, MintTxPrefix};
+    use crate::mint::{constants::NONCE_LENGTH, MintTxPrefix};
     use mc_crypto_keys::{Ed25519Pair, RistrettoPublic, Signer};
     use mc_crypto_multisig::MultiSig;
     use mc_util_from_random::FromRandom;
@@ -120,7 +120,7 @@ mod tests {
             amount: 100,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -159,7 +159,7 @@ mod tests {
             amount: 100,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -201,7 +201,7 @@ mod tests {
             amount: mint_config.mint_limit + 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -243,7 +243,7 @@ mod tests {
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -269,7 +269,7 @@ mod tests {
             amount: 10,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -293,7 +293,7 @@ mod tests {
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();
@@ -316,7 +316,7 @@ mod tests {
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
-            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
         };
         let message = prefix.hash();

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! MintTx transaction validation.
+
+/*
+use crate::{
+    mint::{
+        config::{MintTx},
+        constants::{NONCE_MAX_LENGTH, NONCE_MIN_LENGTH},
+    },
+    validation::{validate_tombstone, TransactionValidationError},
+    BlockVersion, TokenId,
+};
+use displaydoc::Display;
+use mc_crypto_keys::Ed25519Public;
+use mc_crypto_multisig::SignerSet;
+use serde::{Deserialize, Serialize};
+
+/// Determines if the transaction is valid, with respect to the provided
+/// context.
+///
+/// # Arguments
+/// * `tx` - A pending transaction.
+/// * `current_block_index` - The index of the current block that is being
+///   built.
+/// * `block_version` - The version of the block that is being built.
+pub fn validate_set_mint_config_tx(
+    tx: &MintTx,
+    current_block_index: u64,
+    block_version: BlockVersion,
+) -> Result<(), Error> {
+}
+*/

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -323,6 +323,12 @@ mod tests {
         let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
         let signer_set = SignerSet::new(vec![signer_1.public_key()], 1);
 
+        let tx = MintTx {
+            prefix: prefix.clone(),
+            signature: signature.clone(),
+        };
+        assert_eq!(validate_signature(&tx, &signer_set), Ok(()), "sanity check");
+
         let mut prefix1 = prefix.clone();
         prefix1.amount = 2;
         let tx = MintTx {

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -47,7 +47,7 @@ pub fn validate_mint_tx(
     Ok(())
 }
 
-/// Validate the trnasaction against a specific mint config.
+/// Validate the transaction against a specific mint config.
 ///
 /// # Arguments
 /// * `tx` - A pending transaction that is being validated.

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -2,19 +2,21 @@
 
 //! MintTx transaction validation.
 
-/*
 use crate::{
     mint::{
-        config::{MintTx},
-        constants::{NONCE_MAX_LENGTH, NONCE_MIN_LENGTH},
+        config::MintConfig,
+        tx::MintTx,
+        validation::{
+            common::{
+                validate_block_version, validate_nonce, validate_token_id, validate_tombstone,
+            },
+            error::Error,
+        },
     },
-    validation::{validate_tombstone, TransactionValidationError},
-    BlockVersion, TokenId,
+    BlockVersion,
 };
-use displaydoc::Display;
 use mc_crypto_keys::Ed25519Public;
 use mc_crypto_multisig::SignerSet;
-use serde::{Deserialize, Serialize};
 
 /// Determines if the transaction is valid, with respect to the provided
 /// context.
@@ -24,10 +26,316 @@ use serde::{Deserialize, Serialize};
 /// * `current_block_index` - The index of the current block that is being
 ///   built.
 /// * `block_version` - The version of the block that is being built.
-pub fn validate_set_mint_config_tx(
+/// * `mint_config` - The minting configuration that is authorizing this minting
+///   transaction.
+pub fn validate_mint_tx(
     tx: &MintTx,
     current_block_index: u64,
     block_version: BlockVersion,
+    mint_config: &MintConfig,
 ) -> Result<(), Error> {
+    validate_block_version(block_version)?;
+
+    validate_token_id(tx.prefix.token_id)?;
+
+    validate_nonce(&tx.prefix.nonce)?;
+
+    validate_tombstone(current_block_index, tx.prefix.tombstone_block)?;
+
+    validate_against_mint_config(tx, mint_config)?;
+
+    Ok(())
 }
-*/
+
+/// Validate the trnasaction against a specific mint config.
+pub fn validate_against_mint_config(tx: &MintTx, mint_config: &MintConfig) -> Result<(), Error> {
+    // The token id must match.
+    if tx.prefix.token_id != mint_config.token_id {
+        return Err(Error::TokenId(tx.prefix.token_id));
+    }
+
+    // The amount must not exceed the mint limit.
+    if tx.prefix.amount > mint_config.mint_limit {
+        return Err(Error::AmountExceedsMintLimit);
+    }
+
+    // The transaction must be signed by the mint config's signer set.
+    validate_signature(tx, &mint_config.signer_set)?;
+
+    // All good
+    Ok(())
+}
+
+/// The transaction must be properly signed by the signer set.
+fn validate_signature(tx: &MintTx, signer_set: &SignerSet<Ed25519Public>) -> Result<(), Error> {
+    let message = tx.prefix.hash();
+
+    signer_set
+        .verify(&message[..], &tx.signature)
+        .map_err(|_| Error::Signature)
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mint::{constants::NONCE_MIN_LENGTH, MintTxPrefix};
+    use mc_crypto_keys::{Ed25519Pair, RistrettoPublic, Signer};
+    use mc_crypto_multisig::MultiSig;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn validate_against_mint_config_accepts_valid_config() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let signer_3 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(
+                vec![
+                    signer_1.public_key(),
+                    signer_2.public_key(),
+                    signer_3.public_key(),
+                ],
+                2,
+            ),
+            mint_limit: 500,
+        };
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: 100,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![
+            signer_1.try_sign(message.as_ref()).unwrap(),
+            signer_3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = MintTx { prefix, signature };
+
+        assert_eq!(validate_against_mint_config(&tx, &mint_config), Ok(()));
+    }
+
+    #[test]
+    fn validate_against_mint_config_rejects_token_id_mismatch() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let signer_3 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(
+                vec![
+                    signer_1.public_key(),
+                    signer_2.public_key(),
+                    signer_3.public_key(),
+                ],
+                2,
+            ),
+            mint_limit: 500,
+        };
+
+        let prefix = MintTxPrefix {
+            token_id: token_id + 1,
+            amount: 100,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![
+            signer_1.try_sign(message.as_ref()).unwrap(),
+            signer_3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = MintTx { prefix, signature };
+
+        assert_eq!(
+            validate_against_mint_config(&tx, &mint_config),
+            Err(Error::TokenId(token_id + 1))
+        );
+    }
+
+    #[test]
+    fn validate_against_mint_config_rejects_amount_over_limit() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let signer_3 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(
+                vec![
+                    signer_1.public_key(),
+                    signer_2.public_key(),
+                    signer_3.public_key(),
+                ],
+                2,
+            ),
+            mint_limit: 500,
+        };
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: mint_config.mint_limit + 1,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![
+            signer_1.try_sign(message.as_ref()).unwrap(),
+            signer_3.try_sign(message.as_ref()).unwrap(),
+        ]);
+        let tx = MintTx { prefix, signature };
+
+        assert_eq!(
+            validate_against_mint_config(&tx, &mint_config),
+            Err(Error::AmountExceedsMintLimit)
+        );
+    }
+
+    #[test]
+    fn validate_against_mint_config_rejects_signature_mismatch() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+        let signer_3 = Ed25519Pair::from_random(&mut rng);
+
+        let mint_config = MintConfig {
+            token_id: token_id,
+            signer_set: SignerSet::new(
+                vec![
+                    signer_1.public_key(),
+                    signer_2.public_key(),
+                    signer_3.public_key(),
+                ],
+                2,
+            ),
+            mint_limit: 500,
+        };
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: 1,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![
+            signer_1.try_sign(message.as_ref()).unwrap(), // Only one signer is not enough
+        ]);
+        let tx = MintTx { prefix, signature };
+
+        assert_eq!(
+            validate_against_mint_config(&tx, &mint_config),
+            Err(Error::Signature)
+        );
+    }
+
+    #[test]
+    fn validate_signature_accepts_valid_signature() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: 10,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
+        let tx = MintTx { prefix, signature };
+
+        let signer_set = SignerSet::new(vec![signer_1.public_key()], 1);
+
+        assert_eq!(validate_signature(&tx, &signer_set), Ok(()));
+    }
+
+    #[test]
+    fn validate_signature_rejects_signers_mismatch() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+        let signer_2 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: 1,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
+        let tx = MintTx { prefix, signature };
+
+        let signer_set = SignerSet::new(vec![signer_2.public_key()], 1);
+
+        assert_eq!(validate_signature(&tx, &signer_set), Err(Error::Signature));
+    }
+
+    #[test]
+    fn validate_signature_rejects_tampered_messages() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let token_id = 123;
+        let signer_1 = Ed25519Pair::from_random(&mut rng);
+
+        let prefix = MintTxPrefix {
+            token_id: token_id,
+            amount: 1,
+            view_public_key: RistrettoPublic::from_random(&mut rng),
+            spend_public_key: RistrettoPublic::from_random(&mut rng),
+            nonce: vec![1u8; NONCE_MIN_LENGTH],
+            tombstone_block: 10,
+        };
+        let message = prefix.hash();
+        let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
+        let signer_set = SignerSet::new(vec![signer_1.public_key()], 1);
+
+        let mut prefix1 = prefix.clone();
+        prefix1.amount = 2;
+        let tx = MintTx {
+            prefix: prefix1,
+            signature: signature.clone(),
+        };
+        assert_eq!(validate_signature(&tx, &signer_set), Err(Error::Signature));
+
+        let mut prefix2 = prefix.clone();
+        prefix2.token_id += 1;
+        let tx = MintTx {
+            prefix: prefix2,
+            signature: signature.clone(),
+        };
+        assert_eq!(validate_signature(&tx, &signer_set), Err(Error::Signature));
+
+        let mut prefix3 = prefix.clone();
+        prefix3.nonce.push(5);
+        let tx = MintTx {
+            prefix: prefix3,
+            signature,
+        };
+        assert_eq!(validate_signature(&tx, &signer_set), Err(Error::Signature));
+    }
+}

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -195,7 +195,11 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                 let key_images = tx.key_images();
                 let outputs = tx.prefix.outputs.clone();
 
-                let block_contents = BlockContents::new(key_images, outputs);
+                let block_contents = BlockContents {
+                    key_images,
+                    outputs,
+                    ..Default::default()
+                };
 
                 let block = Block::new(
                     block_version,
@@ -226,7 +230,10 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                     .collect();
 
                 let block = Block::new_origin_block(&outputs);
-                let block_contents = BlockContents::new(Vec::new(), outputs);
+                let block_contents = BlockContents {
+                    outputs,
+                    ..Default::default()
+                };
                 (block, block_contents)
             }
         };
@@ -278,7 +285,11 @@ pub fn get_blocks<T: Rng + RngCore + CryptoRng>(
         // Non-origin blocks must have at least one key image.
         let key_images = vec![KeyImage::from(block_index as u64)];
 
-        let block_contents = BlockContents::new(key_images, outputs);
+        let block_contents = BlockContents {
+            key_images,
+            outputs,
+            ..Default::default()
+        };
 
         // Fake proofs
         let root_element = TxOutMembershipElement {

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -88,7 +88,11 @@ pub fn bootstrap_ledger(
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let block_contents = BlockContents::new(key_images, outputs.clone());
+        let block_contents = BlockContents {
+            key_images,
+            outputs: outputs.clone(),
+            ..Default::default()
+        };
 
         let block = match previous_block {
             Some(parent) => {


### PR DESCRIPTION
### Motivation

Being able to perform SCP over the new minting transaction types requires being able to validate them. The minting transaction validation, similar to the standard Tx validation we have right now, can be broken into two parts:
1. Validation that can happen independently of having access to the full ledger database - this part can run in the enclave, and in general does not need to be repeated at each SCP round[^1].
2. Validation that requires access to the ledger data - checking uniqueness (e.g. key images, or nonces in this case) and matching against the currently active mint configuration (that can change every block).

This PR focuses on the first part - since that can easily live inside the `no_std` `mc_transaction_core` crate.

[^1]: The validation code presented in this PR does actually require knowledge of the currently active `MintConfig` - which changes over time and is derived from the LedgerDb. That is unavoidable since the signature of the `MintTx` is tied to a given `MintConfig`. The nice thing about it, is that it will enable a chain of trust that can be implemented inside the enclave: the enclave will be initialized with the master minters list, and that gets hashed into its responder id - this ensures all nodes have the same configuration. Then, untrusted can tell the enclave what the currently active mint configuration is, and the enclave can verify it since it can require the signature of the SetMintConfigTx that altered the configuration to be present. Now that the enclave knows which `MintConfig`s are active, and has verified that the master minters have signed on that, it could pass the validated `MintConfig` to `validate_mint_tx`. Note that the code to do this is currently not written yet - this is a future improvement after the basics are working.

### In this PR
* The main point of the PR is to expose two new methods - `validate_set_mint_config_tx` and `validate_mint_tx`. These methods will be used to validate incoming `SetMintConfigTx` and `MintTx` transactions. 
* The validation code presented here deals with individual transactions, and is suitable to run in the enclave.

### Future Work
* Validation code that takes the ledger state into account - the ledger is needed to ensure nonce uniqueness
* Combine code that is capable of combining a list of `MintTx` objects while ensuring mint limit is not exceeded.
* SCP integration
* New RPC endpoints for submitting these transaction types

