### PR TITLE
Feature/no panic on unparsable sealed key

### DIFF
--- a/attest/core/src/lib.rs
+++ b/attest/core/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
         EpidPseudonymError, IasQuoteError, IasQuoteResult, JsonError, NonceError, PibError,
         PseManifestError, PseManifestHashError, PseManifestResult, QuoteError, QuoteSignTypeError,
         QuoteVerifyError, ReportBodyVerifyError, ReportDetailsError, RevocationCause, SgxError,
-        SgxResult, SignatureError, TargetInfoError, VerifyError,
+        SgxResult, SignatureError, TargetInfoError, VerifyError
     },
     ias::verify::{
         EpidPseudonym, VerificationReport, VerificationReportData, VerificationSignature,
@@ -31,7 +31,7 @@ pub use crate::{
     nonce::{IasNonce, Nonce, QuoteNonce},
     quote::{Quote, QuoteSignType},
     report::Report,
-    seal::{IntelSealed, ParseSealedError, Sealed},
+    seal::{IntelSealed, ParseSealedError, Sealed, IntelSealingError},
     sigrl::SigRL,
     types::{
         attributes::Attributes,

--- a/attest/core/src/lib.rs
+++ b/attest/core/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::{
         EpidPseudonymError, IasQuoteError, IasQuoteResult, JsonError, NonceError, PibError,
         PseManifestError, PseManifestHashError, PseManifestResult, QuoteError, QuoteSignTypeError,
         QuoteVerifyError, ReportBodyVerifyError, ReportDetailsError, RevocationCause, SgxError,
-        SgxResult, SignatureError, TargetInfoError, VerifyError
+        SgxResult, SignatureError, TargetInfoError, VerifyError,
     },
     ias::verify::{
         EpidPseudonym, VerificationReport, VerificationReportData, VerificationSignature,
@@ -31,7 +31,7 @@ pub use crate::{
     nonce::{IasNonce, Nonce, QuoteNonce},
     quote::{Quote, QuoteSignType},
     report::Report,
-    seal::{IntelSealed, ParseSealedError, Sealed, IntelSealingError},
+    seal::{IntelSealed, IntelSealingError, ParseSealedError, Sealed},
     sigrl::SigRL,
     types::{
         attributes::Attributes,

--- a/attest/core/src/seal.rs
+++ b/attest/core/src/seal.rs
@@ -9,10 +9,9 @@ use crate::SgxError;
 use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt::Display as DisplayTrait};
 use displaydoc::Display;
-use prost::Message;
 use mc_sgx_types::sgx_status_t;
-use serde::{Serialize, Deserialize};
-
+use prost::Message;
+use serde::{Deserialize, Serialize};
 
 /// A `Sealed<T>` is a Sealed representation of a T, with some additional
 /// mac text which has been computed from T and whcih is visible.

--- a/attest/core/src/seal.rs
+++ b/attest/core/src/seal.rs
@@ -11,7 +11,7 @@ use core::{convert::TryFrom, fmt::Display as DisplayTrait};
 use displaydoc::Display;
 use prost::Message;
 use mc_sgx_types::sgx_status_t;
-use serde::{ser::Serialize, de::Deserialize};
+use serde::{Serialize, Deserialize};
 
 
 /// A `Sealed<T>` is a Sealed representation of a T, with some additional
@@ -190,7 +190,7 @@ pub fn get_add_mac_txt_offset(sealed_data: &[u8]) -> Result<u32, ParseSealedErro
     Ok(result)
 }
 
-#[derive(Clone, Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, PartialOrd, Serialize)]
 pub enum ParseSealedError {
     /// Byte range is too short to be a sealed blob: {0} < {1}
     TooShort(usize, usize),
@@ -205,7 +205,7 @@ pub enum ParseSealedError {
 
 /// Represents an error that can occur during sealing an IntelSealed blob
 /// This is the error type of seal_raw
-#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, PartialOrd, Serialize)]
 pub enum IntelSealingError {
     /// SGX error: {0}
     Sgx(SgxError),

--- a/attest/trusted/src/lib.rs
+++ b/attest/trusted/src/lib.rs
@@ -15,8 +15,8 @@ use displaydoc::Display;
 use mc_attest_core::{
     IntelSealed, ParseSealedError, Report, ReportData, Sealed, SgxError, SgxResult, TargetInfo,
 };
-use mc_sgx_types::sgx_status_t;
 use prost::Message;
+use mc_attest_core::IntelSealingError;
 
 /// Methods on the `mc_attest_core::Report` object which are only usable inside
 /// a running SGX enclave.
@@ -92,34 +92,6 @@ impl SealAlgo for IntelSealed {
         let mut mac_txt = vec![0u8; mac_txt_len as usize];
         mc_sgx_compat::unseal_data(self.as_ref(), &mut plaintext[..], &mut mac_txt[..])?;
         Ok((plaintext, mac_txt))
-    }
-}
-
-/// Represents an error that can occur during sealing an IntelSealed blob
-/// This is the error type of seal_raw
-#[derive(Clone, Debug, Display, Eq, PartialEq)]
-pub enum IntelSealingError {
-    /// SGX error: {0}
-    Sgx(SgxError),
-    /// Bad sealed format: {0}
-    SealFormat(ParseSealedError),
-}
-
-impl From<SgxError> for IntelSealingError {
-    fn from(src: SgxError) -> Self {
-        Self::Sgx(src)
-    }
-}
-
-impl From<sgx_status_t> for IntelSealingError {
-    fn from(src: sgx_status_t) -> Self {
-        Self::Sgx(SgxError::from(src))
-    }
-}
-
-impl From<ParseSealedError> for IntelSealingError {
-    fn from(src: ParseSealedError) -> Self {
-        Self::SealFormat(src)
     }
 }
 

--- a/attest/trusted/src/lib.rs
+++ b/attest/trusted/src/lib.rs
@@ -13,10 +13,10 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 use displaydoc::Display;
 use mc_attest_core::{
-    IntelSealed, ParseSealedError, Report, ReportData, Sealed, SgxError, SgxResult, TargetInfo,
+    IntelSealed, IntelSealingError, ParseSealedError, Report, ReportData, Sealed, SgxError,
+    SgxResult, TargetInfo,
 };
 use prost::Message;
-use mc_attest_core::IntelSealingError;
 
 /// Methods on the `mc_attest_core::Report` object which are only usable inside
 /// a running SGX enclave.

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -16,7 +16,7 @@ use mc_util_serial::{
     DecodeError as ProstDecodeError, EncodeError as ProstEncodeError,
 };
 use serde::{Deserialize, Serialize};
-use mc_attest_core::IntelSealingError;
+use mc_attest_core::{IntelSealingError, ParseSealedError};
 
 /// An enumeration of errors which can occur inside a consensus enclave.
 #[derive(Clone, Debug, Deserialize, Display, PartialEq, PartialOrd, Serialize)]
@@ -65,6 +65,12 @@ pub enum Error {
     
     /// Sealing Error: {0}
     IntelSealing(IntelSealingError)
+}
+
+impl From<ParseSealedError> for Error {
+    fn from(src: ParseSealedError) -> Self {
+        Error::IntelSealing(src.into())
+    }
 }
 
 impl From<IntelSealingError> for Error {

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -5,7 +5,7 @@
 use crate::FeeMapError;
 use alloc::string::String;
 use displaydoc::Display;
-use mc_attest_core::SgxError;
+use mc_attest_core::{IntelSealingError, ParseSealedError, SgxError};
 use mc_attest_enclave_api::Error as AttestEnclaveError;
 use mc_crypto_keys::SignatureError;
 use mc_crypto_message_cipher::CipherError as MessageCipherError;
@@ -16,7 +16,6 @@ use mc_util_serial::{
     DecodeError as ProstDecodeError, EncodeError as ProstEncodeError,
 };
 use serde::{Deserialize, Serialize};
-use mc_attest_core::{IntelSealingError, ParseSealedError};
 
 /// An enumeration of errors which can occur inside a consensus enclave.
 #[derive(Clone, Debug, Deserialize, Display, PartialEq, PartialOrd, Serialize)]
@@ -62,9 +61,9 @@ pub enum Error {
 
     /// Block Version Error: {0}
     BlockVersion(String),
-    
+
     /// Sealing Error: {0}
-    IntelSealing(IntelSealingError)
+    IntelSealing(IntelSealingError),
 }
 
 impl From<ParseSealedError> for Error {

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -16,6 +16,7 @@ use mc_util_serial::{
     DecodeError as ProstDecodeError, EncodeError as ProstEncodeError,
 };
 use serde::{Deserialize, Serialize};
+use mc_attest_core::IntelSealingError;
 
 /// An enumeration of errors which can occur inside a consensus enclave.
 #[derive(Clone, Debug, Deserialize, Display, PartialEq, PartialOrd, Serialize)]
@@ -61,6 +62,15 @@ pub enum Error {
 
     /// Block Version Error: {0}
     BlockVersion(String),
+    
+    /// Sealing Error: {0}
+    IntelSealing(IntelSealingError)
+}
+
+impl From<IntelSealingError> for Error {
+    fn from(src: IntelSealingError) -> Self {
+        Error::IntelSealing(src)
+    }
 }
 
 impl From<MessageCipherError> for Error {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -329,10 +329,10 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         match sealed_key {
             Some(sealed) => {
                 log::trace!(self.logger, "trying to unseal key");
-                let cached = IntelSealed::try_from(sealed.clone()).unwrap();
+                let cached = IntelSealed::try_from(sealed.clone())?;
                 let (key, _mac) = cached.unseal_raw()?;
                 let mut lock = self.ake.get_identity().signing_keypair.lock().unwrap();
-                *lock = Ed25519Pair::try_from(&key[..]).unwrap();
+                *lock = Ed25519Pair::try_from(&key[..])?;
             }
             None => (),
         }
@@ -340,7 +340,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Either way seal the private key and return it.
         let lock = self.ake.get_identity().signing_keypair.lock().unwrap();
         let key = (*lock).private_key();
-        let sealed = IntelSealed::seal_raw(key.as_ref(), &[]).unwrap();
+        let sealed = IntelSealed::seal_raw(key.as_ref(), &[])?;
 
         Ok((
             sealed.as_ref().to_vec(),

--- a/fog/ingest/enclave/api/src/error.rs
+++ b/fog/ingest/enclave/api/src/error.rs
@@ -4,7 +4,8 @@
 
 use displaydoc::Display;
 use mc_attest_core::{
-    NonceError, ParseSealedError, QuoteError, SgxError, SignatureError, VerifyError,
+    IntelSealingError, NonceError, ParseSealedError, QuoteError, SgxError, SignatureError,
+    VerifyError,
 };
 use mc_attest_enclave_api::Error as AttestEnclaveError;
 use mc_crypto_keys::KeyError;
@@ -122,6 +123,12 @@ impl From<AttestEnclaveError> for Error {
 impl From<NonceError> for Error {
     fn from(src: NonceError) -> Error {
         Error::Nonce(src)
+    }
+}
+
+impl From<IntelSealingError> for Error {
+    fn from(src: IntelSealingError) -> Error {
+        src.into()
     }
 }
 

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -20,7 +20,8 @@ use aligned_cmov::{typenum::U32, A8Bytes, Aligned, GenericArray};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use mc_attest_core::{
-    IasNonce, IntelSealed, IntelSealingError, Quote, QuoteNonce, Report, TargetInfo, VerificationReport,
+    IasNonce, IntelSealed, IntelSealingError, Quote, QuoteNonce, Report, TargetInfo,
+    VerificationReport,
 };
 use mc_attest_enclave_api::{
     EnclaveMessage, Error as AttestEnclaveError, PeerAuthRequest, PeerAuthResponse, PeerSession,

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -20,8 +20,7 @@ use aligned_cmov::{typenum::U32, A8Bytes, Aligned, GenericArray};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use mc_attest_core::{
-    IasNonce, IntelSealed, IntelSealingError, Quote, QuoteNonce, Report, TargetInfo,
-    VerificationReport,
+    IasNonce, IntelSealed, Quote, QuoteNonce, Report, TargetInfo, VerificationReport,
 };
 use mc_attest_enclave_api::{
     EnclaveMessage, Error as AttestEnclaveError, PeerAuthRequest, PeerAuthResponse, PeerSession,
@@ -383,18 +382,5 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> IngestEnclave
 
 // Helper for sealing a key, which maps the error to IngestEnclaveError
 fn seal_private_key(src: &RistrettoPrivate) -> Result<SealedIngestKey> {
-    Ok(IntelSealed::seal_raw(src.as_ref(), &[])
-        .map_err(map_sealing_error)?
-        .as_ref()
-        .to_vec())
-}
-
-// Helper for converting error type living only in mc_attest_trusted to the
-// error type in enclave_api (The attest_trusted crate will not compile in
-// non-sgx environment.)
-fn map_sealing_error(src: IntelSealingError) -> Error {
-    match src {
-        IntelSealingError::Sgx(err) => err.into(),
-        IntelSealingError::SealFormat(err) => err.into(),
-    }
+    Ok(IntelSealed::seal_raw(src.as_ref(), &[])?.as_ref().to_vec())
 }

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -20,12 +20,12 @@ use aligned_cmov::{typenum::U32, A8Bytes, Aligned, GenericArray};
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use mc_attest_core::{
-    IasNonce, IntelSealed, Quote, QuoteNonce, Report, TargetInfo, VerificationReport,
+    IasNonce, IntelSealed, IntelSealingError, Quote, QuoteNonce, Report, TargetInfo, VerificationReport,
 };
 use mc_attest_enclave_api::{
     EnclaveMessage, Error as AttestEnclaveError, PeerAuthRequest, PeerAuthResponse, PeerSession,
 };
-use mc_attest_trusted::{IntelSealingError, SealAlgo};
+use mc_attest_trusted::SealAlgo;
 use mc_common::{logger::Logger, ResponderId};
 use mc_crypto_ake_enclave::AkeEnclaveState;
 use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
@@ -391,7 +391,7 @@ fn seal_private_key(src: &RistrettoPrivate) -> Result<SealedIngestKey> {
 // Helper for converting error type living only in mc_attest_trusted to the
 // error type in enclave_api (The attest_trusted crate will not compile in
 // non-sgx environment.)
-fn map_sealing_error(src: mc_attest_trusted::IntelSealingError) -> Error {
+fn map_sealing_error(src: IntelSealingError) -> Error {
     match src {
         IntelSealingError::Sgx(err) => err.into(),
         IntelSealingError::SealFormat(err) => err.into(),


### PR DESCRIPTION
Previously `ConsensusEnclave::enclave_init` would panic if there was a failure parsing or sealing the key.  Now an an ` mc_attest_core::IntelSealingError` is provided back.

### In this PR
fixes: #287

