### PR TITLE
Block Streaming: Ledger Sink Component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4551,6 +4551,7 @@ dependencies = [
  "grpcio",
  "mc-common",
  "mc-crypto-keys",
+ "mc-ledger-db",
  "mc-ledger-streaming-api",
  "mc-transaction-core",
  "mc-util-build-grpc",
@@ -4558,6 +4559,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-uri",
+ "pin-project",
  "rand_core 0.6.3",
  "rand_hc 0.3.1",
 ]
@@ -5987,18 +5989,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",

--- a/ledger/streaming/api/src/error.rs
+++ b/ledger/streaming/api/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
 
     /// Invalid signature: {0}
     Signature(String),
+
+    /// Ledger DB Access Error
+    DBError,
 }
 
 impl std::error::Error for Error {}

--- a/ledger/streaming/api/src/error.rs
+++ b/ledger/streaming/api/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     Signature(String),
 
     /// Ledger DB Access Error
-    DBError,
+    DBAccess,
 }
 
 impl std::error::Error for Error {}

--- a/ledger/streaming/api/src/test_utils/stream.rs
+++ b/ledger/streaming/api/src/test_utils/stream.rs
@@ -3,7 +3,9 @@
 //! Mock BlockStream
 
 use crate::{BlockStream, BlockStreamComponents, Result};
-use futures::Stream;
+use futures::{stream::Iter, Stream};
+use mc_transaction_core::{Block, BlockData};
+use std::{iter::FromIterator, vec::IntoIter};
 
 /// Mock implementation of BlockStream, backed by a pre-defined Stream.
 #[derive(Clone, Debug)]
@@ -54,4 +56,82 @@ pub fn mock_stream_from_components(
 ) -> MockStream<impl Stream<Item = Result<BlockStreamComponents>> + Clone> {
     let items: Vec<Result<BlockStreamComponents>> = src.into_iter().map(Ok).collect();
     mock_stream_from_items(items)
+}
+
+/// Mock stream for generating blocks without the need for clone or generics
+#[derive(Clone, Debug)]
+pub struct SimpleMockStream {
+    num_components: u64,
+    components: Vec<BlockStreamComponents>,
+}
+
+impl SimpleMockStream {
+    /// New simple stream with pre-determined initial components
+    pub fn new(num_components: u64) -> Self {
+        Self {
+            num_components,
+            components: super::make_components(num_components as usize),
+        }
+    }
+
+    /// Simple stream initialized with pre-defined components
+    pub fn new_from_components(components: Vec<BlockStreamComponents>) -> Self {
+        let num_components = components.len() as u64;
+        Self {
+            num_components,
+            components,
+        }
+    }
+
+    /// Get simple mock stream
+    fn get_stream(
+        &self,
+        starting_height: u64,
+    ) -> impl Stream<Item = Result<BlockStreamComponents>> {
+        let slice = Vec::from_iter(
+            self.components[starting_height as usize..self.num_components as usize]
+                .iter()
+                .cloned(),
+        );
+        futures::stream::iter(slice.into_iter().map(Ok))
+    }
+
+    /// Get block data for specific block height
+    pub fn get_block_data(&self, height: u64) -> BlockData {
+        self.components
+            .get(height as usize)
+            .unwrap()
+            .block_data
+            .clone()
+    }
+
+    /// Get block for specific block height
+    pub fn get_block(&self, height: u64) -> Block {
+        self.components
+            .get(height as usize)
+            .unwrap()
+            .block_data
+            .block()
+            .clone()
+    }
+}
+
+impl BlockStream for SimpleMockStream {
+    type Stream = impl Stream<Item = Result<BlockStreamComponents>>;
+
+    fn get_block_stream(&self, starting_height: u64) -> Result<Self::Stream> {
+        Ok(self.get_stream(starting_height))
+    }
+}
+
+/// Get stream combinator with n components
+pub fn get_stream_with_n_components(n: u64) -> SimpleMockStream {
+    SimpleMockStream::new(n)
+}
+
+/// Get raw stream with n components
+pub fn get_raw_stream_with_n_components(n: usize) -> Iter<IntoIter<Result<BlockStreamComponents>>> {
+    let components: Vec<Result<BlockStreamComponents>> =
+        super::make_components(n).into_iter().map(Ok).collect();
+    futures::stream::iter(components)
 }

--- a/ledger/streaming/client/Cargo.toml
+++ b/ledger/streaming/client/Cargo.toml
@@ -13,6 +13,7 @@ test_utils = []
 [dependencies]
 mc-common = { path = "../../../common" }
 mc-crypto-keys = { path = "../../../crypto/keys" }
+mc-ledger-db = { path = "../../../ledger/db" }
 mc-ledger-streaming-api = { path = "../api" }
 mc-transaction-core = { path = "../../../transaction/core" }
 mc-util-grpc = { path = "../../../util/grpc" }
@@ -21,6 +22,7 @@ mc-util-uri = { path = "../../../util/uri" }
 displaydoc = "0.2"
 futures = "0.3"
 grpcio = "0.10"
+pin-project = "1.0.10"
 
 [build-dependencies]
 mc-util-build-grpc = { path = "../../../util/build/grpc" }
@@ -30,6 +32,7 @@ cargo-emit = "0.2"
 
 [dev-dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }
+mc-ledger-db = { path = "../../../ledger/db", features = ["test_utils"] }
 mc-ledger-streaming-api = { path = "../api", features = ["test_utils"] }
 mc-util-from-random = { path = "../../../util/from-random" }
 

--- a/ledger/streaming/client/src/error.rs
+++ b/ledger/streaming/client/src/error.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! MobileCoin stream errors to manage client future & stream operation
+
+use displaydoc::Display;
+use mc_ledger_db::{Error as LedgerDBError, Ledger};
+use mc_transaction_core::BlockIndex;
+use std::sync::{RwLockReadGuard, RwLockWriteGuard, TryLockError};
+
+/// Errors specific to client
+#[derive(Debug, Eq, PartialEq, Clone, Display)]
+pub enum Error {
+    /// LedgerDBError,
+    LedgerDBNotFound,
+
+    /// Failed to access DB
+    CantAccessDB,
+
+    /// Other Ledger DB Error
+    LedgerDB(LedgerDBError),
+
+    /// Block index {0} is too far ahead current index {1}, wait
+    BlockIndexTooFar(BlockIndex, BlockIndex),
+
+    /// Mutex Lock Error {0}
+    Locked(LockReason),
+}
+
+/// A non-generic helper enum to avoid having to pass in generic type params
+#[derive(Debug, Eq, PartialEq, Clone, Display)]
+pub enum LockReason {
+    /// Acquiring the lock would block
+    WouldBlock,
+
+    /// Lock poisoned
+    Poisoned,
+}
+
+// Return specific errors for checking
+impl From<LedgerDBError> for Error {
+    fn from(ledgerdb_error: LedgerDBError) -> Self {
+        match ledgerdb_error {
+            LedgerDBError::NotFound => Error::LedgerDBNotFound,
+            LedgerDBError::BadRslot => Error::CantAccessDB,
+            err => Error::LedgerDB(err),
+        }
+    }
+}
+
+impl<L: Ledger> From<TryLockError<RwLockReadGuard<'_, L>>> for Error {
+    fn from(lock_error: TryLockError<RwLockReadGuard<'_, L>>) -> Self {
+        match lock_error {
+            TryLockError::WouldBlock => Error::Locked(LockReason::WouldBlock),
+            TryLockError::Poisoned(..) => Error::Locked(LockReason::Poisoned),
+        }
+    }
+}
+
+impl<L: Ledger> From<TryLockError<RwLockWriteGuard<'_, L>>> for Error {
+    fn from(lock_error: TryLockError<RwLockWriteGuard<'_, L>>) -> Self {
+        match lock_error {
+            TryLockError::WouldBlock => Error::Locked(LockReason::WouldBlock),
+            TryLockError::Poisoned(..) => Error::Locked(LockReason::Poisoned),
+        }
+    }
+}

--- a/ledger/streaming/client/src/ledger_sink.rs
+++ b/ledger/streaming/client/src/ledger_sink.rs
@@ -92,6 +92,7 @@ mod tests {
         futures::executor::block_on(async move {
             let mut index: u64 = 0;
             let mut threshold = 0;
+
             while let Some(component_result) = sink.next().await {
                 let component = component_result.unwrap();
                 index = component.block_data.block().index;

--- a/ledger/streaming/client/src/ledger_sink.rs
+++ b/ledger/streaming/client/src/ledger_sink.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Helper class for creating a blocksink
+
+use crate::streaming_futures::LedgerStream;
+use futures::stream::{Buffered, Stream, StreamExt};
+use mc_ledger_db::Ledger;
+use mc_ledger_streaming_api::{BlockStream, BlockStreamComponents, Result as StreamResult};
+
+/// A block sink that takes blocks from a passed stream and puts them into
+/// ledger db. This sink should live downstream from a verification source that
+/// has already done block content, scp, and avr validation and thus is
+/// considered a trusted stream
+pub struct DbStream<US: BlockStream, L: Ledger + 'static> {
+    /// Upstream block stream combinator
+    upstream: US,
+
+    /// Block database ledger object
+    ledger: L,
+
+    /// Maximum # of blocks that can be buffered before writing
+    buffer: usize,
+}
+
+impl<US: BlockStream + 'static, L: Ledger + Clone + 'static> BlockStream for DbStream<US, L> {
+    type Stream = impl Stream<Item = StreamResult<BlockStreamComponents>>;
+
+    fn get_block_stream(&self, starting_height: u64) -> StreamResult<Self::Stream> {
+        let stream = self.upstream.get_block_stream(starting_height).unwrap();
+        Ok(LedgerStream::new(self.ledger.clone(), stream).buffered(self.buffer))
+    }
+}
+
+impl<US: BlockStream + 'static, L: Ledger + Clone + 'static> DbStream<US, L> {
+    /// Initialize a pass through stream factory from an upstream source
+    pub fn new(upstream: US, ledger: L, buffer: usize) -> Self {
+        Self {
+            upstream,
+            ledger,
+            buffer,
+        }
+    }
+
+    /// If the sink is the terminal element, get it without initializing state
+    pub fn get_sink_from_upstream(
+        upstream: US,
+        ledger: L,
+        buffer: usize,
+        starting_height: u64,
+    ) -> Buffered<LedgerStream<L, impl Stream<Item = StreamResult<BlockStreamComponents>>>> {
+        let stream = upstream.get_block_stream(starting_height).unwrap();
+        LedgerStream::new(ledger, stream).buffered(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use mc_common::logger::{log, test_with_logger, Logger};
+    use mc_ledger_db::test_utils::get_mock_ledger;
+    use mc_ledger_streaming_api::test_utils::stream::get_stream_with_n_components;
+
+    #[test_with_logger]
+    fn assert_pass_through_and_storage(logger: Logger) {
+        let upstream = get_stream_with_n_components(43);
+        let dest_ledger = get_mock_ledger(0);
+        let bs = DbStream::new(upstream, dest_ledger, 43);
+        let mut stream = bs.get_block_stream(0).unwrap();
+
+        futures::executor::block_on(async move {
+            let mut index: u64 = 0;
+            let mut threshold = 0;
+            while let Some(component_result) = stream.next().await {
+                let component = component_result.unwrap();
+                index = component.block_data.block().index;
+                threshold = component.quorum_set.unwrap().threshold;
+            }
+
+            log::info!(logger, "{} blocks recorded via pass through stream", index);
+            assert_eq!(threshold, 2);
+            assert_eq!(index, 42);
+        });
+    }
+
+    #[test_with_logger]
+    fn assert_sink_only_works(logger: Logger) {
+        let upstream = get_stream_with_n_components(43);
+        let dest_ledger = get_mock_ledger(0);
+        let mut sink = DbStream::get_sink_from_upstream(upstream, dest_ledger, 43, 0);
+
+        futures::executor::block_on(async move {
+            let mut index: u64 = 0;
+            let mut threshold = 0;
+            while let Some(component_result) = sink.next().await {
+                let component = component_result.unwrap();
+                index = component.block_data.block().index;
+                threshold = component.quorum_set.unwrap().threshold;
+            }
+
+            log::info!(logger, "{} blocks recorded via sink only", index);
+
+            assert_eq!(threshold, 2);
+            assert_eq!(index, 42);
+        });
+    }
+}

--- a/ledger/streaming/client/src/lib.rs
+++ b/ledger/streaming/client/src/lib.rs
@@ -7,6 +7,10 @@
 
 mod grpc;
 
+pub mod error;
+pub mod ledger_sink;
+pub mod streaming_futures;
+
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;
 

--- a/ledger/streaming/client/src/streaming_futures.rs
+++ b/ledger/streaming/client/src/streaming_futures.rs
@@ -84,10 +84,10 @@ impl<L: Ledger> Future for WriteBlock<L> {
                     if reason == LockReason::WouldBlock {
                         Poll::Pending
                     } else {
-                        Poll::Ready(Err(StreamError::DBError))
+                        Poll::Ready(Err(StreamError::DBAccess))
                     }
                 }
-                _ => Poll::Ready(Err(StreamError::DBError)),
+                _ => Poll::Ready(Err(StreamError::DBAccess)),
             },
         }
     }
@@ -145,10 +145,10 @@ impl<'a, L: Ledger> Future for ReadLedger<'a, L> {
                     if reason == LockReason::WouldBlock {
                         Poll::Pending
                     } else {
-                        Poll::Ready(Err(StreamError::DBError))
+                        Poll::Ready(Err(StreamError::DBAccess))
                     }
                 }
-                _ => Poll::Ready(Err(StreamError::DBError)),
+                _ => Poll::Ready(Err(StreamError::DBAccess)),
             },
         }
     }

--- a/ledger/streaming/client/src/streaming_futures.rs
+++ b/ledger/streaming/client/src/streaming_futures.rs
@@ -1,0 +1,231 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Custom Future implementations for the block streaming client
+
+use crate::error::{Error as ClientError, LockReason};
+use futures::{
+    task::{Context, Poll},
+    Future, Stream,
+};
+use mc_ledger_db::Ledger;
+use mc_ledger_streaming_api::{
+    BlockStreamComponents, Error as StreamError, Result as StreamResult,
+};
+use mc_transaction_core::{ring_signature::KeyImage, BlockIndex};
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    sync::{Arc, RwLock},
+};
+
+/// Enum to allow monadic results other than Some & None for
+/// stream types were None would terminate the stream. Useful for
+/// stream combinations like Scan --> Filter_Map
+#[allow(dead_code)]
+pub enum Ready<T> {
+    /// Value with data container to indicate a value is ready
+    Ready(T),
+
+    /// Indicates to subsequent future/stream upstream is not ready
+    NotReady,
+}
+
+/// Future for writing blocks to LedgerDB
+pub struct WriteBlock<L: Ledger> {
+    ledger: Arc<RwLock<L>>,
+    stream_components: Option<BlockStreamComponents>,
+}
+
+impl<L: Ledger> WriteBlock<L> {
+    /// Initialize future with ledger copy & block data
+    pub fn new(ledger: Arc<RwLock<L>>, stream_components: BlockStreamComponents) -> Self {
+        Self {
+            ledger,
+            stream_components: Some(stream_components),
+        }
+    }
+
+    /// future to error Attempt to write block, an error result here results
+    /// in the future returning Poll:Pending
+    fn write_block(&mut self) -> Result<BlockStreamComponents, ClientError> {
+        let block_index: BlockIndex;
+        {
+            let stream_components = self.stream_components.as_ref().unwrap();
+            {
+                let read_only_ledger = self.ledger.try_read()?;
+                block_index = stream_components.block_data.block().index;
+                let current_index = read_only_ledger.num_blocks()? + 1;
+                if current_index < block_index {
+                    return Err(ClientError::BlockIndexTooFar(block_index, current_index));
+                }
+            }
+
+            let mut write_ledger = self.ledger.try_write()?;
+            write_ledger.append_block(
+                stream_components.block_data.block(),
+                stream_components.block_data.contents(),
+                stream_components.block_data.signature().clone(),
+            )?;
+        }
+        Ok(self.stream_components.take().unwrap())
+    }
+}
+
+impl<L: Ledger> Future for WriteBlock<L> {
+    type Output = StreamResult<BlockStreamComponents>;
+
+    ///Attempt to write block and return the block index written
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut().write_block() {
+            Ok(component) => Poll::Ready(Ok(component)),
+            Err(err) => match err {
+                ClientError::BlockIndexTooFar(_, _) => Poll::Pending,
+                ClientError::Locked(reason) => {
+                    if reason == LockReason::WouldBlock {
+                        Poll::Pending
+                    } else {
+                        Poll::Ready(Err(StreamError::DBError))
+                    }
+                }
+                _ => Poll::Ready(Err(StreamError::DBError)),
+            },
+        }
+    }
+}
+
+/// Future for reading ledger db
+pub struct ReadLedger<'a, L: Ledger> {
+    ledger: Arc<RwLock<L>>,
+    method: ReadRequest<'a>,
+}
+
+/// List of read requests to make against ledgerdb
+pub enum ReadRequest<'a> {
+    /// Contains key image method
+    ContainsKeyImage(&'a KeyImage),
+}
+
+/// List of responses from ledgerdb
+pub enum ReadResponse {
+    /// Key image response
+    ContainsKeyImage(bool),
+}
+
+impl<'a, L: Ledger> ReadLedger<'a, L> {
+    /// Initialize future with ledger copy & read method
+    pub fn new(ledger: Arc<RwLock<L>>, method: ReadRequest<'a>) -> Self {
+        Self { ledger, method }
+    }
+
+    /// Attempt to do requested read
+    fn do_read(&mut self) -> Result<ReadResponse, ClientError> {
+        {
+            {
+                let r_ledger = self.ledger.try_read()?;
+                match &self.method {
+                    ReadRequest::ContainsKeyImage(key_image) => {
+                        let contains = r_ledger.contains_key_image(key_image)?;
+                        Ok(ReadResponse::ContainsKeyImage(contains))
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a, L: Ledger> Future for ReadLedger<'a, L> {
+    type Output = StreamResult<ReadResponse>;
+
+    ///Attempt to write block and return the block index written
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut().do_read() {
+            Ok(read_result) => Poll::Ready(Ok(read_result)),
+            Err(err) => match err {
+                ClientError::Locked(reason) => {
+                    if reason == LockReason::WouldBlock {
+                        Poll::Pending
+                    } else {
+                        Poll::Ready(Err(StreamError::DBError))
+                    }
+                }
+                _ => Poll::Ready(Err(StreamError::DBError)),
+            },
+        }
+    }
+}
+
+/// Stream that allows db write futures to be passed through
+#[pin_project]
+pub struct LedgerStream<L: Ledger, US: Stream<Item = StreamResult<BlockStreamComponents>>> {
+    ledger: Arc<RwLock<L>>,
+    #[pin]
+    upstream: US,
+}
+
+impl<L: Ledger, US: Stream<Item = StreamResult<BlockStreamComponents>>> LedgerStream<L, US> {
+    /// Initialize new ledger stream with ledger and upstream
+    pub fn new(ledger: L, upstream: US) -> Self {
+        Self {
+            ledger: Arc::new(RwLock::new(ledger)),
+            upstream,
+        }
+    }
+}
+
+impl<L: Ledger, US: Stream<Item = StreamResult<BlockStreamComponents>>> Stream
+    for LedgerStream<L, US>
+{
+    type Item = WriteBlock<L>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let ledger = self.ledger.clone();
+        let this = self.project();
+        match this.upstream.poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(result) => {
+                if let Some(block_result) = result {
+                    let write_future = WriteBlock::new(ledger, block_result.unwrap());
+                    Poll::Ready(Some(write_future))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use futures::StreamExt;
+    use mc_common::logger::{log, test_with_logger, Logger};
+    use mc_ledger_db::test_utils::get_mock_ledger;
+    use mc_ledger_streaming_api::test_utils::stream::get_raw_stream_with_n_components;
+    use std::sync::Arc;
+
+    #[test_with_logger]
+    fn future_drives_correctly(logger: Logger) {
+        let mock_ledger = get_mock_ledger(0);
+        let dest_ledger = Arc::new(RwLock::new(mock_ledger));
+        let ledger_ref = dest_ledger.clone();
+        let stream = get_raw_stream_with_n_components(30);
+        let mut stream2 = stream
+            .map(move |block_data| WriteBlock::new(ledger_ref.clone(), block_data.unwrap()))
+            .buffered(2000);
+
+        futures::executor::block_on(async move {
+            let mut index: u64;
+            while let Some(block_component) = stream2.next().await {
+                index = block_component.unwrap().block_data.block().index;
+                if index >= 30 {
+                    log::info!(logger, "wrote {} blocks with ledger future", index);
+                    break;
+                }
+            }
+        });
+
+        let ledger = dest_ledger.read().unwrap();
+        assert_eq!(30, ledger.num_blocks().unwrap());
+    }
+}


### PR DESCRIPTION
## Motivation
As part of the Block Streaming mcip we are composing a bunch of simple streams which each take on a specific domain of functionality. This particular PR represents the final link in this chain and assumes a validated stream of blocks from a consensus node.

It's expected that ahead of this node, there's a validation streaming component that is collating streams from several peers and doing all the necessary validations (SCP, Block Content Verification, etc.)

## In this PR
Addittions/Changes:

* Adds the beginning of a config file to launch the client
* Adds a Block Sink that takes a single stream of validated blocks and pushes them to a sync thread for ingest into ledgerdb
* Suggests some changes to Block streaming API namings (notably Error & Result as those override keywords in the Rust 
prologue)

Ticket Status: In Progress
* Needs fuller test coverage
* Needs more error handling

## Future Work
* The sink should be self-healing (i.e. try to re-establish connection) rather than crashing if a stream dies, but this is somewhat dependent on the upstream component.
* Validation stream needs to be added directly in front of this
* This chose tokio, but generic executors may be able to be used
* Blockstreaming client components need to be decided