### PR TITLE
move mint_output into TxOut::mint so it can be reused by the consensus mock enclave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,7 +2916,6 @@ dependencies = [
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-crypto-ake-enclave",
- "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-message-cipher",
  "mc-crypto-multisig",
@@ -2953,6 +2952,7 @@ dependencies = [
 name = "mc-consensus-enclave-mock"
 version = "1.3.0-pre0"
 dependencies = [
+ "mc-account-keys",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -32,7 +32,6 @@ mc-attest-trusted = { path = "../../../attest/trusted", default-features = false
 mc-common = { path = "../../../common", default-features = false }
 mc-consensus-enclave-api = { path = "../api", default-features = false }
 mc-crypto-ake-enclave = { path = "../../../crypto/ake/enclave" }
-mc-crypto-digestible = { path = "../../../crypto/digestible" }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-crypto-message-cipher = { path = "../../../crypto/message-cipher" }
 mc-crypto-rand = { path = "../../../crypto/rand" }

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
+mc-account-keys = { path = "../../../account-keys" }
 mc-attest-core = { path = "../../../attest/core" }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
 mc-common = { path = "../../../common" }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -329,9 +329,6 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             outputs.push(output);
         }
 
-        outputs.sort_by(|a, b| a.public_key.cmp(&b.public_key));
-        key_images.sort();
-
         let block_contents = BlockContents {
             key_images,
             outputs,

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -823,7 +823,6 @@ dependencies = [
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-crypto-ake-enclave",
- "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-message-cipher",
  "mc-crypto-rand",

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt};
 use mc_account_keys::PublicAddress;
 use mc_common::Hash;
-use mc_crypto_digestible::{Digestible, MerlinTranscript, DigestTranscript};
+use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_crypto_hashes::{Blake2b256, Digest};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use mc_util_repr_bytes::{
@@ -24,7 +24,7 @@ use crate::{
     membership_proofs::Range,
     memo::{EncryptedMemo, MemoPayload},
     onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
-    ring_signature::{KeyImage, SignatureRctBulletproofs, Scalar},
+    ring_signature::{KeyImage, Scalar, SignatureRctBulletproofs},
     CompressedCommitment, NewMemoError, NewTxError, ViewKeyMatchError,
 };
 
@@ -404,14 +404,15 @@ impl TxOut {
     }
 
     /// Creates a single output belonging to a specific recipient account.
-    /// The output is created using a predictable private key that is derived from
-    /// the input parameters.
+    /// The output is created using a predictable private key that is derived
+    /// from the input parameters.
     ///
     /// # Arguments:
     /// * `recipient` - The recipient of the output.
     /// * `domain_tag` - Domain separator for hashing the input parameters.
     /// * `parent_block` - The parent block.
-    /// * `transactions` - The transactions that are included in the current block.
+    /// * `transactions` - The transactions that are included in the current
+    ///   block.
     /// * `amount` - Output amount.
     pub fn mint<T: Digestible>(
         recipient: &PublicAddress,


### PR DESCRIPTION
### Motivation

While working on adding a unit test to `ByzantineLedger` I ran into the need to have the consensus mock enclave support MintTxs. Part of that support includes the actual minting of the `TxOut`s - so instead of duplicating `fn mint_output` I opted to move it into `TxOut`.

### In this PR
* Move `mint_output` into the `TxOut` object
* Modify the mock consensus enclave to perform minting when `MintTx`s are present.