### PR TITLE
Fix/ocall oram storage authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,6 +3861,7 @@ dependencies = [
  "lazy_static",
  "mc-oblivious-traits",
  "mc-sgx-compat",
+ "mc-util-test-helper",
  "rand_core 0.6.3",
  "subtle 2.4.1",
 ]

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -22,7 +22,11 @@ rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2", default-features = false }
 
 [target.'cfg(any(target_feature = "avx2", target_feature = "avx"))'.dependencies]
-blake2 = { version = "0.10.4", default-features = false, features = ["simd"] }
+blake2 = { version = "0.10.2", default-features = false, features = ["simd"] }
 
 [target.'cfg(not(any(target_feature = "avx2", target_feature = "avx")))'.dependencies]
 blake2 = { version = "0.10.2", default-features = false }
+
+[dev-dependencies]
+lazy_static = "1.4"
+mc-util-test-helper = { path = "../../../util/test-helper" }

--- a/fog/ocall_oram_storage/trusted/README.md
+++ b/fog/ocall_oram_storage/trusted/README.md
@@ -31,7 +31,7 @@ An important optimization is used:
 - If the ciphertext metadata from untrusted is all zeroes, then we assume this is
   the first time we access the block, and pass all zero metadata and data back
   to the Oblivious RAM. Effectively, we lazily zero the data segments in blocks
-  living untrusted memory memory, and dont require that we write encryptions of
+  living untrusted memory, and don't require that we write encryptions of
   zeros to every memory cell at initialization.
 
 Authentication design


### PR DESCRIPTION
This is a clone of [1585](https://github.com/mobilecoinfoundation/mobilecoin/pull/1585)
Adds some naming clarification around the various indices used in the tests.
Fixes the tests by using indices that actually share a trusted merkle root.
