### PR TITLE
Make the mint auditor validate MintTxs against MintConfigTxs

### DIFF
--- a/mint-auditor/src/bin/main.rs
+++ b/mint-auditor/src/bin/main.rs
@@ -266,6 +266,8 @@ fn update_counters(mint_auditor_db: &MintAuditorDb) -> Result<(), Error> {
 
     counters::NUM_BLOCKS_SYNCED.set(counters.num_blocks_synced as i64);
     counters::NUM_BURNS_EXCEEDING_BALANCE.set(counters.num_burns_exceeding_balance as i64);
+    counters::NUM_MINT_TXS_WITHOUT_MATCHING_MINT_CONFIG
+        .set(counters.num_mint_txs_without_matching_mint_config as i64);
 
     Ok(())
 }

--- a/mint-auditor/src/counters.rs
+++ b/mint-auditor/src/counters.rs
@@ -15,5 +15,5 @@ lazy_static::lazy_static! {
     pub static ref NUM_BURNS_EXCEEDING_BALANCE: IntGauge = OP_COUNTERS.gauge("num_burns_exceeding_balance");
 
     /// Number of MintTxs without a matching MintConfig.
-    pub static ref NUM_MINT_TXS_WITHOUT_MATCHING_MINT_CONFIG = OP_COUNTERS.gauge("num_mint_txs_without_matching_mint_config");
+    pub static ref NUM_MINT_TXS_WITHOUT_MATCHING_MINT_CONFIG: IntGauge = OP_COUNTERS.gauge("num_mint_txs_without_matching_mint_config");
 }

--- a/mint-auditor/src/counters.rs
+++ b/mint-auditor/src/counters.rs
@@ -13,4 +13,7 @@ lazy_static::lazy_static! {
 
     /// Number of burns exceeding calculated balance.
     pub static ref NUM_BURNS_EXCEEDING_BALANCE: IntGauge = OP_COUNTERS.gauge("num_burns_exceeding_balance");
+
+    /// Number of MintTxs without a matching MintConfig.
+    pub static ref NUM_MINT_TXS_WITHOUT_MATCHING_MINT_CONFIG = OP_COUNTERS.gauge("num_mint_txs_without_matching_mint_config");
 }

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -837,7 +837,6 @@ mod tests {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
         let token_id1 = TokenId::from(1);
         let token_id2 = TokenId::from(22);
-        let token_id3 = TokenId::from(3);
 
         let mint_audit_db_path = tempdir().unwrap();
         let mint_audit_db = MintAuditorDb::create_or_open(&mint_audit_db_path, logger).unwrap();

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -297,9 +297,9 @@ impl MintAuditorDb {
             WriteFlags::NO_OVERWRITE,
         )?;
 
-        self.mint_config_store.write_mint_config_txs(
+        self.mint_config_store.write_validated_mint_config_txs(
             block_index,
-            &block_contents.mint_config_txs,
+            &block_contents.validated_mint_config_txs,
             &mut db_txn,
         )?;
 
@@ -357,7 +357,7 @@ mod tests {
     use mc_transaction_core::{tx::TxOut, Amount, BlockVersion, TokenId};
     use mc_transaction_core_test_utils::{
         create_ledger, create_mint_config_tx_and_signers, create_mint_tx, create_test_tx_out,
-        initialize_ledger,
+        initialize_ledger, mint_config_tx_to_validated as to_validated,
     };
     use mc_util_from_random::FromRandom;
     use rand_core::SeedableRng;
@@ -404,7 +404,11 @@ mod tests {
         let (mint_config_tx3, signers3) = create_mint_config_tx_and_signers(token_id3, &mut rng);
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx1, mint_config_tx2, mint_config_tx3],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx1),
+                to_validated(&mint_config_tx2),
+                to_validated(&mint_config_tx3),
+            ],
             ..Default::default()
         };
 
@@ -866,7 +870,10 @@ mod tests {
         let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx1, mint_config_tx2],
+            validated_mint_config_txs: vec![
+                to_validated(&mint_config_tx1),
+                to_validated(&mint_config_tx2),
+            ],
             ..Default::default()
         };
 
@@ -919,7 +926,7 @@ mod tests {
         let (mint_config_tx3, signers3) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
         let block_contents = BlockContents {
-            mint_config_txs: vec![mint_config_tx3],
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx3)],
             ..Default::default()
         };
 


### PR DESCRIPTION
### Motivation

We'd like the mint auditor to validate as many mint-related things as possible. This PR adds a check that validates whether `MintTx`s in a block match the currently active `MintConfigTx` for the minted token.

### In this PR
* Add the check mentioned above + a counter to keep track of any discrepancies found.

