### PR TITLE
decrement block version everywhere, bump to -pre2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmobilecoin"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "criterion",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2500,7 +2500,7 @@ dependencies = [
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "mc-common",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "bincode",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "cookie 0.16.0",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-connection",
  "mc-consensus-enclave-api",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures 0.3.21",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2876,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "bigint",
  "crossbeam-channel",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-consensus-scp",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "chrono",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest 0.9.0",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "blake2",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "digest 0.9.0",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.4",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3245,7 +3245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-crypto-keys",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3311,7 +3311,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "crossbeam-channel",
  "curve25519-dalek",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "cookie 0.16.0",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "assert_cmd",
  "displaydoc",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "dirs 4.0.0",
  "displaydoc",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "mc-attest-core",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "mc-account-keys",
@@ -3792,14 +3792,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3810,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures 0.3.21",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "binascii",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "futures 0.3.21",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3997,7 +3997,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4089,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4100,7 +4100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "chrono",
  "diesel",
@@ -4148,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "digest 0.9.0",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "crc",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "mc-account-keys",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "futures 0.3.21",
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "dirs 4.0.0",
  "displaydoc",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-api",
  "mc-common",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "lmdb-rkv",
  "mc-common",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "futures 0.3.21",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "hex",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "hex",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2 0.9.8",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "hex_fmt",
  "mc-sgx-css",
@@ -4798,21 +4798,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -4849,18 +4849,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-slam"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "crossbeam-channel",
  "curve25519-dalek",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -4931,7 +4931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "blake2",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "hex",
  "mc-api",
@@ -5022,7 +5022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.14.1",
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5076,7 +5076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "binascii",
@@ -5088,18 +5088,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "curve25519-dalek",
  "hex",
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "cookie 0.16.0",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "grpcio",
  "mc-common",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "hex",
  "mc-common",
@@ -5178,11 +5178,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "hex",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "itertools",
  "mc-sgx-css",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "generic-array 0.14.5",
  "prost",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -5271,7 +5271,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "itertools",
  "lazy_static",
@@ -5296,7 +5296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "datatest",
  "serde",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64 0.13.0",
  "displaydoc",
@@ -5324,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "futures 0.3.21",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/account-keys/slip10/Cargo.toml
+++ b/account-keys/slip10/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-slip10"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1168,7 +1168,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
             env.get_rust_field(fog_resolver, RUST_OBJ_FIELD)?;
         // FIXME: block version should be a parameter, it should be the latest
         // version that fog ledger told us about, or that we got from ledger-db
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
         // Note: RTHMemoBuilder can be selected here, but we will only actually
         // write memos if block_version is large enough that memos are supported.
         // If block version is < 2, then transaction builder will filter out memos.

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -65,6 +65,7 @@ message BlockSignature {
 }
 
 // Version 1 of an archived block.
+// Note: The block.version field within the block may or may not be equal to 1.
 message ArchiveBlockV1 {
     // Block
     Block block = 1;

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -148,7 +148,7 @@ mod tests {
 
             let block_contents = BlockContents::new(vec![key_image.clone()], vec![tx_out.clone()]);
             let block = Block::new(
-                BlockVersion::ONE,
+                BlockVersion::ZERO,
                 &parent_block_id,
                 99 + block_idx,
                 400 + block_idx,

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -85,17 +85,17 @@ mod test {
     fn different_fee_maps_result_in_different_responder_ids() {
         let config1: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 2000)]).unwrap(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
         let config2: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 300)]).unwrap(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
         let config3: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
 
@@ -129,7 +129,7 @@ mod test {
 
         let config4: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
-            block_version: BlockVersion::TWO,
+            block_version: BlockVersion::ONE,
         }
         .into();
 

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1456,7 +1456,7 @@ mod tests {
     fn form_block_refuses_decreasing_block_version(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([77u8; 32]);
 
-        for block_version in BlockVersion::iterator() {
+        for block_version in BlockVersion::iterator().skip(1) {
             let enclave = SgxConsensusEnclave::new(logger.clone());
             let blockchain_config = BlockchainConfig {
                 block_version: BlockVersion::try_from(*block_version - 1).unwrap(),

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "blake2",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1044,11 +1044,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1079,29 +1079,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1130,14 +1130,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1145,11 +1145,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "blake2",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1214,14 +1214,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "prost",
  "serde",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -272,7 +272,7 @@ mod tests {
     };
 
     // Run these tests with a particular block version
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     fn test_peer_uri(node_id: u32, pubkey: String) -> PeerUri {
         PeerUri::from_str(&format!(

--- a/consensus/service/src/config/mod.rs
+++ b/consensus/service/src/config/mod.rs
@@ -99,7 +99,7 @@ pub struct Config {
     pub tokens_path: Option<PathBuf>,
 
     /// The configured block version
-    #[structopt(long, env = "MC_BLOCK_VERSION", default_value = "1")]
+    #[structopt(long, env = "MC_BLOCK_VERSION", default_value = "0")]
     pub block_version: BlockVersion,
 }
 
@@ -180,7 +180,7 @@ mod tests {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
             tokens_path: None,
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         };
 
         assert_eq!(
@@ -247,7 +247,7 @@ mod tests {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
             tokens_path: None,
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         };
 
         assert_eq!(

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -870,7 +870,7 @@ mod tests {
     #[test_with_logger]
     fn test_hashes_to_block(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
         let sender = AccountKey::random(&mut rng);
         let mut ledger = create_ledger();
         let n_blocks = 3;

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin DH Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "blake2",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -1054,14 +1054,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "crc",
@@ -1166,11 +1166,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1201,36 +1201,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1259,14 +1259,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1274,11 +1274,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "blake2",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1343,14 +1343,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -126,7 +126,7 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
     };
 
     let block = Block::new_with_parent(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &last_block,
         &root_element,
         &block_contents,

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "blake2",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1059,14 +1059,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "crc",
@@ -1157,11 +1157,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1192,36 +1192,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1250,14 +1250,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1265,11 +1265,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "blake2",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1334,14 +1334,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -197,7 +197,7 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         LedgerDB::create(ledger_db_path.path()).unwrap();
         let mut ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
 
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
 
         mc_transaction_core_test_utils::initialize_ledger(
             block_version,

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -131,7 +131,7 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
     };
 
     let block = Block::new_with_parent(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &last_block,
         &root_element,
         &block_contents,

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test_infra/src/db_tests.rs
+++ b/fog/test_infra/src/db_tests.rs
@@ -661,7 +661,7 @@ pub fn random_block(
     num_txs: usize,
 ) -> (Block, Vec<ETxOutRecord>) {
     let block = Block::new(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &BlockID::default(),
         block_index,
         0,

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -149,7 +149,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
             .get_block(block_index - 1)
             .unwrap_or_else(|err| panic!("Failed getting block {}: {:?}", block_index - 1, err));
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &parent_block,
             &Default::default(),
             &block_contents,

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "curve25519-dalek",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "bitflags",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "blake2",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "digest",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "displaydoc",
@@ -979,14 +979,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "blake2",
  "crc",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1176,11 +1176,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1220,36 +1220,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1278,14 +1278,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1293,11 +1293,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "aes",
  "blake2",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "base64",
  "binascii",
@@ -1362,14 +1362,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "generic-array",
  "prost",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "prost",
  "serde",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -146,7 +146,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id1,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             0,
             2,
@@ -161,7 +161,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id1,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             1,
             6,
@@ -184,7 +184,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             2,
             12,
@@ -219,7 +219,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             3,
             12,
@@ -234,7 +234,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             4,
             16,
@@ -251,7 +251,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             5,
             20,

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1338,7 +1338,7 @@ mod ledger_db_test {
             // All blocks should've been written (+ origin block).
             assert_eq!(
                 ledger_db.num_blocks().unwrap(),
-                1 + (3 * (*block_version)) as u64
+                1 + (3 * ((*block_version) + 1)) as u64
             );
         }
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -753,7 +753,7 @@ mod ledger_db_test {
     use test::Bencher;
 
     // TODO: Should these tests run over several block versions?
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     /// Creates a LedgerDB instance.
     fn create_db() -> LedgerDB {
@@ -1158,7 +1158,7 @@ mod ledger_db_test {
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &origin_block,
             &Default::default(),
             &block_contents,
@@ -1204,7 +1204,7 @@ mod ledger_db_test {
         let block_contents = BlockContents::new(key_images.clone(), outputs);
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &parent,
             &Default::default(),
             &block_contents,
@@ -1242,7 +1242,7 @@ mod ledger_db_test {
 
         let block_contents = BlockContents::new(key_images.clone(), outputs);
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &origin_block,
             &Default::default(),
             &block_contents,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -249,7 +249,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
             let block_contents = BlockContents::new(key_images, outputs);
 
             let block = Block::new_with_parent(
-                BlockVersion::ONE,
+                BlockVersion::ZERO,
                 &blocks_and_contents[block_index - 1].0,
                 &TxOutMembershipElement::default(),
                 &block_contents,

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -32,7 +32,7 @@ fn _make_ledger_long(ledger: &mut LedgerDB) {
         .collect::<Vec<_>>();
 
     let results: Vec<(Block, BlockContents)> = mc_transaction_core_test_utils::get_blocks(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &recipient_pub_keys[..],
         1,
         1000,

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmobilecoin"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -344,7 +344,7 @@ pub extern "C" fn mc_transaction_builder_create(
                 });
         // FIXME: block version should be a parameter, it should be the latest
         // version that fog ledger told us about, or that we got from ledger-db
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
         // Note: RTHMemoBuilder can be selected here, but we will only actually
         // write memos if block_version is large enough that memos are supported.
         // If block version is < 2, then transaction builder will filter out memos.

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -531,7 +531,7 @@ mod test {
 
         // Set up a db with 3 random recipients and 10 blocks.
         let (_ledger_db, mobilecoind_db) =
-            get_test_databases(BlockVersion::ONE, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
 
         // A test accouunt.
         let account_key = AccountKey::random(&mut rng);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1941,7 +1941,7 @@ mod test {
     };
 
     // None of these tests really depend on any of the new features
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     #[test_with_logger]
     fn test_add_monitor_impl(logger: Logger) {

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -436,7 +436,7 @@ mod test {
     ) -> (LedgerDB, UtxoStore, Vec<UnspentTxOut>) {
         // Set up a db with 3 random recipients and 10 blocks.
         let (ledger_db, _mobilecoind_db) =
-            get_test_databases(BlockVersion::ONE, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
 
         // Get a few TxOuts to play with, and use them to construct UnspentTxOuts.
         let utxos: Vec<UnspentTxOut> = (0..5)

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 
 

--- a/slam/Cargo.toml
+++ b/slam/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-slam"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -213,6 +213,7 @@ mod block_tests {
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 
+    // This is block version 1 to avoid messing with test vectors
     const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
 
     fn get_block_contents<RNG: CryptoRng + RngCore>(rng: &mut RNG) -> BlockContents {
@@ -371,7 +372,7 @@ mod block_tests {
     /// actual block id into the test. This should hopefully catches cases where
     /// we add/change Block/BlockContents and accidentally break id
     /// calculation of old blocks.
-    fn test_hashing_is_consistent() {
+    fn test_hashing_is_consistent_block_version_one() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         //Check hash with memo

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -57,10 +57,12 @@ impl FromStr for BlockVersion {
 impl BlockVersion {
     /// The maximum value of block_version that this build of
     /// mc-transaction-core has support for
-    pub const MAX: Self = Self(2);
+    pub const MAX: Self = Self(1);
 
     /// Refers to the block version number at network launch.
-    /// Note: The origin blocks use block version zero.
+    pub const ZERO: Self = Self(0);
+
+    /// Constant for block version one
     pub const ONE: Self = Self(1);
 
     /// Constant for block version two
@@ -69,13 +71,13 @@ impl BlockVersion {
     /// Iterator over block versions from one up to max, inclusive. For use in
     /// tests.
     pub fn iterator() -> BlockVersionIterator {
-        BlockVersionIterator(1)
+        BlockVersionIterator(0)
     }
 
     /// The encrypted memos [MCIP #3](https://github.com/mobilecoinfoundation/mcips/pull/3)
-    /// feature is introduced in block version 2.
+    /// feature is introduced in block version 1.
     pub fn e_memo_feature_is_supported(&self) -> bool {
-        self.0 >= 2
+        self.0 >= 1
     }
 }
 
@@ -126,7 +128,7 @@ mod tests {
     #[test]
     fn test_block_version_iterator() {
         let observed = BlockVersion::iterator().map(|x| *x).collect::<Vec<u32>>();
-        let expected = (1..=*BlockVersion::MAX).collect::<Vec<u32>>();
+        let expected = (0..=*BlockVersion::MAX).collect::<Vec<u32>>();
         assert_eq!(observed, expected);
     }
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -35,7 +35,7 @@ pub fn validate<R: RngCore + CryptoRng>(
     minimum_fee: u64,
     csprng: &mut R,
 ) -> TransactionValidationResult<()> {
-    if block_version < BlockVersion::ONE || BlockVersion::MAX < block_version {
+    if BlockVersion::MAX < block_version {
         return Err(TransactionValidationError::Ledger(format!(
             "Invalid block version: {}",
             block_version
@@ -528,7 +528,7 @@ mod tests {
     #[test]
     // Should return MissingMemo when memos are missing in any the outputs
     fn test_validate_memos_exist() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let (tx, _) = create_test_tx(BlockVersion::ZERO);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
         assert_eq!(
@@ -536,7 +536,7 @@ mod tests {
             Err(TransactionValidationError::MissingMemo)
         );
 
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
         assert_eq!(validate_memos_exist(&tx), Ok(()));
@@ -545,12 +545,12 @@ mod tests {
     #[test]
     // Should return MemosNotAllowed when memos are present in any of the outputs
     fn test_validate_no_memos_exist() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let (tx, _) = create_test_tx(BlockVersion::ZERO);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
         assert_eq!(validate_no_memos_exist(&tx), Ok(()));
 
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
         assert_eq!(

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/tests/digest-test-vectors.rs
+++ b/transaction/core/tests/digest-test-vectors.rs
@@ -214,7 +214,7 @@ fn origin_block_digestible_ast() {
 
 #[test]
 fn block_contents_digestible_test_vectors() {
-    let results = test_blockchain(BlockVersion::TWO);
+    let results = test_blockchain(BlockVersion::ONE);
 
     // Test digest of block contents
     assert_eq!(
@@ -239,8 +239,7 @@ fn block_contents_digestible_test_vectors() {
         ]
     );
 
-    // Now set block version 1 and run the old test vectors
-    let results = test_blockchain(BlockVersion::ONE);
+    let results = test_blockchain(BlockVersion::ZERO);
 
     // Test digest of block contents
     assert_eq!(

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-std"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -642,8 +642,8 @@ pub mod transaction_builder_tests {
     // in tests
     fn get_block_version_token_id_pairs() -> Vec<(BlockVersion, TokenId)> {
         vec![
+            (BlockVersion::try_from(0).unwrap(), TokenId::from(0)),
             (BlockVersion::try_from(1).unwrap(), TokenId::from(0)),
-            (BlockVersion::try_from(2).unwrap(), TokenId::from(0)),
         ]
     }
 

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -17,7 +17,7 @@ use rand_hc::Hc128Rng as FixedRng;
 use std::{path::Path, vec::Vec};
 
 // This is historically the version created by bootstrap
-const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
 /// Deterministically populates a testnet ledger.
 ///

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Helpers for parsing, particularly, for use with structopt and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "1.2.0-pre1"
+version = "1.2.0-pre2"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -1132,7 +1132,7 @@ pub mod tests {
             .map(|account| account.default_subaddress())
             .collect::<Vec<_>>();
         get_blocks(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &recipient_pub_keys,
             10,
             1,


### PR DESCRIPTION
we have to decrement block version because of a compatibility issue
it turns out that v1.0 always published block version = 0, and not
one as the source code indicated after a bunch of development.
