### PR TITLE
make the fee output conform to block version rules

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -21,7 +21,7 @@ use alloc::{
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
     format,
-    string::String,
+    string::{String, ToString},
     vec::Vec,
 };
 use core::convert::TryFrom;

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -828,9 +828,9 @@ fn mint_output<T: Digestible>(
     if !block_version.masked_token_id_feature_is_supported() {
         output.masked_amount.masked_token_id.clear();
         if amount.token_id != 0 {
-            return Err(Error::FormBlock(format!(
-                "Cannot mint outputs for non-MOB tokens until they are supported"
-            )));
+            return Err(Error::FormBlock(
+                "Cannot mint outputs for non-MOB tokens until they are supported".to_string(),
+            ));
         }
     }
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -58,7 +58,7 @@ use mc_transaction_core::{
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
     validation::TransactionValidationError,
-    Amount, Block, BlockContents, BlockSignature, Token, TokenId,
+    Amount, Block, BlockContents, BlockSignature, BlockVersion, Token, TokenId,
 };
 // Race here refers to, this is thread-safe, first-one-wins behavior, without
 // blocking
@@ -692,6 +692,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             .iter()
             .map(|(token_id, total_fee)| {
                 mint_output(
+                    config.block_version,
                     &fee_recipient,
                     FEES_OUTPUT_PRIVATE_KEY_DOMAIN_TAG.as_bytes(),
                     parent_block,
@@ -729,6 +730,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 &mint_tx.prefix.view_public_key,
             );
             let output = mint_output(
+                config.block_version,
                 &recipient,
                 MINTED_OUTPUT_PRIVATE_KEY_DOMAIN_TAG.as_bytes(),
                 parent_block,
@@ -782,12 +784,14 @@ impl ConsensusEnclave for SgxConsensusEnclave {
 /// the input parameters.
 ///
 /// # Arguments:
+/// * `block_version` - The current block version rules for outputs
 /// * `recipient` - The recipient of the output.
 /// * `domain_tag` - Domain separator for hashing the input parameters.
 /// * `parent_block` - The parent block.
 /// * `transactions` - The transactions that are included in the current block.
 /// * `amount` - Output amount.
 fn mint_output<T: Digestible>(
+    block_version: BlockVersion,
     recipient: &PublicAddress,
     domain_tag: &'static [u8],
     parent_block: &Block,
@@ -813,8 +817,22 @@ fn mint_output<T: Digestible>(
     };
 
     // Create a single TxOut
-    let output = TxOut::new(amount, recipient, &tx_private_key, Default::default())
+    let mut output = TxOut::new(amount, recipient, &tx_private_key, Default::default())
         .map_err(|e| Error::FormBlock(format!("AmountError: {:?}", e)))?;
+
+    // The output must conform to block version rules
+    if !block_version.e_memo_feature_is_supported() {
+        output.e_memo = None;
+    }
+
+    if !block_version.masked_token_id_feature_is_supported() {
+        output.masked_amount.masked_token_id.clear();
+        if amount.token_id != 0 {
+            return Err(Error::FormBlock(format!(
+                "Cannot mint outputs for non-MOB tokens until they are supported"
+            )));
+        }
+    }
 
     Ok(output)
 }
@@ -828,8 +846,10 @@ mod tests {
     use mc_crypto_multisig::SignerSet;
     use mc_ledger_db::Ledger;
     use mc_transaction_core::{
-        tokens::Mob, tx::TxOutMembershipHash, validation::TransactionValidationError, BlockVersion,
-        Token,
+        tokens::Mob,
+        tx::TxOutMembershipHash,
+        validation::{validate_tx_out, TransactionValidationError},
+        BlockVersion, Token,
     };
     use mc_transaction_core_test_utils::{
         create_ledger, create_mint_config_tx_and_signers, create_mint_tx_to_recipient,
@@ -1186,6 +1206,11 @@ mod tests {
             let (amount, _) = fee_output.view_key_match(&fee_view_key).unwrap();
             assert_eq!(amount.value, total_fee);
             assert_eq!(amount.token_id, Mob::ID);
+
+            // The outputs should all conform to block version rules
+            for output in block_contents.outputs.iter() {
+                validate_tx_out(block_version, output).unwrap();
+            }
         }
     }
 

--- a/transaction/core/src/validation/mod.rs
+++ b/transaction/core/src/validation/mod.rs
@@ -7,5 +7,5 @@ mod validate;
 
 pub use self::{
     error::{TransactionValidationError, TransactionValidationResult},
-    validate::{validate, validate_signature, validate_tombstone},
+    validate::{validate, validate_signature, validate_tombstone, validate_tx_out},
 };

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -608,7 +608,7 @@ mod tests {
 
     #[test]
     // Should return MissingMemo when memos are missing in an output
-    fn test_validate_memos_exist() {
+    fn test_validate_memo_exists() {
         let (tx, _) = create_test_tx(BlockVersion::ZERO);
         let tx_out = tx.prefix.outputs.first().unwrap();
 
@@ -627,7 +627,7 @@ mod tests {
 
     #[test]
     // Should return MemosNotAllowed when memos are present in an output
-    fn test_validate_no_memos_exist() {
+    fn test_validate_no_memo_exists() {
         let (tx, _) = create_test_tx(BlockVersion::ZERO);
         let tx_out = tx.prefix.outputs.first().unwrap();
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -72,16 +72,34 @@ pub fn validate<R: RngCore + CryptoRng>(
     // Note: The transaction must not contain a Key Image that has previously been
     // spent. This must be checked outside the enclave.
 
+    // Each tx_out must conform to the structural rules for TxOut's at this block
+    // version
+    for tx_out in tx.prefix.outputs.iter() {
+        validate_tx_out(block_version, tx_out)?;
+    }
+
     ////
     // Validate rules which depend on block version (see MCIP #26)
     ////
 
+    if block_version.validate_transaction_outputs_are_sorted() {
+        validate_outputs_are_sorted(&tx.prefix)?;
+    }
+
+    Ok(())
+}
+
+/// Determines if a tx out conforms to the current block version rules
+pub fn validate_tx_out(
+    block_version: BlockVersion,
+    tx_out: &TxOut,
+) -> TransactionValidationResult<()> {
     // If memos are supported, then all outputs must have memo fields.
     // If memos are not yet supported, then no outputs may have memo fields.
     if block_version.e_memo_feature_is_supported() {
-        validate_memos_exist(tx)?;
+        validate_memo_exists(tx_out)?;
     } else {
-        validate_no_memos_exist(tx)?;
+        validate_no_memo_exists(tx_out)?;
     }
 
     // If masked token id is supported, then all outputs must have masked_token_id
@@ -91,13 +109,9 @@ pub fn validate<R: RngCore + CryptoRng>(
     // Note: This rct_bulletproofs code enforces that token_id = 0 if this feature
     // is not enabled
     if block_version.masked_token_id_feature_is_supported() {
-        validate_masked_token_ids_exist(tx)?;
+        validate_masked_token_id_exists(tx_out)?;
     } else {
-        validate_no_masked_token_ids_exist(tx)?;
-    }
-
-    if block_version.validate_transaction_outputs_are_sorted() {
-        validate_outputs_are_sorted(&tx.prefix)?;
+        validate_no_masked_token_id_exists(tx_out)?;
     }
 
     Ok(())
@@ -224,26 +238,16 @@ fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResu
 }
 
 /// All outputs have no memo (new-style TxOuts (Post MCIP #3) are rejected)
-fn validate_no_memos_exist(tx: &Tx) -> TransactionValidationResult<()> {
-    if tx
-        .prefix
-        .outputs
-        .iter()
-        .any(|output| output.e_memo.is_some())
-    {
+fn validate_no_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+    if tx_out.e_memo.is_some() {
         return Err(TransactionValidationError::MemosNotAllowed);
     }
     Ok(())
 }
 
 /// All outputs have a memo (old-style TxOuts (Pre MCIP #3) are rejected)
-fn validate_memos_exist(tx: &Tx) -> TransactionValidationResult<()> {
-    if tx
-        .prefix
-        .outputs
-        .iter()
-        .any(|output| output.e_memo.is_none())
-    {
+fn validate_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+    if tx_out.e_memo.is_none() {
         return Err(TransactionValidationError::MissingMemo);
     }
     Ok(())
@@ -251,13 +255,8 @@ fn validate_memos_exist(tx: &Tx) -> TransactionValidationResult<()> {
 
 /// All outputs have no masked token id (new-style TxOuts (Post MCIP #25) are
 /// rejected)
-fn validate_no_masked_token_ids_exist(tx: &Tx) -> TransactionValidationResult<()> {
-    if tx
-        .prefix
-        .outputs
-        .iter()
-        .any(|output| !output.masked_amount.masked_token_id.is_empty())
-    {
+fn validate_no_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+    if !tx_out.masked_amount.masked_token_id.is_empty() {
         return Err(TransactionValidationError::MaskedTokenIdNotAllowed);
     }
     Ok(())
@@ -265,13 +264,8 @@ fn validate_no_masked_token_ids_exist(tx: &Tx) -> TransactionValidationResult<()
 
 /// All outputs have a masked token id (old-style TxOuts (Pre MCIP #25) are
 /// rejected)
-fn validate_masked_token_ids_exist(tx: &Tx) -> TransactionValidationResult<()> {
-    if tx
-        .prefix
-        .outputs
-        .iter()
-        .any(|output| output.masked_amount.masked_token_id.len() != 4)
-    {
+fn validate_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+    if tx_out.masked_amount.masked_token_id.len() != 4 {
         return Err(TransactionValidationError::MissingMaskedTokenId);
     }
     Ok(())
@@ -613,36 +607,79 @@ mod tests {
     }
 
     #[test]
-    // Should return MissingMemo when memos are missing in any the outputs
+    // Should return MissingMemo when memos are missing in an output
     fn test_validate_memos_exist() {
         let (tx, _) = create_test_tx(BlockVersion::ZERO);
+        let tx_out = tx.prefix.outputs.first().unwrap();
 
-        assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
+        assert!(tx_out.e_memo.is_none());
         assert_eq!(
-            validate_memos_exist(&tx),
+            validate_memo_exists(&tx_out),
             Err(TransactionValidationError::MissingMemo)
         );
 
         let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let tx_out = tx.prefix.outputs.first().unwrap();
 
-        assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
-        assert_eq!(validate_memos_exist(&tx), Ok(()));
+        assert!(tx_out.e_memo.is_some());
+        assert_eq!(validate_memo_exists(&tx_out), Ok(()));
     }
 
     #[test]
-    // Should return MemosNotAllowed when memos are present in any of the outputs
+    // Should return MemosNotAllowed when memos are present in an output
     fn test_validate_no_memos_exist() {
         let (tx, _) = create_test_tx(BlockVersion::ZERO);
+        let tx_out = tx.prefix.outputs.first().unwrap();
 
-        assert!(tx.prefix.outputs.first().unwrap().e_memo.is_none());
-        assert_eq!(validate_no_memos_exist(&tx), Ok(()));
+        assert!(tx_out.e_memo.is_none());
+        assert_eq!(validate_no_memo_exists(&tx_out), Ok(()));
 
         let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let tx_out = tx.prefix.outputs.first().unwrap();
 
-        assert!(tx.prefix.outputs.first().unwrap().e_memo.is_some());
+        assert!(tx_out.e_memo.is_some());
         assert_eq!(
-            validate_no_memos_exist(&tx),
+            validate_no_memo_exists(&tx_out),
             Err(TransactionValidationError::MemosNotAllowed)
+        );
+    }
+
+    #[test]
+    // Should return MissingMaskedTokenId when masked_token_id are missing in an
+    // output
+    fn test_validate_masked_token_id_exists() {
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let tx_out = tx.prefix.outputs.first().unwrap();
+
+        assert!(tx_out.masked_amount.masked_token_id.is_empty());
+        assert_eq!(
+            validate_masked_token_id_exists(&tx_out),
+            Err(TransactionValidationError::MissingMaskedTokenId)
+        );
+
+        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let tx_out = tx.prefix.outputs.first().unwrap();
+
+        assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+        assert_eq!(validate_memo_exists(&tx_out), Ok(()));
+    }
+
+    #[test]
+    // Should return MemosNotAllowed when memos are present in an output
+    fn test_validate_no_masked_token_id_exists() {
+        let (tx, _) = create_test_tx(BlockVersion::ONE);
+        let tx_out = tx.prefix.outputs.first().unwrap();
+
+        assert!(tx_out.masked_amount.masked_token_id.is_empty());
+        assert_eq!(validate_no_masked_token_id_exists(&tx_out), Ok(()));
+
+        let (tx, _) = create_test_tx(BlockVersion::TWO);
+        let tx_out = tx.prefix.outputs.first().unwrap();
+
+        assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+        assert_eq!(
+            validate_no_masked_token_id_exists(&tx_out),
+            Err(TransactionValidationError::MaskedTokenIdNotAllowed)
         );
     }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -553,7 +553,7 @@ pub mod transaction_builder_tests {
         ring_signature::KeyImage,
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
-        validation::validate_signature,
+        validation::{validate_signature, validate_tx_out},
         TokenId,
     };
     use rand::{rngs::StdRng, SeedableRng};

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -803,6 +803,8 @@ pub mod transaction_builder_tests {
 
             let output: &TxOut = tx.prefix.outputs.get(0).unwrap();
 
+            validate_tx_out(block_version, output).unwrap();
+
             // The output should belong to the correct recipient.
             assert!(
                 subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()
@@ -881,6 +883,8 @@ pub mod transaction_builder_tests {
             assert_eq!(tx.prefix.outputs.len(), 1);
 
             let output: &TxOut = tx.prefix.outputs.get(0).unwrap();
+
+            validate_tx_out(block_version, output).unwrap();
 
             // The output should belong to the correct recipient.
             assert!(
@@ -967,6 +971,8 @@ pub mod transaction_builder_tests {
 
             let output: &TxOut = tx.prefix.outputs.get(0).unwrap();
 
+            validate_tx_out(block_version, output).unwrap();
+
             // The output should belong to the correct recipient.
             assert!(
                 subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()
@@ -1036,6 +1042,8 @@ pub mod transaction_builder_tests {
                 // The transaction should have one output.
                 assert_eq!(tx.prefix.outputs.len(), 1);
 
+                validate_tx_out(block_version, tx.prefix.outputs.first().unwrap()).unwrap();
+
                 // The tombstone block should be the min of what the user requested, and what
                 // fog limits it to
                 assert_eq!(tx.prefix.tombstone_block, 1000);
@@ -1063,6 +1071,8 @@ pub mod transaction_builder_tests {
 
                 // The transaction should have one output.
                 assert_eq!(tx.prefix.outputs.len(), 1);
+
+                validate_tx_out(block_version, tx.prefix.outputs.first().unwrap()).unwrap();
 
                 // The tombstone block should be the min of what the user requested, and what
                 // fog limits it to
@@ -1155,6 +1165,9 @@ pub mod transaction_builder_tests {
                         subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
                     })
                     .expect("Didn't find sender's output");
+
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
 
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
@@ -1329,6 +1342,9 @@ pub mod transaction_builder_tests {
                     })
                     .expect("Didn't find sender's output");
 
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
+
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
                         .unwrap()
@@ -1482,6 +1498,9 @@ pub mod transaction_builder_tests {
                         subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
                     })
                     .expect("Didn't find sender's output");
+
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
 
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
@@ -1637,6 +1656,9 @@ pub mod transaction_builder_tests {
                     })
                     .expect("Didn't find sender's output");
 
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
+
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
                         .unwrap()
@@ -1791,6 +1813,9 @@ pub mod transaction_builder_tests {
                     })
                     .expect("Didn't find sender's output");
 
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
+
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
                         .unwrap()
@@ -1932,6 +1957,9 @@ pub mod transaction_builder_tests {
                         subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
                     })
                     .expect("Didn't find sender's output");
+
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
 
                 assert!(
                     !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
@@ -2098,6 +2126,9 @@ pub mod transaction_builder_tests {
                         subaddress_matches_tx_out(&alice, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
                     })
                     .expect("Didn't find sender's output");
+
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
 
                 assert!(
                     !subaddress_matches_tx_out(&bob, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -971,8 +971,6 @@ pub mod transaction_builder_tests {
 
             let output: &TxOut = tx.prefix.outputs.get(0).unwrap();
 
-            validate_tx_out(block_version, output).unwrap();
-
             // The output should belong to the correct recipient.
             assert!(
                 subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()


### PR DESCRIPTION
this also refactors the transaction validation a bit,
so that there is a function which tests all "structural tx out rules",
and then re-uses this function in tests elsewhere, which will help us
going into the future to maintain all this