### PR TITLE
add a utility for generating predictable Ed25519 private keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ dependencies = [
  "bitflags",
  "cexpr 0.4.0",
  "clang-sys",
- "clap",
+ "clap 2.33.0",
  "env_logger 0.8.3",
  "lazy_static",
  "lazycell",
@@ -309,7 +309,7 @@ dependencies = [
  "bitflags",
  "cexpr 0.6.0",
  "clang-sys",
- "clap",
+ "clap 2.33.0",
  "env_logger 0.9.0",
  "lazy_static",
  "lazycell",
@@ -577,7 +577,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
 dependencies = [
- "clap",
+ "clap 2.33.0",
  "heck 0.3.1",
  "indexmap",
  "log 0.4.11",
@@ -675,10 +675,40 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -793,7 +823,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.33.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -5232,6 +5262,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-seeded-ed25519-key-gen"
+version = "1.3.0-pre0"
+dependencies = [
+ "clap 3.1.6",
+ "hex",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "pem",
+ "rand 0.8.5",
+ "rand_hc 0.3.1",
+]
+
+[[package]]
 name = "mc-util-serial"
 version = "1.3.0-pre0"
 dependencies = [
@@ -5787,6 +5830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7425,12 +7477,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.33.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -7548,9 +7606,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -7563,6 +7621,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ members = [
     "util/metrics",
     "util/parse",
     "util/repr-bytes",
+    "util/seeded-ed25519-key-gen",
     "util/serial",
     "util/telemetry",
     "util/test-helper",

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mc-util-seeded-ed25519-key-gen"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+mc-crypto-keys = { path = "../../crypto/keys" }
+mc-util-from-random = { path = "../from-random" }
+
+clap = { version = "3.1", features = ["derive", "env"] }
+hex = "0.4"
+pem = "1.0"
+rand = "0.8"
+rand_hc = "0.3"

--- a/util/seeded-ed25519-key-gen/src/main.rs
+++ b/util/seeded-ed25519-key-gen/src/main.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A utility for generating a predictable Ed25519 private key from a seed, used
+//! for testing purposes.
+
+use clap::Parser;
+use hex::FromHex;
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair};
+use mc_util_from_random::FromRandom;
+use pem::{encode, Pem};
+use rand::SeedableRng;
+use rand_hc::Hc128Rng;
+
+#[derive(Parser)]
+#[clap(
+    name = "mc-util-seeded-ed25519-key-gen",
+    about = "A utility for generating a predictable Ed25519 private key from a seed, used for testing purposes."
+)]
+pub struct Config {
+    #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_SEED")]
+    seed: [u8; 32],
+}
+
+fn main() {
+    let config = Config::parse();
+
+    let mut rng: Hc128Rng = SeedableRng::from_seed(config.seed);
+    let keypair = Ed25519Pair::from_random(&mut rng);
+    let der_bytes = keypair.private_key().to_der();
+    let pem = encode(&Pem {
+        tag: String::from("PRIVATE KEY"),
+        contents: der_bytes,
+    });
+    println!("{}", pem);
+}


### PR DESCRIPTION
### Motivation

We want to include some predictable Ed25519 keys in our internal dev deployments, and there's currently no way to do that.

### In this PR
* A little utility that can generate a predictable Ed25519 key.
