### PR TITLE
Make GetLastBlockInfo return the configured block version, and use it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,6 @@ commands:
             ./target/release/sample-keys --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
 
             ./target/release/fog-distribution \
-                --block-version 2 \
                 --sample-data-dir . \
                 --max-threads 1 \
                 --peer insecure-mc://localhost:3200/ \

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -65,6 +65,10 @@ pub struct BlockInfo {
 
     /// Minimum fee for each token id supported by the node
     pub minimum_fees: BTreeMap<TokenId, u64>,
+
+    /// Block version reported by the network.
+    /// This is the configured block version on the node.
+    pub block_version: u32,
 }
 
 impl BlockInfo {
@@ -104,6 +108,7 @@ impl From<LastBlockInfoResponse> for BlockInfo {
         BlockInfo {
             block_index: src.index,
             minimum_fees,
+            block_version: src.block_version,
         }
     }
 }

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -8,7 +8,7 @@ use mc_connection::{
 };
 use mc_consensus_enclave_api::FeeMap;
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{tx::Tx, Block, BlockID, BlockIndex};
+use mc_transaction_core::{tx::Tx, Block, BlockID, BlockIndex, BlockVersion};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
     cmp::{min, Ordering},
@@ -118,6 +118,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
             minimum_fees: FeeMap::default_map(),
+            block_version: *BlockVersion::MAX,
         })
     }
 }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -26,6 +26,14 @@ message LastBlockInfoResponse {
 
     // A map of token id -> minimum fee
     map<uint32, uint64> minimum_fees = 3;
+
+    // Current block version, appropriate for new transactions.
+    //
+    // Note that if the server was just reconfigured, this may be HIGHER than
+    // the highest block version in the ledger, so for clients this is a better
+    // source of truth than the local ledger, if the client might possibly be
+    // creating the first transaction after a reconfigure / redeploy.
+    uint32 block_version = 4;
 }
 
 // Requests a range [offset, offset+limit) of Blocks.

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -241,6 +241,7 @@ mod tests {
         expected_response.set_index(block_entities.last().unwrap().index);
         expected_response.set_mob_minimum_fee(12345);
         expected_response.set_minimum_fees(HashMap::from_iter(vec![(0, 12345), (60, 10203040)]));
+        expected_response.set_block_version(*BlockVersion::MAX);
         assert_eq!(
             block_entities.last().unwrap().index,
             ledger_db.num_blocks().unwrap() - 1

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -12,7 +12,7 @@ use mc_consensus_api::{
 };
 use mc_consensus_enclave::FeeMap;
 use mc_ledger_db::Ledger;
-use mc_transaction_core::{tokens::Mob, Token};
+use mc_transaction_core::{tokens::Mob, BlockVersion, Token};
 use mc_util_grpc::{rpc_logger, send_result, Authenticator};
 use mc_util_metrics::{self, SVC_COUNTERS};
 use protobuf::RepeatedField;
@@ -33,6 +33,9 @@ pub struct BlockchainApiService<L: Ledger + Clone> {
     /// Minimum fee per token.
     fee_map: FeeMap,
 
+    /// Configured block version
+    block_version: BlockVersion,
+
     /// Logger.
     logger: Logger,
 }
@@ -42,6 +45,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
         ledger: L,
         authenticator: Arc<dyn Authenticator + Send + Sync>,
         fee_map: FeeMap,
+        block_version: BlockVersion,
         logger: Logger,
     ) -> Self {
         BlockchainApiService {
@@ -49,6 +53,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
             authenticator,
             max_page_size: 2000,
             fee_map,
+            block_version,
             logger,
         }
     }
@@ -74,6 +79,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
                 .iter()
                 .map(|(token_id, fee)| (**token_id, *fee)),
         ));
+        resp.set_block_version(*self.block_version);
 
         Ok(resp)
     }
@@ -241,7 +247,7 @@ mod tests {
         );
 
         let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, fee_map, logger);
+            BlockchainApiService::new(ledger_db, authenticator, fee_map, BlockVersion::MAX, logger);
 
         let block_response = blockchain_api_service.get_last_block_info_helper().unwrap();
         assert_eq!(block_response, expected_response);
@@ -258,8 +264,13 @@ mod tests {
             SystemTimeProvider::default(),
         ));
 
-        let blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
+        let blockchain_api_service = BlockchainApiService::new(
+            ledger_db,
+            authenticator,
+            FeeMap::default(),
+            BlockVersion::MAX,
+            logger,
+        );
 
         let (client, _server) = get_client_server(blockchain_api_service);
 
@@ -296,8 +307,13 @@ mod tests {
             .map(|block_entity| blockchain::Block::from(&block_entity))
             .collect();
 
-        let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
+        let mut blockchain_api_service = BlockchainApiService::new(
+            ledger_db,
+            authenticator,
+            FeeMap::default(),
+            BlockVersion::MAX,
+            logger,
+        );
 
         {
             // The empty range [0,0) should return an empty collection of Blocks.
@@ -340,8 +356,13 @@ mod tests {
             &mut rng,
         );
 
-        let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
+        let mut blockchain_api_service = BlockchainApiService::new(
+            ledger_db,
+            authenticator,
+            FeeMap::default(),
+            BlockVersion::MAX,
+            logger,
+        );
 
         {
             // The range [0, 1000) requests values that don't exist. The response should
@@ -372,8 +393,13 @@ mod tests {
             .map(|block_entity| blockchain::Block::from(&block_entity))
             .collect();
 
-        let mut blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
+        let mut blockchain_api_service = BlockchainApiService::new(
+            ledger_db,
+            authenticator,
+            FeeMap::default(),
+            BlockVersion::MAX,
+            logger,
+        );
         blockchain_api_service.set_max_page_size(5);
 
         // The request exceeds the max_page_size, so only max_page_size items should be
@@ -396,8 +422,13 @@ mod tests {
             SystemTimeProvider::default(),
         ));
 
-        let blockchain_api_service =
-            BlockchainApiService::new(ledger_db, authenticator, FeeMap::default(), logger);
+        let blockchain_api_service = BlockchainApiService::new(
+            ledger_db,
+            authenticator,
+            FeeMap::default(),
+            BlockVersion::MAX,
+            logger,
+        );
 
         let (client, _server) = get_client_server(blockchain_api_service);
 

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -353,6 +353,7 @@ impl<
                 self.ledger_db.clone(),
                 self.client_authenticator.clone(),
                 self.config.tokens().fee_map()?,
+                self.config.block_version,
                 self.logger.clone(),
             ));
 
@@ -446,6 +447,7 @@ impl<
                 self.ledger_db.clone(),
                 peer_authenticator.clone(),
                 self.config.tokens().fee_map()?,
+                self.config.block_version,
                 self.logger.clone(),
             ));
 

--- a/fog/distribution/src/config.rs
+++ b/fog/distribution/src/config.rs
@@ -73,10 +73,6 @@ pub struct Config {
     #[clap(long, default_value = "0", env = "MC_ADD_TX_DELAY_MS")]
     pub add_tx_delay_ms: u64,
 
-    /// Block version to use (otherwise fall back to ledger)
-    #[clap(long, env = "MC_BLOCK_VERSION")]
-    pub block_version: Option<u32>,
-
     /// Destination keys subdirectory. Defaults to `fog_keys`
     #[clap(long, default_value = "fog_keys", env = "MC_FOG_KEYS_SUBDIR")]
     pub fog_keys_subdir: String,

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -19,7 +19,7 @@
 
 #![deny(missing_docs)]
 
-use core::{cell::RefCell, convert::TryFrom};
+use core::{cell::RefCell, cmp::max, convert::TryFrom};
 use lazy_static::lazy_static;
 use mc_account_keys::AccountKey;
 use mc_attest_verifier::{Verifier, DEBUG_ENCLAVE};
@@ -97,8 +97,8 @@ lazy_static! {
     /// Keeps track of block version we are targetting
     pub static ref BLOCK_VERSION: AtomicU32 = AtomicU32::new(1);
 
-    /// Keeps track of the current fee value
-    pub static ref FEE: AtomicU64 = AtomicU64::default();
+    /// Keeps track of the current MOB fee value
+    pub static ref MOB_FEE: AtomicU64 = AtomicU64::default();
 
     /// A map of tx pub keys to account index. This is used in conjunction with ledger syncing to
     /// identify which new txs belong to which accounts without having to do any slow crypto.
@@ -152,21 +152,31 @@ fn main() {
 
     let ledger_db = LedgerDB::open(ledger_dir.path()).expect("Could not open ledger_db");
 
-    let block_version = config
-        .block_version
-        .unwrap_or_else(|| ledger_db.get_latest_block().unwrap().version);
-
     BLOCK_HEIGHT.store(ledger_db.num_blocks().unwrap(), Ordering::SeqCst);
-    BLOCK_VERSION.store(block_version, Ordering::SeqCst);
 
-    // Use the maximum fee of all configured consensus nodes
-    FEE.store(
-        get_conns(&config, &logger)
-            .par_iter()
-            .filter_map(|conn| conn.fetch_block_info(empty()).ok())
+    // Get the block info of all configured consensus nodes
+    let block_infos: Vec<_> = get_conns(&config, &logger)
+        .par_iter()
+        .filter_map(|conn| conn.fetch_block_info(empty()).ok())
+        .collect();
+
+    MOB_FEE.store(
+        block_infos
+            .iter()
             .filter_map(|block_info| block_info.minimum_fee_or_none(&Mob::ID))
             .max()
             .unwrap_or(Mob::MINIMUM_FEE),
+        Ordering::SeqCst,
+    );
+    BLOCK_VERSION.store(
+        max(
+            ledger_db.get_latest_block().unwrap().version,
+            block_infos
+                .iter()
+                .map(|block_info| block_info.block_version)
+                .max()
+                .unwrap_or(0),
+        ),
         Ordering::SeqCst,
     );
 
@@ -719,7 +729,9 @@ fn build_tx(
         EmptyMemoBuilder::default(),
     );
 
-    tx_builder.set_fee(FEE.load(Ordering::SeqCst)).unwrap();
+    // FIXME: This needs to be the fee for the current token, not MOB.
+    // However, bootstrapping non MOB tokens is not supported right now.
+    tx_builder.set_fee(MOB_FEE.load(Ordering::SeqCst)).unwrap();
 
     // Unzip each vec of tuples into a tuple of vecs.
     let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings
@@ -802,7 +814,7 @@ fn build_tx(
             let mut value = utxo.amount.value;
             // Use the first input to pay for the fee.
             if i == 0 {
-                value -= FEE.load(Ordering::SeqCst);
+                value -= MOB_FEE.load(Ordering::SeqCst);
             }
 
             let target_address = to_account.default_subaddress();

--- a/fog/distribution/tests/bootstrap.rs
+++ b/fog/distribution/tests/bootstrap.rs
@@ -50,8 +50,6 @@ fn test_find_spendable_tx_outs() {
             "mc://test.com",
             "--num-tx-to-send",
             "5",
-            "--block-version",
-            "3",
             "--num-seed-transactions-per-destination-account",
             "2",
             "--dry-run"

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -187,6 +187,12 @@ impl CachedTxData {
         self.latest_block_version
     }
 
+    /// Update the latest block version. This may include e.g. knowledge of how
+    /// consensus nodes are actually configured
+    pub fn notify_block_version(&mut self, network_block_version: u32) {
+        self.latest_block_version = max(self.latest_block_version, network_block_version);
+    }
+
     /// Helper function: Compute the set of Txos contributing to the balance,
     /// not known to be spent at all.
     /// These can be used creating transaction input sets.

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -534,9 +534,13 @@ impl Client {
     }
 
     /// Retrieve the current last block info structure from consensus service.
-    /// This includes fee data and last block index
+    /// This includes fee data and last block index, and the configured block
+    /// version
     pub fn get_last_block_info(&mut self) -> Result<BlockInfo> {
-        Ok(self.consensus_service_conn.fetch_block_info()?)
+        let block_info = self.consensus_service_conn.fetch_block_info()?;
+        // Opportunistically update our cached block version value
+        self.tx_data.notify_block_version(block_info.block_version);
+        Ok(block_info)
     }
 
     /// Retrieve the currently configured minimum fee for a token id from the

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -9,7 +9,7 @@ use mc_common::{
     HashMap, HashSet,
 };
 use mc_connection::{
-    BlockchainConnection, ConnectionManager, RetryableBlockchainConnection,
+    BlockInfo, BlockchainConnection, ConnectionManager, RetryableBlockchainConnection,
     RetryableUserTxConnection, UserTxConnection,
 };
 use mc_crypto_keys::RistrettoPublic;
@@ -30,7 +30,7 @@ use mc_util_uri::FogUri;
 use rand::Rng;
 use rayon::prelude::*;
 use std::{
-    cmp::Reverse,
+    cmp::{max, Reverse},
     convert::TryFrom,
     iter::empty,
     str::FromStr,
@@ -134,23 +134,35 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
     }
 }
 
-fn get_fee<T: BlockchainConnection + UserTxConnection + 'static>(
+fn get_block_infos<T: BlockchainConnection + UserTxConnection + 'static>(
     peer_manager: &ConnectionManager<T>,
-    token_id: TokenId,
-    opt_fee: u64,
-) -> u64 {
+) -> Vec<BlockInfo> {
+    peer_manager
+        .conns()
+        .par_iter()
+        .filter_map(|conn| conn.fetch_block_info(empty()).ok())
+        .collect()
+}
+
+fn get_network_block_version(block_infos: &[BlockInfo]) -> u32 {
+    block_infos
+        .iter()
+        .map(|block_info| block_info.block_version)
+        .max()
+        .unwrap_or(0)
+}
+
+fn get_fee(block_infos: &[BlockInfo], token_id: TokenId, opt_fee: u64) -> u64 {
     if opt_fee > 0 {
         opt_fee
-    } else if peer_manager.is_empty() {
+    } else if block_infos.is_empty() {
         FALLBACK_FEE
     } else {
         // iterate an owned list of connections in parallel, get the block info for
         // each, and extract the fee. If no fees are returned, use the hard-coded
         // minimum.
-        peer_manager
-            .conns()
-            .par_iter()
-            .filter_map(|conn| conn.fetch_block_info(empty()).ok())
+        block_infos
+            .iter()
             .filter_map(|block_info| block_info.minimum_fee_or_none(&token_id))
             .max()
             .unwrap_or(FALLBACK_FEE)
@@ -178,6 +190,26 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             fog_resolver_factory,
             logger,
         }
+    }
+
+    // Gets the network fee and block_version, unless opt_fee is nonzero.
+    // If opt fee is nonzero then we use local ledger block version and this fee,
+    // and don't make a network call
+    fn get_network_fee_and_block_version(&self, opt_fee: u64) -> Result<(u64, u32), Error> {
+        // Figure out the block_version and fee (involves network round-trips to
+        // consensus, unless opt_fee is non-zero
+        let candidate_block_version = self.ledger_db.get_latest_block()?.version;
+        Ok(if opt_fee != 0 {
+            (opt_fee, candidate_block_version)
+        } else {
+            let block_infos = get_block_infos(&self.peer_manager);
+            let fee = get_fee(&block_infos, self.token_id, opt_fee);
+            let block_version = max(
+                candidate_block_version,
+                get_network_block_version(&block_infos),
+            );
+            (fee, block_version)
+        })
     }
 
     /// Create a TxProposal.
@@ -218,9 +250,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             total_value
         );
 
-        // Figure out the fee (involves network round-trips to consensus, unless
-        // opt_fee is non-zero
-        let fee = get_fee(&self.peer_manager, self.token_id, opt_fee);
+        // Figure out the block_version and fee (involves network round-trips to
+        // consensus, unless opt_fee is non-zero)
+        let (fee, block_version) = self.get_network_fee_and_block_version(opt_fee)?;
+
+        // Confirm that we understand this block version
+        let block_version =
+            BlockVersion::try_from(block_version).map_err(|err| Error::TxBuild(err.to_string()))?;
 
         // Select the UTXOs to be used for this transaction.
         let selected_utxos = Self::select_utxos_for_value(
@@ -272,10 +308,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         };
         log::trace!(logger, "Tombstone block set to {}", tombstone_block);
 
-        // Come up with a block version
-        let block_version = BlockVersion::try_from(self.ledger_db.get_latest_block()?.version)
-            .map_err(|err| Error::TxBuild(err.to_string()))?;
-
         // Build and return the TxProposal object
         let mut rng = rand::thread_rng();
         let tx_proposal = Self::build_tx_proposal(
@@ -319,7 +351,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         let num_blocks_in_ledger = self.ledger_db.num_blocks()?;
 
-        let fee = get_fee(&self.peer_manager, self.token_id, fee);
+        // Figure out the block_version and fee (involves network round-trips to
+        // consensus, unless fee arg is non-zero)
+        let (fee, block_version) = self.get_network_fee_and_block_version(fee)?;
+
+        // Make sure we understand this block version
+        let block_version =
+            BlockVersion::try_from(block_version).map_err(|err| Error::TxBuild(err.to_string()))?;
 
         // Select UTXOs that will be spent by this transaction.
         let selected_utxos = {
@@ -381,10 +419,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let tombstone_block = num_blocks_in_ledger + DEFAULT_NEW_TX_BLOCK_ATTEMPTS;
         log::trace!(logger, "Tombstone block set to {}", tombstone_block);
 
-        // Come up with a block version
-        let block_version = BlockVersion::try_from(self.ledger_db.get_latest_block()?.version)
-            .map_err(|err| Error::TxBuild(err.to_string()))?;
-
         // We are paying ourselves the entire amount.
         let outlays = vec![Outlay {
             receiver: monitor_data.account_key.subaddress(subaddress_index),
@@ -435,7 +469,13 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let logger = self.logger.new(o!("receiver" => receiver.to_string()));
         log::trace!(logger, "Generating txo list transaction...");
 
-        let fee = get_fee(&self.peer_manager, self.token_id, fee);
+        // Figure out the block_version and fee (involves network round-trips to
+        // consensus, unless fee arg is non-zero)
+        let (fee, block_version) = self.get_network_fee_and_block_version(fee)?;
+
+        // Make sure we understand this block version
+        let block_version =
+            BlockVersion::try_from(block_version).map_err(|err| Error::TxBuild(err.to_string()))?;
 
         // All inputs are to be spent, except those with wrong token id
         let total_value: u64 = inputs
@@ -478,10 +518,6 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // Come up with tombstone block.
         let tombstone_block = self.ledger_db.num_blocks()? + DEFAULT_NEW_TX_BLOCK_ATTEMPTS;
         log::trace!(logger, "Tombstone block set to {}", tombstone_block);
-
-        // Come up with a block version
-        let block_version = BlockVersion::try_from(self.ledger_db.get_latest_block()?.version)
-            .map_err(|err| Error::TxBuild(err.to_string()))?;
 
         // The entire value goes to receiver
         let outlays = vec![Outlay {


### PR DESCRIPTION
We realized that there is a chicken and egg problem for many clients around
the block version:

* For mobilecoind and for fog clients, they were getting block version
  from their local copy of the ledger, or fog-ledger's copy of the ledger
* However, when we upgrade consensus and increase block version, the
  first transaction takes place when the ledger has the old block version
  but the consensus config is the new block version.
* There has to be at least one client capable of determining the configured
  block version and making a transaction according to those rules.

To fix this, James suggested that we use the `GetLastBlock` call, where
most clients are getting the minimum fees right now. We added a field
on this response that returns the configured block version, so this is
a good source of truth for the mentioned situation. Then we made mobilecoind,
fog-distro, and fog sample paykit all track the responded value and incorporate
it into their caches, so they are tracking the max of the ledger and this
response value.

This will also ease CD work because fog distro doesn't need to be told
the block version any more, and none of these other clients will have
problems after we deploy a new version.

We may want to backport this to 1.2.0 also.