### PR TITLE
introduce FormBlockInputs and break out some code from form_block into its own method

### DIFF
--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -222,6 +222,14 @@ pub struct FeePublicKey {
     pub view_public_key: RistrettoPublic,
 }
 
+/// The collection of transaction types we form blocks from.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct FormBlockInputs {
+    /// The original transactions (the ones that are used to move tokens)
+    pub well_formed_encrypted_txs_with_proofs:
+        Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>,
+}
+
 /// The API for interacting with a consensus node's enclave.
 pub trait ConsensusEnclave: ReportableEnclave {
     // UTILITY METHODS
@@ -318,7 +326,7 @@ pub trait ConsensusEnclave: ReportableEnclave {
     fn form_block(
         &self,
         parent_block: &Block,
-        encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        inputs: FormBlockInputs,
         root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)>;
 }

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -3,7 +3,8 @@
 //! The message types used by the consensus_enclave_api.
 
 use crate::{
-    BlockchainConfig, LocallyEncryptedTx, ResponderId, SealedBlockSigningKey, WellFormedEncryptedTx,
+    BlockchainConfig, FormBlockInputs, LocallyEncryptedTx, ResponderId, SealedBlockSigningKey,
+    WellFormedEncryptedTx,
 };
 use alloc::vec::Vec;
 use mc_attest_core::{Quote, Report, TargetInfo, VerificationReport};
@@ -129,13 +130,8 @@ pub enum EnclaveCall {
 
     /// The [ConsensusEnclave::form_block()] method.
     ///
-    /// Converts a list of well-formed, encrypted txs + proofs into a block,
-    /// block contents (key images + tx outs) and a signature.
-    FormBlock(
-        Block,
-        Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>,
-        TxOutMembershipElement,
-    ),
+    /// Converts a list of inputs into a block, block contents and a signature.
+    FormBlock(Block, FormBlockInputs, TxOutMembershipElement),
 
     /// The [ConsensusEnclave::get_minimum_fee()] method.
     ///

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -287,7 +287,6 @@ impl SgxConsensusEnclave {
     }
 }
 
-
 impl ReportableEnclave for SgxConsensusEnclave {
     fn new_ereport(&self, qe_info: TargetInfo) -> ReportableEnclaveResult<(Report, QuoteNonce)> {
         Ok(self.ake.new_ereport(qe_info)?)

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -8,7 +8,7 @@ use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, Verificati
 use mc_attest_enclave_api::*;
 use mc_common::ResponderId;
 use mc_consensus_enclave_api::{
-    BlockchainConfig, ConsensusEnclave, FeePublicKey, LocallyEncryptedTx,
+    BlockchainConfig, ConsensusEnclave, FeePublicKey, FormBlockInputs, LocallyEncryptedTx,
     Result as ConsensusEnclaveResult, SealedBlockSigningKey, TxContext, WellFormedEncryptedTx,
     WellFormedTxContext,
 };
@@ -79,7 +79,7 @@ mock! {
         fn form_block(
             &self,
             parent_block: &Block,
-            encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+            inputs: FormBlockInputs,
             root_element: &TxOutMembershipElement,
         ) -> ConsensusEnclaveResult<(Block, BlockContents, BlockSignature)>;
     }

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -4,8 +4,8 @@
 
 pub use mc_consensus_enclave_api::{
     BlockchainConfig, ConsensusEnclave, ConsensusEnclaveProxy, EnclaveCall, Error, FeeMap,
-    FeeMapError, FeePublicKey, LocallyEncryptedTx, Result, TxContext, WellFormedEncryptedTx,
-    WellFormedTxContext,
+    FeeMapError, FeePublicKey, FormBlockInputs, LocallyEncryptedTx, Result, TxContext,
+    WellFormedEncryptedTx, WellFormedTxContext,
 };
 
 use mc_attest_core::{
@@ -251,12 +251,12 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
     fn form_block(
         &self,
         parent_block: &Block,
-        encrypted_txs_with_proofs: &[(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)],
+        inputs: FormBlockInputs,
         root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::FormBlock(
             parent_block.clone(),
-            encrypted_txs_with_proofs.to_vec(),
+            inputs,
             root_element.clone(),
         ))?;
         let outbuf = self.enclave_call(&inbuf)?;

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -73,8 +73,8 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::TxsForPeer(txs, aad, peer) => {
             serialize(&ENCLAVE.txs_for_peer(&txs, &aad, &peer))
         }
-        EnclaveCall::FormBlock(parent_block, encrypted_txs_with_proofs, root_element) => {
-            serialize(&ENCLAVE.form_block(&parent_block, &encrypted_txs_with_proofs, &root_element))
+        EnclaveCall::FormBlock(parent_block, inputs, root_element) => {
+            serialize(&ENCLAVE.form_block(&parent_block, inputs, &root_element))
         }
     }
     .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -14,7 +14,7 @@ use mc_common::{
     HashMap, HashSet,
 };
 use mc_consensus_enclave::{
-    ConsensusEnclave, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
+    ConsensusEnclave, FormBlockInputs, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
 };
 use mc_peers::ConsensusValue;
 use mc_transaction_core::{

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -279,7 +279,7 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
         let cache_entries = Self::get_cache_entries(&cache, tx_hashes.iter())?;
 
         // Proceed with forming the block.
-        let encrypted_txs_with_proofs = cache_entries
+        let well_formed_encrypted_txs_with_proofs = cache_entries
             .into_iter()
             .map(|entry| {
                 // Highest indices proofs must be w.r.t. the current ledger.
@@ -294,9 +294,13 @@ impl<E: ConsensusEnclave + Send, UI: UntrustedInterfaces + Send> TxManager
 
         let root_element = self.untrusted.get_root_tx_out_membership_element()?;
 
-        let (block, block_contents, mut signature) =
-            self.enclave
-                .form_block(parent_block, &encrypted_txs_with_proofs, &root_element)?;
+        let (block, block_contents, mut signature) = self.enclave.form_block(
+            parent_block,
+            FormBlockInputs {
+                well_formed_encrypted_txs_with_proofs,
+            },
+            &root_element,
+        )?;
 
         // The enclave cannot provide a timestamp, so this happens in untrusted.
         signature.set_signed_at(chrono::Utc::now().timestamp() as u64);


### PR DESCRIPTION
### Motivation

The consensus enclave's `form_block` method currently receives the list of encrypted transactions paired with membership proofs in one of its arguments, and uses that to form a new block. As we add more transaction types, the list of arguments will start to grow and require a tedious change across the various enclave crates. I am encountering this in the minting branch, and figured this is a small enough change to bring in immediately which will help keep minting-related PRs shorter.

### In this PR
* Add a new `FormBlockInputs` struct that can easily be extended to add more transaction types that will be fed into the enclave
* Break out a bunch of transaction validation code `form_block` was doing into its own method, so that `form_block` can be easier to read and maintain.
