### PR TITLE
decrement block version everywhere (master branch)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,14 +478,14 @@ commands:
 
             MC_LOG="info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
             LEDGER_BASE=$(pwd)/ledger \
-            python3 tools/fog-local-network/fog_local_network.py --network-type dense5 --skip-build &
+            python3 tools/fog-local-network/fog_local_network.py --network-type dense5 --skip-build --block-version 2 &
 
             sleep 20
 
             ./target/release/sample-keys --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
             ./target/release/fog-distribution \
-                --block-version 3 \
+                --block-version 2 \
                 --sample-data-dir . \
                 --max-threads 1 \
                 --peer insecure-mc://localhost:3200/ \

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1175,7 +1175,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
             env.get_rust_field(fog_resolver, RUST_OBJ_FIELD)?;
         // FIXME: block version should be a parameter, it should be the latest
         // version that fog ledger told us about, or that we got from ledger-db
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
         // Note: RTHMemoBuilder can be selected here, but we will only actually
         // write memos if block_version is large enough that memos are supported.
         // If block version is < 2, then transaction builder will filter out memos.

--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -71,6 +71,7 @@ message BlockSignature {
 }
 
 // Version 1 of an archived block.
+// Note: The block.version field within the block may or may not be equal to 1.
 message ArchiveBlockV1 {
     // Block
     Block block = 1;

--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -159,7 +159,7 @@ mod tests {
                 ..Default::default()
             };
             let block = Block::new(
-                BlockVersion::ONE,
+                BlockVersion::ZERO,
                 &parent_block_id,
                 99 + block_idx,
                 400 + block_idx,

--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -93,19 +93,19 @@ mod test {
         let config1: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 2000)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
         let config2: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
         let config3: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         }
         .into();
 
@@ -140,7 +140,7 @@ mod test {
         let config4: BlockchainConfigWithDigest = BlockchainConfig {
             fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
-            block_version: BlockVersion::TWO,
+            block_version: BlockVersion::ONE,
         }
         .into();
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1616,7 +1616,7 @@ mod tests {
     fn form_block_refuses_decreasing_block_version(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([77u8; 32]);
 
-        for block_version in BlockVersion::iterator() {
+        for block_version in BlockVersion::iterator().skip(1) {
             let enclave = SgxConsensusEnclave::new(logger.clone());
             let blockchain_config = BlockchainConfig {
                 block_version: BlockVersion::try_from(*block_version - 1).unwrap(),

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -339,7 +339,7 @@ mod tests {
     };
 
     // Run these tests with a particular block version
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     fn test_peer_uri(node_id: u32, pubkey: String) -> PeerUri {
         PeerUri::from_str(&format!(

--- a/consensus/service/src/config/mod.rs
+++ b/consensus/service/src/config/mod.rs
@@ -109,7 +109,7 @@ pub struct Config {
     pub tokens_path: Option<PathBuf>,
 
     /// The configured block version
-    #[clap(long, default_value = "1", parse(try_from_str = parse_block_version), env = "MC_BLOCK_VERSION")]
+    #[clap(long, default_value = "0", parse(try_from_str = parse_block_version), env = "MC_BLOCK_VERSION")]
     pub block_version: BlockVersion,
 }
 
@@ -196,7 +196,7 @@ mod tests {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
             tokens_path: None,
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         };
 
         assert_eq!(
@@ -263,7 +263,7 @@ mod tests {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Duration::from_secs(60),
             tokens_path: None,
-            block_version: BlockVersion::ONE,
+            block_version: BlockVersion::ZERO,
         };
 
         assert_eq!(

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -887,7 +887,7 @@ mod tests {
     #[test_with_logger]
     fn test_hashes_to_block(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
         let sender = AccountKey::random(&mut rng);
         let mut ledger = create_ledger();
         let n_blocks = 3;

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -130,7 +130,7 @@ fn add_test_block<T: RngCore + CryptoRng>(ledger: &mut LedgerDB, watcher: &Watch
     };
 
     let block = Block::new_with_parent(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &last_block,
         &root_element,
         &block_contents,

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -204,7 +204,7 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         LedgerDB::create(ledger_db_path.path()).unwrap();
         let mut ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
 
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
 
         mc_transaction_core_test_utils::initialize_ledger(
             block_version,

--- a/fog/overseer/server/tests/utils/mod.rs
+++ b/fog/overseer/server/tests/utils/mod.rs
@@ -135,7 +135,7 @@ pub fn add_test_block<T: RngCore + CryptoRng>(
     };
 
     let block = Block::new_with_parent(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &last_block,
         &root_element,
         &block_contents,

--- a/fog/test_infra/src/db_tests.rs
+++ b/fog/test_infra/src/db_tests.rs
@@ -663,7 +663,7 @@ pub fn random_block(
     num_txs: usize,
 ) -> (Block, Vec<ETxOutRecord>) {
     let block = Block::new(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &BlockID::default(),
         block_index,
         0,

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -159,7 +159,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
             .get_block(block_index - 1)
             .unwrap_or_else(|err| panic!("Failed getting block {}: {:?}", block_index - 1, err));
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &parent_block,
             &Default::default(),
             &block_contents,

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -146,7 +146,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id1,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             0,
             2,
@@ -161,7 +161,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id1,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             1,
             6,
@@ -184,7 +184,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             2,
             12,
@@ -219,7 +219,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             3,
             12,
@@ -234,7 +234,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             4,
             16,
@@ -251,7 +251,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
     db.add_block_data(
         &invoc_id2,
         &Block::new(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &BlockID::default(),
             5,
             20,

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -2528,7 +2528,7 @@ mod ledger_db_test {
             ..Default::default()
         };
         let block = Block::new_with_parent(
-            BlockVersion::ZERO,
+            BLOCK_VERSION,
             &origin_block,
             &Default::default(),
             &block_contents,
@@ -2570,12 +2570,8 @@ mod ledger_db_test {
             ..Default::default()
         };
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
-        let block = Block::new_with_parent(
-            BlockVersion::ZERO,
-            &parent,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &parent, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -2610,7 +2606,7 @@ mod ledger_db_test {
             ..Default::default()
         };
         let block = Block::new_with_parent(
-            BlockVersion::ZERO,
+            BLOCK_VERSION,
             &origin_block,
             &Default::default(),
             &block_contents,

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -903,7 +903,7 @@ mod ledger_db_test {
     use test::Bencher;
 
     // TODO: Should these tests run over several block versions?
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     /// Creates a LedgerDB instance.
     fn create_db() -> LedgerDB {
@@ -2528,7 +2528,7 @@ mod ledger_db_test {
             ..Default::default()
         };
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &origin_block,
             &Default::default(),
             &block_contents,
@@ -2571,7 +2571,7 @@ mod ledger_db_test {
         };
         let parent = ledger_db.get_block(n_blocks - 1).unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &parent,
             &Default::default(),
             &block_contents,
@@ -2610,7 +2610,7 @@ mod ledger_db_test {
             ..Default::default()
         };
         let block = Block::new_with_parent(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &origin_block,
             &Default::default(),
             &block_contents,
@@ -2699,7 +2699,7 @@ mod ledger_db_test {
             // All blocks should've been written (+ origin block).
             assert_eq!(
                 ledger_db.num_blocks().unwrap(),
-                1 + (3 * (*block_version)) as u64
+                1 + (3 * (*block_version + 1)) as u64
             );
         }
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -280,7 +280,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
             };
 
             let block = Block::new_with_parent(
-                BlockVersion::ONE,
+                BlockVersion::ZERO,
                 &blocks_and_contents[block_index - 1].0,
                 &TxOutMembershipElement::default(),
                 &block_contents,

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -32,7 +32,7 @@ fn _make_ledger_long(ledger: &mut LedgerDB) {
         .collect::<Vec<_>>();
 
     let results: Vec<(Block, BlockContents)> = mc_transaction_core_test_utils::get_blocks(
-        BlockVersion::ONE,
+        BlockVersion::ZERO,
         &recipient_pub_keys[..],
         1,
         1000,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -347,7 +347,7 @@ pub extern "C" fn mc_transaction_builder_create(
                 });
         // FIXME: block version should be a parameter, it should be the latest
         // version that fog ledger told us about, or that we got from ledger-db
-        let block_version = BlockVersion::ONE;
+        let block_version = BlockVersion::ZERO;
 
         // TODO #1596: Support token id other than Mob
         let token_id = Mob::ID;

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -527,7 +527,7 @@ mod test {
 
         // Set up a db with 3 random recipients and 10 blocks.
         let (_ledger_db, mobilecoind_db) =
-            get_test_databases(BlockVersion::ONE, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
 
         // A test accouunt.
         let account_key = AccountKey::random(&mut rng);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1985,7 +1985,7 @@ mod test {
     };
 
     // None of these tests really depend on any of the new features
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
     #[test_with_logger]
     fn test_add_monitor_impl(logger: Logger) {

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -442,7 +442,7 @@ mod test {
     ) -> (Arc<Environment>, LedgerDB, UtxoStore, Vec<UnspentTxOut>) {
         // Set up a db with 3 random recipients and 10 blocks.
         let (ledger_db, _mobilecoind_db) =
-            get_test_databases(BlockVersion::ONE, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
 
         // Get a few TxOuts to play with, and use them to construct UnspentTxOuts.
         let utxos: Vec<UnspentTxOut> = (0..5)

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -150,7 +150,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
     parser.add_argument('--network-type', help='Type of network to create', required=True)
     parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
-    parser.add_argument('--block-version', help='Set the block version argument', action='store_true')
+    parser.add_argument('--block-version', help='Set the block version argument', type=int)
     args = parser.parse_args()
 
     FogNetwork().default_entry_point(args.network_type, args.skip_build, args.block_version)

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -150,6 +150,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
     parser.add_argument('--network-type', help='Type of network to create', required=True)
     parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
+    parser.add_argument('--block-version', help='Set the block version argument', action='store_true')
     args = parser.parse_args()
 
-    FogNetwork().default_entry_point(args.network_type, args.skip_build)
+    FogNetwork().default_entry_point(args.network_type, args.skip_build, args.block_version)

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -154,7 +154,7 @@ class Node:
         self.peers = peers
         self.quorum_set = quorum_set
         self.minimum_fee = 400_000_000
-        self.block_verison = block_version or 2
+        self.block_version = block_version or 2
 
         self.consensus_process = None
         self.ledger_distribution_process = None
@@ -435,7 +435,6 @@ class Network:
         self.nodes = []
         self.ledger_distribution = None
         self.cli = None
-        self.block_version = None
         try:
             shutil.rmtree(WORK_DIR)
         except FileNotFoundError:

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -594,7 +594,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
     parser.add_argument('--network-type', help='Type of network to create', required=True)
     parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
-    parser.add_argument('--block-version', help='Set the block version argument', action='store_true')
+    parser.add_argument('--block-version', help='Set the block version argument', type=int)
     args = parser.parse_args()
 
     Network().default_entry_point(args.network_type, args.skip_build, args.block_version)

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -141,7 +141,7 @@ class Peer:
 
 
 class Node:
-    def __init__(self, name, node_num, client_port, peer_port, admin_port, admin_http_gateway_port, peers, quorum_set):
+    def __init__(self, name, node_num, client_port, peer_port, admin_port, admin_http_gateway_port, peers, quorum_set, block_version):
         assert all(isinstance(peer, Peer) for peer in peers)
         assert isinstance(quorum_set, QuorumSet)
 
@@ -154,6 +154,7 @@ class Node:
         self.peers = peers
         self.quorum_set = quorum_set
         self.minimum_fee = 400_000_000
+        self.block_verison = block_version or 2
 
         self.consensus_process = None
         self.ledger_distribution_process = None
@@ -249,7 +250,7 @@ class Node:
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
             f'--origin-block-path {LEDGER_BASE}',
-            f'--block-version 3',
+            f'--block-version {self.block_version}',
             f'--ledger-path {self.ledger_dir}',
             f'--admin-listen-uri="insecure-mca://0.0.0.0:{self.admin_port}/"',
             f'--client-listen-uri="insecure-mc://0.0.0.0:{self.client_port}/"',
@@ -434,6 +435,7 @@ class Network:
         self.nodes = []
         self.ledger_distribution = None
         self.cli = None
+        self.block_version = None
         try:
             shutil.rmtree(WORK_DIR)
         except FileNotFoundError:
@@ -467,6 +469,7 @@ class Network:
             BASE_ADMIN_HTTP_GATEWAY_PORT + node_num,
             peers,
             quorum_set,
+            self.block_version,
         ))
 
     def get_node(self, name):
@@ -539,7 +542,9 @@ class Network:
                 raise
 
 
-    def default_entry_point(self, network_type, skip_build=False):
+    def default_entry_point(self, network_type, skip_build=False, block_version=None):
+        self.block_version = block_version
+
         if network_type == 'dense5':
             #  5 node interconnected network requiring 4 out of 5  nodes.
             num_nodes = 5
@@ -589,6 +594,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
     parser.add_argument('--network-type', help='Type of network to create', required=True)
     parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
+    parser.add_argument('--block-version', help='Set the block version argument', action='store_true')
     args = parser.parse_args()
 
-    Network().default_entry_point(args.network_type, args.skip_build)
+    Network().default_entry_point(args.network_type, args.skip_build, args.block_version)

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -217,6 +217,7 @@ mod block_tests {
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 
+    // This is block version 1 to avoid messing with test vectors
     const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
 
     fn get_block_contents<RNG: CryptoRng + RngCore>(rng: &mut RNG) -> BlockContents {
@@ -388,7 +389,7 @@ mod block_tests {
     /// actual block id into the test. This should hopefully catches cases where
     /// we add/change Block/BlockContents and accidentally break id
     /// calculation of old blocks.
-    fn test_hashing_is_consistent() {
+    fn test_hashing_is_consistent_block_version_one() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         //Check hash with memo

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -57,44 +57,43 @@ impl FromStr for BlockVersion {
 impl BlockVersion {
     /// The maximum value of block_version that this build of
     /// mc-transaction-core has support for
-    pub const MAX: Self = Self(3);
+    pub const MAX: Self = Self(2);
 
     /// Refers to the block version number at network launch.
-    /// Note: The origin blocks use block version zero.
+    pub const ZERO: Self = Self(0);
+
+    /// Constant for block version one
     pub const ONE: Self = Self(1);
 
     /// Constant for block version two
     pub const TWO: Self = Self(2);
 
-    /// Constant for block version three
-    pub const THREE: Self = Self(3);
-
     /// Iterator over block versions from one up to max, inclusive. For use in
     /// tests.
     pub fn iterator() -> BlockVersionIterator {
-        BlockVersionIterator(1)
+        BlockVersionIterator(0)
     }
 
     /// The encrypted memos [MCIP #3](https://github.com/mobilecoinfoundation/mcips/pull/3)
-    /// feature is introduced in block version 2.
+    /// feature is introduced in block version 1.
     pub fn e_memo_feature_is_supported(&self) -> bool {
+        self.0 >= 1
+    }
+
+    /// The confidential token ids [MCIP #25](https://github.com/mobilecoinfoundation/mcips/pull/25)
+    /// feature is introduced in block version 2.
+    pub fn masked_token_id_feature_is_supported(&self) -> bool {
         self.0 >= 2
     }
 
-    /// The confidential token ids [MCIP #25](https://github.com/mobilecoinfoundation/mcips/pull/3)
-    /// feature is introduced in block version 3.
-    pub fn masked_token_id_feature_is_supported(&self) -> bool {
-        self.0 >= 3
-    }
-
-    /// transactions shall be sorted after version 3
+    /// transactions shall be sorted after version 2
     pub fn validate_transaction_outputs_are_sorted(&self) -> bool {
-        self.0 > 3
+        self.0 > 2
     }
 
-    /// mint transactions are introduced in block version 3
+    /// mint transactions are introduced in block version 2
     pub fn mint_transactions_are_supported(&self) -> bool {
-        self.0 >= 3
+        self.0 >= 2
     }
 }
 
@@ -148,7 +147,7 @@ mod tests {
     #[test]
     fn test_block_version_iterator() {
         let observed = BlockVersion::iterator().map(|x| *x).collect::<Vec<u32>>();
-        let expected = (1..=*BlockVersion::MAX).collect::<Vec<u32>>();
+        let expected = (0..=*BlockVersion::MAX).collect::<Vec<u32>>();
         assert_eq!(observed, expected);
     }
 

--- a/transaction/core/src/mint/validation/common.rs
+++ b/transaction/core/src/mint/validation/common.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn validate_block_version_accepts_valid_block_versions() {
-        assert!(validate_block_version(BlockVersion::THREE).is_ok());
+        assert!(validate_block_version(BlockVersion::TWO).is_ok());
         assert!(validate_block_version(BlockVersion::MAX).is_ok());
     }
 
@@ -84,8 +84,8 @@ mod tests {
             Err(Error::InvalidBlockVersion(BlockVersion::ONE))
         );
         assert_eq!(
-            validate_block_version(BlockVersion::TWO),
-            Err(Error::InvalidBlockVersion(BlockVersion::TWO))
+            validate_block_version(BlockVersion::ZERO),
+            Err(Error::InvalidBlockVersion(BlockVersion::ZERO))
         );
     }
 

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -612,7 +612,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -634,7 +634,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -655,7 +655,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -680,7 +680,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -706,7 +706,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -738,7 +738,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -773,7 +773,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 1..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -814,7 +814,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 4..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -848,7 +848,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 4..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);
@@ -873,7 +873,7 @@ mod rct_bulletproofs_tests {
             num_inputs in 2..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
-            block_version in 2..=3u32,
+            block_version in 1..=2u32,
         ) {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: StdRng = SeedableRng::from_seed(seed);

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -394,7 +394,7 @@ fn compute_extended_message_either_version(
     pseudo_output_commitments: &[CompressedCommitment],
     range_proof_bytes: &[u8],
 ) -> Vec<u8> {
-    if block_version >= BlockVersion::THREE {
+    if block_version >= BlockVersion::TWO {
         // New-style extended message using merlin
         digest_extended_message(message, pseudo_output_commitments, range_proof_bytes).to_vec()
     } else {
@@ -420,7 +420,7 @@ fn digest_extended_message(
 }
 
 /// Concatenates [message || pseudo_output_commitments || range_proof].
-/// (Used before block version three)
+/// (Used before block version two)
 fn extend_message(
     message: &[u8],
     pseudo_output_commitments: &[CompressedCommitment],
@@ -915,40 +915,14 @@ mod rct_bulletproofs_tests {
         }
 
         #[test]
-        // block version two signatures should not validate at block version three
-        fn validate_block_version_two_as_three_should_fail(
+        // block version two signatures should not validate at block version two
+        fn validate_block_version_one_as_two_should_fail(
             num_inputs in 2..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
-            let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
-            // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
-
-            let signature = params.sign(fee, &mut rng).unwrap();
-
-            let result = signature.verify(
-                BlockVersion::THREE,
-                &params.message,
-                &params.rings,
-                &params.get_output_commitments(),
-                fee,
-                params.token_id,
-                &mut rng,
-            );
-            assert!(result.is_err());
-        }
-
-        #[test]
-        // block version three signatures should not validate at block version two
-        fn validate_block_version_three_as_two_should_fail(
-            num_inputs in 2..8usize,
-            num_mixins in 1..17usize,
-            seed in any::<[u8; 32]>(),
-        ) {
-            let mut rng: StdRng = SeedableRng::from_seed(seed);
-            let mut params = SignatureParams::random(BlockVersion::THREE, num_inputs, num_mixins, &mut rng);
+            let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let (fee, _) = params.output_values_and_blindings.pop().unwrap();
 
@@ -967,21 +941,47 @@ mod rct_bulletproofs_tests {
         }
 
         #[test]
-        // block version three signatures should not validate if we change the token id
-        fn validate_block_version_three_with_changed_token_id_should_fail(
+        // block version two signatures should not validate at block version one
+        fn validate_block_version_two_as_one_should_fail(
             num_inputs in 2..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
-            let mut params = SignatureParams::random(BlockVersion::THREE, num_inputs, num_mixins, &mut rng);
+            let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
+            // Remove one of the outputs, and use its value as the fee. This conserves value.
+            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+
+            let signature = params.sign(fee, &mut rng).unwrap();
+
+            let result = signature.verify(
+                BlockVersion::ONE,
+                &params.message,
+                &params.rings,
+                &params.get_output_commitments(),
+                fee,
+                params.token_id,
+                &mut rng,
+            );
+            assert!(result.is_err());
+        }
+
+        #[test]
+        // block version two signatures should not validate if we change the token id
+        fn validate_block_version_two_with_changed_token_id_should_fail(
+            num_inputs in 2..8usize,
+            num_mixins in 1..17usize,
+            seed in any::<[u8; 32]>(),
+        ) {
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+            let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let (fee, _) = params.output_values_and_blindings.pop().unwrap();
 
             let signature = params.sign(fee, &mut rng).unwrap();
 
             signature.verify(
-                BlockVersion::THREE,
+                BlockVersion::TWO,
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
@@ -992,7 +992,7 @@ mod rct_bulletproofs_tests {
 
 
             let result = signature.verify(
-                BlockVersion::THREE,
+                BlockVersion::TWO,
                 &params.message,
                 &params.rings,
                 &params.get_output_commitments(),
@@ -1004,14 +1004,14 @@ mod rct_bulletproofs_tests {
         }
 
         #[test]
-        // block version two signatures should not work if token id is not zero
-        fn validate_block_version_two_with_token_id_should_fail(
+        // block version one signatures should not work if token id is not zero
+        fn validate_block_version_one_with_token_id_should_fail(
             num_inputs in 2..8usize,
             num_mixins in 1..17usize,
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
-            let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
+            let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let (fee, _) = params.output_values_and_blindings.pop().unwrap();
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -38,7 +38,7 @@ pub fn validate<R: RngCore + CryptoRng>(
     minimum_fee: u64,
     csprng: &mut R,
 ) -> TransactionValidationResult<()> {
-    if block_version < BlockVersion::ONE || BlockVersion::MAX < block_version {
+    if BlockVersion::MAX < block_version {
         return Err(TransactionValidationError::Ledger(format!(
             "Invalid block version: {}",
             block_version
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     // Should return MissingMemo when memos are missing in any the outputs
     fn test_validate_memos_exist() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let (tx, _) = create_test_tx(BlockVersion::ZERO);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
         assert_eq!(
@@ -610,7 +610,7 @@ mod tests {
             Err(TransactionValidationError::MissingMemo)
         );
 
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
         assert_eq!(validate_memos_exist(&tx), Ok(()));
@@ -619,12 +619,12 @@ mod tests {
     #[test]
     // Should return MemosNotAllowed when memos are present in any of the outputs
     fn test_validate_no_memos_exist() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let (tx, _) = create_test_tx(BlockVersion::ZERO);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
         assert_eq!(validate_no_memos_exist(&tx), Ok(()));
 
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
 
         assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
         assert_eq!(
@@ -1117,11 +1117,11 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         for _ in 0..3 {
-            let (mut tx, _ledger) = create_test_tx(BlockVersion::THREE);
+            let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
 
             tx.prefix.token_id = tx.prefix.token_id + 1;
 
-            match validate_signature(BlockVersion::THREE, &tx, &mut rng) {
+            match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
                 Err(e) => {
                     panic!("Unexpected error {}", e);
@@ -1132,34 +1132,32 @@ mod tests {
     }
 
     #[test]
-    // Should return InvalidTransactionSignature if block version 2 is validated as
-    // 3
-    fn test_transaction_signature_err_version_two_as_three() {
+    // Should return InvalidTransactionSignature if block v 1 is validated as 2
+    fn test_transaction_signature_err_version_one_as_two() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        for _ in 0..3 {
+            let (tx, _ledger) = create_test_tx(BlockVersion::ONE);
+
+            match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
+                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+                Err(e) => {
+                    panic!("Unexpected error {}", e);
+                }
+                Ok(()) => panic!("Unexpected success"),
+            }
+        }
+    }
+
+    #[test]
+    // Should return InvalidTransactionSignature if block v 2 is validated as 1
+    fn test_transaction_signature_err_version_two_as_one() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
         for _ in 0..3 {
             let (tx, _ledger) = create_test_tx(BlockVersion::TWO);
 
-            match validate_signature(BlockVersion::THREE, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if block version 3 is validated as
-    // 2
-    fn test_transaction_signature_err_version_three_as_two() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for _ in 0..3 {
-            let (tx, _ledger) = create_test_tx(BlockVersion::THREE);
-
-            match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
+            match validate_signature(BlockVersion::ONE, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
                 Err(e) => {
                     panic!("Unexpected error {}", e);

--- a/transaction/core/tests/digest-test-vectors.rs
+++ b/transaction/core/tests/digest-test-vectors.rs
@@ -220,7 +220,7 @@ fn origin_block_digestible_ast() {
 
 #[test]
 fn block_contents_digestible_test_vectors() {
-    let results = test_blockchain(BlockVersion::TWO);
+    let results = test_blockchain(BlockVersion::ONE);
 
     // Test digest of block contents
     assert_eq!(
@@ -245,8 +245,7 @@ fn block_contents_digestible_test_vectors() {
         ]
     );
 
-    // Now set block version 1 and run the old test vectors
-    let results = test_blockchain(BlockVersion::ONE);
+    let results = test_blockchain(BlockVersion::ZERO);
 
     // Test digest of block contents
     assert_eq!(

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -715,11 +715,11 @@ pub mod transaction_builder_tests {
     // in tests
     fn get_block_version_token_id_pairs() -> Vec<(BlockVersion, TokenId)> {
         vec![
+            (BlockVersion::try_from(0).unwrap(), TokenId::from(0)),
             (BlockVersion::try_from(1).unwrap(), TokenId::from(0)),
             (BlockVersion::try_from(2).unwrap(), TokenId::from(0)),
-            (BlockVersion::try_from(3).unwrap(), TokenId::from(0)),
-            (BlockVersion::try_from(3).unwrap(), TokenId::from(1)),
-            (BlockVersion::try_from(3).unwrap(), TokenId::from(2)),
+            (BlockVersion::try_from(2).unwrap(), TokenId::from(1)),
+            (BlockVersion::try_from(2).unwrap(), TokenId::from(2)),
         ]
     }
 

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -21,7 +21,7 @@ use rand_hc::Hc128Rng as FixedRng;
 use std::{path::Path, vec::Vec};
 
 // This is historically the version created by bootstrap
-const BLOCK_VERSION: BlockVersion = BlockVersion::ONE;
+const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
 
 /// Deterministically populates a testnet ledger.
 ///
@@ -80,7 +80,7 @@ pub fn bootstrap_ledger(
     let mut rng: FixedRng = SeedableRng::from_seed(seed.unwrap_or([33u8; 32]));
 
     let block_version = if max_token_id > 0 {
-        BlockVersion::THREE
+        BlockVersion::TWO
     } else {
         BLOCK_VERSION
     };

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -1128,7 +1128,7 @@ pub mod tests {
             .map(|account| account.default_subaddress())
             .collect::<Vec<_>>();
         get_blocks(
-            BlockVersion::ONE,
+            BlockVersion::ZERO,
             &recipient_pub_keys,
             10,
             1,


### PR DESCRIPTION
we have to decrement block version because of a compatibility issue
it turns out that v1.0 always published block version = 0, and not
one as the source code indicated after a bunch of development.

this was made by cherry-picking the fix from release 1.2 branch, then removing `BlockVerision::THREE` for now and fixing up a bunch of things in minting and ring signature logic and tests.