### PR TITLE
Monitor gRPC status codes with prometheus

### DIFF
--- a/util/grpc/src/lib.rs
+++ b/util/grpc/src/lib.rs
@@ -67,7 +67,7 @@ pub fn send_result<T>(
 ) {
     let logger = logger.clone();
     let success = resp.is_ok();
-    let mut code = RpcStatusCode::from(0);
+    let mut code = RpcStatusCode::OK;
 
     match resp {
         Ok(ok) => ctx.spawn(

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -49,10 +49,10 @@ use std::str;
 /// e.g., calc_service.duration_sum{method="add"} = 6
 #[derive(Clone)]
 pub struct ServiceMetrics {
-    /// Number of requests made by each gRPC method tracked
+    /// Count of requests made by each gRPC method tracked
     num_req: IntCounterVec,
 
-    /// Number of error responses for each gRPC method tracked
+    /// Count of error responses for each gRPC method tracked
     num_error: IntCounterVec,
 
     /// Count of gRPC status codes for each gRPC method tracked
@@ -193,8 +193,8 @@ impl Collector for ServiceMetrics {
     }
 }
 
-/// This method reads the full URI from gRpcContext (looks like:
-/// `/{package}.{service_name}/{method}`
+/// This method reads the full URI from gRpcContext
+/// which looks like `/{package}.{service_name}/{method}`
 /// ('/' equates to ascii code 47)
 /// and converts it into a dot-delimited string, dropping the 1st `/`
 fn path_from_ctx(ctx: &RpcContext) -> Option<String> {
@@ -202,8 +202,8 @@ fn path_from_ctx(ctx: &RpcContext) -> Option<String> {
     path_from_byte_slice(method)
 }
 
-/// This method reads the full URI from gRpcContext (looks like:
-/// `/{package}.{service_name}/{method}`
+/// This method reads the full URI from gRpcContext
+/// which looks like `/{package}.{service_name}/{method}`
 /// ('/' equates to ascii code 47)
 /// and converts it into a dot-delimited string, dropping the 1st `/`
 fn path_from_byte_slice(bytes: &[u8]) -> Option<String> {

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -105,7 +105,7 @@ impl ServiceMetrics {
 
     /// Takes the RpcContext used during a gRPC method call to get the method
     /// name and increments counters tracking the number of calls to and
-    /// durations of that method
+    /// returns a counter to track the duration of the method
     pub fn req(&self, ctx: &RpcContext) -> Option<HistogramTimer> {
         let mut method_name = "unknown_method".to_string();
         if let Some(name) = path_from_ctx(ctx) {
@@ -144,7 +144,8 @@ impl ServiceMetrics {
         }
     }
 
-    /// Tracks gRPC message name and corresponding message size into a histogram
+    /// Tracks gRPC message name and size for aggregation into a Prometheus
+    /// histogram
     pub fn message<M: Message>(&self, message: &M) {
         let computed_size = message.compute_size();
         let message_fullname = message.descriptor().full_name();


### PR DESCRIPTION
### Motivation

As part of #1370 operations has expressed the desire to be able to profile different gRPC status (and error) codes in a similar way to how HTTP codes are often profiled as 2XX/4XX/5XX, etc. so that errors in FOG & Consensus can be profiled and monitored for early alerts when FOG services become unhealthy. This PR enables Prometheus metrics to be shipped for most gRPC calls in Consensus & FOG.

### In this PR
* Implementation status code tracking in the "send_result" method in the mc-util-grpc lib that most FOG & Consensus grpc calls go through
* gRPC metrics service used by Mobilecoin was ported from a 3rd party with comments not up to MC doc standards. This PR improves them.
