### PR TITLE
circle ci --exclude fix attempt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --workspace --exclude "mc-fog-*" --exclude "mc-consensus-*" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4
+        default: cargo test --workspace --exclude "mc-fog-" --exclude "mc-consensus-" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4
     steps:
       - run:
           name: Run mobilecoin tests
@@ -392,7 +392,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
+            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-" -j 4 --frozen --no-fail-fast
       - run:
           command: |
             mkdir -p /tmp/core_dumps


### PR DESCRIPTION
try to remove the globs from `--exclude` in cargo invocations,
since ehuss says it's not implemented in some github comment,
and instead the implementation uses `starts_with()`, so maybe this
will have the effect we were seeking