### PR TITLE
Mint auditor exposes counters over GRPC

### DIFF
--- a/mint-auditor/api/proto/mint_auditor.proto
+++ b/mint-auditor/api/proto/mint_auditor.proto
@@ -16,11 +16,24 @@ option java_outer_classname = "MintAuditor";
 service MintAuditorApi {
     rpc GetBlockAuditData(GetBlockAuditDataRequest) returns (GetBlockAuditDataResponse) {}
     rpc GetLastBlockAuditData(google.protobuf.Empty) returns (GetLastBlockAuditDataResponse) {}
+    rpc GetCounters(google.protobuf.Empty) returns (Counters) {}
 }
 
 message BlockAuditData {
     // Current balance in circulation (excluding MOB).
     map<uint32, uint64> balance_map = 1;
+}
+
+/// Statistics we keep track of.
+message Counters {
+    /// Number of blocks we've synced so far.
+    uint64 num_blocks_synced = 1;
+
+    // Number of times we've encountered a burn that exceeds the calculated balance.
+    uint64 num_burns_exceeding_balance = 2;
+
+    // Number of `MintTx`s that did not match an active mint config.
+    uint64 num_mint_txs_without_matching_mint_config = 3;
 }
 
 message GetBlockAuditDataRequest {

--- a/mint-auditor/src/convert/counters.rs
+++ b/mint-auditor/src/convert/counters.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Convert to/from mc_mint_auditor_api::Counters.
+
+use crate::Counters;
+
+/// Convert Counters --> mc_mint_auditor_api::Counters
+impl From<&Counters> for mc_mint_auditor_api::Counters {
+    fn from(src: &Counters) -> Self {
+        let mut dst = mc_mint_auditor_api::Counters::new();
+        dst.set_num_blocks_synced(src.num_blocks_synced);
+        dst.set_num_burns_exceeding_balance(src.num_burns_exceeding_balance);
+        dst.set_num_mint_txs_without_matching_mint_config(
+            src.num_mint_txs_without_matching_mint_config,
+        );
+        dst
+    }
+}
+
+/// Convert mc_mint_auditor_api::Counters --> Counters
+impl From<&mc_mint_auditor_api::Counters> for Counters {
+    fn from(src: &mc_mint_auditor_api::Counters) -> Self {
+        Self {
+            num_blocks_synced: src.get_num_blocks_synced(),
+            num_burns_exceeding_balance: src.get_num_burns_exceeding_balance(),
+            num_mint_txs_without_matching_mint_config: src
+                .get_num_mint_txs_without_matching_mint_config(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_util_serial::{decode, encode};
+    use protobuf::Message;
+
+    #[test]
+    // Counters --> mc_mint_auditor_api::Counters --> Counters
+    // should be the identity function.
+    fn test_convert_block_audit_data() {
+        let source = Counters {
+            num_blocks_synced: 10,
+            num_burns_exceeding_balance: 20,
+            num_mint_txs_without_matching_mint_config: 30,
+        };
+
+        // decode(encode(source)) should be the identity function.
+        {
+            let bytes = encode(&source);
+            let recovered = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
+
+        // Converting should be the identity function.
+        {
+            let external = mc_mint_auditor_api::Counters::from(&source);
+            let recovered = Counters::from(&external);
+            assert_eq!(source, recovered);
+        }
+
+        // Encoding with prost, decoding with protobuf should be the identity
+        // function.
+        {
+            let bytes = encode(&source);
+            let recovered = mc_mint_auditor_api::Counters::parse_from_bytes(&bytes).unwrap();
+            assert_eq!(recovered, mc_mint_auditor_api::Counters::from(&source));
+        }
+
+        // Encoding with protobuf, decoding with prost should be the identity function.
+        {
+            let external = mc_mint_auditor_api::Counters::from(&source);
+            let bytes = external.write_to_bytes().unwrap();
+            let recovered: Counters = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
+    }
+}

--- a/mint-auditor/src/convert/mod.rs
+++ b/mint-auditor/src/convert/mod.rs
@@ -3,3 +3,4 @@
 //! Convertion trait implementations betweens Prost and Protobuf.
 
 mod block_audit_data;
+mod counters;

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -55,17 +55,19 @@ pub struct BlockAuditData {
     pub balance_map: BTreeMap<u32, u64>,
 }
 
+/// Statistics we keep track of.
 #[derive(Deserialize, Eq, Message, PartialEq, Serialize)]
 pub struct Counters {
     /// Number of blocks we've synced so far.
     #[prost(uint64, tag = 1)]
     pub num_blocks_synced: u64,
 
-    // Number of times we've encountered a burn that exceeds the calculated balance.
+    /// Number of times we've encountered a burn that exceeds the calculated
+    /// balance.
     #[prost(uint64, tag = 2)]
     pub num_burns_exceeding_balance: u64,
 
-    // Number of `MintTx`s that did not match an active mint config.
+    /// Number of `MintTx`s that did not match an active mint config.
     #[prost(uint64, tag = 3)]
     pub num_mint_txs_without_matching_mint_config: u64,
 }

--- a/mint-auditor/src/lib.rs
+++ b/mint-auditor/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod service;
 
 pub use crate::{
-    db::{BlockAuditData, MintAuditorDb},
+    db::{BlockAuditData, Counters, MintAuditorDb},
     error::Error,
     service::MintAuditorService,
 };

--- a/mint-auditor/src/service.rs
+++ b/mint-auditor/src/service.rs
@@ -280,4 +280,22 @@ mod tests {
             }
         );
     }
+
+    #[test_with_logger]
+    fn test_get_counters(logger: Logger) {
+        let mint_audit_db = get_test_db(&logger);
+        let (client, _server) = get_client_server(&mint_audit_db, &logger);
+
+        let response = client.get_counters(&Empty::default()).unwrap();
+
+        assert_eq!(
+            response,
+            // This depends on what database [get_test_db] generates.
+            Counters {
+                num_blocks_synced: 2,
+                num_mint_txs_without_matching_mint_config: 3,
+                ..Default::default()
+            }
+        );
+    }
 }

--- a/mint-auditor/src/service.rs
+++ b/mint-auditor/src/service.rs
@@ -8,7 +8,8 @@ use mc_common::logger::Logger;
 use mc_mint_auditor_api::{
     empty::Empty,
     mint_auditor::{
-        GetBlockAuditDataRequest, GetBlockAuditDataResponse, GetLastBlockAuditDataResponse,
+        Counters, GetBlockAuditDataRequest, GetBlockAuditDataResponse,
+        GetLastBlockAuditDataResponse,
     },
     mint_auditor_grpc::{create_mint_auditor_api, MintAuditorApi},
 };
@@ -122,6 +123,18 @@ impl MintAuditorApi for MintAuditorService {
                 resp.set_block_index(last_synced_block_index);
                 resp
             });
+
+        send_result(ctx, sink, result, &logger);
+    }
+
+    fn get_counters(&mut self, ctx: RpcContext, _req: Empty, sink: UnarySink<Counters>) {
+        let logger = rpc_logger(&ctx, &self.logger);
+
+        let result = self
+            .mint_auditor_db
+            .get_counters()
+            .map(|counters| Counters::from(&counters))
+            .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, err.to_string()));
 
         send_result(ctx, sink, result, &logger);
     }


### PR DESCRIPTION
We'd like the `mc-mint-auditor` GRPC service to expose all the information it has, in case it needs to get consumed by any external service.

This PRs adds an endpoint for getting the counters, which includes statistics on how many blocks were scanned and number of discrepancies found.