### PR TITLE
Clean up Python in tools/fog-local-network

### DIFF
--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -44,7 +44,7 @@ class TestLedger:
             os.makedirs(ledger_db_path)
 
             cmd = ' '.join([
-                f'cd {self.ledger_db_path} && exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/init_test_ledger',
+                f'cd {self.ledger_db_path} && exec {PROJECT_DIR}/{target_dir(self.release)}/init_test_ledger',
                 f'--keys {keys_dir}',
                 f'--ledger-db {self.ledger_db_path}',
                 f'--watcher-db {self.watcher_db_path}',
@@ -72,7 +72,7 @@ class TestLedger:
     def add_block(self, credits, key_images, fog_pubkey):
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && exec {target_dir(self.release)}/add_test_block',
+            f'cd {PROJECT_DIR} && exec {target_dir(self.release)}/add_test_block',
             f'--ledger-db {self.ledger_db_path}',
             f'--watcher-db {self.watcher_db_path}',
             f'--keys {self.keys_dir}',
@@ -361,7 +361,7 @@ class RustSamplePaykitRemoteWallet:
         assert self.wallet_process is None
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && MC_LOG=info exec {target_dir(self.release)}/sample_paykit_remote_wallet',
+            f'cd {PROJECT_DIR} && MC_LOG=info exec {target_dir(self.release)}/sample_paykit_remote_wallet',
         ])
 
         print(f'Starting rust sample paykit remote wallet')
@@ -386,7 +386,7 @@ class FogConformanceTest:
         if not os.path.exists(enclave_pem):
             log_and_run_shell(f'openssl genrsa -out {enclave_pem} -3 3072')
 
-        log_and_run_shell(f"cd {FOG_PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY={enclave_pem} INGEST_ENCLAVE_PRIVKEY={enclave_pem} LEDGER_ENCLAVE_PRIVKEY={enclave_pem} VIEW_ENCLAVE_PRIVKEY={enclave_pem} exec cargo build -p mc-util-keyfile -p mc-admin-http-gateway -p mc-crypto-x509-test-vectors -p mc-fog-view-server -p mc-fog-ledger-server -p mc-fog-ingest-server -p mc-fog-report-server -p mc-fog-report-cli -p mc-fog-ingest-client -p mc-fog-sql-recovery-db -p mc-fog-sample-paykit -p mc-fog-test-infra {FLAGS}")
+        log_and_run_shell(f"cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY={enclave_pem} INGEST_ENCLAVE_PRIVKEY={enclave_pem} LEDGER_ENCLAVE_PRIVKEY={enclave_pem} VIEW_ENCLAVE_PRIVKEY={enclave_pem} exec cargo build -p mc-util-keyfile -p mc-admin-http-gateway -p mc-crypto-x509-test-vectors -p mc-fog-view-server -p mc-fog-ledger-server -p mc-fog-ingest-server -p mc-fog-report-server -p mc-fog-report-cli -p mc-fog-ingest-client -p mc-fog-sql-recovery-db -p mc-fog-sample-paykit -p mc-fog-test-infra {FLAGS}")
 
     def __init__(self, work_dir, args):
         self.release = args.release
@@ -539,7 +539,7 @@ class FogConformanceTest:
         # Get fog pubkey
         print("Getting fog pubkey...")
         keyfile = os.path.join(self.keys_dir, "account_keys_0.pub")
-        fog_pubkey = subprocess.check_output(f"cd {FOG_PROJECT_DIR} && exec {target_dir(self.release)}/fog-report-cli --public-address {keyfile} --retry-seconds={FOG_REPORT_RETRY_SECONDS}", shell = True).decode("utf-8")
+        fog_pubkey = subprocess.check_output(f"cd {PROJECT_DIR} && exec {target_dir(self.release)}/fog-report-cli --public-address {keyfile} --retry-seconds={FOG_REPORT_RETRY_SECONDS}", shell = True).decode("utf-8")
         assert len(fog_pubkey) == 64
         print("Fog pubkey = ", fog_pubkey)
 
@@ -1000,7 +1000,7 @@ class FogConformanceTest:
         assert status["mode"] == "Active"
 
         self.fog_ingest2.report_lost_ingress_key(fog_pubkey)
-        new_fog_pubkey = subprocess.check_output(f"cd {FOG_PROJECT_DIR} && exec {target_dir(self.release)}/fog-report-cli --public-address {keyfile} --retry-seconds={FOG_REPORT_RETRY_SECONDS}", shell = True).decode("utf-8")
+        new_fog_pubkey = subprocess.check_output(f"cd {PROJECT_DIR} && exec {target_dir(self.release)}/fog-report-cli --public-address {keyfile} --retry-seconds={FOG_REPORT_RETRY_SECONDS}", shell = True).decode("utf-8")
         assert new_fog_pubkey != fog_pubkey
         # Add the block to the restarted ingest. While ingest won't successfully decode the hints in
         # TxOuts in the block because it is using a new fog pubkey, it's required

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -6,7 +6,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import time
 import grpc
 

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -7,8 +7,6 @@ import subprocess
 from local_network import *
 from local_fog import *
 
-MOBILECOIN_PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
-
 class FogNetwork(Network):
     def build_binaries(self):
         super().build_binaries()
@@ -18,7 +16,7 @@ class FogNetwork(Network):
 
         subprocess.run(
             ' '.join([
-                f'cd {MOBILECOIN_PROJECT_DIR} &&',
+                f'cd {PROJECT_DIR} &&',
                 f'CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}"',
                 f'INGEST_ENCLAVE_PRIVKEY="{enclave_pem}"',
                 f'LEDGER_ENCLAVE_PRIVKEY="{enclave_pem}"',
@@ -33,7 +31,7 @@ class FogNetwork(Network):
         cmd = ' && '.join([
             f'dropdb --if-exists {FOG_SQL_DATABASE_NAME}',
             f'createdb {FOG_SQL_DATABASE_NAME}',
-            f'DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} {MOBILECOIN_PROJECT_DIR}/{TARGET_DIR}/fog-sql-recovery-db-migrations',
+            f'DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} {PROJECT_DIR}/{TARGET_DIR}/fog-sql-recovery-db-migrations',
         ])
         print(f'Creating postgres database: {cmd}')
         subprocess.check_output(cmd, shell=True)
@@ -57,11 +55,11 @@ class FogNetwork(Network):
             pass
 
         # Get chain and key
-        root = subprocess.check_output(f"{MOBILECOIN_PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head",
+        root = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head",
                                    encoding='utf8', shell=True).strip()
-        chain = subprocess.check_output(f"{MOBILECOIN_PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_chain_25519_leaf",
+        chain = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_chain_25519_leaf",
                                    encoding='utf8', shell=True).strip()
-        key = subprocess.check_output(f"{MOBILECOIN_PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=key --test-name=ok_rsa_chain_25519_leaf",
+        key = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=key --test-name=ok_rsa_chain_25519_leaf",
                                  encoding='utf8', shell=True).strip()
         print(f"chain path = {chain}, key path = {key}")
 
@@ -124,7 +122,7 @@ class FogNetwork(Network):
         # Tell the ingest server to activate, giving it a little time for RPC to wakeup
         time.sleep(15)
         cmd = ' '.join([
-            f'exec {MOBILECOIN_PROJECT_DIR}/{TARGET_DIR}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{TARGET_DIR}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{BASE_INGEST_CLIENT_PORT}',
             f'activate',
         ])

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -14,18 +14,23 @@ class FogNetwork(Network):
         enclave_pem = os.path.join(PROJECT_DIR, 'Enclave_private.pem')
         assert os.path.exists(enclave_pem), enclave_pem
 
-        subprocess.run(
-            ' '.join([
-                f'cd {PROJECT_DIR} &&',
-                f'CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}"',
-                f'INGEST_ENCLAVE_PRIVKEY="{enclave_pem}"',
-                f'LEDGER_ENCLAVE_PRIVKEY="{enclave_pem}"',
-                f'VIEW_ENCLAVE_PRIVKEY="{enclave_pem}"',
-                f'cargo build -p mc-fog-ingest-server -p mc-fog-ingest-client -p mc-fog-view-server -p mc-fog-report-server -p mc-fog-ledger-server -p mc-fog-distribution -p mc-fog-test-client -p mc-fog-ingest-client -p mc-fog-sql-recovery-db -p mc-fog-test-client {CARGO_FLAGS}',
-            ]),
-            shell=True,
-            check=True,
-        )
+        log_and_run_shell(' '.join([
+            f'cd {PROJECT_DIR} &&',
+            f'CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}"',
+            f'INGEST_ENCLAVE_PRIVKEY="{enclave_pem}"',
+            f'LEDGER_ENCLAVE_PRIVKEY="{enclave_pem}"',
+            f'VIEW_ENCLAVE_PRIVKEY="{enclave_pem}"',
+            f'cargo build',
+            '-p mc-fog-distribution',
+            '-p mc-fog-ingest-client',
+            '-p mc-fog-ingest-server',
+            '-p mc-fog-ledger-server',
+            '-p mc-fog-report-server',
+            '-p mc-fog-sql-recovery-db',
+            '-p mc-fog-test-client'
+            '-p mc-fog-view-server',
+            f'{CARGO_FLAGS}',
+        ]))
 
     def start(self):
         cmd = ' && '.join([

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -3,13 +3,11 @@
 import argparse
 import os
 import subprocess
-import sys
 
-MOBILECOIN_PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
-# FIXME: Avoid modifying sys.path
-sys.path.append(os.path.join(MOBILECOIN_PROJECT_DIR, 'tools', 'local-network'))
 from local_network import *
 from local_fog import *
+
+MOBILECOIN_PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 
 class FogNetwork(Network):
     def build_binaries(self):

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -26,7 +26,6 @@ BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT = 7500
 BASE_NGINX_CLIENT_PORT = 8200
 
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-FOG_PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 IAS_API_KEY = os.getenv('IAS_API_KEY', default='0'*64) # 32 bytes
 IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
@@ -79,7 +78,7 @@ class FogIngest:
         self.stop()
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && MC_LOG=trace DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/fog_ingest_server',
+            f'cd {PROJECT_DIR} && MC_LOG=trace DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/fog_ingest_server',
             f'--ledger-db={self.ledger_db_path}',
             f'--client-listen-uri={self.client_listen_url}',
             f'--peer-listen-uri=insecure-igp://{LISTEN_HOST}:{self.peer_port}/',
@@ -121,7 +120,7 @@ class FogIngest:
 
     def get_status(self):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'get-status',
         ])
@@ -131,7 +130,7 @@ class FogIngest:
 
     def activate(self):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'activate',
         ])
@@ -141,7 +140,7 @@ class FogIngest:
 
     def set_pubkey_expiry_window(self, value):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'set-pubkey-expiry-window',
             str(value),
@@ -152,7 +151,7 @@ class FogIngest:
 
     def set_peers(self, peers):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'set-peers',
         ] + peers)
@@ -162,7 +161,7 @@ class FogIngest:
 
     def retire(self):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'retire',
         ])
@@ -172,7 +171,7 @@ class FogIngest:
 
     def report_lost_ingress_key(self, lost_key):
         cmd = ' '.join([
-            f'exec {FOG_PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
+            f'exec {PROJECT_DIR}/{target_dir(self.release)}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{self.client_port}',
             'report-lost-ingress-key',
             f"-k '{lost_key}'",
@@ -204,7 +203,7 @@ class FogView:
         self.stop()
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/fog_view_server',
+            f'cd {PROJECT_DIR} && DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/fog_view_server',
             f'--client-listen-uri={self.client_listen_url}',
             f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
@@ -261,7 +260,7 @@ class FogReport:
         self.stop()
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/report_server',
+            f'cd {PROJECT_DIR} && DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} exec {target_dir(self.release)}/report_server',
             f'--client-listen-uri={self.client_listen_url}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
             f'--signing-chain={self.chain}',
@@ -319,7 +318,7 @@ class FogLedger:
         self.stop()
 
         cmd = ' '.join([
-            f'cd {FOG_PROJECT_DIR} && exec {target_dir(self.release)}/ledger_server',
+            f'cd {PROJECT_DIR} && exec {target_dir(self.release)}/ledger_server',
             f'--ledger-db={self.ledger_db_path}',
             f'--client-listen-uri={self.client_listen_url}',
             f'--client-responder-id={self.client_responder_id}',

--- a/tools/fog-local-network/local_network.py
+++ b/tools/fog-local-network/local_network.py
@@ -1,0 +1,1 @@
+../local-network/local_network.py


### PR DESCRIPTION
Some fixes and cleanups I made for #1693, split into a separate PR.

* Symlink `local_network.py` next to `fog_local_network.py` to avoid mucking with sys.modules
* Use absolute paths when executing binaries
* Dedupe `PROJECT_DIR` constants across `tools/*/*.py`
* DRY up target_dir references