### PR TITLE
SetMintConfigTx -> MintConfigTx

### DIFF
--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -51,8 +51,8 @@ message BlockContents {
     // Outputs created in this block.
     repeated external.TxOut outputs = 2;
 
-    /// Set-mint-config transactions in this block.
-    repeated external.SetMintConfigTx set_mint_config_txs = 3;
+    /// mint-config transactions in this block.
+    repeated external.MintConfigTx mint_config_txs = 3;
 
     /// Mint transactions in this block.
     repeated external.MintTx mint_txs = 4;

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -352,9 +352,9 @@ message MintConfig {
     uint64 mint_limit = 3;
 }
 
-/// The contents of a set-mint-config transaction. This transaction alters the
+/// The contents of a mint-config transaction. This transaction alters the
 /// minting configuration for a single token ID.
-message SetMintConfigTxPrefix {
+message MintConfigTxPrefix {
     /// Token ID we are replacing the configuration set for.
     uint32 token_id = 1;
 
@@ -368,8 +368,8 @@ message SetMintConfigTxPrefix {
     uint64 tombstone_block = 4;
 }
 
-/// A set-mint-config transaction coupled with a signature over it.
-message SetMintConfigTx {
-    SetMintConfigTxPrefix prefix = 1;
+/// A mint-config transaction coupled with a signature over it.
+message MintConfigTx {
+    MintConfigTxPrefix prefix = 1;
     Ed25519MultiSig signature = 2;
 }

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -2,7 +2,7 @@
 
 use crate::{blockchain, convert::ConversionError, external};
 use mc_transaction_core::{
-    mint::{MintTx, SetMintConfigTx},
+    mint::{MintConfigTx, MintTx},
     ring_signature::KeyImage,
     tx::TxOut,
     BlockContents,
@@ -21,17 +21,17 @@ impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {
 
         let outputs = source.outputs.iter().map(external::TxOut::from).collect();
 
-        let set_mint_config_txs = source
-            .set_mint_config_txs
+        let mint_config_txs = source
+            .mint_config_txs
             .iter()
-            .map(external::SetMintConfigTx::from)
+            .map(external::MintConfigTx::from)
             .collect();
 
         let mint_txs = source.mint_txs.iter().map(external::MintTx::from).collect();
 
         block_contents.set_key_images(key_images);
         block_contents.set_outputs(outputs);
-        block_contents.set_set_mint_config_txs(set_mint_config_txs);
+        block_contents.set_mint_config_txs(mint_config_txs);
         block_contents.set_mint_txs(mint_txs);
         block_contents
     }
@@ -53,10 +53,10 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
             .map(TxOut::try_from)
             .collect::<Result<_, _>>()?;
 
-        let set_mint_config_txs = source
-            .get_set_mint_config_txs()
+        let mint_config_txs = source
+            .get_mint_config_txs()
             .iter()
-            .map(SetMintConfigTx::try_from)
+            .map(MintConfigTx::try_from)
             .collect::<Result<_, _>>()?;
 
         let mint_txs = source
@@ -70,7 +70,7 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
         Ok(BlockContents {
             key_images,
             outputs,
-            set_mint_config_txs,
+            mint_config_txs,
             mint_txs,
         })
     }

--- a/api/src/convert/mint_config.rs
+++ b/api/src/convert/mint_config.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Convert to/from external:MintConfig/SetMintConfigTxPrefix/SetMintConfigTx.
+//! Convert to/from external:MintConfig/MintConfigTxPrefix/MintConfigTx.
 
 use crate::{convert::ConversionError, external};
 use mc_crypto_multisig::{MultiSig, SignerSet};
-use mc_transaction_core::mint::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
+use mc_transaction_core::mint::{MintConfig, MintConfigTx, MintConfigTxPrefix};
 use protobuf::RepeatedField;
 
 use std::convert::TryFrom;
@@ -34,10 +34,10 @@ impl TryFrom<&external::MintConfig> for MintConfig {
     }
 }
 
-/// Convert SetMintConfigTxPrefix --> external::SetMintConfigTxPrefix.
-impl From<&SetMintConfigTxPrefix> for external::SetMintConfigTxPrefix {
-    fn from(src: &SetMintConfigTxPrefix) -> Self {
-        let mut dst = external::SetMintConfigTxPrefix::new();
+/// Convert MintConfigTxPrefix --> external::MintConfigTxPrefix.
+impl From<&MintConfigTxPrefix> for external::MintConfigTxPrefix {
+    fn from(src: &MintConfigTxPrefix) -> Self {
+        let mut dst = external::MintConfigTxPrefix::new();
         dst.set_token_id(src.token_id);
         dst.set_configs(RepeatedField::from_vec(
             src.configs.iter().map(external::MintConfig::from).collect(),
@@ -48,11 +48,11 @@ impl From<&SetMintConfigTxPrefix> for external::SetMintConfigTxPrefix {
     }
 }
 
-/// Convert external::SetMintConfigTxPrefix --> SetMintConfigTxPrefix.
-impl TryFrom<&external::SetMintConfigTxPrefix> for SetMintConfigTxPrefix {
+/// Convert external::MintConfigTxPrefix --> MintConfigTxPrefix.
+impl TryFrom<&external::MintConfigTxPrefix> for MintConfigTxPrefix {
     type Error = ConversionError;
 
-    fn try_from(source: &external::SetMintConfigTxPrefix) -> Result<Self, Self::Error> {
+    fn try_from(source: &external::MintConfigTxPrefix) -> Result<Self, Self::Error> {
         let configs: Vec<MintConfig> = source
             .get_configs()
             .iter()
@@ -68,22 +68,22 @@ impl TryFrom<&external::SetMintConfigTxPrefix> for SetMintConfigTxPrefix {
     }
 }
 
-/// Convert SetMintConfigTx --> external::SetMintConfigTx.
-impl From<&SetMintConfigTx> for external::SetMintConfigTx {
-    fn from(src: &SetMintConfigTx) -> Self {
-        let mut dst = external::SetMintConfigTx::new();
+/// Convert MintConfigTx --> external::MintConfigTx.
+impl From<&MintConfigTx> for external::MintConfigTx {
+    fn from(src: &MintConfigTx) -> Self {
+        let mut dst = external::MintConfigTx::new();
         dst.set_prefix((&src.prefix).into());
         dst.set_signature((&src.signature).into());
         dst
     }
 }
 
-/// Convert external::SetMintConfigTx --> SetMintConfigTx.
-impl TryFrom<&external::SetMintConfigTx> for SetMintConfigTx {
+/// Convert external::MintConfigTx --> MintConfigTx.
+impl TryFrom<&external::MintConfigTx> for MintConfigTx {
     type Error = ConversionError;
 
-    fn try_from(source: &external::SetMintConfigTx) -> Result<Self, Self::Error> {
-        let prefix = SetMintConfigTxPrefix::try_from(source.get_prefix())?;
+    fn try_from(source: &external::MintConfigTx) -> Result<Self, Self::Error> {
+        let prefix = MintConfigTxPrefix::try_from(source.get_prefix())?;
         let signature = MultiSig::try_from(source.get_signature())?;
 
         Ok(Self { prefix, signature })
@@ -140,11 +140,11 @@ mod tests {
     }
 
     #[test]
-    // SetMintConfigTx -> external::SetMintConfigTx -> SetMintConfigTx should be the
+    // MintConfigTx -> external::MintConfigTx -> MintConfigTx should be the
     // identity function.
-    fn test_convert_set_mint_config_tx() {
-        let source = SetMintConfigTx {
-            prefix: SetMintConfigTxPrefix {
+    fn test_convert_mint_config_tx() {
+        let source = MintConfigTx {
+            prefix: MintConfigTxPrefix {
                 token_id: 123,
                 configs: vec![
                     MintConfig {
@@ -171,12 +171,12 @@ mod tests {
             assert_eq!(source, recovered);
         }
 
-        // Converting mc_transaction_core::mint::SetMintConfigTx ->
-        // external::SetMintConfigTx -> mc_transaction_core::mint::
-        // SetMintConfigTx should be the identity function.
+        // Converting mc_transaction_core::mint::MintConfigTx ->
+        // external::MintConfigTx -> mc_transaction_core::mint::
+        // MintConfigTx should be the identity function.
         {
-            let external = external::SetMintConfigTx::from(&source);
-            let recovered = SetMintConfigTx::try_from(&external).unwrap();
+            let external = external::MintConfigTx::from(&source);
+            let recovered = MintConfigTx::try_from(&external).unwrap();
             assert_eq!(source, recovered);
         }
 
@@ -184,15 +184,15 @@ mod tests {
         // function.
         {
             let bytes = encode(&source);
-            let recovered = external::SetMintConfigTx::parse_from_bytes(&bytes).unwrap();
-            assert_eq!(recovered, external::SetMintConfigTx::from(&source));
+            let recovered = external::MintConfigTx::parse_from_bytes(&bytes).unwrap();
+            assert_eq!(recovered, external::MintConfigTx::from(&source));
         }
 
         // Encoding with protobuf, decoding with prost should be the identity function.
         {
-            let external = external::SetMintConfigTx::from(&source);
+            let external = external::MintConfigTx::from(&source);
             let bytes = external.write_to_bytes().unwrap();
-            let recovered: SetMintConfigTx = decode(&bytes).unwrap();
+            let recovered: MintConfigTx = decode(&bytes).unwrap();
             assert_eq!(source, recovered);
         }
     }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -602,8 +602,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
         key_images.sort();
 
-        // Right now set-mint-config-txs and mint-txs are not actually created anywhere.
-        let set_mint_config_txs = Vec::new();
+        // Right now mint-config-txs and mint-txs are not actually created anywhere.
+        let mint_config_txs = Vec::new();
         let mint_txs = Vec::new();
 
         // We purposefully do not ..Default::default() here so that new block fields
@@ -611,7 +611,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let block_contents = BlockContents {
             key_images,
             outputs,
-            set_mint_config_txs,
+            mint_config_txs,
             mint_txs,
         };
         //

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -192,7 +192,7 @@ impl Ledger for MockLedger {
         unimplemented!()
     }
 
-    fn check_set_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
+    fn check_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }
 

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -79,8 +79,8 @@ pub enum Error {
     /// DuplicateMintTx
     DuplicateMintTx,
 
-    /// DuplicateSetMintConfigTx
-    DuplicateSetMintConfigTx,
+    /// DuplicateMintConfigTx
+    DuplicateMintConfigTx,
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -96,10 +96,10 @@ pub trait Ledger: Send {
     /// given token id.
     fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
 
-    /// Checks if the ledger contains a given SetMintConfigTx nonce.
+    /// Checks if the ledger contains a given MintConfigTx nonce.
     /// If so, returns the index of the block in which it entered the ledger.
     /// Ok(None) is returned when the nonce is not in the ledger.
-    fn check_set_mint_config_tx_nonce(&self, nonce: &[u8]) -> Result<Option<BlockIndex>, Error>;
+    fn check_mint_config_tx_nonce(&self, nonce: &[u8]) -> Result<Option<BlockIndex>, Error>;
 
     /// Checks if the ledger contains a given MintTx nonce.
     /// If so, returns the index of the block in which it entered the ledger.

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -26,9 +26,9 @@ use mc_util_serial::{decode, encode, Message};
 // LMDB Database names.
 pub const ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME: &str =
     "mint_config_store:active_mint_configs_by_token_id";
-pub const BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME: &str =
+pub const BLOCK_INDEX_BY_MINT_CONFIG_TX_NONCE_DB_NAME: &str =
     "mint_config_store:block_index_by_mint_config_tx_nonce";
-pub const SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str = "mint_config_store:mint_config_txs_by_block";
+pub const MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str = "mint_config_store:mint_config_txs_by_block";
 
 /// An active mint configuration for a single token.
 #[derive(Clone, Eq, Message, PartialEq)]
@@ -93,8 +93,8 @@ impl MintConfigStore {
             active_mint_configs_by_token_id: env
                 .open_db(Some(ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME))?,
             block_index_by_mint_config_tx_nonce: env
-                .open_db(Some(BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME))?,
-            mint_config_txs_by_block: env.open_db(Some(SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
+                .open_db(Some(BLOCK_INDEX_BY_MINT_CONFIG_TX_NONCE_DB_NAME))?,
+            mint_config_txs_by_block: env.open_db(Some(MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
         })
     }
 
@@ -105,11 +105,11 @@ impl MintConfigStore {
             DatabaseFlags::empty(),
         )?;
         env.create_db(
-            Some(BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME),
+            Some(BLOCK_INDEX_BY_MINT_CONFIG_TX_NONCE_DB_NAME),
             DatabaseFlags::empty(),
         )?;
         env.create_db(
-            Some(SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME),
+            Some(MINT_CONFIG_TXS_BY_BLOCK_DB_NAME),
             DatabaseFlags::empty(),
         )?;
 

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -10,15 +10,15 @@
 //!      2) It enables keeping track of how much was minted using a given
 //! configuration. This is used to enforce the per-configuration mint limit.
 //! 2) A mapping of nonce -> block index of the block containing the
-//! SetMintConfigTx with that nonce. This is mainly used to prevent replay
+//! MintConfigTx with that nonce. This is mainly used to prevent replay
 //! attacks.
-//! 3) A mapping of block index -> list of SetMintConfigTx objects
+//! 3) A mapping of block index -> list of MintConfigTx objects
 //! included in the block.
 
 use crate::{key_bytes_to_u64, u32_to_key_bytes, u64_to_key_bytes, Error};
 use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
 use mc_transaction_core::{
-    mint::{MintConfig, MintTx, SetMintConfigTx},
+    mint::{MintConfig, MintConfigTx, MintTx},
     BlockIndex, TokenId,
 };
 use mc_util_serial::{decode, encode, Message};
@@ -27,9 +27,8 @@ use mc_util_serial::{decode, encode, Message};
 pub const ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME: &str =
     "mint_config_store:active_mint_configs_by_token_id";
 pub const BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME: &str =
-    "mint_config_store:block_index_by_set_mint_config_tx_nonce";
-pub const SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str =
-    "mint_config_store:set_mint_config_txs_by_block";
+    "mint_config_store:block_index_by_mint_config_tx_nonce";
+pub const SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str = "mint_config_store:mint_config_txs_by_block";
 
 /// An active mint configuration for a single token.
 #[derive(Clone, Eq, Message, PartialEq)]
@@ -51,10 +50,10 @@ struct ActiveMintConfigs {
     pub configs: Vec<ActiveMintConfig>,
 }
 
-impl From<&SetMintConfigTx> for ActiveMintConfigs {
-    fn from(set_mint_config_tx: &SetMintConfigTx) -> Self {
+impl From<&MintConfigTx> for ActiveMintConfigs {
+    fn from(mint_config_tx: &MintConfigTx) -> Self {
         ActiveMintConfigs {
-            configs: set_mint_config_tx
+            configs: mint_config_tx
                 .prefix
                 .configs
                 .iter()
@@ -67,12 +66,12 @@ impl From<&SetMintConfigTx> for ActiveMintConfigs {
     }
 }
 
-/// A list of set-mint-config-txs that can be prost-encoded. This is needed
-/// since that's the only way to encode a Vec<SetMintConfigTx>.
+/// A list of mint-config-txs that can be prost-encoded. This is needed
+/// since that's the only way to encode a Vec<MintConfigTx>.
 #[derive(Clone, Message)]
-pub struct SetMintConfigTxList {
+pub struct MintConfigTxList {
     #[prost(message, repeated, tag = "1")]
-    pub set_mint_config_txs: Vec<SetMintConfigTx>,
+    pub mint_config_txs: Vec<MintConfigTx>,
 }
 
 #[derive(Clone)]
@@ -81,10 +80,10 @@ pub struct MintConfigStore {
     active_mint_configs_by_token_id: Database,
 
     /// nonce -> block index
-    block_index_by_set_mint_config_tx_nonce: Database,
+    block_index_by_mint_config_tx_nonce: Database,
 
-    /// block_index -> SetMintConfigTxList
-    set_mint_config_txs_by_block: Database,
+    /// block_index -> MintConfigTxList
+    mint_config_txs_by_block: Database,
 }
 
 impl MintConfigStore {
@@ -93,10 +92,9 @@ impl MintConfigStore {
         Ok(MintConfigStore {
             active_mint_configs_by_token_id: env
                 .open_db(Some(ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME))?,
-            block_index_by_set_mint_config_tx_nonce: env
+            block_index_by_mint_config_tx_nonce: env
                 .open_db(Some(BLOCK_INDEX_BY_SET_MINT_CONFIG_TX_NONCE_DB_NAME))?,
-            set_mint_config_txs_by_block: env
-                .open_db(Some(SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
+            mint_config_txs_by_block: env.open_db(Some(SET_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
         })
     }
 
@@ -118,35 +116,35 @@ impl MintConfigStore {
         Ok(())
     }
 
-    /// Write set-mint-config-txs in a given block.
-    pub fn write_set_mint_config_txs(
+    /// Write mint-config-txs in a given block.
+    pub fn write_mint_config_txs(
         &self,
         block_index: u64,
-        set_mint_config_txs: &[SetMintConfigTx],
+        mint_config_txs: &[MintConfigTx],
         db_transaction: &mut RwTransaction,
     ) -> Result<(), Error> {
         let block_index_bytes = u64_to_key_bytes(block_index);
 
-        // Store the list of SetMintConfigTxs.
-        let set_mint_config_tx_list = SetMintConfigTxList {
-            set_mint_config_txs: set_mint_config_txs.to_vec(),
+        // Store the list of MintConfigTxs.
+        let mint_config_tx_list = MintConfigTxList {
+            mint_config_txs: mint_config_txs.to_vec(),
         };
 
         db_transaction.put(
-            self.set_mint_config_txs_by_block,
+            self.mint_config_txs_by_block,
             &block_index_bytes,
-            &encode(&set_mint_config_tx_list),
+            &encode(&mint_config_tx_list),
             WriteFlags::NO_OVERWRITE, // We should not be updating existing blocks
         )?;
 
         // Update active mint configurations.
-        for set_mint_config_tx in set_mint_config_txs {
+        for mint_config_tx in mint_config_txs {
             // All mint configurations must have the same token id.
-            if set_mint_config_tx
+            if mint_config_tx
                 .prefix
                 .configs
                 .iter()
-                .any(|mint_config| mint_config.token_id != set_mint_config_tx.prefix.token_id)
+                .any(|mint_config| mint_config.token_id != mint_config_tx.prefix.token_id)
             {
                 return Err(Error::InvalidMintConfig(
                     "All mint configurations must have the same token id".to_string(),
@@ -154,12 +152,12 @@ impl MintConfigStore {
             }
 
             // MintConfigs -> ActiveMintConfigs
-            let active_mint_configs = ActiveMintConfigs::from(set_mint_config_tx);
+            let active_mint_configs = ActiveMintConfigs::from(mint_config_tx);
 
             // Store in database
             db_transaction.put(
-                self.block_index_by_set_mint_config_tx_nonce,
-                &set_mint_config_tx.prefix.nonce,
+                self.block_index_by_mint_config_tx_nonce,
+                &mint_config_tx.prefix.nonce,
                 &block_index_bytes,
                 //  ensures we do not overwrite a nonce that was already used
                 WriteFlags::NO_OVERWRITE,
@@ -167,7 +165,7 @@ impl MintConfigStore {
 
             db_transaction.put(
                 self.active_mint_configs_by_token_id,
-                &u32_to_key_bytes(set_mint_config_tx.prefix.token_id),
+                &u32_to_key_bytes(mint_config_tx.prefix.token_id),
                 &encode(&active_mint_configs),
                 WriteFlags::empty(),
             )?;
@@ -176,17 +174,17 @@ impl MintConfigStore {
         Ok(())
     }
 
-    /// Get SetMintConfigTxs in a given block.
-    pub fn get_set_mint_config_txs_by_block_index(
+    /// Get MintConfigTxs in a given block.
+    pub fn get_mint_config_txs_by_block_index(
         &self,
         block_index: u64,
         db_transaction: &impl Transaction,
-    ) -> Result<Vec<SetMintConfigTx>, Error> {
-        let set_mint_config_tx_list: SetMintConfigTxList = decode(db_transaction.get(
-            self.set_mint_config_txs_by_block,
+    ) -> Result<Vec<MintConfigTx>, Error> {
+        let mint_config_tx_list: MintConfigTxList = decode(db_transaction.get(
+            self.mint_config_txs_by_block,
             &u64_to_key_bytes(block_index),
         )?)?;
-        Ok(set_mint_config_tx_list.set_mint_config_txs)
+        Ok(mint_config_tx_list.mint_config_txs)
     }
 
     /// Get mint configurations for a given token.
@@ -298,12 +296,12 @@ impl MintConfigStore {
         Ok(())
     }
 
-    pub fn check_set_mint_config_tx_nonce(
+    pub fn check_mint_config_tx_nonce(
         &self,
         nonce: &[u8],
         db_transaction: &impl Transaction,
     ) -> Result<Option<BlockIndex>, Error> {
-        match db_transaction.get(self.block_index_by_set_mint_config_tx_nonce, &nonce) {
+        match db_transaction.get(self.block_index_by_mint_config_tx_nonce, &nonce) {
             Ok(db_bytes) => Ok(Some(key_bytes_to_u64(db_bytes))),
             Err(lmdb::Error::NotFound) => Ok(None),
             Err(e) => Err(Error::Lmdb(e)),
@@ -317,9 +315,7 @@ pub mod tests {
     use crate::tx_out_store::tx_out_store_tests::get_env;
     use mc_crypto_keys::{Ed25519Pair, RistrettoPublic, Signer};
     use mc_crypto_multisig::{MultiSig, SignerSet};
-    use mc_transaction_core::mint::{
-        MintConfig, MintTxPrefix, SetMintConfigTx, SetMintConfigTxPrefix,
-    };
+    use mc_transaction_core::mint::{MintConfig, MintConfigTx, MintConfigTxPrefix, MintTxPrefix};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
     use rand_core::{CryptoRng, RngCore};
@@ -334,7 +330,7 @@ pub mod tests {
     pub fn generate_test_mint_config_tx_and_signers(
         token_id: TokenId,
         rng: &mut (impl RngCore + CryptoRng),
-    ) -> (SetMintConfigTx, Vec<Ed25519Pair>) {
+    ) -> (MintConfigTx, Vec<Ed25519Pair>) {
         let signer_1 = Ed25519Pair::from_random(rng);
         let signer_2 = Ed25519Pair::from_random(rng);
         let signer_3 = Ed25519Pair::from_random(rng);
@@ -342,7 +338,7 @@ pub mod tests {
         let mut nonce: Vec<u8> = vec![0u8; 32];
         rng.fill_bytes(&mut nonce);
 
-        let prefix = SetMintConfigTxPrefix {
+        let prefix = MintConfigTxPrefix {
             token_id: *token_id,
             configs: vec![
                 MintConfig {
@@ -367,7 +363,7 @@ pub mod tests {
         let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
 
         (
-            SetMintConfigTx { prefix, signature },
+            MintConfigTx { prefix, signature },
             vec![signer_1, signer_2, signer_3],
         )
     }
@@ -375,10 +371,9 @@ pub mod tests {
     pub fn generate_test_mint_config_tx(
         token_id: TokenId,
         rng: &mut (impl RngCore + CryptoRng),
-    ) -> SetMintConfigTx {
-        let (set_mint_config_tx, _signers) =
-            generate_test_mint_config_tx_and_signers(token_id, rng);
-        set_mint_config_tx
+    ) -> MintConfigTx {
+        let (mint_config_tx, _signers) = generate_test_mint_config_tx_and_signers(token_id, rng);
+        mint_config_tx
     }
 
     // Generate a random mint tx
@@ -423,7 +418,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -449,7 +444,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -486,7 +481,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -494,7 +489,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.write_set_mint_config_txs(
+                mint_config_store.write_mint_config_txs(
                     1,
                     &[test_tx_1.clone()],
                     &mut db_transaction
@@ -508,7 +503,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.write_set_mint_config_txs(
+                mint_config_store.write_mint_config_txs(
                     2,
                     &[test_tx_1.clone()],
                     &mut db_transaction
@@ -523,7 +518,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(3, &[test_tx_2], &mut db_transaction)
+                .write_mint_config_txs(3, &[test_tx_2], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -542,7 +537,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -562,7 +557,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -585,8 +580,8 @@ pub mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         let test_tx_1 = generate_test_mint_config_tx(TokenId::from(1), &mut rng);
-        let test_tx_2 = SetMintConfigTx {
-            prefix: SetMintConfigTxPrefix {
+        let test_tx_2 = MintConfigTx {
+            prefix: MintConfigTxPrefix {
                 token_id: test_tx_1.prefix.token_id,
                 configs: vec![],
                 nonce: vec![5u8; 32],
@@ -600,7 +595,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -620,7 +615,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -647,7 +642,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -722,7 +717,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -753,7 +748,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -806,7 +801,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -856,7 +851,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -928,7 +923,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1013,7 +1008,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1061,7 +1056,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(
+                .write_mint_config_txs(
                     0,
                     &[test_tx_1.clone(), test_tx_2.clone()],
                     &mut db_transaction,
@@ -1099,7 +1094,7 @@ pub mod tests {
                 let mut nonce: Vec<u8> = vec![0u8; 32];
                 rng.fill_bytes(&mut nonce);
 
-                let prefix = SetMintConfigTxPrefix {
+                let prefix = MintConfigTxPrefix {
                     token_id: *token_id1,
                     configs: vec![],
                     nonce,
@@ -1109,11 +1104,11 @@ pub mod tests {
                 let message = prefix.hash();
                 let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
 
-                SetMintConfigTx { prefix, signature }
+                MintConfigTx { prefix, signature }
             };
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
+                .write_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1136,7 +1131,7 @@ pub mod tests {
     }
 
     #[test]
-    fn check_set_mint_config_tx_nonce_works() {
+    fn check_mint_config_tx_nonce_works() {
         let (mint_config_store, env) = init_mint_config_store();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let token_id1 = TokenId::from(1);
@@ -1149,7 +1144,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(
+                .write_mint_config_txs(
                     0,
                     &[test_tx_1.clone(), test_tx_2.clone()],
                     &mut db_transaction,
@@ -1163,18 +1158,18 @@ pub mod tests {
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
                 Ok(Some(0)),
             );
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
                 Ok(Some(0)),
             );
 
             assert_eq!(
-                mint_config_store.check_set_mint_config_tx_nonce(
+                mint_config_store.check_mint_config_tx_nonce(
                     &test_tx_2.prefix.nonce[0..test_tx_2.prefix.nonce.len() - 1],
                     &db_transaction
                 ),
@@ -1183,12 +1178,12 @@ pub mod tests {
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
                 Ok(None),
             );
 
             assert_eq!(
-                mint_config_store.check_set_mint_config_tx_nonce(&[1, 2, 3], &db_transaction),
+                mint_config_store.check_mint_config_tx_nonce(&[1, 2, 3], &db_transaction),
                 Ok(None),
             );
         }
@@ -1196,7 +1191,7 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_set_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
+                .write_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1206,19 +1201,19 @@ pub mod tests {
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_1.prefix.nonce, &db_transaction),
                 Ok(Some(0)),
             );
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_2.prefix.nonce, &db_transaction),
                 Ok(Some(0)),
             );
 
             assert_eq!(
                 mint_config_store
-                    .check_set_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
+                    .check_mint_config_tx_nonce(&test_tx_3.prefix.nonce, &db_transaction),
                 Ok(Some(1)),
             );
         }

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -161,16 +161,16 @@ mod tests {
         let token_id2 = TokenId::from(2);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
-        let (set_mint_config_tx2, signers2) =
+        let (mint_config_tx2, signers2) =
             generate_test_mint_config_tx_and_signers(token_id2, &mut rng);
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(
+            .write_mint_config_txs(
                 0,
-                &[set_mint_config_tx1.clone(), set_mint_config_tx2.clone()],
+                &[mint_config_tx1.clone(), mint_config_tx2.clone()],
                 &mut db_txn,
             )
             .unwrap();
@@ -193,11 +193,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[0].clone(),
                     total_minted: 1,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: 0,
                 }
             ]
@@ -221,11 +221,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[0].clone(),
                     total_minted: 3,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: 0,
                 }
             ]
@@ -254,11 +254,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[0].clone(),
                     total_minted: 3,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: 5,
                 }
             ]
@@ -272,11 +272,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx2.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx2.prefix.configs[0].clone(),
                     total_minted: 0,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx2.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx2.prefix.configs[1].clone(),
                     total_minted: 0,
                 }
             ]
@@ -305,11 +305,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[0].clone(),
                     total_minted: 3,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: 5,
                 }
             ]
@@ -322,11 +322,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx2.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx2.prefix.configs[0].clone(),
                     total_minted: 0,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx2.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx2.prefix.configs[1].clone(),
                     total_minted: 15,
                 }
             ]
@@ -340,12 +340,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1.clone()], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -381,12 +381,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1.clone()], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -415,11 +415,11 @@ mod tests {
             active_mint_configs,
             vec![
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[0].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[0].clone(),
                     total_minted: 0,
                 },
                 ActiveMintConfig {
-                    mint_config: set_mint_config_tx1.prefix.configs[1].clone(),
+                    mint_config: mint_config_tx1.prefix.configs[1].clone(),
                     total_minted: 12,
                 }
             ]
@@ -434,12 +434,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, _signers1) =
+        let (mint_config_tx1, _signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1.clone()], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -467,12 +467,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1.clone()], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -493,12 +493,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1.clone()], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -508,8 +508,8 @@ mod tests {
             token_id1,
             &signers1,
             max(
-                set_mint_config_tx1.prefix.configs[0].mint_limit,
-                set_mint_config_tx1.prefix.configs[1].mint_limit,
+                mint_config_tx1.prefix.configs[0].mint_limit,
+                mint_config_tx1.prefix.configs[1].mint_limit,
             ) + 1,
             &mut rng,
         );
@@ -530,12 +530,12 @@ mod tests {
         let token_id1 = TokenId::from(1);
 
         // Generate and store a mint configurations.
-        let (set_mint_config_tx1, signers1) =
+        let (mint_config_tx1, signers1) =
             generate_test_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_set_mint_config_txs(0, &[set_mint_config_tx1], &mut db_txn)
+            .write_mint_config_txs(0, &[mint_config_tx1], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -195,7 +195,7 @@ impl Ledger for MockLedger {
         unimplemented!()
     }
 
-    fn check_set_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
+    fn check_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }
 

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -234,7 +234,7 @@ fn backfill_empty_mint_stores(env: &Environment, logger: &Logger) -> Result<(), 
 
     let mut percents: u64 = 0;
     for block_index in 0..num_blocks {
-        mint_config_store.write_set_mint_config_txs(block_index, &[], &mut db_txn)?;
+        mint_config_store.write_mint_config_txs(block_index, &[], &mut db_txn)?;
         mint_tx_store.write_mint_txs(block_index, &[], &mint_config_store, &mut db_txn)?;
 
         // Throttled logging.

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use crate::{
-    mint::{MintTx, SetMintConfigTx},
+    mint::{MintConfigTx, MintTx},
     ring_signature::KeyImage,
     tx::TxOut,
     ConvertError,
@@ -27,9 +27,9 @@ pub struct BlockContents {
     #[prost(message, repeated, tag = "2")]
     pub outputs: Vec<TxOut>,
 
-    /// Set-mint-config transactions in this block.
+    /// mint-config transactions in this block.
     #[prost(message, repeated, tag = "3")]
-    pub set_mint_config_txs: Vec<SetMintConfigTx>,
+    pub mint_config_txs: Vec<MintConfigTx>,
 
     /// Mint transactions in this block.
     #[prost(message, repeated, tag = "4")]

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -44,8 +44,8 @@ pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";
 /// Domain separator for hashing the confirmation number
 pub const TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG: &str = "mc_tx_out_confirmation_number";
 
-/// Domain separator for hashing SetMintConfigTxPrefixs
-pub const SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_set_mint_config_tx_prefix";
+/// Domain separator for hashing MintConfigTxPrefixs
+pub const SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_config_tx_prefix";
 
 /// Domain separator for hashing MintTxPrefixs
 pub const MINT_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_tx_prefix";

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -45,7 +45,7 @@ pub const RING_MLSAG_CHALLENGE_DOMAIN_TAG: &str = "mc_ring_mlsag_challenge";
 pub const TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG: &str = "mc_tx_out_confirmation_number";
 
 /// Domain separator for hashing MintConfigTxPrefixs
-pub const SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_config_tx_prefix";
+pub const MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_config_tx_prefix";
 
 /// Domain separator for hashing MintTxPrefixs
 pub const MINT_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_tx_prefix";

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -31,12 +31,12 @@ pub struct MintConfig {
     pub mint_limit: u64,
 }
 
-/// The contents of a set-mint-config transaction. This transaction alters the
+/// The contents of a mint-config transaction. This transaction alters the
 /// minting configuration for a single token ID.
 #[derive(
     Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
 )]
-pub struct SetMintConfigTxPrefix {
+pub struct MintConfigTxPrefix {
     /// Token ID we are replacing the configuration set for.
     #[prost(uint32, tag = "1")]
     pub token_id: u32,
@@ -54,20 +54,20 @@ pub struct SetMintConfigTxPrefix {
     pub tombstone_block: u64,
 }
 
-impl SetMintConfigTxPrefix {
+impl MintConfigTxPrefix {
     /// Digestible-crate hash of `self` using Merlin
     pub fn hash(&self) -> [u8; 32] {
         self.digest32::<MerlinTranscript>(SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG.as_bytes())
     }
 }
 
-/// A set-mint-config transaction coupled with a signature over it.
+/// A mint-config transaction coupled with a signature over it.
 #[derive(
     Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
 )]
-pub struct SetMintConfigTx {
+pub struct MintConfigTx {
     #[prost(message, required, tag = "1")]
-    pub prefix: SetMintConfigTxPrefix,
+    pub prefix: MintConfigTxPrefix,
 
     #[prost(message, required, tag = "2")]
     pub signature: MultiSig<Ed25519Signature>,

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -2,7 +2,7 @@
 
 //! Minting transaction configuration.
 
-use crate::domain_separators::SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG;
+use crate::domain_separators::MINT_CONFIG_TX_PREFIX_DOMAIN_TAG;
 use alloc::vec::Vec;
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::{Ed25519Public, Ed25519Signature};
@@ -57,7 +57,7 @@ pub struct MintConfigTxPrefix {
 impl MintConfigTxPrefix {
     /// Digestible-crate hash of `self` using Merlin
     pub fn hash(&self) -> [u8; 32] {
-        self.digest32::<MerlinTranscript>(SET_MINT_CONFIG_TX_PREFIX_DOMAIN_TAG.as_bytes())
+        self.digest32::<MerlinTranscript>(MINT_CONFIG_TX_PREFIX_DOMAIN_TAG.as_bytes())
     }
 }
 

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -8,8 +8,8 @@ mod validation;
 
 pub mod constants;
 
-pub use config::{MintConfig, SetMintConfigTx, SetMintConfigTxPrefix};
+pub use config::{MintConfig, MintConfigTx, MintConfigTxPrefix};
 pub use tx::{MintTx, MintTxPrefix};
 pub use validation::{
-    config::validate_set_mint_config_tx, error::Error as MintValidationError, tx::validate_mint_tx,
+    config::validate_mint_config_tx, error::Error as MintValidationError, tx::validate_mint_tx,
 };

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! SetMintConfigTx transaction validation.
+//! MintConfigTx transaction validation.
 
 use crate::{
     mint::{
-        config::{MintConfig, SetMintConfigTx},
+        config::{MintConfig, MintConfigTx},
         validation::{
             common::{
                 validate_block_version, validate_nonce, validate_token_id, validate_tombstone,
@@ -26,9 +26,9 @@ use mc_crypto_multisig::SignerSet;
 ///   built.
 /// * `block_version` - The version of the block that is being built.
 /// * `master_minters` - The set of signers that are allowed to sign
-///   SetMintConfigTx transactions.
-pub fn validate_set_mint_config_tx(
-    tx: &SetMintConfigTx,
+///   MintConfigTx transactions.
+pub fn validate_mint_config_tx(
+    tx: &MintConfigTx,
     current_block_index: u64,
     block_version: BlockVersion,
     master_minters: &SignerSet<Ed25519Public>,
@@ -75,7 +75,7 @@ fn validate_configs(token_id: u32, configs: &[MintConfig]) -> Result<(), Error> 
 /// * `tx` - A pending transaction that is being validated.
 /// * `signer_set` - The signer set that is permitted to sign the transaction.
 fn validate_signature(
-    tx: &SetMintConfigTx,
+    tx: &MintConfigTx,
     master_minters: &SignerSet<Ed25519Public>,
 ) -> Result<(), Error> {
     let message = tx.prefix.hash();
@@ -89,7 +89,7 @@ fn validate_signature(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mint::{config::SetMintConfigTxPrefix, constants::NONCE_LENGTH};
+    use crate::mint::{config::MintConfigTxPrefix, constants::NONCE_LENGTH};
     use mc_crypto_keys::{Ed25519Pair, Signer};
     use mc_crypto_multisig::MultiSig;
     use mc_util_from_random::FromRandom;
@@ -214,7 +214,7 @@ mod tests {
         let master_minter_2 = Ed25519Pair::from_random(&mut rng);
         let master_minter_3 = Ed25519Pair::from_random(&mut rng);
 
-        let prefix = SetMintConfigTxPrefix {
+        let prefix = MintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
@@ -224,7 +224,7 @@ mod tests {
 
         // Try with 1 out of 3 signers.
         let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -246,7 +246,7 @@ mod tests {
             master_minter_1.try_sign(message.as_ref()).unwrap(),
             master_minter_2.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -268,7 +268,7 @@ mod tests {
             master_minter_3.try_sign(message.as_ref()).unwrap(),
             master_minter_1.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -291,7 +291,7 @@ mod tests {
             master_minter_2.try_sign(message.as_ref()).unwrap(),
             master_minter_3.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = SetMintConfigTx { prefix, signature };
+        let tx = MintConfigTx { prefix, signature };
         assert!(validate_signature(
             &tx,
             &SignerSet::new(
@@ -330,7 +330,7 @@ mod tests {
         let master_minter_2 = Ed25519Pair::from_random(&mut rng);
         let master_minter_3 = Ed25519Pair::from_random(&mut rng);
 
-        let prefix = SetMintConfigTxPrefix {
+        let prefix = MintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
@@ -340,7 +340,7 @@ mod tests {
 
         // Tamper with the mint limit.
         let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
-        let mut tx = SetMintConfigTx {
+        let mut tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -362,7 +362,7 @@ mod tests {
 
         // Tamper with the tombstone block.
         let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
-        let mut tx = SetMintConfigTx {
+        let mut tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -407,7 +407,7 @@ mod tests {
         let master_minter_2 = Ed25519Pair::from_random(&mut rng);
         let master_minter_3 = Ed25519Pair::from_random(&mut rng);
 
-        let prefix = SetMintConfigTxPrefix {
+        let prefix = MintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
@@ -417,7 +417,7 @@ mod tests {
 
         // Signing below threshold
         let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -438,7 +438,7 @@ mod tests {
 
         // Signing with unknown signers.
         let signature = MultiSig::new(vec![master_minter_1.try_sign(message.as_ref()).unwrap()]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -458,7 +458,7 @@ mod tests {
             master_minter_1.try_sign(message.as_ref()).unwrap(),
             master_minter_2.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };
@@ -498,7 +498,7 @@ mod tests {
         let master_minter_2 = Ed25519Pair::from_random(&mut rng);
         let master_minter_3 = Ed25519Pair::from_random(&mut rng);
 
-        let prefix = SetMintConfigTxPrefix {
+        let prefix = MintConfigTxPrefix {
             token_id: token_id,
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
@@ -511,7 +511,7 @@ mod tests {
             master_minter_1.try_sign(message.as_ref()).unwrap(),
             master_minter_1.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = SetMintConfigTx {
+        let tx = MintConfigTx {
             prefix: prefix.clone(),
             signature,
         };


### PR DESCRIPTION
No need for the `Set` prefix, it's overly verbose and results in weird method names like `get_se_mint_config_txs`.