### PR TITLE
Add missing comma for fog_local_networ.py

### DIFF
--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -27,7 +27,7 @@ class FogNetwork(Network):
             '-p mc-fog-ledger-server',
             '-p mc-fog-report-server',
             '-p mc-fog-sql-recovery-db',
-            '-p mc-fog-test-client'
+            '-p mc-fog-test-client',
             '-p mc-fog-view-server',
             f'{CARGO_FLAGS}',
         ]))


### PR DESCRIPTION
fog_local_network.py was missing a comma in one of the shell commands.
This resulted in `-p mc-fog-test-client-p mc-fog-view-server` being
passed on the command line with an error of
`mc-fog-view-server not expected at this time`

### In this PR
minor python script fix


