### PR TITLE
Mint client improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,8 @@ dependencies = [
  "mc-util-uri",
  "pem",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -29,3 +29,5 @@ grpcio = "0.10.0"
 hex = "0.4"
 pem = "1.0"
 rand = "0.8"
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_json = "1.0"

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -13,7 +13,7 @@ use mc_transaction_core::mint::{
 };
 use mc_util_uri::ConsensusClientUri;
 use rand::{thread_rng, RngCore};
-use std::{convert::TryFrom, fs};
+use std::{convert::TryFrom, fs, path::PathBuf};
 
 #[derive(Args)]
 pub struct MintConfigTxParams {
@@ -165,6 +165,28 @@ pub enum Commands {
 
         #[clap(flatten)]
         params: MintConfigTxParams,
+    },
+
+    // Generate a MintConfigTx and write it to a JSON file.
+    GenerateMintConfigTx {
+        /// Filename to write the mint configuration to.
+        #[clap(long, env = "MC_MINTING_OUT_FILE")]
+        out: PathBuf,
+
+        #[clap(flatten)]
+        params: MintConfigTxParams,
+    },
+
+    // Submit json-encoded MintConfigTx(s). If multiple transactions are provided, signatures will
+    // be merged.
+    SubmitMintConfigTxs {
+        /// URI of consensus node to connect to.
+        #[clap(long, env = "MC_CONSENSUS_URI")]
+        node: ConsensusClientUri,
+
+        /// Filename to read the mint configuration from.
+        #[clap(long = "tx", required(true), env = "MC_MINTING_TXS")]
+        tx_filenames: Vec<PathBuf>,
     },
 
     /// Generate and submit a MintTx transaction.

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -6,7 +6,8 @@ use clap::{Parser, Subcommand};
 use hex::FromHex;
 use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
-use mc_crypto_keys::{DistinguishedEncoding, Ed25519Private};
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Private, Ed25519Public};
+use mc_crypto_multisig::SignerSet;
 use mc_transaction_core::mint::constants::NONCE_LENGTH;
 use mc_util_uri::ConsensusClientUri;
 use std::{convert::TryFrom, fs};
@@ -35,6 +36,16 @@ pub enum Commands {
         /// Nonce.
         #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_NONCE")]
         nonce: Option<[u8; NONCE_LENGTH]>,
+
+        /// Mint configs. Each configuration must be of the format: <mint
+        /// limit>:<signing threshold>:<signer 1 public keyfile>[:<signer 2
+        /// public keyfile....>]. For example:
+        /// 10000:2:signer1.pem:signer2.pem:signer3.pem defines a minting
+        /// configuration capable of minting up to 1000 tokens: and requiring 2
+        /// out of 3 signers.
+        #[clap(long = "config", parse(try_from_str = parse_mint_config), env = "MC_MINTING_CONFIGS")]
+        // Tuple of (mint limit, SignerSet)
+        configs: Vec<(u64, SignerSet<Ed25519Public>)>,
     },
 
     /// Generate and submit a MintTx transaction.
@@ -44,9 +55,9 @@ pub enum Commands {
         #[clap(long, env = "MC_CONSENSUS_URI")]
         node: ConsensusClientUri,
 
-        /// The key to sign the transaction with.
-        #[clap(long, parse(try_from_str = load_key_from_pem), env = "MC_MINTING_SIGNING_KEY")]
-        signing_key: Ed25519Private,
+        /// The key(s) to sign the transaction with.
+        #[clap(long = "signing-key", required(true), parse(try_from_str = load_key_from_pem), env = "MC_MINTING_SIGNING_KEY")]
+        signing_keys: Vec<Ed25519Private>,
 
         /// The b58 address we are minting to.
         #[clap(long, parse(try_from_str = parse_public_address), env = "MC_MINTING_RECIPIENT")]
@@ -110,4 +121,54 @@ fn parse_public_address(b58: &str) -> Result<PublicAddress, String> {
     } else {
         Err(format!("b58 address '{}' is not a public address", b58))
     }
+}
+
+/// Parses a minting limit and signer set from a string in the format:
+/// mint limit:threshold:keyfile1.pem[:keyfile2.pem...]
+fn parse_mint_config(src: &str) -> Result<(u64, SignerSet<Ed25519Public>), String> {
+    let parts = src.split(':').collect::<Vec<_>>();
+
+    // At the minimum we should have 3 parts: mint limit, signing threshold, one
+    // public key file
+    if parts.len() < 3 {
+        return Err(format!(
+            "mint config '{}' is not in the correct format",
+            src
+        ));
+    }
+
+    // Parse the mint limit and signing theshold
+    let mint_limit = parts[0]
+        .parse::<u64>()
+        .map_err(|err| format!("failed parsing mint limit '{}': {}", parts[0], err))?;
+    let threshold = parts[1]
+        .parse::<u32>()
+        .map_err(|err| format!("failed parsing signing threshold '{}': {}", parts[1], err))?;
+
+    // Load public keys
+    let public_keys = parts[2..]
+        .iter()
+        .map(|filename| {
+            let bytes = fs::read(filename)
+                .map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+
+            let parsed_pem = pem::parse(&bytes)
+                .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
+
+            Ed25519Public::try_from_der(&parsed_pem.contents[..])
+                .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Sanity check signing threshold against keys
+    if threshold > public_keys.len() as u32 {
+        return Err(format!(
+            "signing threshold '{}' is greater than the number of public keys '{}'",
+            threshold,
+            public_keys.len()
+        ));
+    }
+
+    // Success.
+    Ok((mint_limit, SignerSet::new(public_keys, threshold)))
 }

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -134,6 +134,11 @@ mod tests {
     }
 
     #[test]
+    fn validate_configs_accepts_no_configs() {
+        assert!(validate_configs(123, &[]).is_ok());
+    }
+
+    #[test]
     fn validate_configs_rejects_mismatching_token_ids() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let signer_1 = Ed25519Pair::from_random(&mut rng);


### PR DESCRIPTION
### Motivation

We'd like the mint client to support offline signing flow, as well as multi-signatures.
Additionally, we'd like the minting client to support properly specifying mint configurations.

### In this PR
* Evolve `mc-consensus-mint-client` to support passing mint configurations via command line (previously hardcoded)
* Add support for writing generated txs into a JSON file
* Add support for gathering a few txs stored in JSON files, merging their signatures and submitting to consensus

