### PR TITLE
Make `TxOut::new` take `Amount` as parameter

### DIFF
--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -501,7 +501,7 @@ mod combine_tests {
         onetime_keys::recover_onetime_private_key,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipProof},
-        BlockVersion, Token,
+        Amount, BlockVersion, Token,
     };
     use mc_transaction_core_test_utils::{AccountKey, MockFogResolver};
     use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
@@ -542,8 +542,10 @@ mod combine_tests {
             let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
             let tx_out = TxOut::new(
-                123,
-                Mob::ID,
+                Amount {
+                    value: 123,
+                    token_id: Mob::ID,
+                },
                 &alice.default_subaddress(),
                 &tx_secret_key_for_txo,
                 Default::default(),
@@ -622,8 +624,10 @@ mod combine_tests {
                     let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
                     let tx_out = TxOut::new(
-                        88,
-                        Mob::ID,
+                        Amount {
+                            value: 88,
+                            token_id: Mob::ID,
+                        },
                         &alice.default_subaddress(),
                         &tx_secret_key_for_txo,
                         Default::default(),
@@ -700,8 +704,10 @@ mod combine_tests {
 
             // Create a TxOut that was sent to Alice.
             let tx_out = TxOut::new(
-                123,
-                Mob::ID,
+                Amount {
+                    value: 123,
+                    token_id: Mob::ID,
+                },
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -796,8 +802,10 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
-                    123,
-                    Mob::ID,
+                    Amount {
+                        value: 123,
+                        token_id: Mob::ID,
+                    },
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
                     Default::default(),
@@ -872,8 +880,10 @@ mod combine_tests {
 
             // Create two TxOuts that were sent to Alice.
             let tx_out1 = TxOut::new(
-                123,
-                Mob::ID,
+                Amount {
+                    value: 123,
+                    token_id: Mob::ID,
+                },
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -881,8 +891,10 @@ mod combine_tests {
             .unwrap();
 
             let tx_out2 = TxOut::new(
-                123,
-                Mob::ID,
+                Amount {
+                    value: 123,
+                    token_id: Mob::ID,
+                },
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -985,8 +997,10 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
-                    123,
-                    Mob::ID,
+                    Amount {
+                        value: 123,
+                        token_id: Mob::ID,
+                    },
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
                     Default::default(),

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -18,7 +18,7 @@ use mc_transaction_core::{
     fog_hint::{FogHint, PlaintextArray},
     tokens::Mob,
     tx::TxOut,
-    Token,
+    Amount, Token,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_logger_macros::test_with_logger;
@@ -59,8 +59,10 @@ fn test_ingest_enclave(logger: Logger) {
                 let tx_private_key = RistrettoPrivate::from_random(&mut rng);
                 let e_fog_hint = FogHint::from(&bob_public_address).encrypt(&fog_pubkey, &mut rng);
                 TxOut::new(
-                    10,
-                    token_id,
+                    Amount {
+                        value: 10,
+                        token_id,
+                    },
                     &bob_account.default_subaddress(),
                     &tx_private_key,
                     e_fog_hint,
@@ -229,8 +231,10 @@ fn test_ingest_enclave_malformed_txos(logger: Logger) {
                     _ => panic!("this should be unreachable"),
                 };
                 TxOut::new(
-                    10,
-                    token_id,
+                    Amount {
+                        value: 10,
+                        token_id,
+                    },
                     &bob_account.default_subaddress(),
                     &tx_private_key,
                     e_fog_hint,
@@ -372,7 +376,16 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                     };
                     let tx_private_key = RistrettoPrivate::from_random(&mut rng);
                     let e_fog_hint = FogHint::from(pub_addr).encrypt(&fog_pubkey, &mut rng);
-                    TxOut::new(10, token_id, pub_addr, &tx_private_key, e_fog_hint).unwrap()
+                    TxOut::new(
+                        Amount {
+                            value: 10,
+                            token_id,
+                        },
+                        pub_addr,
+                        &tx_private_key,
+                        e_fog_hint,
+                    )
+                    .unwrap()
                 })
                 .collect();
 

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -24,7 +24,7 @@ use mc_fog_test_infra::get_enclave_path;
 use mc_fog_uri::{ConnectionUri, FogLedgerUri};
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
-    ring_signature::KeyImage, tokens::Mob, tx::TxOut, Block, BlockContents, BlockSignature,
+    ring_signature::KeyImage, tokens::Mob, tx::TxOut, Amount, Block, BlockContents, BlockSignature,
     BlockVersion, Token,
 };
 use mc_util_from_random::FromRandom;
@@ -788,8 +788,10 @@ fn add_block_to_ledger_db(
         .map(|recipient| {
             TxOut::new(
                 // TODO: allow for subaddress index!
-                value,
-                Mob::ID,
+                Amount {
+                    value,
+                    token_id: Mob::ID,
+                },
                 recipient,
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -37,7 +37,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-    Block, BlockContents, BlockData, BlockSignature, BlockVersion, Token,
+    Amount, Block, BlockContents, BlockData, BlockSignature, BlockVersion, Token,
 };
 use mc_util_from_random::FromRandom;
 use rand_core::SeedableRng;
@@ -168,8 +168,10 @@ fn main() {
 
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let tx_out = TxOut::new(
-            credit.amount,
-            token_id,
+            Amount {
+                value: credit.amount,
+                token_id,
+            },
             &account_keys[credit.account].default_subaddress(),
             &tx_private_key,
             e_fog_hint,

--- a/fog/view/protocol/src/user_private.rs
+++ b/fog/view/protocol/src/user_private.rs
@@ -111,7 +111,7 @@ mod testing {
     use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
     use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_fog_types::view::{FogTxOut, FogTxOutMetadata};
-    use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Token};
+    use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, Token};
     pub use rand_core::{CryptoRng, RngCore, SeedableRng};
     use rand_hc::Hc128Rng;
 
@@ -147,8 +147,10 @@ mod testing {
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let token_id = Mob::ID;
         let txo = TxOut::new(
-            10,
-            token_id,
+            Amount {
+                value: 10,
+                token_id,
+            },
             &recipient.default_subaddress(),
             &tx_private_key,
             hint.encrypt(&ingest_public, &mut rng),

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -745,7 +745,7 @@ mod ledger_db_test {
     use mc_account_keys::AccountKey;
     use mc_crypto_keys::RistrettoPrivate;
     use mc_transaction_core::{
-        compute_block_id, membership_proofs::compute_implied_merkle_root, tokens::Mob,
+        compute_block_id, membership_proofs::compute_implied_merkle_root, tokens::Mob, Amount,
         BlockVersion, Token,
     };
     use mc_util_from_random::FromRandom;
@@ -791,8 +791,10 @@ mod ledger_db_test {
             let outputs: Vec<TxOut> = (0..num_outputs_per_block)
                 .map(|_i| {
                     let mut result = TxOut::new(
-                        initial_amount,
-                        Mob::ID,
+                        Amount {
+                            value: initial_amount,
+                            token_id: Mob::ID,
+                        },
                         &account_key.default_subaddress(),
                         &RistrettoPrivate::from_random(&mut rng),
                         Default::default(),
@@ -850,8 +852,10 @@ mod ledger_db_test {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         let mut output = TxOut::new(
-            1000,
-            Mob::ID,
+            Amount {
+                value: 1000,
+                token_id: Mob::ID,
+            },
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
@@ -909,8 +913,10 @@ mod ledger_db_test {
         let outputs: Vec<TxOut> = (0..4)
             .map(|_i| {
                 TxOut::new(
-                    1000,
-                    Mob::ID,
+                    Amount {
+                        value: 1000,
+                        token_id: Mob::ID,
+                    },
                     &recipient_account_key.default_subaddress(),
                     &RistrettoPrivate::from_random(&mut rng),
                     Default::default(),
@@ -991,8 +997,10 @@ mod ledger_db_test {
         let outputs: Vec<TxOut> = (0..4)
             .map(|_i| {
                 TxOut::new(
-                    1000,
-                    Mob::ID,
+                    Amount {
+                        value: 1000,
+                        token_id: Mob::ID,
+                    },
                     &recipient_account_key.default_subaddress(),
                     &RistrettoPrivate::from_random(&mut rng),
                     Default::default(),
@@ -1154,8 +1162,10 @@ mod ledger_db_test {
             .collect();
 
         let tx_out = TxOut::new(
-            10,
-            Mob::ID,
+            Amount {
+                value: 10,
+                token_id: Mob::ID,
+            },
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
@@ -1200,8 +1210,10 @@ mod ledger_db_test {
             .collect();
 
         let tx_out = TxOut::new(
-            10,
-            Mob::ID,
+            Amount {
+                value: 10,
+                token_id: Mob::ID,
+            },
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
@@ -1318,8 +1330,10 @@ mod ledger_db_test {
                 let outputs: Vec<TxOut> = (0..4)
                     .map(|_i| {
                         TxOut::new(
-                            1000,
-                            Mob::ID,
+                            Amount {
+                                value: 1000,
+                                token_id: Mob::ID,
+                            },
                             &recipient_account_key.default_subaddress(),
                             &RistrettoPrivate::from_random(&mut rng),
                             Default::default(),
@@ -1363,8 +1377,10 @@ mod ledger_db_test {
             let outputs: Vec<TxOut> = (0..4)
                 .map(|_i| {
                     TxOut::new(
-                        1000,
-                        Mob::ID,
+                        Amount {
+                            value: 1000,
+                            token_id: Mob::ID,
+                        },
                         &recipient_account_key.default_subaddress(),
                         &RistrettoPrivate::from_random(&mut rng),
                         Default::default(),
@@ -1421,8 +1437,10 @@ mod ledger_db_test {
         let key_images = vec![KeyImage::from(rng.next_u64())];
 
         let tx_out = TxOut::new(
-            100,
-            Mob::ID,
+            Amount {
+                value: 100,
+                token_id: Mob::ID,
+            },
             &account_key.default_subaddress(),
             &RistrettoPrivate::from_random(&mut rng),
             Default::default(),
@@ -1479,8 +1497,10 @@ mod ledger_db_test {
 
         let block_one_contents = {
             let tx_out = TxOut::new(
-                10,
-                Mob::ID,
+                Amount {
+                    value: 10,
+                    token_id: Mob::ID,
+                },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -1504,8 +1524,10 @@ mod ledger_db_test {
         // The next block reuses a key image.
         let block_two_contents = {
             let tx_out = TxOut::new(
-                33,
-                Mob::ID,
+                Amount {
+                    value: 33,
+                    token_id: Mob::ID,
+                },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -1549,8 +1571,10 @@ mod ledger_db_test {
 
         let block_one_contents = {
             let mut tx_out = TxOut::new(
-                33,
-                Mob::ID,
+                Amount {
+                    value: 33,
+                    token_id: Mob::ID,
+                },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -1611,8 +1635,10 @@ mod ledger_db_test {
         // append_block rejects a block with non-existent parent.
         {
             let tx_out = TxOut::new(
-                100,
-                Mob::ID,
+                Amount {
+                    value: 100,
+                    token_id: Mob::ID,
+                },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -8,7 +8,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-    Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, Token,
+    Amount, Block, BlockContents, BlockData, BlockID, BlockSignature, BlockVersion, Token,
 };
 use mc_util_from_random::FromRandom;
 use rand::{rngs::StdRng, SeedableRng};
@@ -213,6 +213,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
     // The owner of all outputs in the mock ledger.
     let account_key = AccountKey::random(&mut rng);
     let value = 134_217_728; // 2^27
+    let token_id = Mob::ID;
 
     let mut block_ids: Vec<BlockID> = Vec::with_capacity(n_blocks);
     let mut blocks_and_contents: Vec<(Block, BlockContents)> = Vec::with_capacity(n_blocks);
@@ -221,8 +222,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
         if block_index == 0 {
             // Create the origin block.
             let mut tx_out = TxOut::new(
-                value,
-                Mob::ID,
+                Amount { value, token_id },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -239,8 +239,10 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
         } else {
             // Create a normal block.
             let tx_out = TxOut::new(
-                16,
-                Mob::ID,
+                Amount {
+                    value: 16,
+                    token_id,
+                },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1008,7 +1008,7 @@ mod test {
     use mc_connection::{HardcodedCredentialsProvider, ThickClient};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_fog_report_validation::MockFogPubkeyResolver;
-    use mc_transaction_core::{constants::MILLIMOB_TO_PICOMOB, tokens::Mob, Token};
+    use mc_transaction_core::{constants::MILLIMOB_TO_PICOMOB, tokens::Mob, Amount, Token};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -1020,8 +1020,7 @@ mod test {
         let token_id = Mob::ID;
 
         let tx_out = TxOut::new(
-            1,
-            token_id,
+            Amount { value: 1, token_id },
             &alice.default_subaddress(),
             &tx_secret_key_for_txo,
             Default::default(),

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -24,7 +24,7 @@ use mc_ledger_db::{Ledger, LedgerDB};
 use mc_ledger_sync::PollingNetworkState;
 use mc_mobilecoind_api::{mobilecoind_api_grpc::MobilecoindApiClient, MobilecoindUri};
 use mc_transaction_core::{
-    ring_signature::KeyImage, tokens::Mob, tx::TxOut, Block, BlockContents, Token,
+    ring_signature::KeyImage, tokens::Mob, tx::TxOut, Amount, Block, BlockContents, Token,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
@@ -168,9 +168,11 @@ pub fn add_block_to_ledger_db(
         .map(|recipient| {
             let mut result = TxOut::new(
                 // TODO: allow for subaddress index!
-                output_value,
-                // TODO: allow for other token id
-                Mob::ID,
+                Amount {
+                    value: output_value,
+                    // TODO: allow for other token id
+                    token_id: Mob::ID,
+                },
                 recipient,
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -205,7 +205,7 @@ mod block_tests {
         ring_signature::KeyImage,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash},
-        Block, BlockContents, BlockContentsHash, BlockID, BlockVersion, Token,
+        Amount, Block, BlockContents, BlockContentsHash, BlockID, BlockVersion, Token,
     };
     use alloc::vec::Vec;
     use core::convert::TryFrom;
@@ -229,8 +229,10 @@ mod block_tests {
         let outputs: Vec<TxOut> = (0..8)
             .map(|_i| {
                 let mut result = TxOut::new(
-                    rng.next_u64(),
-                    Mob::ID,
+                    Amount {
+                        value: rng.next_u64(),
+                        token_id: Mob::ID,
+                    },
                     &recipient.default_subaddress(),
                     &RistrettoPrivate::from_random(rng),
                     EncryptedFogHint::fake_onetime_hint(rng),

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -13,7 +13,7 @@ pub use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
-    Block, BlockID, BlockIndex, BlockVersion, Token,
+    Amount, Block, BlockID, BlockIndex, BlockVersion, Token,
 };
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
 use mc_util_from_random::FromRandom;
@@ -173,6 +173,7 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
     rng: &mut R,
 ) -> Vec<Block> {
     let value: u64 = INITIALIZE_LEDGER_AMOUNT;
+    let token_id = Mob::ID;
 
     // TxOut from the previous block
     let mut to_spend: Option<TxOut> = None;
@@ -214,8 +215,7 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                 let outputs: Vec<TxOut> = (0..RING_SIZE)
                     .map(|_i| {
                         let mut tx_out = TxOut::new(
-                            value,
-                            Mob::ID,
+                            Amount { value, token_id },
                             &account_key.default_subaddress(),
                             &RistrettoPrivate::from_random(rng),
                             Default::default(),
@@ -309,8 +309,10 @@ pub fn get_outputs<T: RngCore + CryptoRng>(
         .iter()
         .map(|(recipient, value)| {
             let mut result = TxOut::new(
-                *value,
-                Mob::ID,
+                Amount {
+                    value: *value,
+                    token_id: Mob::ID,
+                },
                 recipient,
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),

--- a/transaction/core/tests/digest-test-vectors.rs
+++ b/transaction/core/tests/digest-test-vectors.rs
@@ -2,7 +2,7 @@ use mc_account_keys::AccountKey;
 use mc_crypto_digestible_test_utils::*;
 use mc_crypto_keys::RistrettoPrivate;
 use mc_transaction_core::{
-    encrypted_fog_hint::EncryptedFogHint, tokens::Mob, tx::TxOut, Block, BlockContents,
+    encrypted_fog_hint::EncryptedFogHint, tokens::Mob, tx::TxOut, Amount, Block, BlockContents,
     BlockVersion, Token,
 };
 use mc_util_from_random::FromRandom;
@@ -23,8 +23,10 @@ fn test_origin_tx_outs() -> Vec<TxOut> {
         .iter()
         .map(|acct| {
             let mut tx_out = TxOut::new(
-                rng.next_u32() as u64,
-                Mob::ID,
+                Amount {
+                    value: rng.next_u32() as u64,
+                    token_id: Mob::ID,
+                },
                 &acct.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 EncryptedFogHint::fake_onetime_hint(&mut rng),

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -17,7 +17,8 @@ use mc_transaction_core::{
     ring_signature::SignatureRctBulletproofs,
     tokens::Mob,
     tx::{Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
-    BlockVersion, CompressedCommitment, MemoContext, MemoPayload, NewMemoError, Token, TokenId,
+    Amount, BlockVersion, CompressedCommitment, MemoContext, MemoPayload, NewMemoError, Token,
+    TokenId,
 };
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
@@ -463,8 +464,8 @@ fn create_output_with_fog_hint<RNG: CryptoRng + RngCore>(
     rng: &mut RNG,
 ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
     let private_key = RistrettoPrivate::from_random(rng);
-    let mut tx_out =
-        TxOut::new_with_memo(value, token_id, recipient, &private_key, fog_hint, memo_fn)?;
+    let amount = Amount { value, token_id };
+    let mut tx_out = TxOut::new_with_memo(amount, recipient, &private_key, fog_hint, memo_fn)?;
 
     if !block_version.e_memo_feature_is_supported() {
         tx_out.e_memo = None;

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -164,14 +164,7 @@ fn create_output(
         EncryptedFogHint::fake_onetime_hint(rng)
     };
 
-    let output = TxOut::new(
-        amount.value,
-        amount.token_id,
-        recipient,
-        &tx_private_key,
-        hint,
-    )
-    .unwrap();
+    let output = TxOut::new(amount, recipient, &tx_private_key, hint).unwrap();
     log::debug!(logger, "Creating output: {:?}", output);
     output
 }


### PR DESCRIPTION
This is consistent with `MaskedAmount::new`, and we generally
want to pass `value: u64` around with its token id to avoid confusing
token types.

This is a minor fixup after confidential token ids PR