### PR TITLE
Fix a bug in fee output minting and add a test

### DIFF
--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -33,7 +33,7 @@ pub use compressed_commitment::CompressedCommitment;
 pub use error::AmountError;
 
 /// An amount of some token, in the "base" (u64) denomination.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Digestible, Eq, PartialEq)]
 pub struct Amount {
     /// The "raw" value of this amount as a u64
     pub value: u64,

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -147,7 +147,7 @@ pub fn create_transaction_with_amount_and_comparer<
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
-    let (sender_amount, _) = tx_out.view_key_match(&sender.view_private_key()).unwrap();
+    let (sender_amount, _) = tx_out.view_key_match(sender.view_private_key()).unwrap();
 
     let mut transaction_builder = TransactionBuilder::new(
         block_version,

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -81,7 +81,10 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
         tx_out,
         sender,
         recipient,
-        amount.value - Mob::MINIMUM_FEE,
+        Amount {
+            value: amount.value - Mob::MINIMUM_FEE,
+            token_id: amount.token_id,
+        },
         Mob::MINIMUM_FEE,
         tombstone_block,
         rng,
@@ -104,7 +107,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
-    amount: u64,
+    amount: Amount,
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
@@ -142,14 +145,14 @@ pub fn create_transaction_with_amount_and_comparer<
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
-    amount: u64,
+    amount: Amount,
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
     let mut transaction_builder = TransactionBuilder::new(
         block_version,
-        Mob::ID,
+        amount.token_id,
         MockFogResolver::default(),
         EmptyMemoBuilder::default(),
     );
@@ -193,7 +196,7 @@ pub fn create_transaction_with_amount_and_comparer<
 
     // Output
     transaction_builder
-        .add_output(amount, recipient, rng)
+        .add_output(amount.value, recipient, rng)
         .unwrap();
 
     // Tombstone block

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -81,10 +81,7 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
         tx_out,
         sender,
         recipient,
-        Amount {
-            value: amount.value - Mob::MINIMUM_FEE,
-            token_id: amount.token_id,
-        },
+        amount.value - Mob::MINIMUM_FEE,
         Mob::MINIMUM_FEE,
         tombstone_block,
         rng,
@@ -107,7 +104,7 @@ pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
-    amount: Amount,
+    amount: u64,
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
@@ -145,14 +142,16 @@ pub fn create_transaction_with_amount_and_comparer<
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
-    amount: Amount,
+    amount: u64,
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
 ) -> Tx {
+    let (sender_amount, _) = tx_out.view_key_match(&sender.view_private_key()).unwrap();
+
     let mut transaction_builder = TransactionBuilder::new(
         block_version,
-        amount.token_id,
+        sender_amount.token_id,
         MockFogResolver::default(),
         EmptyMemoBuilder::default(),
     );
@@ -196,7 +195,7 @@ pub fn create_transaction_with_amount_and_comparer<
 
     // Output
     transaction_builder
-        .add_output(amount.value, recipient, rng)
+        .add_output(amount, recipient, rng)
         .unwrap();
 
     // Tombstone block


### PR DESCRIPTION
Prior to this PR, `mint_output` generated the same tx private key for all minted fee outputs. This PR addresses that by adding the `Amount` into what gets hashed to produce the key. It also adds a unit test (that was originally failing and then passed once the fix was applied).

Thank you @garbageslam for flagging this!