### PR TITLE
Add version flag to consensus and fog executables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-transaction-std",
+ "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-logger-macros",
@@ -3372,6 +3373,7 @@ dependencies = [
  "mc-ledger-db",
  "mc-transaction-core",
  "mc-transaction-std",
+ "mc-util-cli",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
  "mc-util-uri",
@@ -3429,6 +3431,7 @@ dependencies = [
  "mc-fog-types",
  "mc-fog-uri",
  "mc-ledger-db",
+ "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-keyfile",
@@ -3585,6 +3588,7 @@ dependencies = [
  "mc-sgx-report-cache-untrusted",
  "mc-transaction-core",
  "mc-util-build-info",
+ "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-metrics",
@@ -3766,6 +3770,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "mc-util-cli",
  "mc-util-encodings",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -3895,6 +3900,7 @@ dependencies = [
  "mc-fog-uri",
  "mc-ledger-db",
  "mc-transaction-core",
+ "mc-util-cli",
  "mc-util-from-random",
  "mc-util-metrics",
  "mc-watcher",
@@ -3969,6 +3975,7 @@ dependencies = [
  "mc-fog-ingest-enclave-measurement",
  "mc-fog-report-connection",
  "mc-fog-report-validation",
+ "mc-util-cli",
  "mc-util-keyfile",
  "mc-util-uri",
 ]
@@ -4009,6 +4016,7 @@ dependencies = [
  "mc-fog-sig-report",
  "mc-fog-sql-recovery-db",
  "mc-fog-test-infra",
+ "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-metrics",
@@ -4203,6 +4211,7 @@ dependencies = [
  "mc-sgx-css",
  "mc-transaction-core",
  "mc-transaction-std",
+ "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-metrics",
@@ -4400,6 +4409,7 @@ dependencies = [
  "mc-fog-view-connection",
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
+ "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
 ]
@@ -4458,6 +4468,7 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-sgx-report-cache-untrusted",
  "mc-transaction-core",
+ "mc-util-cli",
  "mc-util-encodings",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -5082,6 +5093,14 @@ dependencies = [
  "displaydoc",
  "mc-util-build-script",
  "pkg-config",
+]
+
+[[package]]
+name = "mc-util-cli"
+version = "0.1.0"
+dependencies = [
+ "clap 3.1.6",
+ "mc-util-build-info",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ members = [
     "util/build/grpc",
     "util/build/script",
     "util/build/sgx",
+    "util/cli",
     "util/encodings",
     "util/ffi",
     "util/from-random",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -31,6 +31,7 @@ mc-peers = { path = "../../peers" }
 mc-sgx-report-cache-untrusted = { path = "../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-transaction-std = { path = "../../transaction/std" }
+mc-util-cli = { path = "../../util/cli" }
 mc-util-grpc = { path = "../../util/grpc" }
 mc-util-metered-channel = { path = "../../util/metered-channel" }
 mc-util-metrics = { path = "../../util/metrics" }

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -3,7 +3,6 @@
 
 //! Entrypoint for the MobileCoin server.
 
-use clap::Parser;
 use mc_attest_net::{Client, RaClient};
 use mc_attest_verifier::DEBUG_ENCLAVE;
 use mc_common::{
@@ -19,6 +18,7 @@ use mc_consensus_service::{
     validators::DefaultTxManagerUntrustedInterfaces,
 };
 use mc_ledger_db::LedgerDB;
+use mc_util_cli::ParserWithBuildInfo;
 use std::{
     env,
     fs::File,

--- a/consensus/service/src/config/mod.rs
+++ b/consensus/service/src/config/mod.rs
@@ -20,7 +20,8 @@ use std::{fmt::Debug, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
 #[derive(Clone, Debug, Parser)]
 #[clap(
     name = "consensus_service",
-    about = "The MobileCoin Consensus Service."
+    about = "The MobileCoin Consensus Service.",
+    version
 )]
 pub struct Config {
     /// Peer Responder ID

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -23,6 +23,7 @@ mc-fog-report-validation = { path = "../../fog/report/validation" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-transaction-std = { path = "../../transaction/std" }
+mc-util-cli = { path = "../../util/cli" }
 mc-util-keyfile = { path = "../../util/keyfile" }
 mc-util-uri = { path = "../../util/uri" }
 

--- a/fog/distribution/src/config.rs
+++ b/fog/distribution/src/config.rs
@@ -16,7 +16,8 @@ use std::{path::PathBuf, sync::Arc};
 #[derive(Clone, Debug, Parser)]
 #[structopt(
     name = "fog-distribution",
-    about = "Transfer funds from source accounts (bootstrapped) to destination accounts (which may have fog). This slams the network with many Txs in parallel as a stress test."
+    about = "Transfer funds from source accounts (bootstrapped) to destination accounts (which may have fog). This slams the network with many Txs in parallel as a stress test.",
+    version
 )]
 pub struct Config {
     /// Path to sample data for keys/ and ledger/

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -19,7 +19,6 @@
 
 #![deny(missing_docs)]
 
-use clap::Parser;
 use core::{cell::RefCell, convert::TryFrom};
 use lazy_static::lazy_static;
 use mc_account_keys::AccountKey;
@@ -47,6 +46,7 @@ use mc_transaction_core::{
     Amount, BlockVersion, Token,
 };
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_uri::FogUri;
 use rand::{seq::SliceRandom, thread_rng, Rng};
 use rayon::prelude::*;

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -46,6 +46,7 @@ mc-account-keys = { path = "../../../account-keys" }
 mc-api = { path = "../../../api" }
 mc-common = { path = "../../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-keyfile = { path = "../../../util/keyfile" }
 mc-util-parse = { path = "../../../util/parse" }

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 /// Configuration parameters for the Fog ingest client
 #[derive(Clone, Debug, Parser)]
+#[clap(version)]
 pub struct IngestConfig {
     /// URI for ingest server
     #[clap(long, env = "MC_URI")]

--- a/fog/ingest/client/src/main.rs
+++ b/fog/ingest/client/src/main.rs
@@ -2,7 +2,6 @@
 
 //! Fog Ingest client
 
-use clap::Parser;
 use mc_common::logger::{create_root_logger, log, Logger};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_api::ingest_common::IngestSummary;
@@ -11,6 +10,7 @@ use mc_fog_ingest_client::{
     ClientResult, FogIngestGrpcClient,
 };
 use mc_fog_uri::FogIngestUri;
+use mc_util_cli::ParserWithBuildInfo;
 use serde_json::{json, to_string_pretty};
 use std::{str::FromStr, sync::Arc};
 

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -37,6 +37,7 @@ mc-ledger-db = { path = "../../../ledger/db" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
 mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../../transaction/core" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metrics = { path = "../../../util/metrics" }
 mc-util-parse = { path = "../../../util/parse" }

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -3,7 +3,6 @@
 
 //! Fog Ingest target
 
-use clap::Parser;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_attest_net::{Client, RaClient};
 use mc_common::logger::{log, o};
@@ -15,6 +14,7 @@ use mc_fog_ingest_server::{
 };
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
 use mc_ledger_db::LedgerDB;
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -15,6 +15,7 @@ use std::{path::PathBuf, time::Duration};
 
 /// Command-line configuration options for an Ingest Server
 #[derive(Clone, Serialize, Parser)]
+#[clap(version)]
 pub struct IngestConfig {
     /// The IAS SPID to use when getting a quote
     #[clap(long, env = "MC_IAS_SPID")]

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -24,6 +24,7 @@ mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../../transaction/core" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-encodings = { path = "../../../util/encodings" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-grpc = { path = "../../../util/grpc" }

--- a/fog/ledger/server/src/bin/main.rs
+++ b/fog/ledger/server/src/bin/main.rs
@@ -3,7 +3,6 @@
 
 //! Ledger Server target
 
-use clap::Parser;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_attest_net::{Client, RaClient};
 use mc_common::{
@@ -13,6 +12,7 @@ use mc_common::{
 use mc_fog_ledger_enclave::{LedgerSgxEnclave, ENCLAVE_FILE};
 use mc_fog_ledger_server::{LedgerServer, LedgerServerConfig};
 use mc_ledger_db::LedgerDB;
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -15,6 +15,7 @@ use std::{path::PathBuf, time::Duration};
 
 /// Configuration parameters for the ledger server
 #[derive(Clone, Parser, Serialize)]
+#[clap(version)]
 pub struct LedgerServerConfig {
     /// gRPC listening URI for client requests.
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -26,6 +26,7 @@ mc-api = { path = "../../../api" }
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-transaction-core = { path = "../../../transaction/core" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-metrics = { path = "../../../util/metrics" }
 
 # fog

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -4,13 +4,13 @@
 //! Starts a Rocket server that allows clients to access Fog Overseer APIs
 //! over HTTP.
 
-use clap::Parser;
 use mc_common::{
     logger::{log, o},
     sentry,
 };
 use mc_fog_overseer_server::{config::OverseerConfig, server, service::OverseerService};
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
+use mc_util_cli::ParserWithBuildInfo;
 
 fn main() {
     mc_common::setup_panic_handler();

--- a/fog/overseer/server/src/config.rs
+++ b/fog/overseer/server/src/config.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 /// Parser configuration options for an Overseer Server
 #[derive(Clone, Serialize, Parser)]
+#[clap(version)]
 pub struct OverseerConfig {
     /// Host to listen on.
     #[clap(long, default_value = "127.0.0.1", env = "MC_OVERSEER_LISTEN_HOST")]

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -19,6 +19,7 @@ mc-fog-api = { path = "../../api" }
 mc-fog-ingest-enclave-measurement = { path = "../../ingest/enclave/measurement" }
 mc-fog-report-connection = { path = "../connection" }
 mc-fog-report-validation = { path = "../validation" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-keyfile = { path = "../../../util/keyfile" }
 mc-util-uri = { path = "../../../util/uri" }
 

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -15,7 +15,6 @@
 //! useful diagnostic tool.
 
 use binascii::bin2hex;
-use clap::Parser;
 use grpcio::EnvBuilder;
 use mc_account_keys::{AccountKey, PublicAddress};
 use mc_attest_verifier::{Verifier, DEBUG_ENCLAVE};
@@ -26,6 +25,7 @@ use mc_fog_report_connection::{Error, GrpcFogReportConnection};
 use mc_fog_report_validation::{
     FogPubkeyResolver, FogReportResponses, FogResolver, FullyValidatedFogPubkey,
 };
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_uri::FogUri;
 use std::{
     convert::TryFrom,
@@ -51,7 +51,8 @@ use std::{
 ///   would be performed for a fog user with these values in their address.
 /// - Supply only a fog-url. This can only be used with the "no-validate"
 ///   option.
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
+#[clap(version)]
 struct Config {
     /// Path to mobilecoin public address. Fog url and spki will be extracted,
     /// and fog signature will be checked, unless no-validate is passed.

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -23,6 +23,7 @@ mc-fog-recovery-db-iface = { path = "../../recovery_db_iface" }
 mc-fog-report-types = { path = "../../report/types" }
 mc-fog-sig-report = { path = "../../sig/report" }
 mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metrics = { path = "../../../util/metrics" }
 mc-util-parse = { path = "../../../util/parse" }

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -2,11 +2,11 @@
 
 //! Main Method for the Fog Report Server
 
-use clap::Parser;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_common::{logger, sentry};
 use mc_fog_report_server::{Config, Materials, Server};
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use std::{convert::TryFrom, env, sync::Arc};
 

--- a/fog/report/server/src/config.rs
+++ b/fog/report/server/src/config.rs
@@ -16,7 +16,11 @@ use x509_signature::X509Certificate;
 
 /// Configuration options for the report server
 #[derive(Clone, Debug, Parser, Serialize)]
-#[clap(name = "report-server", about = "Ingest Attestation Report Server.")]
+#[clap(
+    name = "report-server",
+    about = "Ingest Attestation Report Server.",
+    version
+)]
 pub struct Config {
     /// gRPC listening URI for client requests.
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -18,6 +18,7 @@ mc-crypto-rand = { path = "../../crypto/rand" }
 mc-sgx-css = { path = "../../sgx/css" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-transaction-std = { path = "../../transaction/std" }
+mc-util-cli = { path = "../../util/cli" }
 mc-util-grpc = { path = "../../util/grpc" }
 mc-util-keyfile = { path = "../../util/keyfile" }
 mc-util-metrics = { path = "../../util/metrics" }

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -5,13 +5,13 @@
 
 use mc_common::logger::{create_app_logger, log, o};
 
-use clap::Parser;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_fog_test_client::{
     config::TestClientConfig,
     error::TestClientError,
     test_client::{TestClient, TestClientPolicy},
 };
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use mc_util_parse::{load_css_file, CssSignature};
 use serde::Serialize;

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -17,7 +17,11 @@ use std::{path::PathBuf, time::Duration};
 ///
 /// Serialize is used to create a json summary
 #[derive(Clone, Debug, Parser, Serialize)]
-#[clap(name = "test-client", about = "Test client for Fog infrastructure.")]
+#[clap(
+    name = "test-client",
+    about = "Test client for Fog infrastructure.",
+    version
+)]
 pub struct TestClientConfig {
     /// A URI to host the prometheus data at.
     ///

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -18,6 +18,7 @@ grpcio = "0.10.0"
 mc-account-keys = { path = "../../../account-keys" }
 mc-attest-verifier = { path = "../../../attest/verifier" }
 mc-common = { path = "../../../common", features = ["log"] }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-keyfile = { path = "../../../util/keyfile" }
 

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -3,7 +3,6 @@
 
 //! A utility to load-test a fog-view server.
 
-use clap::Parser;
 use grpcio::EnvBuilder;
 use mc_account_keys::AccountKey;
 use mc_attest_verifier::{Verifier, DEBUG_ENCLAVE};
@@ -12,6 +11,7 @@ use mc_fog_kex_rng::{NewFromKex, VersionedKexRng};
 use mc_fog_uri::FogViewUri;
 use mc_fog_view_connection::FogViewGrpcClient;
 use mc_fog_view_protocol::FogViewConnection;
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::GrpcRetryConfig;
 use std::{
     path::PathBuf,
@@ -24,7 +24,8 @@ use std::{
     time::Duration,
 };
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
+#[clap(version)]
 struct Config {
     /// Path to root identity file to use
     /// Note: This contains the fog-url which is the same as the report-server

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -31,6 +31,7 @@ mc-attest-net = { path = "../../../attest/net" }
 mc-common = { path = "../../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
+mc-util-cli = { path = "../../../util/cli" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-grpc = { path = "../../../util/grpc" }
 mc-util-metered-channel = { path = "../../../util/metered-channel" }

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -2,13 +2,13 @@
 #![deny(missing_docs)]
 
 //! MobileCoin Fog View target
-use clap::Parser;
 use grpcio::{RpcStatus, RpcStatusCode};
 use mc_attest_net::{Client, RaClient};
 use mc_common::{logger::log, time::SystemTimeProvider};
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
 use mc_fog_view_enclave::{SgxViewEnclave, ENCLAVE_FILE};
 use mc_fog_view_server::{config::MobileAcctViewConfig, server::ViewServer};
+use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 /// Configuration parameters for the MobileCoin Fog View Node
 #[derive(Clone, Parser, Serialize)]
+#[clap(version)]
 pub struct MobileAcctViewConfig {
     /// The ID with which to respond to client attestation requests.
     ///

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mc-util-cli"
+version = "0.1.0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+mc-util-build-info = { path = "../build/info" }
+
+clap = { version = "3.1" }
+
+[dev-dependencies]
+clap = { version = "3.1", features = ['derive'] }

--- a/util/cli/README.md
+++ b/util/cli/README.md
@@ -1,0 +1,4 @@
+mc-util-cli
+========
+
+Command line interface (CLI) utilities.

--- a/util/cli/src/lib.rs
+++ b/util/cli/src/lib.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+use clap::{CommandFactory, FromArgMatches, Parser};
+
+/// Command line parser trait that provides build information into the version
+/// string. In order to use this, one must pass in the `version` argument to the
+/// `clap` attribute.  When the `version` flag is present it will be extended to
+/// include the git commit of the crate.
+///
+/// Using the `version` argument:
+/// ```rust
+/// #[derive(Clone, Debug, Parser)]
+/// #[clap(version)]
+/// pub struct CommandLine {
+///     verbose: bool,
+///     name: Option<String>,
+/// }
+/// ```
+pub trait ParserWithBuildInfo: Parser {
+    /// Returns the `clap::Command` with the long version appended with the git commit information
+    ///
+    /// # Arguments
+    ///
+    /// * `build_info` - A String that will be populated with the build info (git commit).
+    ///     This is passed in as it needs to live as long as the `clap::Command`.
+    fn command_with_build_info(build_info: &mut String) -> clap::Command {
+        let mut command = <Self as CommandFactory>::command();
+        if let Some(version) = command.get_version() {
+            *build_info = format!("{} commit: {}", version, mc_util_build_info::git_commit());
+            command = command.long_version(&**build_info);
+        }
+        command
+    }
+
+    /// Similar to clap::Command::parse(), but will update the version on the
+    /// clap::Command to have build information.
+    fn parse() -> Self {
+        let mut build_info = String::new();
+        let command = Self::command_with_build_info(&mut build_info);
+        let matches = command.get_matches();
+        let res =
+            <Self as FromArgMatches>::from_arg_matches(&matches).map_err(format_error::<Self>);
+        match res {
+            Ok(s) => s,
+            Err(e) => {
+                e.exit()
+            }
+        }
+    }
+}
+
+impl<T> ParserWithBuildInfo for T where T: Parser {}
+
+fn format_error<T: CommandFactory>(err: clap::Error) -> clap::Error {
+    let mut cmd = T::command();
+    err.format(&mut cmd)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ParserWithBuildInfo;
+
+    #[test]
+    fn version_on_clap_command() {
+        #[derive(Clone, Debug, clap::Parser)]
+        #[clap(version)]
+        pub struct CommandWithVersion {}
+
+        let mut info = String::new();
+        let command = CommandWithVersion::command_with_build_info(&mut info);
+        let expected_long_version = format!(
+            "{} commit: {}",
+            command.get_version().unwrap(),
+            mc_util_build_info::git_commit()
+        );
+        assert_eq!(command.get_long_version(), Some(&*expected_long_version));
+    }
+    #[test]
+    fn no_version_on_clap_command() {
+        #[derive(Clone, Debug, clap::Parser)]
+        pub struct CommandWithoutVersion {}
+
+        let mut info = String::new();
+        let command = CommandWithoutVersion::command_with_build_info(&mut info);
+        assert_eq!(command.get_long_version(), None);
+    }
+}


### PR DESCRIPTION
The `-V` and `--version` flags are now available on:
- consensus-service
- fog-distribution
- fog-report-cli
- fog-view-load-test
- fog_ingest_client
- fog_ingest_server
- fog_overseer_server
- fog_view_server

The short version, `-V`, will only list the crate version
The long version, `--version`, will list the crate version and the git
sha.


### Motivation
Make the CLI more friendly.

### In this PR
This is utilizing clap's long versus short version so `-V` behaves differently
than `--version`. I can't decide if the behavior feels too different
```
$ ./target/debug/consensus-service -V
consensus_service 1.3.0-pre0
$ ./target/debug/consensus-service --version
consensus_service 1.3.0-pre0 commit: 0402da82-modified
```

These following exe's were skipped as they aren't using clap
fog_ingest_server_load_test
fog-sql-recovery-db-write-bench
fog-sql-recovery-db-migrations

I'm not fond of passing the build info `String` into
`mc_util_cli::ParserWithBuildInfo::command_with_build_info()`, but needed the
string to live as long as the `command`.  Curious if there is a nicer way to do
this.

At a loss for a good way to test `mc_util_cli::ParserWithBuildInfo::parse()`.  I
know of [assert_cmd](https://docs.rs/assert_cmd/latest/assert_cmd/), but it
seems to normally utilize a specific binary from the crate and not create one on
the fly.

fixes #1114 


