### PR TITLE
remove the Copy trait from ConsensusValue 

### DIFF
--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -560,7 +560,11 @@ mod tests {
             .into();
 
         byzantine_ledger.push_values(
-            vec![hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()],
+            vec![
+                hash_tx_zero.clone(),
+                hash_tx_one.clone(),
+                hash_tx_two.clone(),
+            ],
             Some(Instant::now()),
         );
 
@@ -574,7 +578,11 @@ mod tests {
                 local_quorum_set.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
+                    X: BTreeSet::from_iter(vec![
+                        hash_tx_zero.clone(),
+                        hash_tx_one.clone(),
+                        hash_tx_two.clone(),
+                    ]),
                     Y: BTreeSet::default(),
                 }),
             ),
@@ -619,7 +627,14 @@ mod tests {
                     node_a.quorum_set.clone(),
                     slot_index,
                     Topic::Commit(CommitPayload {
-                        B: Ballot::new(100, &[hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
+                        B: Ballot::new(
+                            100,
+                            &[
+                                hash_tx_zero.clone(),
+                                hash_tx_one.clone(),
+                                hash_tx_two.clone(),
+                            ],
+                        ),
                         PN: 77,
                         CN: 55,
                         HN: 66,
@@ -641,7 +656,14 @@ mod tests {
                     node_b.quorum_set.clone(),
                     slot_index,
                     Topic::Commit(CommitPayload {
-                        B: Ballot::new(100, &[hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
+                        B: Ballot::new(
+                            100,
+                            &[
+                                hash_tx_zero.clone(),
+                                hash_tx_one.clone(),
+                                hash_tx_two.clone(),
+                            ],
+                        ),
                         PN: 77,
                         CN: 55,
                         HN: 66,

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -538,21 +538,21 @@ mod tests {
         let client_tx_one = transactions.pop().unwrap();
         let client_tx_two = transactions.pop().unwrap();
 
-        let hash_tx_zero = tx_manager
+        let hash_tx_zero: ConsensusValue = tx_manager
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_zero,
             ))
             .unwrap()
             .into();
 
-        let hash_tx_one = tx_manager
+        let hash_tx_one: ConsensusValue = tx_manager
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_one,
             ))
             .unwrap()
             .into();
 
-        let hash_tx_two = tx_manager
+        let hash_tx_two: ConsensusValue = tx_manager
             .insert(ConsensusServiceMockEnclave::tx_to_tx_context(
                 &client_tx_two,
             ))
@@ -560,7 +560,7 @@ mod tests {
             .into();
 
         byzantine_ledger.push_values(
-            vec![hash_tx_zero, hash_tx_one, hash_tx_two],
+            vec![hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()],
             Some(Instant::now()),
         );
 
@@ -574,7 +574,7 @@ mod tests {
                 local_quorum_set.clone(),
                 slot_index,
                 Topic::Nominate(NominatePayload {
-                    X: BTreeSet::from_iter(vec![hash_tx_zero, hash_tx_one, hash_tx_two]),
+                    X: BTreeSet::from_iter(vec![hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
                     Y: BTreeSet::default(),
                 }),
             ),
@@ -619,7 +619,7 @@ mod tests {
                     node_a.quorum_set.clone(),
                     slot_index,
                     Topic::Commit(CommitPayload {
-                        B: Ballot::new(100, &[hash_tx_zero, hash_tx_one, hash_tx_two]),
+                        B: Ballot::new(100, &[hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
                         PN: 77,
                         CN: 55,
                         HN: 66,
@@ -641,7 +641,7 @@ mod tests {
                     node_b.quorum_set.clone(),
                     slot_index,
                     Topic::Commit(CommitPayload {
-                        B: Ballot::new(100, &[hash_tx_zero, hash_tx_one, hash_tx_two]),
+                        B: Ballot::new(100, &[hash_tx_zero.clone(), hash_tx_one.clone(), hash_tx_two.clone()]),
                         PN: 77,
                         CN: 55,
                         HN: 66,

--- a/consensus/service/src/byzantine_ledger/pending_values.rs
+++ b/consensus/service/src/byzantine_ledger/pending_values.rs
@@ -65,7 +65,7 @@ impl<TXM: TxManager> PendingValues<TXM> {
     /// list. Returns `true` if the value is valid and not already on the
     /// list, false otherwise.
     pub fn push(&mut self, value: ConsensusValue, timestamp: Option<Instant>) -> bool {
-        if let Vacant(entry) = self.pending_values_map.entry(value) {
+        if let Vacant(entry) = self.pending_values_map.entry(value.clone()) {
             match value {
                 ConsensusValue::TxHash(tx_hash) => {
                     // A new transaction.

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -14,9 +14,10 @@ use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
 
 /// A single value in a consensus round.
 #[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
+    Clone, Debug, Deserialize, Digestible, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub enum ConsensusValue {
+    /// TxHash({0})
     TxHash(TxHash),
 }
 

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -14,21 +14,9 @@ use std::{convert::TryFrom, hash::Hash, result::Result as StdResult};
 
 /// A single value in a consensus round.
 #[derive(
-    Clone,
-    Copy,
-    Display,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Serialize,
-    Deserialize,
-    Digestible,
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Digestible,
 )]
 pub enum ConsensusValue {
-    /// TxHash({0})
     TxHash(TxHash),
 }
 


### PR DESCRIPTION
… since is makes it impossible to add transaction types that cant implement it.

### Motivation

I ran into a problem when I extended `ConsensusValue` to include a struct that has a `Vec<>` (can't implement `Copy`). 

### In this PR
* Removing the `Copy` trait derive on `ConsensusValue` and dealing with the aftermath of that (fairly minimal).
