### PR TITLE
added a mechanism to generate unsorted outputs to be able to execute …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5008,6 +5008,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-ledger-db",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
@@ -5046,6 +5047,7 @@ dependencies = [
 name = "mc-transaction-std"
 version = "1.3.0-pre0"
 dependencies = [
+ "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",
  "hmac 0.12.1",

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -60,5 +60,6 @@ mc-crypto-digestible-test-utils = { path = "../../crypto/digestible/test-utils" 
 mc-crypto-rand = { path = "../../crypto/rand" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
+mc-transaction-std = { path = "../../transaction/std", features= ["test-only"] }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 mc-util-test-helper = { path = "../../util/test-helper" }

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -89,7 +89,7 @@ impl BlockVersion {
 
     /// transactions shall be sorted after version 3
     pub fn validate_transaction_outputs_are_sorted(&self) -> bool {
-        self.0 > 3
+        self.0 >= 3
     }
 
     /// mint transactions are introduced in block version 3

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -511,10 +511,9 @@ mod tests {
     use mc_ledger_db::{Ledger, LedgerDB};
     use mc_transaction_core_test_utils::{
         create_ledger, create_transaction, create_transaction_with_amount_and_comparer,
-        initialize_ledger, outputs_comparer_inverse, outputs_comparer_normal, AccountKey,
-        INITIALIZE_LEDGER_AMOUNT,
+        initialize_ledger, AccountKey, InverseTxOutputsOrdering, INITIALIZE_LEDGER_AMOUNT,
     };
-    use mc_transaction_std::TxOutputsComparerOption;
+    use mc_transaction_std::{DefaultTxOutputsOrdering, TxOutputsOrdering};
     use rand::{rngs::StdRng, SeedableRng};
     use serde::{de::DeserializeOwned, ser::Serialize};
 
@@ -573,15 +572,15 @@ mod tests {
             block_version,
             amount,
             fee,
-            Some(outputs_comparer_normal),
+            DefaultTxOutputsOrdering,
         )
     }
 
-    fn create_test_tx_with_amount_and_comparer(
+    fn create_test_tx_with_amount_and_comparer<O: TxOutputsOrdering>(
         block_version: BlockVersion,
         amount: u64,
         fee: u64,
-        outputs_comparer_option: TxOutputsComparerOption,
+        outputs_ordering: O,
     ) -> (Tx, LedgerDB) {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let sender = AccountKey::random(&mut rng);
@@ -610,7 +609,7 @@ mod tests {
             fee,
             n_blocks + 1,
             &mut rng,
-            outputs_comparer_option,
+            outputs_ordering,
         );
 
         (adapt_hack(&tx), ledger)
@@ -1308,7 +1307,7 @@ mod tests {
                 fee,
                 // for block version < 3 it doesn't matter
                 // for >= 3 it shall return an error about unsorted outputs
-                Some(outputs_comparer_inverse),
+                InverseTxOutputsOrdering,
             );
 
             let highest_indices = tx.get_membership_proof_highest_indices();

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -16,5 +16,5 @@ mc-crypto-rand = { path = "../../../crypto/rand" }
 mc-fog-report-validation-test-utils = { path = "../../../fog/report/validation/test-utils" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-transaction-core = { path = "../../../transaction/core" }
-mc-transaction-std = { path = "../../../transaction/std" }
+mc-transaction-std = { path = "../../../transaction/std", features= ["test-only"] }
 mc-util-from-random = { path = "../../../util/from-random" }

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -46,7 +46,7 @@ pub struct InverseTxOutputsOrdering;
 
 impl TxOutputsOrdering for InverseTxOutputsOrdering {
     fn cmp(&self, a: &CompressedRistrettoPublic, b: &CompressedRistrettoPublic) -> Ordering {
-        b.cmp(&a)
+        b.cmp(a)
     }
 }
 

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -45,7 +45,7 @@ pub fn create_ledger() -> LedgerDB {
 pub struct InverseTxOutputsOrdering;
 
 impl TxOutputsOrdering for InverseTxOutputsOrdering {
-    fn cmp(&self, a: &CompressedRistrettoPublic, b: &CompressedRistrettoPublic) -> Ordering {
+    fn cmp(a: &CompressedRistrettoPublic, b: &CompressedRistrettoPublic) -> Ordering {
         b.cmp(a)
     }
 }
@@ -109,7 +109,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
-    create_transaction_with_amount_and_comparer(
+    create_transaction_with_amount_and_comparer::<L, R, DefaultTxOutputsOrdering>(
         block_version,
         ledger,
         tx_out,
@@ -119,7 +119,6 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
         fee,
         tombstone_block,
         rng,
-        DefaultTxOutputsOrdering,
     )
 }
 
@@ -147,7 +146,6 @@ pub fn create_transaction_with_amount_and_comparer<
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
-    outputs_ordering: O,
 ) -> Tx {
     let mut transaction_builder = TransactionBuilder::new(
         block_version,
@@ -205,9 +203,7 @@ pub fn create_transaction_with_amount_and_comparer<
     transaction_builder.set_fee(fee).unwrap();
 
     // Build and return the transaction
-    transaction_builder
-        .build_with_sorter(rng, &outputs_ordering)
-        .unwrap()
+    transaction_builder.build_with_sorter::<R, O>(rng).unwrap()
 }
 
 /// Populates the LedgerDB with initial data.

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [features]
-test-only=[]
+test-only = []
 
 [dependencies]
 # External dependencies

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -4,8 +4,12 @@ version = "1.3.0-pre0"
 authors = ["MobileCoin"]
 edition = "2018"
 
+[features]
+test-only=[]
+
 [dependencies]
 # External dependencies
+cfg-if = "1.0"
 displaydoc = { version = "0.2", default-features = false }
 hmac = "0.12"
 prost = { version = "0.9", default-features = false, features = ["prost-derive"] }

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -23,7 +23,7 @@ pub use memo::{
     UnusedMemo,
 };
 pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
-pub use transaction_builder::{TransactionBuilder, TxOutputsComparerOption};
+pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
 
 // Re-export this to help the exported macros work
 pub use mc_transaction_core::MemoPayload;

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![deny(missing_docs)]
 
+extern crate core;
+
 mod change_destination;
 mod error;
 mod input_credentials;
@@ -21,7 +23,7 @@ pub use memo::{
     UnusedMemo,
 };
 pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
-pub use transaction_builder::TransactionBuilder;
+pub use transaction_builder::{TransactionBuilder, TxOutputsComparerOption};
 
 // Re-export this to help the exported macros work
 pub use mc_transaction_core::MemoPayload;

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -323,7 +323,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         comparer_option: TxOutputsComparerOption,
     ) -> Result<Tx, TxBuilderError> {
         match comparer_option {
-            Some(_) => return self.build_with_comparer_internal(rng, comparer_option),
+            Some(_) => self.build_with_comparer_internal(rng, comparer_option),
             _ => panic!("A valid comparer must be provided or use build() method."),
         }
     }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -35,7 +35,7 @@ pub struct DefaultTxOutputsOrdering;
 
 impl TxOutputsOrdering for DefaultTxOutputsOrdering {
     fn cmp(&self, a: &CompressedRistrettoPublic, b: &CompressedRistrettoPublic) -> Ordering {
-        a.cmp(&b)
+        a.cmp(b)
     }
 }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -316,17 +316,17 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
 
     /// Consume the builder and return the transaction with a comparer.
     /// Used only in testing library.
-   #[cfg(feature = "test-only")]
-   pub fn build_with_comparer<RNG: CryptoRng + RngCore>(
-       self,
-       rng: &mut RNG,
-       comparer_option: TxOutputsComparerOption,
-   ) -> Result<Tx, TxBuilderError> {
-       match comparer_option {
-           Some(_) => return self.build_with_comparer_internal(rng, comparer_option),
-           _ => panic!("A valid comparer must be provided or use build() method."),
-       }
-   }
+    #[cfg(feature = "test-only")]
+    pub fn build_with_comparer<RNG: CryptoRng + RngCore>(
+        self,
+        rng: &mut RNG,
+        comparer_option: TxOutputsComparerOption,
+    ) -> Result<Tx, TxBuilderError> {
+        match comparer_option {
+            Some(_) => return self.build_with_comparer_internal(rng, comparer_option),
+            _ => panic!("A valid comparer must be provided or use build() method."),
+        }
+    }
 
     /// Consume the builder and return the transaction with a comparer
     /// (internal usage only).


### PR DESCRIPTION
…the global transaction validate method

### Motivation

we didn't have a way to generate a wrongly sorted transaction outputs.  

### In this PR
added a mechanism to sort outputs using a custom comparator

#1639 


