### PR TITLE
removed pretty-assertions dependency from SCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,7 +663,7 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -1029,16 +1020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
-dependencies = [
- "quote 1.0.15",
- "syn 1.0.86",
-]
-
-[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,12 +1160,6 @@ dependencies = [
  "migrations_internals",
  "migrations_macros",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "difflib"
@@ -3003,7 +2978,6 @@ dependencies = [
  "mc-util-serial",
  "mc-util-test-helper",
  "mockall",
- "pretty_assertions",
  "rand 0.8.5",
  "rand_hc 0.3.1",
  "serde",
@@ -5843,15 +5817,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "packed_simd_2"
 version = "0.3.5"
 source = "git+https://github.com/rust-lang/packed_simd.git?rev=064df9b1869b942fa768bfa83596f6965fa858c8#064df9b1869b942fa768bfa83596f6965fa858c8"
@@ -6109,18 +6074,6 @@ checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 dependencies = [
  "predicates-core",
  "treeline",
-]
-
-[[package]]
-name = "pretty_assertions"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c038cb5319b9c704bf9c227c261d275bfec0ad438118a2787ce47944fb228b"
-dependencies = [
- "ansi_term 0.12.1",
- "ctor",
- "diff",
- "output_vt100",
 ]
 
 [[package]]

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -31,6 +31,5 @@ mc-util-logger-macros = { path = "../../util/logger-macros" }
 mc-util-test-helper = { path = "../../util/test-helper" }
 
 crossbeam-channel = "0.5"
-pretty_assertions = "1.2.0"
 serial_test = "0.6"
 tempdir = "0.3"

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -2408,7 +2408,6 @@ mod ballot_protocol_tests {
     use crate::{core_types::*, quorum_set::*, test_utils::*};
     use maplit::{btreeset, hashset};
     use mc_common::logger::test_with_logger;
-    use pretty_assertions::assert_eq;
     use std::iter::FromIterator;
 
     // TODO: reject a message if it contains a ballot containing incorrectly ordered


### PR DESCRIPTION
### Motivation

there was no need for the pretty-assertions dependency

### In this PR
removed the dependency

fixes #1437 

