### PR TITLE
Add Xcode 12 Check

### DIFF
--- a/libmobilecoin/Makefile
+++ b/libmobilecoin/Makefile
@@ -90,6 +90,8 @@ bitcode-init:
 
 .PHONY: setup
 setup:
+	$(info "Checking selected Xcode is version 12")
+	xcodebuild -version | grep 'Xcode 12'
 	mkdir -p rust-bitcode
 	cd rust-bitcode && \
 	git init && \


### PR DESCRIPTION
Soundtrack of this PR: [Bok Bok - Papaya Lipgloss](https://youtu.be/MsIBb8IhF6Q)

### Motivation

`mobilecoin/libmobilecoin` will make static libraries that return `BadSignature` errors if "compiled with Xcode 13". Adding a check in the Makefile stops the problem early.

### In this PR
* Check that the version of Xcode `xcode-select`  is pointing to is version 12

Output if the user has Xcode 13 selected
```bash
$ sudo xcode-select -s /Applications/Xcode.app/Contents/Developer                                                                                                                                                                                                                                              
$ make                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
profile: mobile-release
"Checking selected Xcode is version 12"
xcodebuild -version | grep 'Xcode 12'
make: *** [setup] Error 1
```

### Future Work
* Fix underlying issue

