### PR TITLE
Rename amount

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -46,7 +46,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    Amount, BlockVersion, CompressedCommitment, Token,
+    BlockVersion, CompressedCommitment, MaskedAmount, Token,
 };
 use mc_transaction_std::{InputCredentials, RTHMemoBuilder, TransactionBuilder};
 use mc_util_from_random::FromRandom;
@@ -313,7 +313,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni(
 
         // FIXME #1595: We should get a masked token id also, here we default to
         // 0 bytes, which is backwards compatible
-        let amount = Amount {
+        let amount = MaskedAmount {
             commitment: CompressedCommitment::try_from(&commitment_bytes[..])?,
             masked_value: masked_value as u64,
             masked_token_id: Default::default(),
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
             env.get_rust_field(tx_out_shared_secret, RUST_OBJ_FIELD)?;
         // FIXME #1595: the masked token id should be 0 or 4 bytes.
         // To avoid breaking changes, it is hard coded to 0 bytes here
-        let amount = Amount::reconstruct(masked_value as u64, &[], &tx_out_shared_secret)?;
+        let amount = MaskedAmount::reconstruct(masked_value as u64, &[], &tx_out_shared_secret)?;
 
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, amount)?)
     })
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_get_1bytes(
         || Ok(JObject::null().into_inner()),
         &env,
         |env| {
-            let amount_key: MutexGuard<Amount> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let amount_key: MutexGuard<MaskedAmount> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
             let bytes = mc_util_serial::encode(&*amount_key);
             Ok(env.byte_array_from_slice(&bytes)?)
         },
@@ -359,7 +359,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_get_1bytes(
 #[no_mangle]
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_finalize_1jni(env: JNIEnv, obj: JObject) {
     jni_ffi_call(&env, |env| {
-        let _: Amount = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
+        let _: MaskedAmount = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
         Ok(())
     })
 }
@@ -375,7 +375,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_unmask_1value(
         || Ok(JObject::null().into_inner()),
         &env,
         |env| {
-            let amount: MutexGuard<Amount> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let amount: MutexGuard<MaskedAmount> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
             let view_key: MutexGuard<RistrettoPrivate> =
                 env.get_rust_field(view_key, RUST_OBJ_FIELD)?;
             let tx_pub_key: MutexGuard<RistrettoPublic> =

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -204,7 +204,7 @@ message EncryptedMemo {
 // A Transaction Output.
 message TxOut {
     // Amount.
-    MaskedAmount amount = 1;
+    MaskedAmount masked_amount = 1;
 
     // Public key.
     CompressedRistretto target_key = 2;

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -179,8 +179,8 @@ message TxOutConfirmationNumber {
     bytes hash = 1;
 }
 
-// Amount.
-message Amount {
+// MaskedAmount.
+message MaskedAmount {
     // A Pedersen commitment `v*G + s*H`
     CompressedRistretto commitment = 1;
 
@@ -204,7 +204,7 @@ message EncryptedMemo {
 // A Transaction Output.
 message TxOut {
     // Amount.
-    Amount amount = 1;
+    MaskedAmount amount = 1;
 
     // Public key.
     CompressedRistretto target_key = 2;
@@ -292,7 +292,7 @@ message Receipt {
 
     // Amount of the TxOut.
     // Note: This value is self-reported by the sender and is unverifiable.
-    Amount amount = 4;
+    MaskedAmount amount = 4;
 }
 
 /// The signature over an IAS JSON reponse, created by Intel

--- a/api/src/convert/amount.rs
+++ b/api/src/convert/amount.rs
@@ -1,14 +1,14 @@
 //! Convert to/from external::Amount
 
 use crate::{convert::ConversionError, external};
-use mc_transaction_core::{Amount, CompressedCommitment};
+use mc_transaction_core::{CompressedCommitment, MaskedAmount};
 use mc_util_repr_bytes::ReprBytes;
 use std::convert::TryFrom;
 
-impl From<&Amount> for external::Amount {
-    fn from(source: &Amount) -> Self {
+impl From<&MaskedAmount> for external::MaskedAmount {
+    fn from(source: &MaskedAmount) -> Self {
         let commitment_bytes = source.commitment.to_bytes().to_vec();
-        let mut amount = external::Amount::new();
+        let mut amount = external::MaskedAmount::new();
         amount.mut_commitment().set_data(commitment_bytes);
         amount.set_masked_value(source.masked_value);
         amount.set_masked_token_id(source.masked_token_id.clone());
@@ -16,14 +16,14 @@ impl From<&Amount> for external::Amount {
     }
 }
 
-impl TryFrom<&external::Amount> for Amount {
+impl TryFrom<&external::MaskedAmount> for MaskedAmount {
     type Error = ConversionError;
 
-    fn try_from(source: &external::Amount) -> Result<Self, Self::Error> {
+    fn try_from(source: &external::MaskedAmount) -> Result<Self, Self::Error> {
         let commitment = CompressedCommitment::try_from(source.get_commitment())?;
         let masked_value = source.get_masked_value();
         let masked_token_id = source.get_masked_token_id();
-        let amount = Amount {
+        let amount = MaskedAmount {
             commitment,
             masked_value,
             masked_token_id: masked_token_id.to_vec(),

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -123,8 +123,8 @@ mod tests {
         ring_signature::KeyImage,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-        Amount, AmountData, Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion,
-        Token,
+        AmountData, Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion,
+        MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -140,7 +140,8 @@ mod tests {
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                    .unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -140,7 +140,8 @@ mod tests {
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
+                    .unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -123,7 +123,7 @@ mod tests {
         ring_signature::KeyImage,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-        AmountData, Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion,
+        Amount, Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion,
         MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
@@ -135,13 +135,12 @@ mod tests {
         let mut last_block: Option<Block> = None;
 
         for block_idx in 0..num_blocks {
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: 1u64 << 13,
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                    .unwrap(),
+                amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/api/src/convert/tx_out.rs
+++ b/api/src/convert/tx_out.rs
@@ -2,7 +2,7 @@
 
 use crate::{convert::ConversionError, external};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
-use mc_transaction_core::{encrypted_fog_hint::EncryptedFogHint, tx, Amount, EncryptedMemo};
+use mc_transaction_core::{encrypted_fog_hint::EncryptedFogHint, tx, EncryptedMemo, MaskedAmount};
 use std::convert::TryFrom;
 
 /// Convert tx::TxOut --> external::TxOut.
@@ -10,7 +10,7 @@ impl From<&tx::TxOut> for external::TxOut {
     fn from(source: &tx::TxOut) -> Self {
         let mut tx_out = external::TxOut::new();
 
-        let amount = external::Amount::from(&source.amount);
+        let amount = external::MaskedAmount::from(&source.amount);
         tx_out.set_amount(amount);
 
         let target_key_bytes = source.target_key.as_bytes().to_vec();
@@ -37,7 +37,7 @@ impl TryFrom<&external::TxOut> for tx::TxOut {
     type Error = ConversionError;
 
     fn try_from(source: &external::TxOut) -> Result<Self, Self::Error> {
-        let amount = Amount::try_from(source.get_amount())?;
+        let amount = MaskedAmount::try_from(source.get_amount())?;
 
         let target_key_bytes: &[u8] = source.get_target_key().get_data();
         let target_key: CompressedRistrettoPublic = RistrettoPublic::try_from(target_key_bytes)
@@ -79,7 +79,7 @@ mod tests {
     use generic_array::GenericArray;
     use mc_crypto_keys::RistrettoPublic;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, AmountData, Token,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -94,7 +94,8 @@ mod tests {
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -117,7 +118,8 @@ mod tests {
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/api/src/convert/tx_out.rs
+++ b/api/src/convert/tx_out.rs
@@ -10,8 +10,8 @@ impl From<&tx::TxOut> for external::TxOut {
     fn from(source: &tx::TxOut) -> Self {
         let mut tx_out = external::TxOut::new();
 
-        let amount = external::MaskedAmount::from(&source.amount);
-        tx_out.set_amount(amount);
+        let masked_amount = external::MaskedAmount::from(&source.masked_amount);
+        tx_out.set_masked_amount(masked_amount);
 
         let target_key_bytes = source.target_key.as_bytes().to_vec();
         tx_out.mut_target_key().set_data(target_key_bytes);
@@ -37,7 +37,7 @@ impl TryFrom<&external::TxOut> for tx::TxOut {
     type Error = ConversionError;
 
     fn try_from(source: &external::TxOut) -> Result<Self, Self::Error> {
-        let amount = MaskedAmount::try_from(source.get_amount())?;
+        let masked_amount = MaskedAmount::try_from(source.get_masked_amount())?;
 
         let target_key_bytes: &[u8] = source.get_target_key().get_data();
         let target_key: CompressedRistrettoPublic = RistrettoPublic::try_from(target_key_bytes)
@@ -63,7 +63,7 @@ impl TryFrom<&external::TxOut> for tx::TxOut {
         };
 
         let tx_out = tx::TxOut {
-            amount,
+            masked_amount,
             target_key,
             public_key,
             e_fog_hint,
@@ -94,7 +94,8 @@ mod tests {
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -104,7 +105,7 @@ mod tests {
         let converted = external::TxOut::from(&source);
 
         let recovered_tx_out = tx::TxOut::try_from(&converted).unwrap();
-        assert_eq!(source.amount, recovered_tx_out.amount);
+        assert_eq!(source.masked_amount, recovered_tx_out.masked_amount);
     }
 
     #[test]
@@ -117,7 +118,8 @@ mod tests {
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -127,7 +129,7 @@ mod tests {
         let converted = external::TxOut::from(&source);
 
         let recovered_tx_out = tx::TxOut::try_from(&converted).unwrap();
-        assert_eq!(source.amount, recovered_tx_out.amount);
+        assert_eq!(source.masked_amount, recovered_tx_out.masked_amount);
         assert_eq!(source.target_key, recovered_tx_out.target_key);
         assert_eq!(source.public_key, recovered_tx_out.public_key);
         assert_eq!(source.e_fog_hint, recovered_tx_out.e_fog_hint);

--- a/api/src/convert/tx_out.rs
+++ b/api/src/convert/tx_out.rs
@@ -79,7 +79,7 @@ mod tests {
     use generic_array::GenericArray;
     use mc_crypto_keys::RistrettoPublic;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, MaskedAmount, Token,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -89,13 +89,12 @@ mod tests {
     fn test_tx_out_from_tx_out_stored() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
-        let amount_data = AmountData {
+        let amount = Amount {
             value: 1u64 << 13,
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                .unwrap(),
+            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -113,13 +112,12 @@ mod tests {
     fn test_tx_out_from_tx_out_stored_with_memo() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
-        let amount_data = AmountData {
+        let amount = Amount {
             value: 1u64 << 13,
             token_id: Mob::ID,
         };
         let source = tx::TxOut {
-            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                .unwrap(),
+            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1098,7 +1098,7 @@ mod tests {
             // The value of the aggregate fee should equal the total value of fees in the
             // input transaction.
             let shared_secret = create_shared_secret(&fee_output_public_key, &view_secret_key);
-            let (amount, _blinding) = fee_output.amount.get_value(&shared_secret).unwrap();
+            let (amount, _blinding) = fee_output.masked_amount.get_value(&shared_secret).unwrap();
             assert_eq!(amount.value, total_fee);
             assert_eq!(amount.token_id, Mob::ID);
         }

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -115,6 +115,11 @@ struct FieldAttributeConfig {
     /// fields that are now omitted when not set (the behavior for
     /// &[u8]/Vec<u8>/&str/String has changed over time).
     pub never_omit: bool,
+
+    /// Whether we should rename this field, using the given
+    /// string for the new name, for purpose of hashing.
+    /// This is a backwards compatibility tool.
+    pub rename: Option<String>,
 }
 
 impl FieldAttributeConfig {
@@ -133,6 +138,17 @@ impl FieldAttributeConfig {
                             return Err("omit_when cannot appear twice as an attribute");
                         } else {
                             self.omit_when = Some(mnv.lit.clone());
+                        }
+                    } else if mnv.path.is_ident("name") {
+                        if self.rename.is_some() {
+                            return Err("name = cannot appear twice in digestible attributes");
+                        } else {
+                            self.rename = match &mnv.lit {
+                                Lit::Str(litstr) => Some(litstr.value()),
+                                _ => {
+                                    return Err("name = must be set to string literal in digestible attributes");
+                                }
+                            }
                         }
                     } else {
                         return Err("unexpected digestible feature attribute");
@@ -253,19 +269,21 @@ fn try_digestible_struct(
                     // Read any #[digestible(...)]` attributes on this field and parse them
                     let attr_config = FieldAttributeConfig::try_from(&field.attrs[..])?;
 
+                    let hashing_name: String = attr_config.rename.clone().unwrap_or_else(|| field_ident.to_string());
+
                     if attr_config.never_omit {
                         Ok(quote! {
-                            self.#field_ident.append_to_transcript(stringify!(#field_ident).as_bytes(), transcript);
+                            self.#field_ident.append_to_transcript(stringify!(#hashing_name).as_bytes(), transcript);
                         })
                     } else if let Some(omit_when) = attr_config.omit_when {
                         Ok(quote! {
                             if self.#field_ident != #omit_when {
-                                self.#field_ident.append_to_transcript_allow_omit(stringify!(#field_ident).as_bytes(), transcript);
+                                self.#field_ident.append_to_transcript_allow_omit(stringify!(#hashing_name).as_bytes(), transcript);
                             }
                         })
                     } else {
                         Ok(quote! {
-                            self.#field_ident.append_to_transcript_allow_omit(stringify!(#field_ident).as_bytes(), transcript);
+                            self.#field_ident.append_to_transcript_allow_omit(stringify!(#hashing_name).as_bytes(), transcript);
                         })
                     }
                 }

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -450,7 +450,7 @@ impl Sample for MaskedAmount {
 impl Sample for TxOut {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
         TxOut {
-            amount: MaskedAmount::sample(rng),
+            masked_amount: MaskedAmount::sample(rng),
             target_key: RistrettoPublic::from_random(rng).into(),
             public_key: RistrettoPublic::from_random(rng).into(),
             e_fog_hint: EncryptedFogHint::fake_onetime_hint(rng),

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -12,7 +12,7 @@ use mc_transaction_core::{
     encrypted_fog_hint::EncryptedFogHint,
     membership_proofs::Range,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash, TxOutMembershipProof},
-    AmountData, EncryptedMemo, MaskedAmount,
+    Amount, EncryptedMemo, MaskedAmount,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_test_helper::{run_with_several_seeds, CryptoRng, RngCore};
@@ -439,11 +439,11 @@ impl Sample for mc_fog_types::view::TxOutSearchResult {
 
 impl Sample for MaskedAmount {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let amount_data = AmountData {
+        let amount = Amount {
             value: rng.next_u32() as u64,
             token_id: rng.next_u32().into(),
         };
-        MaskedAmount::new(amount_data, &RistrettoPublic::from_random(rng)).unwrap()
+        MaskedAmount::new(amount, &RistrettoPublic::from_random(rng)).unwrap()
     }
 }
 

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -12,7 +12,7 @@ use mc_transaction_core::{
     encrypted_fog_hint::EncryptedFogHint,
     membership_proofs::Range,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash, TxOutMembershipProof},
-    Amount, AmountData, EncryptedMemo,
+    AmountData, EncryptedMemo, MaskedAmount,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_test_helper::{run_with_several_seeds, CryptoRng, RngCore};
@@ -377,7 +377,7 @@ fn test_stored_kex_rng_round_trip_protobuf() {
 /// They should not be shipped to production or to customers as part of
 /// libmobilecoin They are not done using the mc_crypto_keys::FromRandom trait
 /// because we don't need to ship them, and not all of these sampling
-/// distributions e.g. Amount::from_random really make sense for any other
+/// distributions e.g. MaskedAmount::from_random really make sense for any other
 /// use-case, we are just generating fuzz data basically.
 trait Sample {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self;
@@ -437,20 +437,20 @@ impl Sample for mc_fog_types::view::TxOutSearchResult {
     }
 }
 
-impl Sample for Amount {
+impl Sample for MaskedAmount {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
         let amount_data = AmountData {
             value: rng.next_u32() as u64,
             token_id: rng.next_u32().into(),
         };
-        Amount::new(amount_data, &RistrettoPublic::from_random(rng)).unwrap()
+        MaskedAmount::new(amount_data, &RistrettoPublic::from_random(rng)).unwrap()
     }
 }
 
 impl Sample for TxOut {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
         TxOut {
-            amount: Amount::sample(rng),
+            amount: MaskedAmount::sample(rng),
             target_key: RistrettoPublic::from_random(rng).into(),
             public_key: RistrettoPublic::from_random(rng).into(),
             e_fog_hint: EncryptedFogHint::fake_onetime_hint(rng),

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -41,7 +41,7 @@ use mc_transaction_core::{
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
-    AmountData, BlockVersion, Token,
+    Amount, BlockVersion, Token,
 };
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
 use mc_util_uri::FogUri;
@@ -109,7 +109,7 @@ pub struct SpendableTxOut {
     /// The tx out that is spendable
     pub tx_out: TxOut,
     /// The amount of the tx out
-    pub amount: AmountData,
+    pub amount: Amount,
     /// The account that owns this tx out
     pub from_account_key: AccountKey,
 }

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -404,7 +404,7 @@ fn select_spendable_tx_outs(
                     get_tx_out_shared_secret(account.view_private_key(), &public_key);
 
                 let (amount, _blinding_factor) = tx_out
-                    .amount
+                    .masked_amount
                     .get_value(&shared_secret)
                     .unwrap_or_else(|err| {
                         panic!(

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -160,7 +160,7 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
 // Make a random output for a block
 fn random_output<T: RngCore + CryptoRng>(rng: &mut T) -> Vec<TxOut> {
     vec![TxOut {
-        amount: MaskedAmount::default(),
+        masked_amount: MaskedAmount::default(),
         target_key: RistrettoPublic::from_random(rng).into(),
         public_key: RistrettoPublic::from_random(rng).into(),
         e_fog_hint: EncryptedFogHint::default(),

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -23,7 +23,7 @@ use mc_transaction_core::{
     membership_proofs::Range,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-    Amount, Block, BlockContents, BlockData, BlockSignature, BlockVersion,
+    Block, BlockContents, BlockData, BlockSignature, BlockVersion, MaskedAmount,
 };
 use mc_util_from_random::FromRandom;
 use mc_watcher::watcher_db::WatcherDB;
@@ -160,7 +160,7 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
 // Make a random output for a block
 fn random_output<T: RngCore + CryptoRng>(rng: &mut T) -> Vec<TxOut> {
     vec![TxOut {
-        amount: Amount::default(),
+        amount: MaskedAmount::default(),
         target_key: RistrettoPublic::from_random(rng).into(),
         public_key: RistrettoPublic::from_random(rng).into(),
         e_fog_hint: EncryptedFogHint::default(),

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -228,7 +228,7 @@ mod test {
         onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-        AmountData, MaskedAmount, Token,
+        Amount, MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
     use mc_util_grpc::AnonymousAuthenticator;
@@ -256,11 +256,11 @@ mod test {
             let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_secret_key);
             // FIXME: Without a different value, the txouts are identical - that
             // may be fine, or we may want a more robust mock ledger populator.
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: value + output_index as u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,
                 target_key: target_key.into(),

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -260,9 +260,9 @@ mod test {
                 value: value + output_index as u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
+            let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             let tx_out = TxOut {
-                amount,
+                masked_amount,
                 target_key: target_key.into(),
                 public_key: public_key.into(),
                 e_fog_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -228,7 +228,7 @@ mod test {
         onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-        Amount, AmountData, Token,
+        AmountData, MaskedAmount, Token,
     };
     use mc_util_from_random::FromRandom;
     use mc_util_grpc::AnonymousAuthenticator;
@@ -260,7 +260,7 @@ mod test {
                 value: value + output_index as u64,
                 token_id: Mob::ID,
             };
-            let amount = Amount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,
                 target_key: target_key.into(),

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -19,7 +19,7 @@ use mc_transaction_core::{
     membership_proofs::Range,
     ring_signature::KeyImage,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-    Amount, Block, BlockContents, BlockData, BlockSignature, BlockVersion,
+    Block, BlockContents, BlockData, BlockSignature, BlockVersion, MaskedAmount,
 };
 use mc_util_from_random::FromRandom;
 use mc_watcher::watcher_db::WatcherDB;
@@ -168,7 +168,7 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
 #[allow(dead_code)]
 pub fn random_output<T: RngCore + CryptoRng>(rng: &mut T) -> Vec<TxOut> {
     vec![TxOut {
-        amount: Amount::default(),
+        amount: MaskedAmount::default(),
         target_key: RistrettoPublic::from_random(rng).into(),
         public_key: RistrettoPublic::from_random(rng).into(),
         e_fog_hint: EncryptedFogHint::default(),

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -168,7 +168,7 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
 #[allow(dead_code)]
 pub fn random_output<T: RngCore + CryptoRng>(rng: &mut T) -> Vec<TxOut> {
     vec![TxOut {
-        amount: MaskedAmount::default(),
+        masked_amount: MaskedAmount::default(),
         target_key: RistrettoPublic::from_random(rng).into(),
         public_key: RistrettoPublic::from_random(rng).into(),
         e_fog_hint: EncryptedFogHint::default(),

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -889,7 +889,7 @@ impl OwnedTxOut {
         let decompressed_tx_pub = RistrettoPublic::try_from(&tx_out.public_key)?;
         let shared_secret =
             get_tx_out_shared_secret(account_key.view_private_key(), &decompressed_tx_pub);
-        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret)?;
+        let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret)?;
 
         // Calculate the subaddress spend public key for tx_out.
         let tx_out_target_key = RistrettoPublic::try_from(&tx_out.target_key)?;

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -27,7 +27,7 @@ use mc_transaction_core::{
     onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
     ring_signature::KeyImage,
     tx::TxOut,
-    AmountData, BlockIndex, TokenId,
+    Amount, BlockIndex, TokenId,
 };
 use mc_transaction_std::MemoType;
 use mc_util_telemetry::{telemetry_static_key, tracer, Key, TraceContextExt, Tracer};
@@ -317,7 +317,7 @@ impl CachedTxData {
     ///   lower.
     pub fn get_transaction_inputs(
         &self,
-        amount: AmountData,
+        amount: Amount,
         max_inputs: usize,
     ) -> Result<Vec<OwnedTxOut>> {
         // All transactions that we could choose to use as an input
@@ -858,7 +858,7 @@ pub struct OwnedTxOut {
     pub tx_out: TxOut,
     /// The value of the TxOut, computed when we matched this tx out
     /// successfully against our account key.
-    pub amount: AmountData,
+    pub amount: Amount,
     /// The subaddress index this tx_out was sent to.
     pub subaddress_index: u64,
     /// The key image that we computed when matching this tx_out against our
@@ -889,7 +889,7 @@ impl OwnedTxOut {
         let decompressed_tx_pub = RistrettoPublic::try_from(&tx_out.public_key)?;
         let shared_secret =
             get_tx_out_shared_secret(account_key.view_private_key(), &decompressed_tx_pub);
-        let (amount_data, _blinding) = tx_out.amount.get_value(&shared_secret)?;
+        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret)?;
 
         // Calculate the subaddress spend public key for tx_out.
         let tx_out_target_key = RistrettoPublic::try_from(&tx_out.target_key)?;
@@ -921,7 +921,7 @@ impl OwnedTxOut {
             block_index: rec.block_index,
             tx_out,
             key_image,
-            amount: amount_data,
+            amount,
             subaddress_index: *subaddress_index,
             status,
         })

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -30,7 +30,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
-    AmountData, BlockIndex, BlockVersion, Token, TokenId,
+    Amount, BlockIndex, BlockVersion, Token, TokenId,
 };
 use mc_transaction_std::{
     ChangeDestination, InputCredentials, MemoType, RTHMemoBuilder, SenderMemoCredential,
@@ -301,7 +301,7 @@ impl Client {
     /// * `fee` - The transaction fee to use
     pub fn build_transaction<T: RngCore + CryptoRng>(
         &mut self,
-        amount: AmountData,
+        amount: Amount,
         target_address: &PublicAddress,
         rng: &mut T,
         fee: u64,
@@ -573,7 +573,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
     block_version: BlockVersion,
     inputs: Vec<(OwnedTxOut, TxOutMembershipProof)>,
     rings: Vec<Vec<(TxOut, TxOutMembershipProof)>>,
-    amount: AmountData,
+    amount: Amount,
     source_account_key: &AccountKey,
     target_address: &PublicAddress,
     tombstone_block: BlockIndex,
@@ -721,7 +721,7 @@ mod test_build_transaction_helper {
     use mc_transaction_core::{
         constants::MILLIMOB_TO_PICOMOB,
         tx::{TxOut, TxOutMembershipProof},
-        AmountData,
+        Amount,
     };
     use mc_transaction_core_test_utils::get_outputs;
     use rand::{rngs::StdRng, SeedableRng};
@@ -750,7 +750,7 @@ mod test_build_transaction_helper {
 
             // Amount per input.
             let initial_amount = 300 * MILLIMOB_TO_PICOMOB;
-            let amount_to_send = AmountData {
+            let amount_to_send = Amount {
                 value: 457 * MILLIMOB_TO_PICOMOB,
                 token_id: Mob::ID,
             };

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -15,7 +15,7 @@ use mc_fog_sample_paykit::{AccountKey, Client, ClientBuilder, TokenId, Transacti
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_sgx_css::Signature;
 use mc_transaction_core::{
-    constants::RING_SIZE, tokens::Mob, AmountData, BlockIndex, BlockVersion, Token,
+    constants::RING_SIZE, tokens::Mob, Amount, BlockIndex, BlockVersion, Token,
 };
 use mc_transaction_std::MemoType;
 use mc_util_grpc::GrpcRetryConfig;
@@ -96,8 +96,8 @@ impl Default for TestClientPolicy {
 
 impl TestClientPolicy {
     /// Get the amount that should be transfered according to the policy
-    pub fn amount(&self) -> AmountData {
-        AmountData {
+    pub fn amount(&self) -> Amount {
+        Amount {
             value: self.transfer_amount,
             token_id: self.token_id,
         }

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -11,9 +11,7 @@ use mc_fog_types::{
     BlockCount,
 };
 use mc_fog_view_protocol::{FogViewConnection, UserPrivate, UserRngSet};
-use mc_transaction_core::{
-    fog_hint::FogHint, tokens::Mob, tx::TxOut, AmountData, MaskedAmount, Token,
-};
+use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, MaskedAmount, Token};
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 use std::collections::{HashMap, HashSet};
@@ -112,12 +110,12 @@ pub fn make_random_tx<T: RngCore + CryptoRng>(
 ) -> TxOut {
     let target_key = RistrettoPublic::from_random(rng);
     let public_key = RistrettoPublic::from_random(rng);
-    let amount_data = AmountData {
+    let amount = Amount {
         value: 1,
         token_id: Mob::ID,
     };
     TxOut {
-        amount: MaskedAmount::new(amount_data, &public_key).expect("amount failed unexpectedly"),
+        amount: MaskedAmount::new(amount, &public_key).expect("amount failed unexpectedly"),
         target_key: target_key.into(),
         public_key: public_key.into(),
         e_fog_hint: recipient.encrypt(acct_server_pubkey, rng),

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -115,7 +115,7 @@ pub fn make_random_tx<T: RngCore + CryptoRng>(
         token_id: Mob::ID,
     };
     TxOut {
-        amount: MaskedAmount::new(amount, &public_key).expect("amount failed unexpectedly"),
+        masked_amount: MaskedAmount::new(amount, &public_key).expect("amount failed unexpectedly"),
         target_key: target_key.into(),
         public_key: public_key.into(),
         e_fog_hint: recipient.encrypt(acct_server_pubkey, rng),

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -11,7 +11,9 @@ use mc_fog_types::{
     BlockCount,
 };
 use mc_fog_view_protocol::{FogViewConnection, UserPrivate, UserRngSet};
-use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, AmountData, Token};
+use mc_transaction_core::{
+    fog_hint::FogHint, tokens::Mob, tx::TxOut, AmountData, MaskedAmount, Token,
+};
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 use std::collections::{HashMap, HashSet};
@@ -115,7 +117,7 @@ pub fn make_random_tx<T: RngCore + CryptoRng>(
         token_id: Mob::ID,
     };
     TxOut {
-        amount: Amount::new(amount_data, &public_key).expect("amount failed unexpectedly"),
+        amount: MaskedAmount::new(amount_data, &public_key).expect("amount failed unexpectedly"),
         target_key: target_key.into(),
         public_key: public_key.into(),
         e_fog_hint: recipient.encrypt(acct_server_pubkey, rng),

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -9,7 +9,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, KeyError, RistrettoPrivate, Rist
 use mc_transaction_core::{
     encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
     tx::TxOut,
-    Amount, AmountError, EncryptedMemo, MemoError,
+    AmountError, EncryptedMemo, MaskedAmount, MemoError,
 };
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -381,7 +381,7 @@ impl FogTxOut {
         let tx_out_shared_secret =
             mc_transaction_core::get_tx_out_shared_secret(view_key, &public_key);
 
-        let (amount, _) = Amount::reconstruct(
+        let (amount, _) = MaskedAmount::reconstruct(
             self.amount_masked_value,
             &self.amount_masked_token_id,
             &tx_out_shared_secret,

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -349,10 +349,10 @@ impl core::convert::From<&TxOut> for FogTxOut {
         Self {
             target_key: src.target_key,
             public_key: src.public_key,
-            amount_masked_value: src.amount.masked_value,
-            amount_masked_token_id: src.amount.masked_token_id.clone(),
+            amount_masked_value: src.masked_amount.masked_value,
+            amount_masked_token_id: src.masked_amount.masked_token_id.clone(),
             amount_commitment_data_crc32: Crc::<u32>::new(&crc::CRC_32_ISO_HDLC)
-                .checksum(src.amount.commitment.point.as_bytes()),
+                .checksum(src.masked_amount.commitment.point.as_bytes()),
             e_memo: src.e_memo,
         }
     }
@@ -381,19 +381,19 @@ impl FogTxOut {
         let tx_out_shared_secret =
             mc_transaction_core::get_tx_out_shared_secret(view_key, &public_key);
 
-        let (amount, _) = MaskedAmount::reconstruct(
+        let (masked_amount, _) = MaskedAmount::reconstruct(
             self.amount_masked_value,
             &self.amount_masked_token_id,
             &tx_out_shared_secret,
         )
         .map_err(|_| FogTxOutError::ChecksumMismatch)?;
 
-        if amount.commitment_crc32() != self.amount_commitment_data_crc32 {
+        if masked_amount.commitment_crc32() != self.amount_commitment_data_crc32 {
             return Err(FogTxOutError::ChecksumMismatch);
         }
 
         Ok(TxOut {
-            amount,
+            masked_amount,
             target_key: self.target_key,
             public_key: self.public_key,
             e_fog_hint: EncryptedFogHint::from(&[0u8; ENCRYPTED_FOG_HINT_LEN]),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -835,9 +835,9 @@ pub mod tx_out_store_tests {
             );
             let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_private_key);
             let amount = Amount { value, token_id };
-            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
+            let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             let tx_out = TxOut {
-                amount,
+                masked_amount,
                 target_key: target_key.into(),
                 public_key: public_key.into(),
                 e_fog_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -790,7 +790,7 @@ pub mod tx_out_store_tests {
         onetime_keys::*,
         tokens::Mob,
         tx::TxOut,
-        Amount, AmountData, MemoPayload, Token,
+        AmountData, MaskedAmount, MemoPayload, Token,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -835,7 +835,7 @@ pub mod tx_out_store_tests {
             );
             let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_private_key);
             let amount_data = AmountData { value, token_id };
-            let amount = Amount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,
                 target_key: target_key.into(),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -790,7 +790,7 @@ pub mod tx_out_store_tests {
         onetime_keys::*,
         tokens::Mob,
         tx::TxOut,
-        AmountData, MaskedAmount, MemoPayload, Token,
+        Amount, MaskedAmount, MemoPayload, Token,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -834,8 +834,8 @@ pub mod tx_out_store_tests {
                 recipient_account.default_subaddress().spend_public_key(),
             );
             let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_private_key);
-            let amount_data = AmountData { value, token_id };
-            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
+            let amount = Amount { value, token_id };
+            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             let tx_out = TxOut {
                 amount,
                 target_key: target_key.into(),

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -195,11 +195,11 @@ pub extern "C" fn mc_tx_out_get_value(
         let view_private_key = RistrettoPrivate::try_from_ffi(&view_private_key)?;
 
         let shared_secret = get_tx_out_shared_secret(&view_private_key, &tx_out_public_key);
-        let (_amount, amount_data) =
+        let (_amount, amount) =
             MaskedAmount::reconstruct(tx_out_amount.masked_value, &[], &shared_secret)?;
 
-        // FIXME #1596: This should also return the amount_data.token_id
-        *out_value.into_mut() = amount_data.value;
+        // FIXME #1596: This should also return the amount.token_id
+        *out_value.into_mut() = amount.value;
         Ok(())
     })
 }

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -12,7 +12,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    Amount, BlockVersion, CompressedCommitment, Token,
+    BlockVersion, CompressedCommitment, MaskedAmount, Token,
 };
 use mc_transaction_std::{InputCredentials, RTHMemoBuilder, TransactionBuilder};
 use mc_util_ffi::*;
@@ -45,14 +45,15 @@ pub extern "C" fn mc_tx_out_reconstruct_commitment(
 
         // FIXME #1596: McTxOutAmount should include the masked_token_id bytes, which
         // are 0 or 4 bytes For now zero to avoid breaking changes to FFI
-        let (amount, _) = Amount::reconstruct(tx_out_amount.masked_value, &[], &shared_secret)?;
+        let (masked_amount, _) =
+            MaskedAmount::reconstruct(tx_out_amount.masked_value, &[], &shared_secret)?;
 
         let out_tx_out_commitment = out_tx_out_commitment
             .into_mut()
             .as_slice_mut_of_len(RistrettoPublic::size())
             .expect("out_tx_out_commitment length is insufficient");
 
-        out_tx_out_commitment.copy_from_slice(&amount.commitment.to_bytes());
+        out_tx_out_commitment.copy_from_slice(&masked_amount.commitment.to_bytes());
         Ok(())
     })
 }
@@ -195,7 +196,7 @@ pub extern "C" fn mc_tx_out_get_value(
 
         let shared_secret = get_tx_out_shared_secret(&view_private_key, &tx_out_public_key);
         let (_amount, amount_data) =
-            Amount::reconstruct(tx_out_amount.masked_value, &[], &shared_secret)?;
+            MaskedAmount::reconstruct(tx_out_amount.masked_value, &[], &shared_secret)?;
 
         // FIXME #1596: This should also return the amount_data.token_id
         *out_value.into_mut() = amount_data.value;

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -1307,7 +1307,7 @@ mod test {
     use mc_crypto_keys::RistrettoPublic;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, BlockVersion,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, BlockVersion,
         MaskedAmount, Token,
     };
     use mc_transaction_core_test_utils::{
@@ -1344,13 +1344,12 @@ mod test {
         };
 
         let utxo = {
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: 1u64 << 13,
                 token_id: Mob::ID,
             };
             let tx_out = mc_transaction_core::tx::TxOut {
-                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                    .unwrap(),
+                amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -3,7 +3,7 @@
 //! Serializeable data types that wrap the mobilecoind API.
 
 use mc_api::external::{
-    Amount, CompressedRistretto, EncryptedFogHint, EncryptedMemo, KeyImage, PublicAddress,
+    CompressedRistretto, EncryptedFogHint, EncryptedMemo, KeyImage, MaskedAmount, PublicAddress,
     RingMLSAG, SignatureRctBulletproofs, Tx, TxIn, TxOutMembershipElement, TxOutMembershipHash,
     TxOutMembershipProof, TxPrefix,
 };
@@ -494,14 +494,14 @@ impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
-pub struct JsonAmount {
+pub struct JsonMaskedAmount {
     pub commitment: String,
     pub masked_value: String,
     pub masked_token_id: String,
 }
 
-impl From<&Amount> for JsonAmount {
-    fn from(src: &Amount) -> Self {
+impl From<&MaskedAmount> for JsonMaskedAmount {
+    fn from(src: &MaskedAmount) -> Self {
         Self {
             commitment: hex::encode(src.get_commitment().get_data()),
             masked_value: src.get_masked_value().to_string(),
@@ -512,7 +512,7 @@ impl From<&Amount> for JsonAmount {
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxOut {
-    pub amount: JsonAmount,
+    pub amount: JsonMaskedAmount,
     pub target_key: String,
     pub public_key: String,
     pub e_fog_hint: String,
@@ -541,15 +541,15 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
             hex::decode(&src.amount.commitment)
                 .map_err(|err| format!("Failed to decode commitment hex: {}", err))?,
         );
-        let mut amount = Amount::new();
-        amount.set_commitment(commitment);
-        amount.set_masked_value(
+        let mut masked_amount = MaskedAmount::new();
+        masked_amount.set_commitment(commitment);
+        masked_amount.set_masked_value(
             src.amount
                 .masked_value
                 .parse::<u64>()
                 .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
         );
-        amount.set_masked_token_id(
+        masked_amount.set_masked_token_id(
             hex::decode(&src.amount.masked_token_id)
                 .map_err(|err| format!("Failed to decode masked token id hex: {}", err))?,
         );
@@ -575,7 +575,7 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
         );
 
         let mut txo = mc_api::external::TxOut::new();
-        txo.set_amount(amount);
+        txo.set_amount(masked_amount);
         txo.set_target_key(target_key);
         txo.set_public_key(public_key);
         txo.set_e_fog_hint(e_fog_hint);
@@ -1307,8 +1307,8 @@ mod test {
     use mc_crypto_keys::RistrettoPublic;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, AmountData, BlockVersion,
-        Token,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, BlockVersion,
+        MaskedAmount, Token,
     };
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey,
@@ -1349,7 +1349,8 @@ mod test {
                 token_id: Mob::ID,
             };
             let tx_out = mc_transaction_core::tx::TxOut {
-                amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                    .unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -177,7 +177,7 @@ mod test {
     use mc_crypto_keys::RistrettoPublic;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, AmountData, Token,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, MaskedAmount, Token,
     };
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey, BlockVersion,
@@ -196,7 +196,8 @@ mod test {
             token_id: Mob::ID,
         };
         let tx_out = TxOut {
-            amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -287,7 +288,8 @@ mod test {
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: Amount::new(amount_data, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
+                    .unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -177,7 +177,7 @@ mod test {
     use mc_crypto_keys::RistrettoPublic;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, AmountData, MaskedAmount, Token,
+        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, MaskedAmount, Token,
     };
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, initialize_ledger, AccountKey, BlockVersion,
@@ -191,13 +191,12 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         // Rust -> Proto
-        let amount_data = AmountData {
+        let amount = Amount {
             value: 1u64 << 13,
             token_id: Mob::ID,
         };
         let tx_out = TxOut {
-            amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                .unwrap(),
+            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -283,13 +282,12 @@ mod test {
         };
 
         let utxo = {
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: 1u64 << 13,
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: MaskedAmount::new(amount_data, &RistrettoPublic::from_random(&mut rng))
-                    .unwrap(),
+                amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -196,7 +196,8 @@ mod test {
             token_id: Mob::ID,
         };
         let tx_out = TxOut {
-            amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+            masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
+                .unwrap(),
             target_key: RistrettoPublic::from_random(&mut rng).into(),
             public_key: RistrettoPublic::from_random(&mut rng).into(),
             e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
@@ -287,7 +288,8 @@ mod test {
                 token_id: Mob::ID,
             };
             let tx_out = TxOut {
-                amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng)).unwrap(),
+                masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
+                    .unwrap(),
                 target_key: RistrettoPublic::from_random(&mut rng).into(),
                 public_key: RistrettoPublic::from_random(&mut rng).into(),
                 e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -575,7 +575,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
 
         let (amount, _blinding) = tx_out
-            .amount
+            .masked_amount
             .get_value(&shared_secret)
             .map_err(|err| rpc_internal_error("amount.get_value", err, &self.logger))?;
 
@@ -3495,7 +3495,7 @@ mod test {
                             account_key.view_private_key(),
                             &output_public_key,
                         );
-                        tx_out.amount.get_value(&shared_secret).ok()
+                        tx_out.masked_amount.get_value(&shared_secret).ok()
                     })
                     .expect("There should be an output belonging to the account key.");
 
@@ -3790,7 +3790,7 @@ mod test {
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret =
             get_tx_out_shared_secret(data.account_key.view_private_key(), &tx_public_key);
-        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+        let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
         assert_eq!(amount.value, tx_proposal.outlays[0].value);
         assert_eq!(amount.token_id, Mob::ID);
 
@@ -3870,7 +3870,7 @@ mod test {
         let tx_out = &tx_proposal.tx.prefix.outputs[0];
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret = get_tx_out_shared_secret(receiver.view_private_key(), &tx_public_key);
-        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+        let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
         assert_eq!(amount.value, expected_value);
         assert_eq!(amount.token_id, Mob::ID);
     }
@@ -4842,7 +4842,7 @@ mod test {
                             get_tx_out_shared_secret(sender.view_private_key(), &tx_public_key);
 
                         let (amount, _blinding) = tx_out
-                            .amount
+                            .masked_amount
                             .get_value(&shared_secret)
                             .expect("Malformed amount");
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3484,7 +3484,7 @@ mod test {
             ] {
                 // Find the first output belonging to the account, and get its value.
                 // This assumes that each output is sent to a different account key.
-                let (amount_data, _blinding) = tx
+                let (amount, _blinding) = tx
                     .prefix
                     .outputs
                     .iter()
@@ -3499,8 +3499,8 @@ mod test {
                     })
                     .expect("There should be an output belonging to the account key.");
 
-                assert_eq!(amount_data.token_id, Mob::ID);
-                assert_eq!(amount_data.value, *expected_value);
+                assert_eq!(amount.token_id, Mob::ID);
+                assert_eq!(amount.value, *expected_value);
             }
 
             // Santity test fee
@@ -3790,9 +3790,9 @@ mod test {
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret =
             get_tx_out_shared_secret(data.account_key.view_private_key(), &tx_public_key);
-        let (amount_data, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
-        assert_eq!(amount_data.value, tx_proposal.outlays[0].value);
-        assert_eq!(amount_data.token_id, Mob::ID);
+        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+        assert_eq!(amount.value, tx_proposal.outlays[0].value);
+        assert_eq!(amount.token_id, Mob::ID);
 
         // Santity test fee
         assert_eq!(tx_proposal.fee(), Mob::MINIMUM_FEE);
@@ -3870,9 +3870,9 @@ mod test {
         let tx_out = &tx_proposal.tx.prefix.outputs[0];
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret = get_tx_out_shared_secret(receiver.view_private_key(), &tx_public_key);
-        let (amount_data, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
-        assert_eq!(amount_data.value, expected_value);
-        assert_eq!(amount_data.token_id, Mob::ID);
+        let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+        assert_eq!(amount.value, expected_value);
+        assert_eq!(amount.token_id, Mob::ID);
     }
 
     #[test_with_logger]
@@ -4841,13 +4841,13 @@ mod test {
                         let shared_secret =
                             get_tx_out_shared_secret(sender.view_private_key(), &tx_public_key);
 
-                        let (amount_data, _blinding) = tx_out
+                        let (amount, _blinding) = tx_out
                             .amount
                             .get_value(&shared_secret)
                             .expect("Malformed amount");
 
-                        assert_eq!(total_value - test_amount - fee, amount_data.value);
-                        assert_eq!(amount_data.token_id, Mob::ID);
+                        assert_eq!(total_value - test_amount - fee, amount.value);
+                        assert_eq!(amount.token_id, Mob::ID);
                     }
                 }
                 Err(Error::SubaddressSPKNotFound) => continue,

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -385,7 +385,7 @@ fn match_tx_outs_into_utxos(
             get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
 
         let (amount, _blinding) = tx_out
-            .amount
+            .masked_amount
             .get_value(&shared_secret)
             .expect("Malformed amount"); // TODO
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -236,7 +236,7 @@ mod block_tests {
                     EncryptedFogHint::fake_onetime_hint(rng),
                 )
                 .unwrap();
-                result.amount.masked_token_id = Default::default();
+                result.masked_amount.masked_token_id = Default::default();
                 result
             })
             .collect();

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -38,7 +38,7 @@ pub mod validation;
 #[cfg(test)]
 pub mod proptest_fixtures;
 
-pub use amount::{Amount, AmountData, AmountError, Commitment, CompressedCommitment};
+pub use amount::{AmountData, AmountError, Commitment, CompressedCommitment, MaskedAmount};
 pub use blockchain::*;
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
 pub use token::{tokens, Token, TokenId};

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -38,7 +38,7 @@ pub mod validation;
 #[cfg(test)]
 pub mod proptest_fixtures;
 
-pub use amount::{AmountData, AmountError, Commitment, CompressedCommitment, MaskedAmount};
+pub use amount::{Amount, AmountError, Commitment, CompressedCommitment, MaskedAmount};
 pub use blockchain::*;
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
 pub use token::{tokens, Token, TokenId};

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{ring_signature::CurveScalar, tokens::Mob, Amount, AmountData, Token};
+use crate::{ring_signature::CurveScalar, tokens::Mob, AmountData, MaskedAmount, Token};
 use curve25519_dalek::scalar::Scalar;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use proptest::prelude::*;
@@ -29,11 +29,11 @@ prop_compose! {
     /// Generates an arbitrary amount with value in [0,max_value].
     /// Of token_id = 0
     pub fn arbitrary_amount(max_value: u64, shared_secret: RistrettoPublic)
-                (value in 0..=max_value) -> Amount {
+                (value in 0..=max_value) -> MaskedAmount {
             let amount_data = AmountData {
                 value,
                 token_id: Mob::ID,
             };
-            Amount::new(amount_data, &shared_secret).unwrap()
+            MaskedAmount::new(amount_data, &shared_secret).unwrap()
     }
 }

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{ring_signature::CurveScalar, tokens::Mob, AmountData, MaskedAmount, Token};
+use crate::{ring_signature::CurveScalar, tokens::Mob, Amount, MaskedAmount, Token};
 use curve25519_dalek::scalar::Scalar;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use proptest::prelude::*;
@@ -26,14 +26,14 @@ pub fn arbitrary_ristretto_public() -> impl Strategy<Value = RistrettoPublic> {
 }
 
 prop_compose! {
-    /// Generates an arbitrary amount with value in [0,max_value].
+    /// Generates an arbitrary masked_amount with value in [0,max_value].
     /// Of token_id = 0
-    pub fn arbitrary_amount(max_value: u64, shared_secret: RistrettoPublic)
+    pub fn arbitrary_masked_amount(max_value: u64, shared_secret: RistrettoPublic)
                 (value in 0..=max_value) -> MaskedAmount {
-            let amount_data = AmountData {
+            let amount = Amount {
                 value,
                 token_id: Mob::ID,
             };
-            MaskedAmount::new(amount_data, &shared_secret).unwrap()
+            MaskedAmount::new(amount, &shared_secret).unwrap()
     }
 }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -16,7 +16,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    amount::{Amount, AmountData, AmountError},
+    amount::{AmountData, AmountError, MaskedAmount},
     domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     get_tx_out_shared_secret,
@@ -245,7 +245,7 @@ pub struct TxIn {
 pub struct TxOut {
     /// The amount being sent.
     #[prost(message, required, tag = "1")]
-    pub amount: Amount,
+    pub amount: MaskedAmount,
 
     /// The one-time public address of this output.
     #[prost(message, required, tag = "2")]
@@ -336,7 +336,7 @@ impl TxOut {
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
 
         let amount_data = AmountData { value, token_id };
-        let amount = Amount::new(amount_data, &shared_secret)?;
+        let amount = MaskedAmount::new(amount_data, &shared_secret)?;
 
         let memo_ctxt = MemoContext {
             tx_public_key: &public_key,
@@ -574,7 +574,7 @@ mod tests {
         subaddress_matches_tx_out,
         tokens::Mob,
         tx::{Tx, TxIn, TxOut, TxPrefix},
-        Amount, AmountData, Token,
+        AmountData, MaskedAmount, Token,
     };
     use alloc::vec::Vec;
     use core::convert::TryFrom;
@@ -596,7 +596,7 @@ mod tests {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = Amount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
             TxOut {
                 amount,
                 target_key,
@@ -659,7 +659,7 @@ mod tests {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = Amount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
             TxOut {
                 amount,
                 target_key,

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -16,7 +16,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    amount::{AmountData, AmountError, MaskedAmount},
+    amount::{Amount, AmountError, MaskedAmount},
     domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     get_tx_out_shared_secret,
@@ -335,8 +335,8 @@ impl TxOut {
 
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
 
-        let amount_data = AmountData { value, token_id };
-        let amount = MaskedAmount::new(amount_data, &shared_secret)?;
+        let amount = Amount { value, token_id };
+        let amount = MaskedAmount::new(amount, &shared_secret)?;
 
         let memo_ctxt = MemoContext {
             tx_public_key: &public_key,
@@ -574,7 +574,7 @@ mod tests {
         subaddress_matches_tx_out,
         tokens::Mob,
         tx::{Tx, TxIn, TxOut, TxPrefix},
-        AmountData, MaskedAmount, Token,
+        Amount, MaskedAmount, Token,
     };
     use alloc::vec::Vec;
     use core::convert::TryFrom;
@@ -592,11 +592,11 @@ mod tests {
             let shared_secret = RistrettoPublic::from_random(&mut rng);
             let target_key = RistrettoPublic::from_random(&mut rng).into();
             let public_key = RistrettoPublic::from_random(&mut rng).into();
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             TxOut {
                 amount,
                 target_key,
@@ -655,11 +655,11 @@ mod tests {
             let shared_secret = RistrettoPublic::from_random(&mut rng);
             let target_key = RistrettoPublic::from_random(&mut rng).into();
             let public_key = RistrettoPublic::from_random(&mut rng).into();
-            let amount_data = AmountData {
+            let amount = Amount {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount_data, &shared_secret).unwrap();
+            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             TxOut {
                 amount,
                 target_key,

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -219,7 +219,7 @@ impl TxPrefix {
     pub fn output_commitments(&self) -> Vec<CompressedCommitment> {
         self.outputs
             .iter()
-            .map(|output| output.amount.commitment)
+            .map(|output| output.masked_amount.commitment)
             .collect()
     }
 }
@@ -245,7 +245,8 @@ pub struct TxIn {
 pub struct TxOut {
     /// The amount being sent.
     #[prost(message, required, tag = "1")]
-    pub amount: MaskedAmount,
+    #[digestible(name = "amount")]
+    pub masked_amount: MaskedAmount,
 
     /// The one-time public address of this output.
     #[prost(message, required, tag = "2")]
@@ -336,7 +337,7 @@ impl TxOut {
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
 
         let amount = Amount { value, token_id };
-        let amount = MaskedAmount::new(amount, &shared_secret)?;
+        let masked_amount = MaskedAmount::new(amount, &shared_secret)?;
 
         let memo_ctxt = MemoContext {
             tx_public_key: &public_key,
@@ -345,7 +346,7 @@ impl TxOut {
         let e_memo = memo.map(|memo| memo.encrypt(&shared_secret));
 
         Ok(TxOut {
-            amount,
+            masked_amount,
             target_key,
             public_key: public_key.into(),
             e_fog_hint: hint,
@@ -596,9 +597,9 @@ mod tests {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
+            let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             TxOut {
-                amount,
+                masked_amount,
                 target_key,
                 public_key,
                 e_fog_hint: EncryptedFogHint::from(&[1u8; ENCRYPTED_FOG_HINT_LEN]),
@@ -659,9 +660,9 @@ mod tests {
                 value: 23u64,
                 token_id: Mob::ID,
             };
-            let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
+            let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
             TxOut {
-                amount,
+                masked_amount,
                 target_key,
                 public_key,
                 e_fog_hint: EncryptedFogHint::from(&[1u8; ENCRYPTED_FOG_HINT_LEN]),

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -259,7 +259,7 @@ fn validate_no_masked_token_ids_exist(tx: &Tx) -> TransactionValidationResult<()
         .prefix
         .outputs
         .iter()
-        .any(|output| !output.amount.masked_token_id.is_empty())
+        .any(|output| !output.masked_amount.masked_token_id.is_empty())
     {
         return Err(TransactionValidationError::MaskedTokenIdNotAllowed);
     }
@@ -273,7 +273,7 @@ fn validate_masked_token_ids_exist(tx: &Tx) -> TransactionValidationResult<()> {
         .prefix
         .outputs
         .iter()
-        .any(|output| output.amount.masked_token_id.len() != 4)
+        .any(|output| output.masked_amount.masked_token_id.len() != 4)
     {
         return Err(TransactionValidationError::MissingMaskedTokenId);
     }
@@ -302,7 +302,7 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
             input
                 .ring
                 .iter()
-                .map(|tx_out| (tx_out.target_key, tx_out.amount.commitment))
+                .map(|tx_out| (tx_out.target_key, tx_out.masked_amount.commitment))
                 .collect()
         })
         .collect();

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -53,7 +53,7 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     // Get the output value.
     let tx_out_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
     let shared_secret = get_tx_out_shared_secret(sender.view_private_key(), &tx_out_public_key);
-    let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+    let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
 
     assert!(amount.value >= Mob::MINIMUM_FEE);
     create_transaction_with_amount(
@@ -319,7 +319,7 @@ pub fn get_outputs<T: RngCore + CryptoRng>(
             if !block_version.e_memo_feature_is_supported() {
                 result.e_memo = None;
             }
-            result.amount.masked_token_id = Default::default();
+            result.masked_amount.masked_token_id = Default::default();
             result
         })
         .collect()

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -53,16 +53,16 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     // Get the output value.
     let tx_out_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
     let shared_secret = get_tx_out_shared_secret(sender.view_private_key(), &tx_out_public_key);
-    let (amount_data, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
+    let (amount, _blinding) = tx_out.amount.get_value(&shared_secret).unwrap();
 
-    assert!(amount_data.value >= Mob::MINIMUM_FEE);
+    assert!(amount.value >= Mob::MINIMUM_FEE);
     create_transaction_with_amount(
         block_version,
         ledger,
         tx_out,
         sender,
         recipient,
-        amount_data.value - Mob::MINIMUM_FEE,
+        amount.value - Mob::MINIMUM_FEE,
         Mob::MINIMUM_FEE,
         tombstone_block,
         rng,

--- a/transaction/core/tests/digest-test-vectors.rs
+++ b/transaction/core/tests/digest-test-vectors.rs
@@ -33,7 +33,7 @@ fn test_origin_tx_outs() -> Vec<TxOut> {
             // Origin TxOuts do not have encrypted memo fields.
             tx_out.e_memo = None;
             // Origin TxOuts do not have masked token id
-            tx_out.amount.masked_token_id = Default::default();
+            tx_out.masked_amount.masked_token_id = Default::default();
             tx_out
         })
         .collect()

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -369,7 +369,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             .outputs_and_shared_secrets
             .iter()
             .map(|(tx_out, shared_secret)| {
-                let masked_amount = &tx_out.amount;
+                let masked_amount = &tx_out.masked_amount;
                 let (amount, blinding) = masked_amount
                     .get_value(shared_secret)
                     .expect("TransactionBuilder created an invalid Amount");
@@ -393,7 +393,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             let ring: Vec<(CompressedRistrettoPublic, CompressedCommitment)> = input
                 .ring
                 .iter()
-                .map(|tx_out| (tx_out.target_key, tx_out.amount.commitment))
+                .map(|tx_out| (tx_out.target_key, tx_out.masked_amount.commitment))
                 .collect();
             rings.push(ring);
         }
@@ -408,7 +408,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         let mut input_secrets: Vec<(RistrettoPrivate, u64, Scalar)> = Vec::new();
         for input_credential in &self.input_credentials {
             let onetime_private_key = input_credential.onetime_private_key;
-            let masked_amount = &input_credential.ring[input_credential.real_index].amount;
+            let masked_amount = &input_credential.ring[input_credential.real_index].masked_amount;
             let shared_secret = create_shared_secret(
                 &input_credential.real_output_public_key,
                 &input_credential.view_private_key,
@@ -470,7 +470,7 @@ fn create_output_with_fog_hint<RNG: CryptoRng + RngCore>(
         tx_out.e_memo = None;
     }
     if !block_version.masked_token_id_feature_is_supported() {
-        tx_out.amount.masked_token_id.clear();
+        tx_out.masked_amount.masked_token_id.clear();
     }
 
     let shared_secret = create_shared_secret(recipient.view_public_key(), &private_key);
@@ -1176,7 +1176,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1207,7 +1207,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1350,7 +1350,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1389,7 +1389,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1505,7 +1505,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE * 4);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1544,7 +1544,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1660,7 +1660,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1700,7 +1700,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1815,7 +1815,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1855,7 +1855,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1958,7 +1958,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1980,7 +1980,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2131,7 +2131,7 @@ pub mod transaction_builder_tests {
                         bob.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2167,7 +2167,7 @@ pub mod transaction_builder_tests {
                         alice.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2549,7 +2549,7 @@ pub mod transaction_builder_tests {
                 let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
                 let shared_secret = get_tx_out_shared_secret(view_private, &tx_public_key);
                 tx_out
-                    .amount
+                    .masked_amount
                     .get_value(&shared_secret)
                     .ok()
                     .map(|(amount, _scalar)| amount.value)

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -13,7 +13,7 @@ use mc_transaction_core::{
     encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
     ring_signature::KeyImage,
     tx::TxOut,
-    AmountData, Block, BlockContents, BlockVersion,
+    Amount, Block, BlockContents, BlockVersion,
 };
 use mc_util_from_random::FromRandom;
 use rand::{RngCore, SeedableRng};
@@ -93,7 +93,7 @@ pub fn bootstrap_ledger(
             for _i in 0..outputs_per_recipient_per_block {
                 // Create outputs of each token id in round-robin
                 for token_id in 0..=max_token_id {
-                    let amount = AmountData {
+                    let amount = Amount {
                         value: picomob_per_output,
                         token_id: token_id.into(),
                     };
@@ -144,7 +144,7 @@ pub fn bootstrap_ledger(
 
 fn create_output(
     recipient: &PublicAddress,
-    amount: AmountData,
+    amount: Amount,
     rng: &mut FixedRng,
     hint_slice: Option<&str>,
     logger: &Logger,
@@ -189,7 +189,7 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([20u8; 32]);
         let mut fixed_rng: FixedRng = SeedableRng::from_seed([33u8; 32]);
 
-        let amount = AmountData {
+        let amount = Amount {
             value: 10,
             token_id: Mob::ID,
         };


### PR DESCRIPTION
This carries out the rename
`Amount -> MaskedAmount`
`AmountData -> Amount`

which was requested during review of confidential token ids PR,
while using Digestible annotations to avoid changing the hashes
of the TxOut's already in the chain.