### PR TITLE
form_block unit tests for MintTx/MintConfigTx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-message-cipher",
+ "mc-crypto-multisig",
  "mc-crypto-rand",
  "mc-ledger-db",
  "mc-sgx-compat",

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -49,6 +49,7 @@ rand_core = { version = "0.6", default-features = false }
 
 [dev-dependencies]
 mc-common = { path = "../../../common", features = ["loggers"] }
+mc-crypto-multisig = { path = "../../../crypto/multisig" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2184,7 +2184,7 @@ mod tests {
             if let Err(Error::FormBlock(description)) = form_block_result {
                 assert!(description.contains("Duplicate MintConfigTx"));
             } else {
-                panic!("Expected result");
+                panic!("Expected FormBlock error, got: {:#?}", form_block_result);
             }
         }
     }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -703,6 +703,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 )
             })
             .collect::<Result<Vec<TxOut>>>()?;
+
         // Get the list of MintTxs included in the block.
         self.validate_mint_txs(&inputs.mint_txs)?;
         let mint_txs = inputs.mint_txs;
@@ -1839,6 +1840,73 @@ mod tests {
                 .unwrap();
             assert_eq!(amount.value, 200);
             assert_eq!(amount.token_id, token_id2);
+        }
+    }
+
+    #[test_with_logger]
+    fn form_block_rejects_duplicate_mint_tx(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+
+        let (_mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+
+        let recipient1 = AccountKey::random(&mut rng);
+
+        let mint_tx1 = create_mint_tx_to_recipient(
+            token_id1,
+            &signers1,
+            12,
+            &recipient1.default_subaddress(),
+            &mut rng,
+        );
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1)]).unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let form_block_result = enclave.form_block(
+                &parent_block,
+                FormBlockInputs {
+                    mint_txs: vec![mint_tx1.clone(), mint_tx1.clone()],
+                    ..Default::default()
+                },
+                &root_element,
+            );
+
+            assert!(form_block_result.is_err());
         }
     }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1909,4 +1909,154 @@ mod tests {
             assert!(form_block_result.is_err());
         }
     }
+
+    #[test_with_logger]
+    fn form_block_accepts_valid_mint_config_txs(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+        let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
+                .unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let (block, block_contents, signature) = enclave
+                .form_block(
+                    &parent_block,
+                    FormBlockInputs {
+                        mint_config_txs: vec![mint_config_tx1.clone(), mint_config_tx2.clone()],
+                        ..Default::default()
+                    },
+                    &root_element,
+                )
+                .unwrap();
+
+            // Verify signature
+            assert_eq!(
+                signature.signer(),
+                &enclave
+                    .ake
+                    .get_identity()
+                    .signing_keypair
+                    .lock()
+                    .unwrap()
+                    .public_key()
+            );
+
+            assert!(signature.verify(&block).is_ok());
+
+            // The block contents should contain the two mint config txs.
+            assert_eq!(
+                block_contents.mint_config_txs,
+                vec![mint_config_tx1.clone(), mint_config_tx2.clone()]
+            );
+
+            // There should be no outputs, key images or mint txs
+            assert!(block_contents.outputs.is_empty());
+            assert!(block_contents.key_images.is_empty());
+            assert!(block_contents.mint_txs.is_empty());
+        }
+    }
+
+    #[test_with_logger]
+    fn form_block_rejects_mint_config_tx_for_unknown_token(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let (mint_config_tx1, _signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+        let (_mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
+
+        let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id2, signer_set2)]).unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let form_block_result = enclave.form_block(
+                &parent_block,
+                FormBlockInputs {
+                    mint_config_txs: vec![mint_config_tx1.clone()],
+                    ..Default::default()
+                },
+                &root_element,
+            );
+
+            assert_eq!(
+                form_block_result,
+                Err(Error::MalformedMintingTx(
+                    MintValidationError::NoMasterMinters(TokenId::from(1))
+                ))
+            )
+        }
+    }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -821,14 +821,18 @@ fn mint_output<T: Digestible>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use mc_common::logger::test_with_logger;
+    use mc_consensus_enclave_api::MasterMintersMap;
+    use mc_crypto_multisig::SignerSet;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
         tokens::Mob, tx::TxOutMembershipHash, validation::TransactionValidationError, BlockVersion,
         Token,
     };
     use mc_transaction_core_test_utils::{
-        create_ledger, create_transaction, initialize_ledger, AccountKey,
+        create_ledger, create_mint_config_tx_and_signers, create_mint_tx_to_recipient,
+        create_transaction, initialize_ledger, AccountKey,
     };
     use rand_core::SeedableRng;
     use rand_hc::Hc128Rng;
@@ -1699,6 +1703,142 @@ mod tests {
                     "Expected a BlockVersion error due to config.block_version being less than parent"
                 ),
             }
+        }
+    }
+
+    #[test_with_logger]
+    fn form_block_can_mint_new_tokens(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let (_mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+        let (_mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
+
+        let recipient1 = AccountKey::random(&mut rng);
+        let recipient2 = AccountKey::random(&mut rng);
+
+        let mint_tx1 = create_mint_tx_to_recipient(
+            token_id1,
+            &signers1,
+            12,
+            &recipient1.default_subaddress(),
+            &mut rng,
+        );
+        let mint_tx2 = create_mint_tx_to_recipient(
+            token_id2,
+            &signers2,
+            200,
+            &recipient2.default_subaddress(),
+            &mut rng,
+        );
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
+                .unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let (block, block_contents, signature) = enclave
+                .form_block(
+                    &parent_block,
+                    FormBlockInputs {
+                        mint_txs: vec![mint_tx1.clone(), mint_tx2.clone()],
+                        ..Default::default()
+                    },
+                    &root_element,
+                )
+                .unwrap();
+
+            // Verify signature
+            assert_eq!(
+                signature.signer(),
+                &enclave
+                    .ake
+                    .get_identity()
+                    .signing_keypair
+                    .lock()
+                    .unwrap()
+                    .public_key()
+            );
+
+            assert!(signature.verify(&block).is_ok());
+
+            // The block contents should contain the two mint txs.
+            assert_eq!(
+                block_contents.mint_txs,
+                vec![mint_tx1.clone(), mint_tx2.clone()]
+            );
+
+            // There should be no key images or mint config txs
+            assert!(block_contents.key_images.is_empty());
+            assert!(block_contents.mint_config_txs.is_empty());
+
+            // The block contents should contain the minted tx outs.
+            assert_eq!(block_contents.outputs.len(), 2);
+
+            let output1 = block_contents
+                .outputs
+                .iter()
+                .find(|output| {
+                    output
+                        .view_key_match(&recipient1.view_private_key())
+                        .is_ok()
+                })
+                .unwrap();
+            let (amount, _) = output1
+                .view_key_match(&recipient1.view_private_key())
+                .unwrap();
+            assert_eq!(amount.value, 12);
+            assert_eq!(amount.token_id, token_id1);
+
+            let output2 = block_contents
+                .outputs
+                .iter()
+                .find(|output| {
+                    output
+                        .view_key_match(&recipient2.view_private_key())
+                        .is_ok()
+                })
+                .unwrap();
+            let (amount, _) = output2
+                .view_key_match(&recipient2.view_private_key())
+                .unwrap();
+            assert_eq!(amount.value, 200);
+            assert_eq!(amount.token_id, token_id2);
         }
     }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2188,4 +2188,268 @@ mod tests {
             }
         }
     }
+
+    #[test_with_logger]
+    fn test_form_block_with_both_regular_outputs_and_mint_txs_works(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let (_mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+        let (_mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
+
+        let recipient1 = AccountKey::random(&mut rng);
+        let recipient2 = AccountKey::random(&mut rng);
+
+        let mint_tx1 = create_mint_tx_to_recipient(
+            token_id1,
+            &signers1,
+            12,
+            &recipient1.default_subaddress(),
+            &mut rng,
+        );
+        let mint_tx2 = create_mint_tx_to_recipient(
+            token_id2,
+            &signers2,
+            200,
+            &recipient2.default_subaddress(),
+            &mut rng,
+        );
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
+                .unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Create a valid test transaction.
+            let sender = AccountKey::random(&mut rng);
+            let recipient = AccountKey::random(&mut rng);
+
+            let mut ledger = create_ledger();
+            let n_blocks = 1;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Spend outputs from the origin block.
+            let origin_block_contents = ledger.get_block_contents(0).unwrap();
+
+            let input_transactions: Vec<Tx> = (0..3)
+                .map(|i| {
+                    let tx_out = origin_block_contents.outputs[i].clone();
+
+                    create_transaction(
+                        block_version,
+                        &mut ledger,
+                        &tx_out,
+                        &sender,
+                        &recipient.default_subaddress(),
+                        n_blocks + 1,
+                        &mut rng,
+                    )
+                })
+                .collect();
+
+            let total_fee: u64 = input_transactions.iter().map(|tx| tx.prefix.fee).sum();
+
+            // Create WellFormedEncryptedTxs + proofs
+            let well_formed_encrypted_txs_with_proofs: Vec<_> = input_transactions
+                .iter()
+                .map(|tx| {
+                    let well_formed_tx = WellFormedTx::from(tx.clone());
+                    let encrypted_tx = enclave
+                        .encrypt_well_formed_tx(&well_formed_tx, &mut rng)
+                        .unwrap();
+
+                    let highest_indices = well_formed_tx.tx.get_membership_proof_highest_indices();
+                    let membership_proofs = ledger
+                        .get_tx_out_proof_of_memberships(&highest_indices)
+                        .expect("failed getting proof");
+                    (encrypted_tx, membership_proofs)
+                })
+                .collect();
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let (block, block_contents, signature) = enclave
+                .form_block(
+                    &parent_block,
+                    FormBlockInputs {
+                        well_formed_encrypted_txs_with_proofs,
+                        mint_txs: vec![mint_tx1.clone(), mint_tx2.clone()],
+                        ..Default::default()
+                    },
+                    &root_element,
+                )
+                .unwrap();
+
+            // Verify signature.
+            {
+                assert_eq!(
+                    signature.signer(),
+                    &enclave
+                        .ake
+                        .get_identity()
+                        .signing_keypair
+                        .lock()
+                        .unwrap()
+                        .public_key()
+                );
+
+                assert!(signature.verify(&block).is_ok());
+            }
+
+            // `block_contents` should include the aggregate fee and two minted outputs.
+
+            let num_outputs: usize = input_transactions
+                .iter()
+                .map(|tx| tx.prefix.outputs.len())
+                .sum();
+            assert_eq!(num_outputs + 3, block_contents.outputs.len());
+
+            // One of the outputs should be the aggregate fee.
+            let fee_view_key = RistrettoPrivate::try_from(&FEE_VIEW_PRIVATE_KEY).unwrap();
+
+            let fee_output = block_contents
+                .outputs
+                .iter()
+                .find(|output| output.view_key_match(&fee_view_key).is_ok())
+                .unwrap();
+
+            // The value of the aggregate fee should equal the total value of fees in the
+            // input transaction.
+            let (amount, _) = fee_output.view_key_match(&fee_view_key).unwrap();
+            assert_eq!(amount.value, total_fee);
+            assert_eq!(amount.token_id, Mob::ID);
+
+            // The block contents should contain the two mint txs.
+            assert_eq!(
+                block_contents.mint_txs,
+                vec![mint_tx1.clone(), mint_tx2.clone()]
+            );
+
+            // There should be no mint config txs
+            assert!(block_contents.mint_config_txs.is_empty());
+
+            // The block contents should contain the minted tx outs.
+            let output1 = block_contents
+                .outputs
+                .iter()
+                .find(|output| {
+                    output
+                        .view_key_match(&recipient1.view_private_key())
+                        .is_ok()
+                })
+                .unwrap();
+            let (amount, _) = output1
+                .view_key_match(&recipient1.view_private_key())
+                .unwrap();
+            assert_eq!(amount.value, 12);
+            assert_eq!(amount.token_id, token_id1);
+
+            let output2 = block_contents
+                .outputs
+                .iter()
+                .find(|output| {
+                    output
+                        .view_key_match(&recipient2.view_private_key())
+                        .is_ok()
+                })
+                .unwrap();
+            let (amount, _) = output2
+                .view_key_match(&recipient2.view_private_key())
+                .unwrap();
+            assert_eq!(amount.value, 200);
+            assert_eq!(amount.token_id, token_id2);
+        }
+    }
+
+    #[test_with_logger]
+    fn form_block_refuses_mint_config_txs_for_unsupported_block_versions(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+        let token_id2 = TokenId::from(2);
+
+        let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+        let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
+                .unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let form_block_result = enclave.form_block(
+                &parent_block,
+                FormBlockInputs {
+                    mint_config_txs: vec![mint_config_tx1.clone(), mint_config_tx2.clone()],
+                    ..Default::default()
+                },
+                &root_element,
+            );
+
+            assert_eq!(
+                form_block_result,
+                Err(Error::MalformedMintingTx(
+                    MintValidationError::InvalidBlockVersion(block_version)
+                ))
+            );
+        }
+    }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2059,4 +2059,69 @@ mod tests {
             )
         }
     }
+
+    #[test_with_logger]
+    fn form_block_rejects_mint_config_tx_with_invalid_signature(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([77u8; 32]);
+
+        let token_id1 = TokenId::from(1);
+
+        let (mut mint_config_tx1, signers1) =
+            create_mint_config_tx_and_signers(token_id1, &mut rng);
+
+        let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+
+        // This will invalidate the signature.
+        mint_config_tx1.prefix.tombstone_block += 1;
+
+        let master_minters_map =
+            MasterMintersMap::try_from_iter([(token_id1, signer_set1)]).unwrap();
+
+        for block_version in BlockVersion::iterator() {
+            if !block_version.mint_transactions_are_supported() {
+                continue;
+            }
+
+            let enclave = SgxConsensusEnclave::new(logger.clone());
+            let blockchain_config = BlockchainConfig {
+                block_version,
+                master_minters_map: master_minters_map.clone(),
+                ..Default::default()
+            };
+            enclave
+                .enclave_init(
+                    &Default::default(),
+                    &Default::default(),
+                    &None,
+                    blockchain_config,
+                )
+                .unwrap();
+
+            // Initialize a ledger.
+            let sender = AccountKey::random(&mut rng);
+            let mut ledger = create_ledger();
+            let n_blocks = 3;
+            initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+            // Form block
+            let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+            let root_element = ledger.get_root_tx_out_membership_element().unwrap();
+
+            let form_block_result = enclave.form_block(
+                &parent_block,
+                FormBlockInputs {
+                    mint_config_txs: vec![mint_config_tx1.clone()],
+                    ..Default::default()
+                },
+                &root_element,
+            );
+            assert_eq!(
+                form_block_result,
+                Err(Error::MalformedMintingTx(
+                    MintValidationError::InvalidSignature
+                ))
+            );
+        }
+    }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1909,7 +1909,7 @@ mod tests {
             if let Err(Error::FormBlock(description)) = form_block_result {
                 assert!(description.contains("Duplicate MintTx"));
             } else {
-                panic!("Expected result");
+                panic!("Expected FormBlock error, got: {:#?}", form_block_result);
             }
         }
     }

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -91,6 +91,11 @@ impl BlockVersion {
     pub fn validate_transaction_outputs_are_sorted(&self) -> bool {
         self.0 > 3
     }
+
+    /// mint transactions are introduced in block version 3
+    pub fn mint_transactions_are_supported(&self) -> bool {
+        self.0 >= 3
+    }
 }
 
 impl Deref for BlockVersion {

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -36,7 +36,7 @@ pub fn validate_tombstone(
 /// # Arguments
 /// * `block_version` - The block version of the block currently being built.
 pub fn validate_block_version(block_version: BlockVersion) -> Result<(), Error> {
-    if block_version < BlockVersion::THREE || BlockVersion::MAX < block_version {
+    if !block_version.mint_transactions_are_supported() || BlockVersion::MAX < block_version {
         return Err(Error::InvalidBlockVersion(block_version));
     }
 

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -12,7 +12,10 @@ pub use mc_transaction_core::{
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
     Amount, Block, BlockID, BlockIndex, BlockVersion, Token,
 };
-pub use mint::{create_mint_config_tx, create_mint_config_tx_and_signers, create_mint_tx};
+pub use mint::{
+    create_mint_config_tx, create_mint_config_tx_and_signers, create_mint_tx,
+    create_mint_tx_to_recipient,
+};
 
 use core::convert::TryFrom;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};


### PR DESCRIPTION
### Motivation

Wanting to have more unit test coverage is pretty self explanatory :)

### In this PR
* Unit tests to exercise the new code flows in `form_block` that deal with `MintTx`s and `MintConfigTx`s.

### Future Work
* Add a unit test for checking that invalid `MintTx`s get rejected. That is blocked by having the active mint configurations fed into the enclave.
