### PR TITLE
mc-consensus-service: add unit tests for new minting transaction flows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --workspace --exclude "mc-fog-*" --exclude "mc-consensus-*" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4 -- --nocapture
+        default: cargo test --workspace --exclude "mc-fog-*" --exclude "mc-consensus-*" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4
     steps:
       - run:
           name: Run mobilecoin tests
@@ -375,7 +375,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --package "mc-consensus-*" -j 4 --frozen --no-fail-fast -- --nocapture
+            cargo test --package "mc-consensus-*" -j 4 --frozen --no-fail-fast
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -392,7 +392,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast -- --nocapture
+            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -408,7 +408,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --release --package "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast -- --nocapture
+            cargo test --release --package "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
       - run:
           command: |
             mkdir -p /tmp/core_dumps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,7 +333,7 @@ commands:
     parameters:
       test_command:
         type: string
-        default: cargo test --workspace --exclude "mc-fog-*" --exclude "mc-consensus-*" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4
+        default: cargo test --workspace --exclude "mc-fog-*" --exclude "mc-consensus-*" --frozen --target "$HOST_TARGET_TRIPLE" --no-fail-fast --tests -j 4 -- --nocapture
     steps:
       - run:
           name: Run mobilecoin tests
@@ -375,7 +375,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --package "mc-consensus-*" -j 4 --frozen --no-fail-fast
+            cargo test --package "mc-consensus-*" -j 4 --frozen --no-fail-fast -- --nocapture
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -392,7 +392,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
+            cargo test --workspace --package "mc-fog-*" --exclude "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast -- --nocapture
       - run:
           command: |
             mkdir -p /tmp/core_dumps
@@ -408,7 +408,7 @@ commands:
           command: |
             # tell the operating system to remove the file size limit on core dump files
             ulimit -c unlimited
-            cargo test --release --package "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast
+            cargo test --release --package "mc-fog-ingest-*" -j 4 --frozen --no-fail-fast -- --nocapture
       - run:
           command: |
             mkdir -p /tmp/core_dumps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
 name = "mc-consensus-enclave-mock"
 version = "1.3.0-pre0"
 dependencies = [
+ "mc-account-keys",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",
@@ -2961,6 +2962,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
+ "mc-transaction-core-test-utils",
  "mc-util-from-random",
  "mc-util-serial",
  "mockall",

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["MobileCoin"]
 edition = "2018"
 
 [dependencies]
-mc-attest-core = { path = "../../../attest/core" }
 mc-account-keys = { path = "../../../account-keys" }
+mc-attest-core = { path = "../../../attest/core" }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
 mc-common = { path = "../../../common" }
 mc-consensus-enclave-api = { path = "../api" }

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 mc-attest-core = { path = "../../../attest/core" }
+mc-account-keys = { path = "../../../account-keys" }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
 mc-common = { path = "../../../common" }
 mc-consensus-enclave-api = { path = "../api" }
@@ -13,6 +14,7 @@ mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-crypto-rand = { path = "../../../crypto/rand" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
 mc-transaction-core = { path = "../../../transaction/core" }
+mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -249,9 +249,9 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             )?;
 
             for proof in proofs {
-                let root_element = compute_implied_merkle_root(proof)
+                let implied_root = compute_implied_merkle_root(proof)
                     .map_err(|_e| TransactionValidationError::InvalidLedgerContext)?;
-                root_elements.push(root_element);
+                root_elements.push(implied_root);
             }
         }
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -258,10 +258,10 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         root_elements.sort();
         root_elements.dedup();
 
-        if !transactions_with_proofs.is_empty() {
-            if root_elements.len() != 1 || root_elements[0] != *root_element {
-                return Err(Error::InvalidLocalMembershipProof);
-            }
+        if !transactions_with_proofs.is_empty()
+            && (root_elements.len() != 1 || root_elements[0] != *root_element)
+        {
+            return Err(Error::InvalidLocalMembershipProof);
         }
 
         let mut key_images: Vec<KeyImage> = Vec::new();

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -12,6 +12,7 @@ pub use mc_consensus_enclave_api::{
     WellFormedEncryptedTx, WellFormedTxContext,
 };
 
+use mc_account_keys::PublicAddress;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, PeerAuthRequest,
@@ -31,6 +32,7 @@ use mc_transaction_core::{
     validation::TransactionValidationError,
     Block, BlockContents, BlockSignature, Token, TokenId,
 };
+use mc_transaction_core_test_utils::get_outputs;
 use mc_util_from_random::FromRandom;
 use rand_core::SeedableRng;
 use rand_hc::Hc128Rng;
@@ -216,7 +218,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         &self,
         parent_block: &Block,
         inputs: FormBlockInputs,
-        _root_element: &TxOutMembershipElement,
+        root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
         let block_version = self.blockchain_config.lock().unwrap().block_version;
         let transactions_with_proofs: Vec<(Tx, Vec<TxOutMembershipProof>)> = inputs
@@ -249,15 +251,17 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             for proof in proofs {
                 let root_element = compute_implied_merkle_root(proof)
                     .map_err(|_e| TransactionValidationError::InvalidLedgerContext)?;
-                root_elements.push(root_element.clone());
+                root_elements.push(root_element);
             }
         }
 
         root_elements.sort();
         root_elements.dedup();
 
-        if root_elements.len() != 1 {
-            return Err(Error::InvalidLocalMembershipProof);
+        if !transactions_with_proofs.is_empty() {
+            if root_elements.len() != 1 || root_elements[0] != *root_element {
+                return Err(Error::InvalidLocalMembershipProof);
+            }
         }
 
         let mut key_images: Vec<KeyImage> = Vec::new();
@@ -267,18 +271,32 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             outputs.extend(tx.prefix.outputs.into_iter());
         }
 
+        let minted_tx_outs = get_outputs(
+            block_version,
+            &inputs
+                .mint_txs
+                .iter()
+                .map(|mint_tx| {
+                    let recipient = PublicAddress::new(
+                        &mint_tx.prefix.spend_public_key,
+                        &mint_tx.prefix.view_public_key,
+                    );
+                    (recipient, mint_tx.prefix.amount)
+                })
+                .collect::<Vec<_>>(),
+            &mut rng,
+        );
+        outputs.extend(minted_tx_outs);
+
         let block_contents = BlockContents {
             key_images,
             outputs,
-            ..Default::default()
+            mint_txs: inputs.mint_txs,
+            mint_config_txs: inputs.mint_config_txs,
         };
 
-        let block = Block::new_with_parent(
-            block_version,
-            parent_block,
-            &root_elements[0],
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(block_version, parent_block, root_element, &block_contents);
 
         let signature = BlockSignature::from_block_and_keypair(&block, &self.signing_keypair)?;
 

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -677,7 +677,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     fn test_propose_mint_config_tx_ok(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let consensus_enclave = MockConsensusEnclave::new();
@@ -741,7 +740,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     // Should return NonceAlreadyUsed if the tx contains a nonce that is already
     // used.
     fn test_propose_mint_config_tx_duplicate_nonce(logger: Logger) {
@@ -806,7 +804,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     // Should return RpcStatus Unavailable if the node is not serving.
     fn test_propose_mint_config_tx_not_serving(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
@@ -915,7 +912,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     fn test_propose_mint_config_tx_unauthenticated(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let tx = create_mint_config_tx(TokenId::from(5), &mut rng);
@@ -968,7 +964,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     fn test_propose_mint_tx_ok(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let consensus_enclave = MockConsensusEnclave::new();
@@ -1037,7 +1032,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     // Should return NonceAlreadyUsed if the tx contains a nonce that is already
     // used.
     fn test_propose_mint_tx_duplicate_nonce(logger: Logger) {
@@ -1107,7 +1101,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     // Should return RpcStatus Unavailable if the node is not serving.
     fn test_propose_mint_tx_not_serving(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
@@ -1226,7 +1219,6 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
-    #[serial(counters)]
     fn test_propose_mint_tx_unauthenticated(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let tx = create_mint_tx(

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -352,7 +352,7 @@ mod client_api_tests {
     // manipulating and observing the value of the global prometheus counters.
     // Since the client API calls that are being tested also manipulate them, the
     // tests have to be serialized so that they do not interfere with eachother.
-  
+
     #[test_with_logger]
     #[serial(counters)]
     fn test_client_tx_propose_ok(logger: Logger) {
@@ -749,6 +749,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -818,6 +819,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -868,6 +870,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -920,6 +923,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -981,6 +985,7 @@ mod client_api_tests {
         );
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -1040,6 +1045,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -1119,6 +1125,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -1174,6 +1181,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -1231,6 +1239,7 @@ mod client_api_tests {
         let authenticator = AnonymousAuthenticator::default();
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),
@@ -1297,6 +1306,7 @@ mod client_api_tests {
         );
 
         let instance = ClientApiService::new(
+            get_config(),
             Arc::new(consensus_enclave),
             scp_client_value_sender,
             Arc::new(ledger),

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -320,6 +320,11 @@ mod client_api_tests {
         (client, server)
     }
 
+    // A note about `#[serial(counters)]`: some of the tests here rely on
+    // manipulating and observing the value of the global prometheus counters.
+    // Since the client API calls that are being tested also manipulate them, the
+    // tests have to be serialized so that they do not interfere with eachother.
+
     #[test_with_logger]
     #[serial(counters)]
     fn test_client_tx_propose_ok(logger: Logger) {
@@ -677,6 +682,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     fn test_propose_mint_config_tx_ok(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let consensus_enclave = MockConsensusEnclave::new();
@@ -740,6 +746,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     // Should return NonceAlreadyUsed if the tx contains a nonce that is already
     // used.
     fn test_propose_mint_config_tx_duplicate_nonce(logger: Logger) {
@@ -804,6 +811,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     // Should return RpcStatus Unavailable if the node is not serving.
     fn test_propose_mint_config_tx_not_serving(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
@@ -912,6 +920,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     fn test_propose_mint_config_tx_unauthenticated(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let tx = create_mint_config_tx(TokenId::from(5), &mut rng);
@@ -964,6 +973,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     fn test_propose_mint_tx_ok(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let consensus_enclave = MockConsensusEnclave::new();
@@ -1032,6 +1042,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     // Should return NonceAlreadyUsed if the tx contains a nonce that is already
     // used.
     fn test_propose_mint_tx_duplicate_nonce(logger: Logger) {
@@ -1101,6 +1112,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     // Should return RpcStatus Unavailable if the node is not serving.
     fn test_propose_mint_tx_not_serving(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
@@ -1219,6 +1231,7 @@ mod client_api_tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     fn test_propose_mint_tx_unauthenticated(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let tx = create_mint_tx(

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -286,13 +286,15 @@ mod client_api_tests {
     };
     use mc_consensus_enclave::TxContext;
     use mc_consensus_enclave_mock::MockConsensusEnclave;
+    use mc_crypto_keys::Ed25519Pair;
     use mc_ledger_db::MockLedger;
     use mc_peers::ConsensusValue;
     use mc_transaction_core::{
         mint::MintValidationError, ring_signature::KeyImage, tx::TxHash,
         validation::TransactionValidationError, TokenId,
     };
-    use mc_transaction_core_test_utils::create_mint_config_tx;
+    use mc_transaction_core_test_utils::{create_mint_config_tx, create_mint_tx};
+    use mc_util_from_random::FromRandom;
     use mc_util_grpc::{AnonymousAuthenticator, TokenAuthenticator};
     use rand_core::SeedableRng;
     use rand_hc::Hc128Rng;
@@ -953,6 +955,322 @@ mod client_api_tests {
         // gRPC client and server.
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
+            Ok(propose_tx_response) => {
+                panic!("Unexpected response {:?}", propose_tx_response);
+            }
+            Err(GrpcError::RpcFailure(rpc_status)) => {
+                assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+
+        assert!(submitted_values.lock().unwrap().is_empty());
+    }
+
+    #[test_with_logger]
+    #[serial(counters)]
+    fn test_propose_mint_tx_ok(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let consensus_enclave = MockConsensusEnclave::new();
+        let submitted_values = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_values2 = submitted_values.clone();
+        let scp_client_value_sender = Arc::new(
+            move |value: ConsensusValue,
+                  _node_id: Option<&NodeID>,
+                  _responder_id: Option<&ResponderId>| {
+                submitted_values2.lock().unwrap().push(value);
+            },
+        );
+
+        let num_blocks = 5;
+        let mut ledger = MockLedger::new();
+        // The service should request num_blocks.
+        ledger
+            .expect_num_blocks()
+            .times(1)
+            .return_const(Ok(num_blocks));
+
+        let mut mint_tx_manager = MockMintTxManager::new();
+        mint_tx_manager
+            .expect_validate_mint_tx()
+            .times(1)
+            .return_const(Ok(()));
+
+        let is_serving_fn = Arc::new(|| -> bool { true });
+        let authenticator = AnonymousAuthenticator::default();
+
+        let instance = ClientApiService::new(
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(MockTxManager::new()),
+            Arc::new(mint_tx_manager),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+        );
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        let tx = create_mint_tx(
+            TokenId::from(5),
+            &[Ed25519Pair::from_random(&mut rng)],
+            100,
+            &mut rng,
+        );
+        match client.propose_mint_tx(&(&tx).into()) {
+            Ok(propose_tx_response) => {
+                assert_eq!(
+                    propose_tx_response.get_result().get_code(),
+                    MintValidationResultCode::Ok
+                );
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+
+        assert_eq!(
+            *submitted_values.lock().unwrap(),
+            vec![ConsensusValue::MintTx(tx)]
+        );
+    }
+
+    #[test_with_logger]
+    #[serial(counters)]
+    // Should return NonceAlreadyUsed if the tx contains a nonce that is already
+    // used.
+    fn test_propose_mint_tx_duplicate_nonce(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let tx = create_mint_tx(
+            TokenId::from(5),
+            &[Ed25519Pair::from_random(&mut rng)],
+            100,
+            &mut rng,
+        );
+        let consensus_enclave = MockConsensusEnclave::new();
+        let submitted_values = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_values2 = submitted_values.clone();
+        let scp_client_value_sender = Arc::new(
+            move |value: ConsensusValue,
+                  _node_id: Option<&NodeID>,
+                  _responder_id: Option<&ResponderId>| {
+                submitted_values2.lock().unwrap().push(value);
+            },
+        );
+
+        let num_blocks = 5;
+        let mut ledger = MockLedger::new();
+        // The service should request num_blocks.
+        ledger
+            .expect_num_blocks()
+            .times(1)
+            .return_const(Ok(num_blocks));
+
+        let mut mint_tx_manager = MockMintTxManager::new();
+        mint_tx_manager
+            .expect_validate_mint_tx()
+            .times(1)
+            .return_const(Err(MintTxManagerError::MintValidation(
+                MintValidationError::NonceAlreadyUsed,
+            )));
+
+        let is_serving_fn = Arc::new(|| -> bool { true });
+        let authenticator = AnonymousAuthenticator::default();
+
+        let instance = ClientApiService::new(
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(MockTxManager::new()),
+            Arc::new(mint_tx_manager),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+        );
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        match client.propose_mint_tx(&(&tx).into()) {
+            Ok(propose_tx_response) => {
+                assert_eq!(
+                    propose_tx_response.get_result().get_code(),
+                    MintValidationResultCode::NonceAlreadyUsed
+                );
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+
+        assert!(submitted_values.lock().unwrap().is_empty());
+    }
+
+    #[test_with_logger]
+    #[serial(counters)]
+    // Should return RpcStatus Unavailable if the node is not serving.
+    fn test_propose_mint_tx_not_serving(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let tx = create_mint_tx(
+            TokenId::from(5),
+            &[Ed25519Pair::from_random(&mut rng)],
+            100,
+            &mut rng,
+        );
+        let consensus_enclave = MockConsensusEnclave::new();
+        let submitted_values = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_values2 = submitted_values.clone();
+        let scp_client_value_sender = Arc::new(
+            move |value: ConsensusValue,
+                  _node_id: Option<&NodeID>,
+                  _responder_id: Option<&ResponderId>| {
+                submitted_values2.lock().unwrap().push(value);
+            },
+        );
+
+        let ledger = MockLedger::new();
+        let mint_tx_manager = MockMintTxManager::new();
+        let is_serving_fn = Arc::new(|| -> bool { false });
+        let authenticator = AnonymousAuthenticator::default();
+
+        let instance = ClientApiService::new(
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(MockTxManager::new()),
+            Arc::new(mint_tx_manager),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+        );
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        match client.propose_mint_tx(&(&tx).into()) {
+            Ok(propose_tx_response) => {
+                panic!("Unexpected response {:?}", propose_tx_response);
+            }
+            Err(GrpcError::RpcFailure(rpc_status)) => {
+                assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+
+        assert!(submitted_values.lock().unwrap().is_empty());
+    }
+
+    #[test_with_logger]
+    #[serial(counters)]
+    // Should return RpcStatus Unavailable if the node is over capacity.
+    // This test modifies a the global variable `counters::CUR_NUM_PENDING_VALUES`,
+    // which means it cannot run in parallel with other tests that depend on
+    // that value (e.g. all tests in this module).
+    fn test_propose_mint_tx_over_capacity(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let tx = create_mint_tx(
+            TokenId::from(5),
+            &[Ed25519Pair::from_random(&mut rng)],
+            100,
+            &mut rng,
+        );
+        let consensus_enclave = MockConsensusEnclave::new();
+        let submitted_values = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_values2 = submitted_values.clone();
+        let scp_client_value_sender = Arc::new(
+            move |value: ConsensusValue,
+                  _node_id: Option<&NodeID>,
+                  _responder_id: Option<&ResponderId>| {
+                submitted_values2.lock().unwrap().push(value);
+            },
+        );
+
+        let ledger = MockLedger::new();
+        let mint_tx_manager = MockMintTxManager::new();
+        let is_serving_fn = Arc::new(|| -> bool { true });
+        let authenticator = AnonymousAuthenticator::default();
+
+        let instance = ClientApiService::new(
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(MockTxManager::new()),
+            Arc::new(mint_tx_manager),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+        );
+
+        // Set the number of pending values to be above the PENDING_LIMIT
+        // This is a global variable, and so affects other unit tests. It must be reset
+        // afterwards :(
+        counters::CUR_NUM_PENDING_VALUES.set(PENDING_LIMIT);
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        match client.propose_mint_tx(&(&tx).into()) {
+            Ok(propose_tx_response) => {
+                panic!("Unexpected response {:?}", propose_tx_response);
+            }
+            Err(GrpcError::RpcFailure(rpc_status)) => {
+                assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
+            }
+            Err(e) => panic!("Unexpected error: {:?}", e),
+        }
+
+        assert!(submitted_values.lock().unwrap().is_empty());
+
+        // This is a global variable. It affects other unit tests, so must be reset :(
+        counters::CUR_NUM_PENDING_VALUES.set(0);
+    }
+
+    #[test_with_logger]
+    #[serial(counters)]
+    fn test_propose_mint_tx_unauthenticated(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let tx = create_mint_tx(
+            TokenId::from(5),
+            &[Ed25519Pair::from_random(&mut rng)],
+            100,
+            &mut rng,
+        );
+        let consensus_enclave = MockConsensusEnclave::new();
+        let submitted_values = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_values2 = submitted_values.clone();
+        let scp_client_value_sender = Arc::new(
+            move |value: ConsensusValue,
+                  _node_id: Option<&NodeID>,
+                  _responder_id: Option<&ResponderId>| {
+                submitted_values2.lock().unwrap().push(value);
+            },
+        );
+
+        let ledger = MockLedger::new();
+        let mint_tx_manager = MockMintTxManager::new();
+        let is_serving_fn = Arc::new(|| -> bool { true });
+
+        let authenticator = TokenAuthenticator::new(
+            [1; 32],
+            Duration::from_secs(60),
+            SystemTimeProvider::default(),
+        );
+
+        let instance = ClientApiService::new(
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(MockTxManager::new()),
+            Arc::new(mint_tx_manager),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+        );
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
                 panic!("Unexpected response {:?}", propose_tx_response);
             }

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -330,6 +330,7 @@ mod tests {
     use mc_util_from_random::FromRandom;
     use mc_util_uri::{ConnectionUri, ConsensusPeerUri as PeerUri, ConsensusPeerUri};
     use rand::{rngs::StdRng, SeedableRng};
+    use serial_test::serial;
     use std::{
         collections::BTreeSet,
         convert::TryInto,
@@ -411,6 +412,7 @@ mod tests {
     }
 
     #[test_with_logger]
+    #[serial(counters)]
     fn test_is_behind(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([216u8; 32]);
 
@@ -479,6 +481,7 @@ mod tests {
     // Initially, ByzantineLedger should emit the normal SCPStatements from
     // single-slot consensus.
     #[test_with_logger]
+    #[serial(counters)]
     fn test_single_slot_consensus(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([209u8; 32]);
 
@@ -837,6 +840,7 @@ mod tests {
     // ByzantineLedger should emit the normal SCPStatements from
     // single-slot consensus that contains mint txs.
     #[test_with_logger]
+    #[serial(counters)]
     fn test_single_slot_consensus_on_mint_txs(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([209u8; 32]);
 

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -322,9 +322,10 @@ mod tests {
     use mc_ledger_db::Ledger;
     use mc_peers::{MockBroadcast, ThreadedBroadcaster};
     use mc_peers_test_utils::MockPeerConnection;
-    use mc_transaction_core::BlockVersion;
+    use mc_transaction_core::{Block, BlockContents, BlockVersion, TokenId};
     use mc_transaction_core_test_utils::{
-        create_ledger, create_transaction, initialize_ledger, AccountKey,
+        create_ledger, create_mint_config_tx_and_signers, create_mint_tx, create_transaction,
+        initialize_ledger, AccountKey,
     };
     use mc_util_from_random::FromRandom;
     use mc_util_uri::{ConnectionUri, ConsensusPeerUri as PeerUri, ConsensusPeerUri};
@@ -831,5 +832,316 @@ mod tests {
     // normal SCPStatements from single-slot consensus.
     fn test_ledger_sync() {
         unimplemented!()
+    }
+
+    // ByzantineLedger should emit the normal SCPStatements from
+    // single-slot consensus that contains mint txs.
+    #[test_with_logger]
+    fn test_single_slot_consensus_on_mint_txs(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([209u8; 32]);
+
+        // Other nodes.
+        let peers = get_peers(&[22, 33, 44], &mut rng);
+
+        let node_a = peers[0].clone();
+        let node_b = peers[1].clone();
+
+        // Local node.
+        let (local_node_id, _, local_signer_key) = get_local_node_config(11);
+
+        // Local node's quorum set.
+        let local_quorum_set =
+            QuorumSet::new_with_node_ids(2, vec![node_a.id.clone(), node_b.id.clone()]);
+
+        // Local node's Ledger.
+        let mut ledger = create_ledger();
+        let sender = AccountKey::random(&mut rng);
+        initialize_ledger(BLOCK_VERSION, &mut ledger, 1, &sender, &mut rng);
+
+        // Generate a mint config and put it in the ledger so that validation of MintTxs
+        // can take place.
+        let token_id1 = TokenId::from(1);
+        let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
+
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let block_contents = BlockContents {
+            mint_config_txs: vec![mint_config_tx1],
+            ..Default::default()
+        };
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Mock peer_manager
+        let mock_peer = MockPeerConnection::new(
+            node_a.uri.clone(),
+            local_node_id.clone(),
+            ledger.clone(),
+            10,
+        );
+
+        // We use this later to examine the messages received by this peer.
+        let mock_peer_state = mock_peer.state.clone();
+
+        // Set up peer_manager.
+        let peer_manager = ConnectionManager::new(
+            vec![
+                mock_peer,
+                MockPeerConnection::new(
+                    node_b.uri.clone(),
+                    local_node_id.clone(),
+                    ledger.clone(),
+                    10,
+                ),
+            ],
+            logger.clone(),
+        );
+
+        let broadcaster = Arc::new(Mutex::new(ThreadedBroadcaster::new(
+            &peer_manager,
+            &mc_peers::ThreadedBroadcasterFibonacciRetryPolicy::default(),
+            logger.clone(),
+        )));
+
+        let enclave = ConsensusServiceMockEnclave::default();
+        enclave.blockchain_config.lock().unwrap().block_version = BlockVersion::MAX;
+
+        let tx_manager = Arc::new(TxManagerImpl::new(
+            enclave.clone(),
+            DefaultTxManagerUntrustedInterfaces::new(ledger.clone()),
+            logger.clone(),
+        ));
+
+        let mint_tx_manager = Arc::new(MintTxManagerImpl::new(
+            ledger.clone(),
+            BlockVersion::MAX,
+            Default::default(),
+            logger.clone(),
+        ));
+
+        let byzantine_ledger = ByzantineLedger::new(
+            local_node_id.clone(),
+            local_quorum_set.clone(),
+            peer_manager,
+            ledger.clone(),
+            tx_manager,
+            mint_tx_manager,
+            broadcaster,
+            local_signer_key.clone(),
+            Vec::new(),
+            None,
+            logger.clone(),
+        );
+
+        // Initially, there should be no messages to the network.
+        {
+            assert_eq!(
+                mock_peer_state
+                    .lock()
+                    .expect("Could not lock mock peer state")
+                    .msgs
+                    .len(),
+                0
+            );
+        }
+
+        // Generate and submit transactions.
+        let tx1 = create_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            10,
+            &mut rng,
+        );
+        let tx2 = create_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            20,
+            &mut rng,
+        );
+        let tx3 = create_mint_tx(
+            token_id1,
+            &[Ed25519Pair::from(signers1[0].private_key())],
+            30,
+            &mut rng,
+        );
+
+        byzantine_ledger.push_values(
+            vec![
+                ConsensusValue::MintTx(tx1.clone()),
+                ConsensusValue::MintTx(tx2.clone()),
+                ConsensusValue::MintTx(tx3.clone()),
+            ],
+            Some(Instant::now()),
+        );
+
+        let num_blocks = ledger.num_blocks().unwrap();
+        let slot_index = num_blocks as SlotIndex;
+
+        // After some time, this node should nominate its client values.
+        let expected_msg = ConsensusMsg::from_scp_msg(
+            &ledger,
+            Msg::new(
+                local_node_id.clone(),
+                local_quorum_set.clone(),
+                slot_index,
+                Topic::Nominate(NominatePayload {
+                    X: BTreeSet::from_iter(vec![
+                        ConsensusValue::MintTx(tx1.clone()),
+                        ConsensusValue::MintTx(tx2.clone()),
+                        ConsensusValue::MintTx(tx3.clone()),
+                    ]),
+                    Y: BTreeSet::default(),
+                }),
+            ),
+            &local_signer_key,
+        )
+        .unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            {
+                if mock_peer_state
+                    .lock()
+                    .expect("Could not lock mock peer state")
+                    .msgs
+                    .contains(&expected_msg)
+                {
+                    break;
+                }
+            }
+
+            thread::sleep(Duration::from_millis(100 as u64));
+        }
+
+        {
+            let msgs = &mock_peer_state
+                .lock()
+                .expect("Could not lock mock peer state")
+                .msgs;
+            assert!(
+                msgs.contains(&expected_msg),
+                "Nominate msg not found. msgs={:#?}",
+                msgs,
+            );
+        }
+
+        // Push ballot statements from node_a and node_b so that consensus is reached.
+        byzantine_ledger.handle_consensus_msg(
+            ConsensusMsg::from_scp_msg(
+                &ledger,
+                Msg::new(
+                    node_a.id.clone(),
+                    node_a.quorum_set.clone(),
+                    slot_index,
+                    Topic::Commit(CommitPayload {
+                        B: Ballot::new(
+                            100,
+                            &[
+                                ConsensusValue::MintTx(tx1.clone()),
+                                ConsensusValue::MintTx(tx2.clone()),
+                                ConsensusValue::MintTx(tx3.clone()),
+                            ],
+                        ),
+                        PN: 77,
+                        CN: 55,
+                        HN: 66,
+                    }),
+                ),
+                &node_a.signer_key,
+            )
+            .unwrap()
+            .try_into()
+            .unwrap(),
+            node_a.id.responder_id.clone(),
+        );
+
+        byzantine_ledger.handle_consensus_msg(
+            ConsensusMsg::from_scp_msg(
+                &ledger,
+                Msg::new(
+                    node_b.id.clone(),
+                    node_b.quorum_set.clone(),
+                    slot_index,
+                    Topic::Commit(CommitPayload {
+                        B: Ballot::new(
+                            100,
+                            &[
+                                ConsensusValue::MintTx(tx1.clone()),
+                                ConsensusValue::MintTx(tx2.clone()),
+                                ConsensusValue::MintTx(tx3.clone()),
+                            ],
+                        ),
+                        PN: 77,
+                        CN: 55,
+                        HN: 66,
+                    }),
+                ),
+                &node_b.signer_key,
+            )
+            .unwrap()
+            .try_into()
+            .unwrap(),
+            node_a.id.responder_id,
+        );
+
+        // After some time, this node should emit some statements and write a new block
+        // to its ledger.
+        let deadline = Instant::now() + Duration::from_secs(60);
+        while Instant::now() < deadline {
+            let num_blocks_after = ledger.num_blocks().unwrap();
+            if num_blocks_after > num_blocks {
+                break;
+            }
+
+            thread::sleep(Duration::from_millis(100 as u64));
+        }
+
+        let mut emitted_msgs = mock_peer_state
+            .lock()
+            .expect("Could not lock peer state")
+            .msgs
+            .clone();
+        assert!(!emitted_msgs.is_empty());
+        assert_eq!(
+            emitted_msgs.pop_back().unwrap(),
+            ConsensusMsg::from_scp_msg(
+                &ledger,
+                Msg::new(
+                    local_node_id,
+                    local_quorum_set,
+                    slot_index,
+                    Topic::Externalize(ExternalizePayload {
+                        C: Ballot::new(
+                            55,
+                            &[
+                                ConsensusValue::MintTx(tx1.clone()),
+                                ConsensusValue::MintTx(tx2.clone()),
+                                ConsensusValue::MintTx(tx3.clone()),
+                            ]
+                        ),
+                        HN: 66,
+                    }),
+                ),
+                &local_signer_key
+            )
+            .unwrap(),
+        );
+
+        // The local ledger should now contain a new block.
+        let num_blocks_after = ledger.num_blocks().unwrap();
+        assert_eq!(num_blocks + 1, num_blocks_after);
+
+        // The block should have a valid signature.
+        let block = ledger.get_block(num_blocks).unwrap();
+        let signature = ledger.get_block_signature(num_blocks).unwrap();
+
+        let signature_verification_result = signature.verify(&block);
+        assert!(signature_verification_result.is_ok());
     }
 }


### PR DESCRIPTION
This PR adds a few unit tests  to `mc-consensus-service` to exercise some of the new minting transaction flows.