### PR TITLE
Store validation data alongside `MintConfigTx`s in the ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-crypto-keys",
+ "mc-crypto-multisig",
  "mc-crypto-rand",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",

--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -51,8 +51,8 @@ message BlockContents {
     // Outputs created in this block.
     repeated external.TxOut outputs = 2;
 
-    /// mint-config transactions in this block.
-    repeated external.MintConfigTx mint_config_txs = 3;
+    /// mint-config transactions in this block coupled with data used to validate them.
+    repeated external.ValidatedMintConfigTx validated_mint_config_txs = 3;
 
     /// Mint transactions in this block.
     repeated external.MintTx mint_txs = 4;

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -383,4 +383,3 @@ message ValidatedMintConfigTx {
     MintConfigTx mint_config_tx = 1;
     Ed25519SignerSet signer_set = 2;
 }
-

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -377,3 +377,10 @@ message MintConfigTx {
     MintConfigTxPrefix prefix = 1;
     Ed25519MultiSig signature = 2;
 }
+
+/// A mint-config transaction coupled with the data used to validate it.
+message ValidatedMintConfigTx {
+    MintConfigTx mint_config_tx = 1;
+    Ed25519SignerSet signer_set = 2;
+}
+

--- a/api/src/convert/block_contents.rs
+++ b/api/src/convert/block_contents.rs
@@ -2,7 +2,7 @@
 
 use crate::{blockchain, convert::ConversionError, external};
 use mc_transaction_core::{
-    mint::{MintConfigTx, MintTx},
+    mint::{MintTx, ValidatedMintConfigTx},
     ring_signature::KeyImage,
     tx::TxOut,
     BlockContents,
@@ -21,17 +21,17 @@ impl From<&mc_transaction_core::BlockContents> for blockchain::BlockContents {
 
         let outputs = source.outputs.iter().map(external::TxOut::from).collect();
 
-        let mint_config_txs = source
-            .mint_config_txs
+        let validated_mint_config_txs = source
+            .validated_mint_config_txs
             .iter()
-            .map(external::MintConfigTx::from)
+            .map(external::ValidatedMintConfigTx::from)
             .collect();
 
         let mint_txs = source.mint_txs.iter().map(external::MintTx::from).collect();
 
         block_contents.set_key_images(key_images);
         block_contents.set_outputs(outputs);
-        block_contents.set_mint_config_txs(mint_config_txs);
+        block_contents.set_validated_mint_config_txs(validated_mint_config_txs);
         block_contents.set_mint_txs(mint_txs);
         block_contents
     }
@@ -53,10 +53,10 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
             .map(TxOut::try_from)
             .collect::<Result<_, _>>()?;
 
-        let mint_config_txs = source
-            .get_mint_config_txs()
+        let validated_mint_config_txs = source
+            .get_validated_mint_config_txs()
             .iter()
-            .map(MintConfigTx::try_from)
+            .map(ValidatedMintConfigTx::try_from)
             .collect::<Result<_, _>>()?;
 
         let mint_txs = source
@@ -70,7 +70,7 @@ impl TryFrom<&blockchain::BlockContents> for mc_transaction_core::BlockContents 
         Ok(BlockContents {
             key_images,
             outputs,
-            mint_config_txs,
+            validated_mint_config_txs,
             mint_txs,
         })
     }

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -39,6 +39,7 @@ mod tx_out_confirmation_number;
 mod tx_out_membership_element;
 mod tx_out_membership_proof;
 mod tx_prefix;
+mod validated_mint_config;
 mod verification_report;
 mod verification_signature;
 mod watcher;

--- a/api/src/convert/validated_mint_config.rs
+++ b/api/src/convert/validated_mint_config.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Convert to/from
-//! external:ValidatedMintConfigTx/ValidatedMintConfigTxTxPrefix/
-//! ValidatedMintConfigTxTx.
+//! Convert between the Rust and Protobuf versions of [ValidatedMintConfigTx]
 
 use crate::{convert::ConversionError, external};
 use mc_crypto_multisig::SignerSet;

--- a/api/src/convert/validated_mint_config.rs
+++ b/api/src/convert/validated_mint_config.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Convert to/from
+//! external:ValidatedMintConfigTx/ValidatedMintConfigTxTxPrefix/
+//! ValidatedMintConfigTxTx.
+
+use crate::{convert::ConversionError, external};
+use mc_crypto_multisig::SignerSet;
+use mc_transaction_core::mint::{MintConfigTx, ValidatedMintConfigTx};
+
+use std::convert::TryFrom;
+
+/// Convert ValidatedMintConfigTx --> external::ValidatedMintConfigTx.
+impl From<&ValidatedMintConfigTx> for external::ValidatedMintConfigTx {
+    fn from(src: &ValidatedMintConfigTx) -> Self {
+        let mut dst = external::ValidatedMintConfigTx::new();
+        dst.set_mint_config_tx((&src.mint_config_tx).into());
+        dst.set_signer_set((&src.signer_set).into());
+        dst
+    }
+}
+
+/// Convert external::ValidatedMintConfigTx --> ValidatedMintConfigTx.
+impl TryFrom<&external::ValidatedMintConfigTx> for ValidatedMintConfigTx {
+    type Error = ConversionError;
+
+    fn try_from(source: &external::ValidatedMintConfigTx) -> Result<Self, Self::Error> {
+        let mint_config_tx = MintConfigTx::try_from(source.get_mint_config_tx())?;
+        let signer_set = SignerSet::try_from(source.get_signer_set())?;
+        Ok(Self {
+            mint_config_tx,
+            signer_set,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::convert::ed25519_multisig::tests::{test_multi_sig, test_signer_set};
+    use mc_transaction_core::mint::{MintConfig, MintConfigTxPrefix};
+    use mc_util_serial::{decode, encode};
+    use protobuf::Message;
+
+    #[test]
+    // ValidatedMintConfigTx -> external::ValidatedMintConfigTx ->
+    // ValidatedMintConfigTx should be the identity function.
+    fn test_convert_validated_mint_config() {
+        let source = ValidatedMintConfigTx {
+            mint_config_tx: MintConfigTx {
+                prefix: MintConfigTxPrefix {
+                    token_id: 123,
+                    configs: vec![
+                        MintConfig {
+                            token_id: 123,
+                            signer_set: test_signer_set(),
+                            mint_limit: 10000,
+                        },
+                        MintConfig {
+                            token_id: 456,
+                            signer_set: test_signer_set(),
+                            mint_limit: 20000,
+                        },
+                    ],
+                    nonce: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+                    tombstone_block: 100,
+                },
+                signature: test_multi_sig(),
+            },
+            signer_set: test_signer_set(),
+        };
+
+        // decode(encode(source)) should be the identity function.
+        {
+            let bytes = encode(&source);
+            let recovered = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
+
+        // Converting mc_transaction_core::mint::ValidatedMintConfigTx ->
+        // external::ValidatedMintConfigTx -> mc_transaction_core::mint::
+        // ValidatedMintConfigTx should be the identity function.
+        {
+            let external = external::ValidatedMintConfigTx::from(&source);
+            let recovered = ValidatedMintConfigTx::try_from(&external).unwrap();
+            assert_eq!(source, recovered);
+        }
+
+        // Encoding with prost, decoding with protobuf should be the identity
+        // function.
+        {
+            let bytes = encode(&source);
+            let recovered = external::ValidatedMintConfigTx::parse_from_bytes(&bytes).unwrap();
+            assert_eq!(recovered, external::ValidatedMintConfigTx::from(&source));
+        }
+
+        // Encoding with protobuf, decoding with prost should be the identity function.
+        {
+            let external = external::ValidatedMintConfigTx::from(&source);
+            let bytes = external.write_to_bytes().unwrap();
+            let recovered: ValidatedMintConfigTx = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
+    }
+}

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1815,7 +1815,7 @@ mod tests {
 
             // There should be no key images or mint config txs
             assert!(block_contents.key_images.is_empty());
-            assert!(block_contents.mint_config_txs.is_empty());
+            assert!(block_contents.validated_mint_config_txs.is_empty());
 
             // The block contents should contain the minted tx outs.
             assert_eq!(block_contents.outputs.len(), 2);
@@ -1936,9 +1936,11 @@ mod tests {
         let signer_set1 = SignerSet::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
         let signer_set2 = SignerSet::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
 
-        let master_minters_map =
-            MasterMintersMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
-                .unwrap();
+        let master_minters_map = MasterMintersMap::try_from_iter([
+            (token_id1, signer_set1.clone()),
+            (token_id2, signer_set2.clone()),
+        ])
+        .unwrap();
 
         for block_version in BlockVersion::iterator() {
             if !block_version.mint_transactions_are_supported() {
@@ -1998,8 +2000,17 @@ mod tests {
 
             // The block contents should contain the two mint config txs.
             assert_eq!(
-                block_contents.mint_config_txs,
-                vec![mint_config_tx1.clone(), mint_config_tx2.clone()]
+                block_contents.validated_mint_config_txs,
+                vec![
+                    ValidatedMintConfigTx {
+                        mint_config_tx: mint_config_tx1.clone(),
+                        signer_set: signer_set1.clone(),
+                    },
+                    ValidatedMintConfigTx {
+                        mint_config_tx: mint_config_tx2.clone(),
+                        signer_set: signer_set2.clone(),
+                    }
+                ]
             );
 
             // There should be no outputs, key images or mint txs
@@ -2361,7 +2372,7 @@ mod tests {
             );
 
             // There should be no mint config txs
-            assert!(block_contents.mint_config_txs.is_empty());
+            assert!(block_contents.validated_mint_config_txs.is_empty());
 
             // The block contents should contain the minted tx outs.
             let output1 = block_contents

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -11,6 +11,7 @@ mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
 mc-common = { path = "../../../common" }
 mc-consensus-enclave-api = { path = "../api" }
 mc-crypto-keys = { path = "../../../crypto/keys" }
+mc-crypto-multisig = { path = "../../../crypto/multisig" }
 mc-crypto-rand = { path = "../../../crypto/rand" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
 mc-transaction-core = { path = "../../../transaction/core" }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -22,10 +22,12 @@ use mc_common::ResponderId;
 use mc_crypto_keys::{
     Ed25519Pair, Ed25519Public, RistrettoPublic, X25519EphemeralPrivate, X25519Public,
 };
+use mc_crypto_multisig::SignerSet;
 use mc_crypto_rand::McRng;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
     membership_proofs::compute_implied_merkle_root,
+    mint::ValidatedMintConfigTx,
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipProof},
@@ -288,11 +290,20 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         );
         outputs.extend(minted_tx_outs);
 
+        let validated_mint_config_txs = inputs
+            .mint_config_txs
+            .into_iter()
+            .map(|mint_config_tx| ValidatedMintConfigTx {
+                mint_config_tx,
+                signer_set: SignerSet::default(),
+            })
+            .collect();
+
         let block_contents = BlockContents {
             key_images,
             outputs,
             mint_txs: inputs.mint_txs,
-            mint_config_txs: inputs.mint_config_txs,
+            validated_mint_config_txs,
         };
 
         let block =

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -325,7 +325,7 @@ mod tests {
     use mc_transaction_core::{Block, BlockContents, BlockVersion, TokenId};
     use mc_transaction_core_test_utils::{
         create_ledger, create_mint_config_tx_and_signers, create_mint_tx, create_transaction,
-        initialize_ledger, AccountKey,
+        initialize_ledger, mint_config_tx_to_validated, AccountKey,
     };
     use mc_util_from_random::FromRandom;
     use mc_util_uri::{ConnectionUri, ConsensusPeerUri as PeerUri, ConsensusPeerUri};
@@ -870,7 +870,7 @@ mod tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx1],
+            validated_mint_config_txs: vec![mint_config_tx_to_validated(&mint_config_tx1)],
             ..Default::default()
         };
         let block = Block::new_with_parent(

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -210,7 +210,8 @@ mod mint_config_tx_tests {
     use mc_crypto_multisig::SignerSet;
     use mc_transaction_core::{Block, BlockContents};
     use mc_transaction_core_test_utils::{
-        create_ledger, create_mint_config_tx_and_signers, initialize_ledger, AccountKey,
+        create_ledger, create_mint_config_tx_and_signers, initialize_ledger,
+        mint_config_tx_to_validated as to_validated, AccountKey,
     };
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -338,7 +339,7 @@ mod mint_config_tx_tests {
         let parent_block = ledger.get_block(n_blocks - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 
@@ -560,7 +561,7 @@ mod mint_tx_tests {
     use mc_transaction_core::{Block, BlockContents};
     use mc_transaction_core_test_utils::{
         create_ledger, create_mint_config_tx_and_signers, create_mint_tx, create_test_tx_out,
-        initialize_ledger, AccountKey,
+        initialize_ledger, mint_config_tx_to_validated as to_validated, AccountKey,
     };
     use rand::{rngs::StdRng, SeedableRng};
     use std::iter::FromIterator;
@@ -584,7 +585,7 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 
@@ -641,7 +642,10 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone(), mint_config_tx2.clone()],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx1),
+                to_validated(&mint_config_tx2),
+            ],
             ..Default::default()
         };
 
@@ -718,7 +722,10 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone(), mint_config_tx2.clone()],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx1),
+                to_validated(&mint_config_tx2),
+            ],
             ..Default::default()
         };
 
@@ -815,7 +822,7 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 
@@ -928,7 +935,7 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 
@@ -993,7 +1000,7 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 
@@ -1089,7 +1096,7 @@ mod mint_tx_tests {
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
             ..Default::default()
         };
 

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -204,10 +204,10 @@ impl Ledger for LedgerDB {
             &mut db_transaction,
         )?;
 
-        // Write MintConfigTxs included in the block.
-        self.mint_config_store.write_mint_config_txs(
+        // Write ValidatedMintConfigTxs included in the block.
+        self.mint_config_store.write_validated_mint_config_txs(
             block.index,
-            &block_contents.mint_config_txs,
+            &block_contents.validated_mint_config_txs,
             &mut db_transaction,
         )?;
 
@@ -682,7 +682,7 @@ impl LedgerDB {
         // - Blocks before minting was introduced always had outputs in them.
         // - Blocks that have MintTxs in them will also have the minted TxOuts in them.
         // - Blocks with only MintConfigTxs are allowed to not have outputs.
-        let has_mint_config_txs = !block_contents.mint_config_txs.is_empty();
+        let has_mint_config_txs = !block_contents.validated_mint_config_txs.is_empty();
         if block_contents.outputs.is_empty() && !has_mint_config_txs {
             return Err(Error::NoOutputs);
         }
@@ -696,8 +696,8 @@ impl LedgerDB {
         // Non-origin blocks must have key images, unless it has minting-related
         // transactions. When we have minting transactions it implies we might've not
         // spent any pre-existing outputs and as such we will not have key images.
-        let has_minting_txs =
-            !block_contents.mint_config_txs.is_empty() || !block_contents.mint_txs.is_empty();
+        let has_minting_txs = !block_contents.validated_mint_config_txs.is_empty()
+            || !block_contents.mint_txs.is_empty();
         if block.index != 0 && block_contents.key_images.is_empty() && !has_minting_txs {
             return Err(Error::NoKeyImages);
         }
@@ -741,10 +741,13 @@ impl LedgerDB {
         }
 
         // Check that none of the mint-config-tx nonces appear in the ledger.
-        for mint_config_tx in block_contents.mint_config_txs.iter() {
+        for validated_mint_config_tx in block_contents.validated_mint_config_txs.iter() {
             if self
                 .mint_config_store
-                .check_mint_config_tx_nonce(&mint_config_tx.prefix.nonce, db_transaction)?
+                .check_mint_config_tx_nonce(
+                    &validated_mint_config_tx.mint_config_tx.prefix.nonce,
+                    db_transaction,
+                )?
                 .is_some()
             {
                 return Err(Error::DuplicateMintConfigTx);
@@ -799,10 +802,10 @@ impl LedgerDB {
         let key_image_list: KeyImageList =
             decode(db_transaction.get(self.key_images_by_block, &u64_to_key_bytes(block_number))?)?;
 
-        // Get all MintConfigTxs in block.
-        let mint_config_txs = self
+        // Get all ValidatedMintConfigTxs in block.
+        let validated_mint_config_txs = self
             .mint_config_store
-            .get_mint_config_txs_by_block_index(block_number, db_transaction)?;
+            .get_validated_mint_config_txs_by_block_index(block_number, db_transaction)?;
 
         // Get all MintTxs in block.
         let mint_txs = self
@@ -813,7 +816,7 @@ impl LedgerDB {
         Ok(BlockContents {
             key_images: key_image_list.key_images,
             outputs,
-            mint_config_txs,
+            validated_mint_config_txs,
             mint_txs,
         })
     }

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -888,6 +888,7 @@ pub fn u32_to_key_bytes(value: u32) -> [u8; 4] {
 #[cfg(test)]
 mod ledger_db_test {
     use super::*;
+
     use core::convert::TryFrom;
     use mc_account_keys::AccountKey;
     use mc_crypto_keys::{Ed25519Pair, RistrettoPrivate};
@@ -897,7 +898,7 @@ mod ledger_db_test {
     };
     use mc_transaction_core_test_utils::{
         create_mint_config_tx, create_mint_config_tx_and_signers, create_mint_tx,
-        create_test_tx_out,
+        create_test_tx_out, mint_config_tx_to_validated as to_validated,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -1156,7 +1157,7 @@ mod ledger_db_test {
         let mint_config_tx1 = create_mint_config_tx(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -1209,7 +1210,10 @@ mod ledger_db_test {
         let mint_config_tx3 = create_mint_config_tx(token_id2, &mut rng);
 
         let block_contents2 = BlockContents {
-            mint_config_txs: vec![mint_config_tx2.clone(), mint_config_tx3.clone()],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx2),
+                to_validated(&mint_config_tx3),
+            ],
             ..Default::default()
         };
 
@@ -1298,7 +1302,7 @@ mod ledger_db_test {
         let mint_config_tx1 = create_mint_config_tx(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -1317,7 +1321,10 @@ mod ledger_db_test {
         let mint_config_tx2 = create_mint_config_tx(token_id1, &mut rng);
 
         let block_contents2 = BlockContents {
-            mint_config_txs: vec![mint_config_tx2.clone(), mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx2),
+                to_validated(&mint_config_tx1),
+            ],
             ..Default::default()
         };
 
@@ -1367,7 +1374,7 @@ mod ledger_db_test {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -1740,7 +1747,10 @@ mod ledger_db_test {
         let block_contents1 = BlockContents {
             key_images: key_images1,
             outputs: outputs1,
-            mint_config_txs: vec![mint_config_tx1.clone(), mint_config_tx2.clone()],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx1),
+                to_validated(&mint_config_tx2),
+            ],
             mint_txs: vec![], /* For this block we cant include any mint txs since we need an
                                * active configuration first. */
         };
@@ -1838,7 +1848,7 @@ mod ledger_db_test {
         let block_contents2 = BlockContents {
             key_images: key_images2,
             outputs: outputs2,
-            mint_config_txs: vec![mint_config_tx3.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx3)],
             mint_txs: vec![mint_tx1.clone(), mint_tx2.clone()],
         };
         let block2 = Block::new_with_parent(
@@ -1953,7 +1963,7 @@ mod ledger_db_test {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -2017,7 +2027,7 @@ mod ledger_db_test {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -2108,7 +2118,7 @@ mod ledger_db_test {
         let (mint_config_tx1, _signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 
@@ -2182,7 +2192,7 @@ mod ledger_db_test {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents1 = BlockContents {
-            mint_config_txs: vec![mint_config_tx1.clone()],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
             ..Default::default()
         };
 

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -325,6 +325,7 @@ pub mod tests {
     use mc_transaction_core::mint::{MintConfigTx, MintConfigTxPrefix};
     use mc_transaction_core_test_utils::{
         create_mint_config_tx, create_mint_config_tx_and_signers, create_mint_tx,
+        mint_config_tx_to_validated as to_validated,
     };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -349,7 +350,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -375,7 +380,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    1,
+                    &[to_validated(&test_tx_2)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -412,7 +421,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -420,9 +433,9 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.write_mint_config_txs(
+                mint_config_store.write_validated_mint_config_txs(
                     1,
-                    &[test_tx_1.clone()],
+                    &[to_validated(&test_tx_1)],
                     &mut db_transaction
                 ),
                 Err(Error::Lmdb(lmdb::Error::KeyExist))
@@ -434,9 +447,9 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             assert_eq!(
-                mint_config_store.write_mint_config_txs(
+                mint_config_store.write_validated_mint_config_txs(
                     2,
-                    &[test_tx_1.clone()],
+                    &[to_validated(&test_tx_1)],
                     &mut db_transaction
                 ),
                 Err(Error::Lmdb(lmdb::Error::KeyExist))
@@ -449,7 +462,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(3, &[test_tx_2], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    3,
+                    &[to_validated(&test_tx_2)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -468,7 +485,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -488,7 +509,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    1,
+                    &[to_validated(&test_tx_2)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -526,7 +551,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -546,7 +575,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(1, &[test_tx_2.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    1,
+                    &[to_validated(&test_tx_2)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -573,7 +606,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -648,7 +685,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -679,7 +720,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -732,7 +777,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -782,7 +831,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -854,7 +907,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -938,7 +995,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(0, &[test_tx_1.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    0,
+                    &[to_validated(&test_tx_1)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -986,9 +1047,9 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(
+                .write_validated_mint_config_txs(
                     0,
-                    &[test_tx_1.clone(), test_tx_2.clone()],
+                    &[to_validated(&test_tx_1), to_validated(&test_tx_2)],
                     &mut db_transaction,
                 )
                 .unwrap();
@@ -1038,7 +1099,11 @@ pub mod tests {
             };
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    1,
+                    &[to_validated(&test_tx_3)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }
@@ -1074,9 +1139,9 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(
+                .write_validated_mint_config_txs(
                     0,
-                    &[test_tx_1.clone(), test_tx_2.clone()],
+                    &[to_validated(&test_tx_1), to_validated(&test_tx_2)],
                     &mut db_transaction,
                 )
                 .unwrap();
@@ -1121,7 +1186,11 @@ pub mod tests {
         {
             let mut db_transaction = env.begin_rw_txn().unwrap();
             mint_config_store
-                .write_mint_config_txs(1, &[test_tx_3.clone()], &mut db_transaction)
+                .write_validated_mint_config_txs(
+                    1,
+                    &[to_validated(&test_tx_3)],
+                    &mut db_transaction,
+                )
                 .unwrap();
             db_transaction.commit().unwrap();
         }

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -12,13 +12,13 @@
 //! 2) A mapping of nonce -> block index of the block containing the
 //! MintConfigTx with that nonce. This is mainly used to prevent replay
 //! attacks.
-//! 3) A mapping of block index -> list of MintConfigTx objects
+//! 3) A mapping of block index -> list of ValidatedMintConfigTx objects
 //! included in the block.
 
 use crate::{key_bytes_to_u64, u32_to_key_bytes, u64_to_key_bytes, Error};
 use lmdb::{Database, DatabaseFlags, Environment, RwTransaction, Transaction, WriteFlags};
 use mc_transaction_core::{
-    mint::{MintConfig, MintConfigTx, MintTx},
+    mint::{MintConfig, MintConfigTx, MintTx, ValidatedMintConfigTx},
     BlockIndex, TokenId,
 };
 use mc_util_serial::{decode, encode, Message};
@@ -28,7 +28,8 @@ pub const ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME: &str =
     "mint_config_store:active_mint_configs_by_token_id";
 pub const BLOCK_INDEX_BY_MINT_CONFIG_TX_NONCE_DB_NAME: &str =
     "mint_config_store:block_index_by_mint_config_tx_nonce";
-pub const MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str = "mint_config_store:mint_config_txs_by_block";
+pub const VALIDATED_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME: &str =
+    "mint_config_store:validated_mint_config_txs_by_block";
 
 /// An active mint configuration for a single token.
 #[derive(Clone, Eq, Message, PartialEq)]
@@ -66,12 +67,12 @@ impl From<&MintConfigTx> for ActiveMintConfigs {
     }
 }
 
-/// A list of mint-config-txs that can be prost-encoded. This is needed
-/// since that's the only way to encode a Vec<MintConfigTx>.
+/// A list of validated mint-config-txs that can be prost-encoded. This is
+/// needed since that's the only way to encode a Vec<ValidatedMintConfigTx>.
 #[derive(Clone, Message)]
-pub struct MintConfigTxList {
+pub struct ValidatedMintConfigTxList {
     #[prost(message, repeated, tag = "1")]
-    pub mint_config_txs: Vec<MintConfigTx>,
+    pub validated_mint_config_txs: Vec<ValidatedMintConfigTx>,
 }
 
 #[derive(Clone)]
@@ -82,8 +83,8 @@ pub struct MintConfigStore {
     /// nonce -> block index
     block_index_by_mint_config_tx_nonce: Database,
 
-    /// block_index -> MintConfigTxList
-    mint_config_txs_by_block: Database,
+    /// block_index -> ValidatedMintConfigTxList
+    validated_mint_config_txs_by_block: Database,
 }
 
 impl MintConfigStore {
@@ -94,7 +95,8 @@ impl MintConfigStore {
                 .open_db(Some(ACTIVE_MINT_CONFIGS_BY_TOKEN_ID_DB_NAME))?,
             block_index_by_mint_config_tx_nonce: env
                 .open_db(Some(BLOCK_INDEX_BY_MINT_CONFIG_TX_NONCE_DB_NAME))?,
-            mint_config_txs_by_block: env.open_db(Some(MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
+            validated_mint_config_txs_by_block: env
+                .open_db(Some(VALIDATED_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME))?,
         })
     }
 
@@ -109,36 +111,38 @@ impl MintConfigStore {
             DatabaseFlags::empty(),
         )?;
         env.create_db(
-            Some(MINT_CONFIG_TXS_BY_BLOCK_DB_NAME),
+            Some(VALIDATED_MINT_CONFIG_TXS_BY_BLOCK_DB_NAME),
             DatabaseFlags::empty(),
         )?;
 
         Ok(())
     }
 
-    /// Write mint-config-txs in a given block.
-    pub fn write_mint_config_txs(
+    /// Write validated mint-config-txs in a given block.
+    pub fn write_validated_mint_config_txs(
         &self,
         block_index: u64,
-        mint_config_txs: &[MintConfigTx],
+        validated_mint_config_txs: &[ValidatedMintConfigTx],
         db_transaction: &mut RwTransaction,
     ) -> Result<(), Error> {
         let block_index_bytes = u64_to_key_bytes(block_index);
 
-        // Store the list of MintConfigTxs.
-        let mint_config_tx_list = MintConfigTxList {
-            mint_config_txs: mint_config_txs.to_vec(),
+        // Store the list of ValidatedMintConfigTxs.
+        let validated_mint_config_tx_list = ValidatedMintConfigTxList {
+            validated_mint_config_txs: validated_mint_config_txs.to_vec(),
         };
 
         db_transaction.put(
-            self.mint_config_txs_by_block,
+            self.validated_mint_config_txs_by_block,
             &block_index_bytes,
-            &encode(&mint_config_tx_list),
+            &encode(&validated_mint_config_tx_list),
             WriteFlags::NO_OVERWRITE, // We should not be updating existing blocks
         )?;
 
         // Update active mint configurations.
-        for mint_config_tx in mint_config_txs {
+        for validated_mint_config_tx in validated_mint_config_txs {
+            let mint_config_tx = &validated_mint_config_tx.mint_config_tx;
+
             // All mint configurations must have the same token id.
             if mint_config_tx
                 .prefix
@@ -174,17 +178,18 @@ impl MintConfigStore {
         Ok(())
     }
 
-    /// Get MintConfigTxs in a given block.
-    pub fn get_mint_config_txs_by_block_index(
+    /// Get ValidatedMintConfigTxs in a given block.
+    pub fn get_validated_mint_config_txs_by_block_index(
         &self,
         block_index: u64,
         db_transaction: &impl Transaction,
-    ) -> Result<Vec<MintConfigTx>, Error> {
-        let mint_config_tx_list: MintConfigTxList = decode(db_transaction.get(
-            self.mint_config_txs_by_block,
-            &u64_to_key_bytes(block_index),
-        )?)?;
-        Ok(mint_config_tx_list.mint_config_txs)
+    ) -> Result<Vec<ValidatedMintConfigTx>, Error> {
+        let validated_mint_config_tx_list: ValidatedMintConfigTxList =
+            decode(db_transaction.get(
+                self.validated_mint_config_txs_by_block,
+                &u64_to_key_bytes(block_index),
+            )?)?;
+        Ok(validated_mint_config_tx_list.validated_mint_config_txs)
     }
 
     /// Get mint configurations for a given token.

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -137,7 +137,10 @@ mod tests {
     use crate::{mint_config_store::ActiveMintConfig, tx_out_store::tx_out_store_tests::get_env};
     use mc_crypto_keys::Ed25519Pair;
     use mc_transaction_core::TokenId;
-    use mc_transaction_core_test_utils::{create_mint_config_tx_and_signers, create_mint_tx};
+    use mc_transaction_core_test_utils::{
+        create_mint_config_tx_and_signers, create_mint_tx,
+        mint_config_tx_to_validated as to_validated,
+    };
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
     use std::cmp::max;
@@ -164,9 +167,12 @@ mod tests {
         let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(
+            .write_validated_mint_config_txs(
                 0,
-                &[mint_config_tx1.clone(), mint_config_tx2.clone()],
+                &[
+                    to_validated(&mint_config_tx1),
+                    to_validated(&mint_config_tx2),
+                ],
                 &mut db_txn,
             )
             .unwrap();
@@ -364,7 +370,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -404,7 +410,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -460,7 +466,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -492,7 +498,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -517,7 +523,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1.clone()], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 
@@ -562,7 +568,7 @@ mod tests {
 
         let mut db_txn = env.begin_rw_txn().unwrap();
         mint_config_store
-            .write_mint_config_txs(0, &[mint_config_tx1], &mut db_txn)
+            .write_validated_mint_config_txs(0, &[to_validated(&mint_config_tx1)], &mut db_txn)
             .unwrap();
         db_txn.commit().unwrap();
 

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -234,7 +234,7 @@ fn backfill_empty_mint_stores(env: &Environment, logger: &Logger) -> Result<(), 
 
     let mut percents: u64 = 0;
     for block_index in 0..num_blocks {
-        mint_config_store.write_mint_config_txs(block_index, &[], &mut db_txn)?;
+        mint_config_store.write_validated_mint_config_txs(block_index, &[], &mut db_txn)?;
         mint_tx_store.write_mint_txs(block_index, &[], &mint_config_store, &mut db_txn)?;
 
         // Throttled logging.

--- a/mint-auditor/Cargo.toml
+++ b/mint-auditor/Cargo.toml
@@ -23,7 +23,7 @@ clap = { version = "3.1", features = ["derive", "env"] }
 displaydoc = "0.2"
 grpcio = "0.10.0"
 lmdb-rkv = "0.14.0"
-prost = { version = "0.9", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.10", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/transaction/core/src/blockchain/block_contents.rs
+++ b/transaction/core/src/blockchain/block_contents.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
 use crate::{
-    mint::{MintConfigTx, MintTx},
+    mint::{MintTx, ValidatedMintConfigTx},
     ring_signature::KeyImage,
     tx::TxOut,
     ConvertError,
@@ -29,7 +29,7 @@ pub struct BlockContents {
 
     /// mint-config transactions in this block.
     #[prost(message, repeated, tag = "3")]
-    pub mint_config_txs: Vec<MintConfigTx>,
+    pub validated_mint_config_txs: Vec<ValidatedMintConfigTx>,
 
     /// Mint transactions in this block.
     #[prost(message, repeated, tag = "4")]

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -82,3 +82,17 @@ impl fmt::Display for MintConfigTx {
         write!(f, "{}", hex_fmt::HexFmt(&self.prefix.nonce))
     }
 }
+
+/// A mint-config transaction coupled with the data used to validate it.
+#[derive(
+    Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct ValidatedMintConfigTx {
+    /// The transaction that was validated.
+    #[prost(message, required, tag = "1")]
+    pub mint_config_tx: MintConfigTx,
+
+    /// The signer set used to validate the transaction's signature.
+    #[prost(message, required, tag = "2")]
+    pub signer_set: SignerSet<Ed25519Public>,
+}

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -8,7 +8,7 @@ mod validation;
 
 pub mod constants;
 
-pub use config::{MintConfig, MintConfigTx, MintConfigTxPrefix};
+pub use config::{MintConfig, MintConfigTx, MintConfigTxPrefix, ValidatedMintConfigTx};
 pub use tx::{MintTx, MintTxPrefix};
 pub use validation::{
     config::validate_mint_config_tx, error::Error as MintValidationError, tx::validate_mint_tx,

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -14,7 +14,7 @@ pub use mc_transaction_core::{
 };
 pub use mint::{
     create_mint_config_tx, create_mint_config_tx_and_signers, create_mint_tx,
-    create_mint_tx_to_recipient,
+    create_mint_tx_to_recipient, mint_config_tx_to_validated,
 };
 
 use core::convert::TryFrom;

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -7,7 +7,8 @@ use mc_crypto_multisig::{MultiSig, SignerSet};
 use mc_crypto_rand::{CryptoRng, RngCore};
 use mc_transaction_core::{
     mint::{
-        constants::NONCE_LENGTH, MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx, MintTxPrefix,
+        constants::NONCE_LENGTH, MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx,
+        MintTxPrefix, ValidatedMintConfigTx,
     },
     TokenId,
 };
@@ -82,6 +83,14 @@ pub fn create_mint_config_tx(
 ) -> MintConfigTx {
     let (mint_config_tx, _signers) = create_mint_config_tx_and_signers(token_id, rng);
     mint_config_tx
+}
+
+/// A helper for mocking a `ValidatedMintConfigTx` from a `MintConfigTx`.
+pub fn mint_config_tx_to_validated(mint_config_tx: &MintConfigTx) -> ValidatedMintConfigTx {
+    ValidatedMintConfigTx {
+        mint_config_tx: mint_config_tx.clone(),
+        signer_set: SignerSet::default(),
+    }
 }
 
 /// Generate a random, valid mint tx


### PR DESCRIPTION
### Motivation

`MintConfigTx`s are validated by checking their signatures against the master minters configured on consensus nodes. We'd like to allow independent auditors to validate those as well, and have a record of which master minter keys were active when a `MintConfigTx` was accepted into the ledger.
The solution proposed here is to store the master minters used to validate a given `MintConfigTx` alongside the `MintConfigTx`.

Down the road we intend on signing the master minters with a key owned by the foundation, and at that point we will store this signature as well.

### In this PR
* Create a new `ValidatedMintConfigTx` struct that holds a `MintConfigTx` and the `SignerSet` that was used to validate its signature.
* Replace `mint_config_txs` in `BlockContents` with `validated_mint_config_txs`. This results in a whole bunch of renames, which makes this PR seem big (but the set of changes is actually pretty trivial).
* Change `form_block` to store `ValidatedMintConfigTx`s in the block.

### Future Work
* Add support for the foundation key signing the master minters, and plumb that into `ValidatedMintConfigTx`.
