### PR TITLE
fix fog-sample-paykit initial block version (release-1.2.0)

### DIFF
--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -133,7 +133,7 @@ impl CachedTxData {
             owned_tx_outs: Default::default(),
             key_image_data_completeness: BlockCount::MAX,
             latest_global_txo_count: 0,
-            latest_block_version: 1,
+            latest_block_version: 0,
             memo_handler: MemoHandler::new(address_book, logger.clone()),
             spsk_to_index,
             missed_block_ranges: Vec::new(),


### PR DESCRIPTION
this should be defaulting to zero, this was missed during the
decrement block versions everywhere project

will cherry-pick this to master after