### PR TITLE
rename GetLastBlockInfoResponse.block_version -> network_block_version

### DIFF
--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -68,7 +68,7 @@ pub struct BlockInfo {
 
     /// Block version reported by the network.
     /// This is the configured block version on the node.
-    pub block_version: u32,
+    pub network_block_version: u32,
 }
 
 impl BlockInfo {
@@ -108,7 +108,7 @@ impl From<LastBlockInfoResponse> for BlockInfo {
         BlockInfo {
             block_index: src.index,
             minimum_fees,
-            block_version: src.block_version,
+            network_block_version: src.network_block_version,
         }
     }
 }

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -118,7 +118,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
         Ok(BlockInfo {
             block_index: self.ledger.num_blocks().unwrap() - 1,
             minimum_fees: FeeMap::default_map(),
-            block_version: *BlockVersion::MAX,
+            network_block_version: *BlockVersion::MAX,
         })
     }
 }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -27,13 +27,13 @@ message LastBlockInfoResponse {
     // A map of token id -> minimum fee
     map<uint32, uint64> minimum_fees = 3;
 
-    // Current block version, appropriate for new transactions.
+    // Current network_block version, appropriate for new transactions.
     //
     // Note that if the server was just reconfigured, this may be HIGHER than
     // the highest block version in the ledger, so for clients this is a better
     // source of truth than the local ledger, if the client might possibly be
     // creating the first transaction after a reconfigure / redeploy.
-    uint32 block_version = 4;
+    uint32 network_block_version = 4;
 }
 
 // Requests a range [offset, offset+limit) of Blocks.

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -34,7 +34,7 @@ pub struct BlockchainApiService<L: Ledger + Clone> {
     fee_map: FeeMap,
 
     /// Configured block version
-    block_version: BlockVersion,
+    network_block_version: BlockVersion,
 
     /// Logger.
     logger: Logger,
@@ -45,7 +45,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
         ledger: L,
         authenticator: Arc<dyn Authenticator + Send + Sync>,
         fee_map: FeeMap,
-        block_version: BlockVersion,
+        network_block_version: BlockVersion,
         logger: Logger,
     ) -> Self {
         BlockchainApiService {
@@ -53,7 +53,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
             authenticator,
             max_page_size: 2000,
             fee_map,
-            block_version,
+            network_block_version,
             logger,
         }
     }
@@ -79,7 +79,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
                 .iter()
                 .map(|(token_id, fee)| (**token_id, *fee)),
         ));
-        resp.set_block_version(*self.block_version);
+        resp.set_network_block_version(*self.network_block_version);
 
         Ok(resp)
     }
@@ -241,7 +241,7 @@ mod tests {
         expected_response.set_index(block_entities.last().unwrap().index);
         expected_response.set_mob_minimum_fee(12345);
         expected_response.set_minimum_fees(HashMap::from_iter(vec![(0, 12345), (60, 10203040)]));
-        expected_response.set_block_version(*BlockVersion::MAX);
+        expected_response.set_network_block_version(*BlockVersion::MAX);
         assert_eq!(
             block_entities.last().unwrap().index,
             ledger_db.num_blocks().unwrap() - 1

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -173,7 +173,7 @@ fn main() {
             ledger_db.get_latest_block().unwrap().version,
             block_infos
                 .iter()
-                .map(|block_info| block_info.block_version)
+                .map(|block_info| block_info.network_block_version)
                 .max()
                 .unwrap_or(0),
         ),

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -539,7 +539,8 @@ impl Client {
     pub fn get_last_block_info(&mut self) -> Result<BlockInfo> {
         let block_info = self.consensus_service_conn.fetch_block_info()?;
         // Opportunistically update our cached block version value
-        self.tx_data.notify_block_version(block_info.block_version);
+        self.tx_data
+            .notify_block_version(block_info.network_block_version);
         Ok(block_info)
     }
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -147,7 +147,7 @@ fn get_block_infos<T: BlockchainConnection + UserTxConnection + 'static>(
 fn get_network_block_version(block_infos: &[BlockInfo]) -> u32 {
     block_infos
         .iter()
-        .map(|block_info| block_info.block_version)
+        .map(|block_info| block_info.network_block_version)
         .max()
         .unwrap_or(0)
 }


### PR DESCRIPTION
This is expected to reduce confusion, because a reader could reasonably
think that the LastBlockInfo.block_version refers to the version of the
last block, and not the current configured version of the network

(cc James)