### PR TITLE
Total mint limit per MintConfigTx

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -370,6 +370,10 @@ message MintConfigTxPrefix {
 
     /// The block index at which this transaction is no longer valid.
     uint64 tombstone_block = 4;
+
+    /// The maximal amount that can be minted from the moment this configuration
+    /// is applied. This amount is shared amongst all configs.
+    uint64 mint_limit = 5;
 }
 
 /// A mint-config transaction coupled with a signature over it.

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -371,9 +371,9 @@ message MintConfigTxPrefix {
     /// The block index at which this transaction is no longer valid.
     uint64 tombstone_block = 4;
 
-    /// The maximal amount that can be minted from the moment this configuration
-    /// is applied. This amount is shared amongst all configs.
-    uint64 mint_limit = 5;
+    /// The maximal amount that can be minted by configurations specified in
+    /// this tx. This amount is shared amongst all configs.
+    uint64 total_mint_limit = 5;
 }
 
 /// A mint-config transaction coupled with a signature over it.

--- a/api/src/convert/mint_config.rs
+++ b/api/src/convert/mint_config.rs
@@ -41,6 +41,7 @@ impl From<&MintConfigTxPrefix> for external::MintConfigTxPrefix {
         dst.set_configs(src.configs.iter().map(external::MintConfig::from).collect());
         dst.set_nonce(src.nonce.clone());
         dst.set_tombstone_block(src.tombstone_block);
+        dst.set_mint_limit(src.mint_limit);
         dst
     }
 }
@@ -61,6 +62,7 @@ impl TryFrom<&external::MintConfigTxPrefix> for MintConfigTxPrefix {
             configs,
             nonce: source.get_nonce().to_vec(),
             tombstone_block: source.get_tombstone_block(),
+            mint_limit: source.get_mint_limit(),
         })
     }
 }
@@ -157,6 +159,7 @@ mod tests {
                 ],
                 nonce: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                 tombstone_block: 100,
+                mint_limit: 123456,
             },
             signature: test_multi_sig(),
         };

--- a/api/src/convert/mint_config.rs
+++ b/api/src/convert/mint_config.rs
@@ -41,7 +41,7 @@ impl From<&MintConfigTxPrefix> for external::MintConfigTxPrefix {
         dst.set_configs(src.configs.iter().map(external::MintConfig::from).collect());
         dst.set_nonce(src.nonce.clone());
         dst.set_tombstone_block(src.tombstone_block);
-        dst.set_mint_limit(src.mint_limit);
+        dst.set_total_mint_limit(src.total_mint_limit);
         dst
     }
 }
@@ -62,7 +62,7 @@ impl TryFrom<&external::MintConfigTxPrefix> for MintConfigTxPrefix {
             configs,
             nonce: source.get_nonce().to_vec(),
             tombstone_block: source.get_tombstone_block(),
-            mint_limit: source.get_mint_limit(),
+            total_mint_limit: source.get_total_mint_limit(),
         })
     }
 }
@@ -159,7 +159,7 @@ mod tests {
                 ],
                 nonce: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                 tombstone_block: 100,
-                mint_limit: 123456,
+                total_mint_limit: 123456,
             },
             signature: test_multi_sig(),
         };

--- a/api/src/convert/validated_mint_config.rs
+++ b/api/src/convert/validated_mint_config.rs
@@ -62,7 +62,7 @@ mod tests {
                     ],
                     nonce: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                     tombstone_block: 100,
-                    mint_limit: 20000,
+                    total_mint_limit: 20000,
                 },
                 signature: test_multi_sig(),
             },

--- a/api/src/convert/validated_mint_config.rs
+++ b/api/src/convert/validated_mint_config.rs
@@ -62,6 +62,7 @@ mod tests {
                     ],
                     nonce: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
                     tombstone_block: 100,
+                    mint_limit: 20000,
                 },
                 signature: test_multi_sig(),
             },

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -68,7 +68,7 @@ impl MintConfigTxParams {
                 .collect(),
             nonce,
             tombstone_block,
-            mint_limit: self.total_mint_limit,
+            total_mint_limit: self.total_mint_limit,
         };
 
         let message = prefix.hash();

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -42,6 +42,9 @@ pub struct MintConfigTxParams {
     #[clap(long = "config", parse(try_from_str = parse_mint_config), required = true, use_value_delimiter = true, env = "MC_MINTING_CONFIGS")]
     // Tuple of (mint limit, SignerSet)
     configs: Vec<(u64, SignerSet<Ed25519Public>)>,
+
+    /// Total mint limit, shared amongst all configs.
+    total_mint_limit: u64,
 }
 
 impl MintConfigTxParams {
@@ -65,6 +68,7 @@ impl MintConfigTxParams {
                 .collect(),
             nonce,
             tombstone_block,
+            mint_limit: self.total_mint_limit,
         };
 
         let message = prefix.hash();

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -804,9 +804,10 @@ mod mint_tx_tests {
         );
     }
 
-    /// validate_mint_tx rejects a mint tx that exceeds the mint limit.
+    /// validate_mint_tx rejects a mint tx that exceeds a specific config mint
+    /// limit.
     #[test_with_logger]
-    fn validate_mint_tx_refused_over_minting(logger: Logger) {
+    fn validate_mint_tx_refused_over_minting_specific_config(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
         let token_id_1 = TokenId::from(1);
 
@@ -903,6 +904,121 @@ mod mint_tx_tests {
             mint_tx_manager.validate_mint_tx(&mint_tx),
             Err(MintTxManagerError::MintValidation(
                 MintValidationError::AmountExceedsMintLimit
+            ))
+        );
+
+        // Sanity that a MintTx that does not exceed the limit passes validation.
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            1,
+            &mut rng,
+        );
+
+        assert_eq!(mint_tx_manager.validate_mint_tx(&mint_tx), Ok(()));
+    }
+
+    /// validate_mint_tx rejects a mint tx that exceeds the overall mint limit.
+    #[test_with_logger]
+    fn validate_mint_tx_refused_over_minting_total_limit(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
+        let token_id_1 = TokenId::from(1);
+
+        let mut ledger = create_ledger();
+        let n_blocks = 3;
+        let block_version = BlockVersion::MAX;
+        let sender = AccountKey::random(&mut rng);
+        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+        // Create a mint configuration and append it to the ledger.
+        let (mut mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
+
+        mint_config_tx.prefix.total_mint_limit = mint_config_tx.prefix.configs[0].mint_limit - 1;
+
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let block_contents = BlockContents {
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Create MintTxManagerImpl
+        let token_id_to_master_minters = MasterMintersMap::try_from_iter(vec![(
+            token_id_1,
+            SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+        )])
+        .unwrap();
+        let mint_tx_manager = MintTxManagerImpl::new(
+            ledger.clone(),
+            BlockVersion::MAX,
+            token_id_to_master_minters,
+            logger,
+        );
+
+        // Create a MintTx that exceeds the total mint limit
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            mint_config_tx.prefix.configs[0].mint_limit,
+            &mut rng,
+        );
+
+        assert_eq!(
+            mint_tx_manager.validate_mint_tx(&mint_tx),
+            Err(MintTxManagerError::MintValidation(
+                MintValidationError::NoMatchingMintConfig
+            ))
+        );
+
+        // Append a block that contains a valid MintTx, to test that the allowed
+        // minting limit decreases.
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            mint_config_tx.prefix.configs[0].mint_limit - 2,
+            &mut rng,
+        );
+
+        assert_eq!(mint_tx_manager.validate_mint_tx(&mint_tx), Ok(()));
+
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let block_contents = BlockContents {
+            mint_txs: vec![mint_tx],
+            outputs: vec![create_test_tx_out(&mut rng)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Create a MintTx that exceeds the mint limit
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            2,
+            &mut rng,
+        );
+
+        assert_eq!(
+            mint_tx_manager.validate_mint_tx(&mint_tx),
+            Err(MintTxManagerError::MintValidation(
+                MintValidationError::NoMatchingMintConfig
             ))
         );
 

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -138,7 +138,7 @@ impl<L: Ledger> MintTxManager for MintTxManagerImpl<L> {
                 LedgerError::NotFound => {
                     MintTxManagerError::MintValidation(MintValidationError::NoMatchingMintConfig)
                 }
-                LedgerError::MintLimitExceeded(_, _) => {
+                LedgerError::MintLimitExceeded(_, _, _) => {
                     MintTxManagerError::MintValidation(MintValidationError::AmountExceedsMintLimit)
                 }
                 err => err.into(),
@@ -975,7 +975,7 @@ mod mint_tx_tests {
         assert_eq!(
             mint_tx_manager.validate_mint_tx(&mint_tx),
             Err(MintTxManagerError::MintValidation(
-                MintValidationError::NoMatchingMintConfig
+                MintValidationError::AmountExceedsMintLimit
             ))
         );
 
@@ -1018,7 +1018,7 @@ mod mint_tx_tests {
         assert_eq!(
             mint_tx_manager.validate_mint_tx(&mint_tx),
             Err(MintTxManagerError::MintValidation(
-                MintValidationError::NoMatchingMintConfig
+                MintValidationError::AmountExceedsMintLimit
             ))
         );
 

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -10,7 +10,7 @@ use mc_fog_ledger_enclave::{
     GetOutputsResponse, LedgerEnclave, OutputContext, Result as EnclaveResult,
 };
 use mc_fog_ledger_enclave_api::{KeyImageData, UntrustedKeyImageQueryResponse};
-use mc_ledger_db::{ActiveMintConfig, Error, Ledger};
+use mc_ledger_db::{ActiveMintConfig, ActiveMintConfigs, Error, Ledger};
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
 use mc_transaction_core::{
     mint::MintTx,
@@ -189,7 +189,10 @@ impl Ledger for MockLedger {
         unimplemented!()
     }
 
-    fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
+    fn get_active_mint_configs(
+        &self,
+        _token_id: TokenId,
+    ) -> Result<Option<ActiveMintConfigs>, Error> {
         unimplemented!()
     }
 

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -70,8 +70,10 @@ pub enum Error {
     /// Invalid mint configuration: {0}
     InvalidMintConfig(String),
 
-    /// Mint limit exceeded: {0} > {1}
-    MintLimitExceeded(u64, u64),
+    /** Mint limit exceeded: Attempted to mint {0}, currently minted {1} out
+     * of {2}
+     */
+    MintLimitExceeded(u64, u64, u64),
 
     /// Total minted amount cannot decrease: {0} < {1}
     TotalMintedAmountCannotDecrease(u64, u64),

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{mint_config_store::ActiveMintConfig, Error};
+use crate::{
+    mint_config_store::{ActiveMintConfig, ActiveMintConfigs},
+    Error,
+};
 use mc_common::Hash;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
@@ -95,7 +98,10 @@ pub trait Ledger: Send {
     /// Get active mint configurations for a given token id.
     /// Returns an empty array if no mint configurations are active for the
     /// given token id.
-    fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error>;
+    fn get_active_mint_configs(
+        &self,
+        token_id: TokenId,
+    ) -> Result<Option<ActiveMintConfigs>, Error>;
 
     /// Checks if the ledger contains a given MintConfigTx nonce.
     /// If so, returns the index of the block in which it entered the ledger.

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -96,8 +96,6 @@ pub trait Ledger: Send {
     }
 
     /// Get active mint configurations for a given token id.
-    /// Returns an empty array if no mint configurations are active for the
-    /// given token id.
     fn get_active_mint_configs(
         &self,
         token_id: TokenId,

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -2297,7 +2297,8 @@ mod ledger_db_test {
         assert_eq!(
             ledger_db.append_block(&block3, &block_contents3, None),
             Err(Error::MintLimitExceeded(
-                mint_config_tx1.prefix.configs[0].mint_limit + 1,
+                11,
+                mint_config_tx1.prefix.configs[0].mint_limit - 10,
                 mint_config_tx1.prefix.configs[0].mint_limit
             ))
         );

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -49,7 +49,7 @@ use std::{
 pub use error::Error;
 pub use ledger_trait::{Ledger, MockLedger};
 pub use mc_util_lmdb::{MetadataStore, MetadataStoreError};
-pub use mint_config_store::{ActiveMintConfig, MintConfigStore};
+pub use mint_config_store::{ActiveMintConfig, ActiveMintConfigs, MintConfigStore};
 pub use mint_tx_store::MintTxStore;
 pub use tx_out_store::TxOutStore;
 
@@ -377,9 +377,10 @@ impl Ledger for LedgerDB {
     }
 
     /// Get active mint configurations for a given token id.
-    /// Returns an empty array of no mint configurations are active for the
-    /// given token id.
-    fn get_active_mint_configs(&self, token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
+    fn get_active_mint_configs(
+        &self,
+        token_id: TokenId,
+    ) -> Result<Option<ActiveMintConfigs>, Error> {
         let db_transaction = self.env.begin_ro_txn()?;
         self.mint_config_store
             .get_active_mint_configs(token_id, &db_transaction)
@@ -1148,10 +1149,7 @@ mod ledger_db_test {
         let origin_tx_out = origin_block_contents.outputs.get(0).unwrap().clone();
         assert_eq!(origin_tx_out, ledger_db.get_tx_out_by_index(0).unwrap());
 
-        assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
-            vec![]
-        );
+        assert_eq!(ledger_db.get_active_mint_configs(token_id1).unwrap(), None,);
 
         // === Append a block with only a single MintConfigTx. ===
         let mint_config_tx1 = create_mint_config_tx(token_id1, &mut rng);
@@ -1187,7 +1185,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1241,7 +1243,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx2.prefix.configs[0].clone(),
@@ -1259,7 +1265,11 @@ mod ledger_db_test {
         );
 
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id2).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id2)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx3.prefix.configs[0].clone(),
@@ -1364,10 +1374,7 @@ mod ledger_db_test {
         let origin_tx_out = origin_block_contents.outputs.get(0).unwrap().clone();
         assert_eq!(origin_tx_out, ledger_db.get_tx_out_by_index(0).unwrap());
 
-        assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
-            vec![]
-        );
+        assert_eq!(ledger_db.get_active_mint_configs(token_id1).unwrap(), None);
 
         // === Append a block wth a MintConfigTx transaction. This is needed since
         // the MintTx must be matched with an active mint config.
@@ -1424,7 +1431,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1486,7 +1497,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1548,7 +1563,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1619,7 +1638,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1694,7 +1717,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1775,7 +1802,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -1793,7 +1824,11 @@ mod ledger_db_test {
         );
 
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id2).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id2)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx2.prefix.configs[0].clone(),
@@ -1877,7 +1912,11 @@ mod ledger_db_test {
 
         // The active mint configs should be updated.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx3.prefix.configs[0].clone(),
@@ -1895,7 +1934,11 @@ mod ledger_db_test {
         );
 
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id2).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id2)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx2.prefix.configs[0].clone(),
@@ -2182,10 +2225,7 @@ mod ledger_db_test {
         let origin_tx_out = origin_block_contents.outputs.get(0).unwrap().clone();
         assert_eq!(origin_tx_out, ledger_db.get_tx_out_by_index(0).unwrap());
 
-        assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
-            vec![]
-        );
+        assert_eq!(ledger_db.get_active_mint_configs(token_id1).unwrap(), None,);
 
         // === Append a block wth a MintConfigTx transaction. This is needed since
         // the MintTx must be matched with an active mint config.
@@ -2264,7 +2304,11 @@ mod ledger_db_test {
 
         // Amount minted should not update.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -2304,7 +2348,11 @@ mod ledger_db_test {
 
         // Amount minted should not update.
         assert_eq!(
-            ledger_db.get_active_mint_configs(token_id1).unwrap(),
+            ledger_db
+                .get_active_mint_configs(token_id1)
+                .unwrap()
+                .unwrap()
+                .configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -309,7 +309,7 @@ impl MintConfigStore {
             .configs
             .iter_mut()
             .find(|active_mint_config| active_mint_config.mint_config == *mint_config)
-            .ok_or_else(|| Error::NotFound)?;
+            .ok_or(Error::NotFound)?;
 
         // Total minted amount should never decrease.
         if amount < active_mint_config.total_minted {

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -63,7 +63,8 @@ impl ActiveMintConfigs {
         self.configs.iter().map(|c| c.total_minted).sum()
     }
 
-    // Check if we can mint a certain amount without exceeding the global limit.
+    /// Check if we can mint a certain amount without exceeding the global
+    /// limit.
     pub fn can_mint(&self, amount: u64) -> bool {
         if let Some(new_total_minted) = self.total_minted().checked_add(amount) {
             new_total_minted <= self.total_mint_limit

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -190,9 +190,10 @@ mod tests {
         let db_txn = env.begin_ro_txn().unwrap();
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id1, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -222,9 +223,10 @@ mod tests {
         let db_txn = env.begin_ro_txn().unwrap();
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id1, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -259,9 +261,10 @@ mod tests {
         let db_txn = env.begin_ro_txn().unwrap();
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id1, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -281,9 +284,10 @@ mod tests {
         // Try with the 2nd token - initially nothing has been minted.
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id2, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx2.prefix.configs[0].clone(),
@@ -318,9 +322,10 @@ mod tests {
         let db_txn = env.begin_ro_txn().unwrap();
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id1, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),
@@ -339,9 +344,10 @@ mod tests {
 
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id2, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx2.prefix.configs[0].clone(),
@@ -434,9 +440,10 @@ mod tests {
         let db_txn = env.begin_ro_txn().unwrap();
         let active_mint_configs = mint_config_store
             .get_active_mint_configs(token_id1, &db_txn)
+            .unwrap()
             .unwrap();
         assert_eq!(
-            active_mint_configs,
+            active_mint_configs.configs,
             vec![
                 ActiveMintConfig {
                     mint_config: mint_config_tx1.prefix.configs[0].clone(),

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -552,8 +552,9 @@ mod tests {
         match mint_tx_store.write_mint_txs(0, &[mint_tx1.clone()], &mint_config_store, &mut db_txn)
         {
             Ok(()) => panic!("Unexpected success"),
-            Err(Error::MintLimitExceeded(tx_amount, mint_limit)) => {
-                assert_eq!(tx_amount, mint_tx1.prefix.amount);
+            Err(Error::MintLimitExceeded(mint_amount, minted_so_far, mint_limit)) => {
+                assert_eq!(mint_amount, mint_tx1.prefix.amount);
+                assert_eq!(minted_so_far, 0);
                 assert!(&[
                     mint_config_tx1.prefix.configs[0].mint_limit,
                     mint_config_tx1.prefix.configs[1].mint_limit,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
-use crate::{ActiveMintConfig, Error, Ledger};
+use crate::{ActiveMintConfig, ActiveMintConfigs, Error, Ledger};
 use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
@@ -194,7 +194,10 @@ impl Ledger for MockLedger {
         unimplemented!();
     }
 
-    fn get_active_mint_configs(&self, _token_id: TokenId) -> Result<Vec<ActiveMintConfig>, Error> {
+    fn get_active_mint_configs(
+        &self,
+        _token_id: TokenId,
+    ) -> Result<Option<ActiveMintConfigs>, Error> {
         unimplemented!()
     }
 

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -240,8 +240,8 @@ impl MintAuditorDb {
                 Ok(_) => {
                     // Got a match, which is what we were hoping would happen.
                 }
-                Err(err @ LedgerDbError::NotFound)
-                | Err(err @ LedgerDbError::MintLimitExceeded(_, _, _)) => {
+                Err(err @ LedgerDbError::NotFound) |
+                Err(err @ LedgerDbError::MintLimitExceeded(_, _, _)) => {
                     log::crit!(
                         self.logger,
                         "Block {}: Found mint tx {} that did not match any active mint config: {}",

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -237,11 +237,18 @@ impl MintAuditorDb {
                 .mint_config_store
                 .get_active_mint_config_for_mint_tx(mint_tx, &db_txn)
             {
-                Ok(_) => {
+                Ok(active_mint_config) => {
                     // Got a match, which is what we were hoping would happen.
+                    // Update the total amount this configuration has minted.
+                    let total_minted = active_mint_config.total_minted + mint_tx.prefix.amount;
+                    self.mint_config_store.update_total_minted(
+                        &active_mint_config.mint_config,
+                        total_minted,
+                        &mut db_txn,
+                    )?;
                 }
-                Err(err @ LedgerDbError::NotFound) |
-                Err(err @ LedgerDbError::MintLimitExceeded(_, _, _)) => {
+                Err(err @ LedgerDbError::NotFound)
+                | Err(err @ LedgerDbError::MintLimitExceeded(_, _, _)) => {
                     log::crit!(
                         self.logger,
                         "Block {}: Found mint tx {} that did not match any active mint config: {}",
@@ -992,6 +999,130 @@ mod tests {
                 num_blocks_synced: block.index + 1,
                 num_burns_exceeding_balance: 0,
                 num_mint_txs_without_matching_mint_config: 2,
+            }
+        );
+    }
+
+    // MintTxs that exceed the MintConfigTx limit get counted.
+    #[test_with_logger]
+    fn test_sync_blocks_counts_mint_txs_exceeding_total_mint_limit(logger: Logger) {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let token_id1 = TokenId::from(1);
+
+        let mint_audit_db_path = tempdir().unwrap();
+        let mint_audit_db = MintAuditorDb::create_or_open(&mint_audit_db_path, logger).unwrap();
+
+        let mut ledger_db = create_ledger();
+        let account_key = AccountKey::random(&mut rng);
+        let initial_num_blocks = 3;
+        initialize_ledger(
+            BlockVersion::MAX,
+            &mut ledger_db,
+            initial_num_blocks,
+            &account_key,
+            &mut rng,
+        );
+
+        // The blocks we currently have in the ledger contain no burning or minting.
+        for block_index in 0..initial_num_blocks {
+            let block_data = ledger_db.get_block_data(block_index).unwrap();
+
+            let mint_audit_data = mint_audit_db
+                .sync_block(block_data.block(), block_data.contents())
+                .unwrap();
+
+            assert_eq!(mint_audit_data, BlockAuditData::default());
+        }
+
+        // Sync a block that contains a MintConfigTx with a total limit we are able to
+        // exceed.
+        let (mut mint_config_tx1, signers1) =
+            create_mint_config_tx_and_signers(token_id1, &mut rng);
+        mint_config_tx1.prefix.total_mint_limit = 2;
+
+        assert!(
+            mint_config_tx1.prefix.configs[0].mint_limit > mint_config_tx1.prefix.total_mint_limit
+        );
+
+        let block_contents = BlockContents {
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx1)],
+            ..Default::default()
+        };
+
+        let parent_block = ledger_db
+            .get_block(ledger_db.num_blocks().unwrap() - 1)
+            .unwrap();
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        let mint_audit_data = mint_audit_db.sync_block(&block, &block_contents).unwrap();
+        assert_eq!(
+            mint_audit_data,
+            BlockAuditData {
+                balance_map: BTreeMap::default(),
+            }
+        );
+
+        // Sync a block that mints the total mint limit.
+        let mint_tx1 = create_mint_tx(
+            token_id1,
+            &signers1,
+            mint_config_tx1.prefix.total_mint_limit,
+            &mut rng,
+        );
+
+        let block_contents = BlockContents {
+            mint_txs: vec![mint_tx1],
+            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        mint_audit_db.sync_block(&block, &block_contents).unwrap();
+
+        assert_eq!(
+            mint_audit_db.get_counters().unwrap(),
+            Counters {
+                num_blocks_synced: block.index + 1,
+                num_burns_exceeding_balance: 0,
+                num_mint_txs_without_matching_mint_config: 0,
+            }
+        );
+
+        // Minting more should get flagged since we are exceeding the total mint limit.
+        let mint_tx1 = create_mint_tx(token_id1, &signers1, 1, &mut rng);
+
+        let block_contents = BlockContents {
+            mint_txs: vec![mint_tx1],
+            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        mint_audit_db.sync_block(&block, &block_contents).unwrap();
+
+        assert_eq!(
+            mint_audit_db.get_counters().unwrap(),
+            Counters {
+                num_blocks_synced: block.index + 1,
+                num_burns_exceeding_balance: 0,
+                num_mint_txs_without_matching_mint_config: 1,
             }
         );
     }

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -240,12 +240,14 @@ impl MintAuditorDb {
                 Ok(_) => {
                     // Got a match, which is what we were hoping would happen.
                 }
-                Err(LedgerDbError::NotFound) | Err(LedgerDbError::MintLimitExceeded(_, _)) => {
+                Err(err @ LedgerDbError::NotFound)
+                | Err(err @ LedgerDbError::MintLimitExceeded(_, _, _)) => {
                     log::crit!(
                         self.logger,
-                        "Block {}: Found mint tx {} that did not match any active mint config!",
+                        "Block {}: Found mint tx {} that did not match any active mint config: {}",
                         block_index,
                         mint_tx,
+                        err,
                     );
 
                     counters.num_mint_txs_without_matching_mint_config += 1;

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -55,10 +55,10 @@ pub struct MintConfigTxPrefix {
     #[prost(uint64, tag = "4")]
     pub tombstone_block: u64,
 
-    /// The maximal amount that can be minted from the moment this configuration
-    /// is applied. This amount is shared amongst all configs.
+    /// The maximal amount that can be minted by configurations specified in
+    /// this tx. This amount is shared amongst all configs.
     #[prost(uint64, tag = "5")]
-    pub mint_limit: u64,
+    pub total_mint_limit: u64,
 }
 
 impl MintConfigTxPrefix {

--- a/transaction/core/src/mint/config.rs
+++ b/transaction/core/src/mint/config.rs
@@ -54,6 +54,11 @@ pub struct MintConfigTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "4")]
     pub tombstone_block: u64,
+
+    /// The maximal amount that can be minted from the moment this configuration
+    /// is applied. This amount is shared amongst all configs.
+    #[prost(uint64, tag = "5")]
+    pub mint_limit: u64,
 }
 
 impl MintConfigTxPrefix {

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -224,6 +224,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
+            mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -340,6 +341,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
+            mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -417,6 +419,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
+            mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -508,6 +511,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
+            mint_limit: 100,
         };
         let message = prefix.hash();
 

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -224,7 +224,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
-            mint_limit: 100,
+            total_mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -341,7 +341,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
-            mint_limit: 100,
+            total_mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -419,7 +419,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
-            mint_limit: 100,
+            total_mint_limit: 100,
         };
         let message = prefix.hash();
 
@@ -511,7 +511,7 @@ mod tests {
             configs: vec![mint_config1.clone(), mint_config2.clone()],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
-            mint_limit: 100,
+            total_mint_limit: 100,
         };
         let message = prefix.hash();
 

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -65,7 +65,7 @@ pub fn create_mint_config_tx_and_signers(
         configs: configs.clone(),
         nonce,
         tombstone_block: 10,
-        mint_limit: configs[0].mint_limit + configs[1].mint_limit + configs[2].mint_limit,
+        total_mint_limit: configs[0].mint_limit + configs[1].mint_limit + configs[2].mint_limit,
     };
 
     let message = prefix.hash();

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -33,34 +33,39 @@ pub fn create_mint_config_tx_and_signers(
     let mut nonce: Vec<u8> = vec![0u8; NONCE_LENGTH];
     rng.fill_bytes(&mut nonce);
 
+    // We use next_u32 for individual configurations mint limit to ensure the total
+    // mint limit does not overflow.
+    let configs = vec![
+        MintConfig {
+            token_id: *token_id,
+            signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
+            mint_limit: rng.next_u32() as u64,
+        },
+        MintConfig {
+            token_id: *token_id,
+            signer_set: SignerSet::new(vec![signer_2.public_key(), signer_3.public_key()], 1),
+            mint_limit: rng.next_u32() as u64,
+        },
+        MintConfig {
+            token_id: *token_id,
+            signer_set: SignerSet::new(
+                vec![
+                    signer_3.public_key(),
+                    signer_4.public_key(),
+                    signer_5.public_key(),
+                ],
+                2,
+            ),
+            mint_limit: rng.next_u32() as u64,
+        },
+    ];
+
     let prefix = MintConfigTxPrefix {
         token_id: *token_id,
-        configs: vec![
-            MintConfig {
-                token_id: *token_id,
-                signer_set: SignerSet::new(vec![signer_1.public_key()], 1),
-                mint_limit: rng.next_u64(),
-            },
-            MintConfig {
-                token_id: *token_id,
-                signer_set: SignerSet::new(vec![signer_2.public_key(), signer_3.public_key()], 1),
-                mint_limit: rng.next_u64(),
-            },
-            MintConfig {
-                token_id: *token_id,
-                signer_set: SignerSet::new(
-                    vec![
-                        signer_3.public_key(),
-                        signer_4.public_key(),
-                        signer_5.public_key(),
-                    ],
-                    2,
-                ),
-                mint_limit: rng.next_u64(),
-            },
-        ],
+        configs: configs.clone(),
         nonce,
         tombstone_block: 10,
+        mint_limit: configs[0].mint_limit + configs[1].mint_limit + configs[2].mint_limit,
     };
 
     let message = prefix.hash();


### PR DESCRIPTION
### Motivation

Currently, each `MintConfigTx` configures a list of minters via an array of `MintConfig`s. Each `MintConfig` has a mint limit that caps the amount it can mint since the moment it has been applied.
As a secondary safety measure we want to also limit the total amount that can be minted by all `MintConfig`s together that are included in a single `MintConfigTx`.

### In this PR
* Add `total_mint_limit` to `MintConfigTx`, enforce it when trying to select active mint configurations, and add unit tests to verify correct behavior.
* Cleanup some error handling. Previously there existed an error variant `MintLimitExceeded(<new amount>, <limit>)`. That presented a problem, since it is possible that the new amount (which is `previous minted amount + amount we are trying to mint`) would exceed what can be represented in a `u64`. In this PR I opted to change it to `MintLimitExceeded(<amount we wanted to mint>, <amount minted so far>, <mint limit>)`. This allows us to actually properly distinguish between cases where no active mint configuration can be found because the signers didn't match, and an active mint configuration is available but cannot be used since the amount being minted is too high for it to be accommodated without exceeding the limits.

### Followup work
* Update the invocation of the mint client in CD to accommodate for the new total mint limit