### PR TITLE
Add Prometheus int counters that track peers

### DIFF
--- a/util/metrics/src/op_counters.rs
+++ b/util/metrics/src/op_counters.rs
@@ -16,6 +16,7 @@ use prometheus::{
 pub struct OpMetrics {
     module: String,
     counters: IntCounterVec,
+    peer_counters: IntCounterVec,
     gauges: IntGaugeVec,
     peer_gauges: IntGaugeVec,
     histograms: HistogramVec,
@@ -31,6 +32,14 @@ impl OpMetrics {
                 &["op"],
             )
             .unwrap(),
+            peer_counters: IntCounterVec::new(
+                Opts::new(
+                    format!("{}_peer_counter", name_str),
+                    format!("Counters for each remote peer of {}", name_str),
+                ),
+                &["op", "remote_responder_id"],
+            )
+            .unwrap(),
             gauges: IntGaugeVec::new(
                 Opts::new(
                     format!("{}_gauge", name_str),
@@ -42,7 +51,7 @@ impl OpMetrics {
             peer_gauges: IntGaugeVec::new(
                 Opts::new(
                     format!("{}_peer_gauge", name_str),
-                    format!("Gauges of each remote peer for {}", name_str),
+                    format!("Gauges for each remote peer of {}", name_str),
                 ),
                 &["op", "remote_responder_id"],
             )
@@ -82,6 +91,12 @@ impl OpMetrics {
     }
 
     #[inline]
+    pub fn peer_counter(&self, name: &str, remote_responder_id: &str) -> IntCounter {
+        self.peer_counters
+            .with_label_values(&[name, remote_responder_id])
+    }
+
+    #[inline]
     pub fn histogram(&self, name: &str) -> Histogram {
         self.histograms.with_label_values(&[name])
     }
@@ -94,6 +109,18 @@ impl OpMetrics {
     #[inline]
     pub fn inc_by(&self, op: &str, v: usize) {
         self.counters.with_label_values(&[op]).inc_by(v as u64);
+    }
+
+    #[inline]
+    pub fn inc_peer(&self, op: &str, peer: &str) {
+        self.peer_counters.with_label_values(&[op, peer]).inc();
+    }
+
+    #[inline]
+    pub fn inc_peer_by(&self, op: &str, v: usize, peer: &str) {
+        self.peer_counters
+            .with_label_values(&[op, peer])
+            .inc_by(v as u64);
     }
 
     #[inline]
@@ -127,6 +154,7 @@ impl Collector for OpMetrics {
     fn desc(&self) -> Vec<&Desc> {
         let mut ms = Vec::with_capacity(4);
         ms.extend(self.counters.desc());
+        ms.extend(self.peer_counters.desc());
         ms.extend(self.gauges.desc());
         ms.extend(self.peer_gauges.desc());
         ms.extend(self.histograms.desc());
@@ -136,6 +164,7 @@ impl Collector for OpMetrics {
     fn collect(&self) -> Vec<MetricFamily> {
         let mut ms = Vec::with_capacity(4);
         ms.extend(self.counters.collect());
+        ms.extend(self.peer_counters.collect());
         ms.extend(self.gauges.collect());
         ms.extend(self.peer_gauges.collect());
         ms.extend(self.histograms.collect());


### PR DESCRIPTION
### Motivation

Several situations have arisen where Prometheus counters that track (mostly misbehaving) peers would be very useful, this small PR addresses that need.

### In this PR
* Addition of peer counters
* Addition of helper methods for peer counters

Part of issue #1370 