### PR TITLE
Use `verify_strict` instead of `verify` in crypto-multisig

### DIFF
--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -147,7 +147,7 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         for signature in signatures.iter() {
             let matched_signer = potential_signers.iter().find_map(|signer| {
                 signer
-                    .verify(message, signature)
+                    .verify_strict(message, signature)
                     .ok()
                     .map(|_| signer.clone())
             });


### PR DESCRIPTION
This is expected to mitigate malleability issues in ed25519
signatures.

Per documentation:

https://doc.dalek.rs/ed25519_dalek/struct.PublicKey.html#on-the-multiple-sources-of-malleability-in-ed25519-signatures

There are two sources of malleability in RFC 8032 ed25519 signatures:

* Scalar Malleability
* Point malleability

This method performs both of the above signature malleability checks.