### PR TITLE
fix python mistakes

### DIFF
--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
 
     dest_b58addresses = [
         read_file(b58_pubfile)
-        for b58pubfile in sorted(glob.glob(os.path.join(args.dest_key_dir, '*.b58pub')), key=filename_key)
+        for b58_pubfile in sorted(glob.glob(os.path.join(args.dest_key_dir, '*.b58pub')), key=filename_key)
     ]
 
     # convert from b58 to external.PublicAddress using mobilecoind helpers

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -117,13 +117,13 @@ if __name__ == '__main__':
 
     stub = connect(args.mobilecoind_host, args.mobilecoind_port)
     source_accounts = [
-        load_key_and_register(os.path.join(args.key_dir, k), stub)
-        for k in sorted(glob.glob(os.path.join(args.key_dir, '*.json')), key=filename_key)
+        load_key_and_register(account_key, stub)
+        for account_key in sorted(glob.glob(os.path.join(args.key_dir, '*.json')), key=filename_key)
     ]
 
     dest_b58addresses = [
-        read_file(os.path.join(args.dest_key_dir, b58pubfile))
-        for b58pubfile in sorted(glob.glob(os.path.join(args.key_dir, '*.b58pub')), key=filename_key)
+        read_file(b58_pubfile)
+        for b58pubfile in sorted(glob.glob(os.path.join(args.dest_key_dir, '*.b58pub')), key=filename_key)
     ]
 
     # convert from b58 to external.PublicAddress using mobilecoind helpers

--- a/mobilecoind/strategies/test_client.py
+++ b/mobilecoind/strategies/test_client.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
 
     stub = connect(args.mobilecoind_host, args.mobilecoind_port)
     accounts = [
-        load_key_and_register(os.path.join(args.key_dir, k), stub)
+        load_key_and_register(k, stub)
         for k in sorted(glob.glob(os.path.join(args.key_dir, '*.json')))
     ]
 


### PR DESCRIPTION
error in deployment was:

```
+ python3 drain-accounts.py --key-dir ./keys --dest-key-dir ./fog_keys --max-accounts 4 --fee 10 --mobilecoind-host 127.0.0.1 --mobilecoind-port 3229
Namespace(dest_key_dir='./fog_keys', fee=10, key_dir='./keys', max_accounts=4, max_seconds=40, mobilecoind_host='127.0.0.1', mobilecoind_port='3229')
Traceback (most recent call last):
  File "drain-accounts.py", line 121, in <module>
    for k in sorted(glob.glob(os.path.join(args.key_dir, '*.json')), key=filename_key)
  File "drain-accounts.py", line 121, in <listcomp>
    for k in sorted(glob.glob(os.path.join(args.key_dir, '*.json')), key=filename_key)
  File "/home/jenkins/agent/workspace/mobilecoin-internal_deploy_build/strategies/accounts.py", line 58, in load_key_and_register
    with open(keyfile, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: './keys/./keys/account_keys_0.json'
+ kill 1988
[Pipeline] }
```