### PR TITLE
Tx fee priority

### DIFF
--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -91,19 +91,19 @@ mod test {
     #[test]
     fn different_fee_maps_result_in_different_responder_ids() {
         let config1: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 2000)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 2000)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
             block_version: BlockVersion::ZERO,
         }
         .into();
         let config2: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
             block_version: BlockVersion::ZERO,
         }
         .into();
         let config3: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(30), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
             block_version: BlockVersion::ZERO,
         }
@@ -138,7 +138,7 @@ mod test {
         );
 
         let config4: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 200), (TokenId::from(30), 300)]).unwrap(),
             master_minters_map: MasterMintersMap::default(),
             block_version: BlockVersion::ONE,
         }

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -110,7 +110,7 @@ impl FeeMap {
         // priority of a payment.
         if let Some((token_id, fee)) = minimum_fees
             .iter()
-            .find(|(_token_id, fee)| (**fee >> SMALLEST_MINIMUM_FEE_LOG2) > 0)
+            .find(|(_token_id, fee)| (**fee >> SMALLEST_MINIMUM_FEE_LOG2) == 0)
         {
             return Err(Error::InvalidFee(*token_id, *fee));
         }

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -9,6 +9,28 @@ use mc_crypto_digestible::Digestible;
 use mc_transaction_core::{tokens::Mob, Token, TokenId};
 use serde::{Deserialize, Serialize};
 
+/// The log base 2 of the smallest allowed minimum fee, in the smallest
+/// representable units.
+/// This minimum exists because it helps the computation of priority from fees
+/// to work in a nice way.
+///
+/// Priority is computed by "normalizing" the fee for each token, using the
+/// minimum fee. However, before dividing fee by minimum fee, we divide minimum
+/// fee by (1 << 7) = 128. This allows that if you increase the fee by e.g. 1%
+/// this always leads to an integer difference in the priority and leads to your
+/// transaction being ranked higher. If we don't do this, then you can only
+/// increase the fee paid in increments of the minimum fee to see an actual
+/// increase in priority.
+///
+/// Because we divide minimum fee by by 128, and the result must be nonzero, we
+/// must have that the minimum fee itself is at least as large as what we are
+/// dividing by. This is fine because 128 in the smallest representable units is
+/// a negligible amount of any currency.
+///
+/// The smallest allowed minimum fee is required to be a power of two, because
+/// dividing by a power of two is fast and constant time.
+pub const SMALLEST_MINIMUM_FEE_LOG2: u64 = 7;
+
 /// A map of fee value by token id.
 #[derive(Clone, Debug, Deserialize, Digestible, Eq, Hash, PartialEq, Serialize)]
 pub struct FeeMap {
@@ -79,7 +101,10 @@ impl FeeMap {
         // This is because we divide the minimum fee by 128 when computing priority
         // numbers, to allow that increments of 1% of the minimum fee affect the
         // priority of a payment.
-        if let Some((token_id, fee)) = minimum_fees.iter().find(|(_token_id, fee)| **fee < 128) {
+        if let Some((token_id, fee)) = minimum_fees
+            .iter()
+            .find(|(_token_id, fee)| **fee < (1 << SMALLEST_MINIMUM_FEE_LOG2))
+        {
             return Err(Error::InvalidFee(*token_id, *fee));
         }
 
@@ -123,13 +148,13 @@ mod test {
     /// Valid fee maps ids should be accepted
     #[test]
     fn valid_fee_maps_accepted() {
-        let fee_map1 = FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 2000)]).unwrap();
+        let fee_map1 = FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 20000)]).unwrap();
         assert!(fee_map1.get_fee_for_token(&Mob::ID).is_some());
 
-        let fee_map2 = FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(2), 300)]).unwrap();
+        let fee_map2 = FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 3000)]).unwrap();
         assert!(fee_map2.get_fee_for_token(&Mob::ID).is_some());
 
-        let fee_map3 = FeeMap::try_from_iter([(Mob::ID, 100), (TokenId::from(30), 300)]).unwrap();
+        let fee_map3 = FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(30), 3000)]).unwrap();
         assert!(fee_map3.get_fee_for_token(&Mob::ID).is_some());
     }
 
@@ -145,7 +170,7 @@ mod test {
         );
 
         assert_eq!(
-            FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(test_token_id, 100)])),
+            FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(test_token_id, 1000)])),
             Err(Error::MissingFee(Mob::ID)),
         );
 
@@ -156,8 +181,13 @@ mod test {
         );
 
         assert_eq!(
+            FeeMap::is_valid_map(&BTreeMap::from_iter(vec![(Mob::ID, 10)])),
+            Err(Error::InvalidFee(Mob::ID, 10)),
+        );
+
+        assert_eq!(
             FeeMap::is_valid_map(&BTreeMap::from_iter(vec![
-                (Mob::ID, 10),
+                (Mob::ID, 1000),
                 (test_token_id, 0)
             ])),
             Err(Error::InvalidFee(test_token_id, 0)),

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -75,8 +75,11 @@ impl FeeMap {
 
     /// Check if a given fee map is valid.
     pub fn is_valid_map(minimum_fees: &BTreeMap<TokenId, u64>) -> Result<(), Error> {
-        // All fees must be greater than 0.
-        if let Some((token_id, fee)) = minimum_fees.iter().find(|(_token_id, fee)| **fee == 0) {
+        // All minimum fees must be greater than 128 in the smallest representable unit.
+        // This is because we divide the minimum fee by 128 when computing priority
+        // numbers, to allow that increments of 1% of the minimum fee affect the
+        // priority of a payment.
+        if let Some((token_id, fee)) = minimum_fees.iter().find(|(_token_id, fee)| **fee < 128) {
             return Err(Error::InvalidFee(*token_id, *fee));
         }
 

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -94,7 +94,7 @@ impl WellFormedTxContext {
     }
 
     /// Create a new WellFormedTxContext, from a Tx and its priority.
-    pub fn new_from_tx(priority: u64, tx: &Tx) -> Self {
+    pub fn from_tx(tx: &Tx, priority: u64) -> Self {
         Self {
             priority,
             tx_hash: tx.tx_hash(),

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -178,7 +178,7 @@ mod well_formed_tx_context_tests {
     use alloc::{vec, vec::Vec};
 
     #[test]
-    /// WellFormedTxContext should be sorted by fee, descending.
+    /// WellFormedTxContext should be sorted by priority, descending.
     fn test_ordering() {
         let a = WellFormedTxContext::new(100, Default::default(), 0, vec![], vec![], vec![]);
         let b = WellFormedTxContext::new(557, Default::default(), 0, vec![], vec![], vec![]);
@@ -187,9 +187,9 @@ mod well_formed_tx_context_tests {
         let mut contexts = vec![a, b, c];
         contexts.sort();
 
-        let fees: Vec<_> = contexts.iter().map(|context| context.fee).collect();
+        let priorities: Vec<_> = contexts.iter().map(|context| context.priority).collect();
         let expected = vec![557, 100, 88];
-        assert_eq!(fees, expected);
+        assert_eq!(priorities, expected);
     }
 }
 

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -16,7 +16,7 @@ mod messages;
 pub use crate::{
     config::{BlockchainConfig, BlockchainConfigWithDigest},
     error::Error,
-    fee_map::{Error as FeeMapError, FeeMap},
+    fee_map::{Error as FeeMapError, FeeMap, SMALLEST_MINIMUM_FEE_LOG2},
     master_minters_map::{Error as MasterMintersMapError, MasterMintersMap},
     messages::EnclaveCall,
 };

--- a/consensus/enclave/impl/src/constant_time_division.rs
+++ b/consensus/enclave/impl/src/constant_time_division.rs
@@ -63,7 +63,7 @@
 //! operations are constant time. We use the subtle crate for constant time
 //! comparisons and conditional assignment.
 
-use subtle::ConstantTimeLess;
+use subtle::ConstantTimeGreater;
 
 /// Divide one u64 integer by another in constant time.
 ///
@@ -103,8 +103,8 @@ pub fn ct_u64_divide(n: u64, d: u64) -> (u64, u64) {
         // Wrapping add is used to avoid any overflow checks.
         r = r.wrapping_add((n >> i) & 1);
 
-        // Test if r >= d in constant time.
-        let must_reduce = !r.ct_lt(&d);
+        // Test if d <= r in constant time. If so we must reduce.
+        let must_reduce = !d.ct_gt(&r);
 
         // If r needs to be reduced, subtract d in constant time.
         r = r.wrapping_sub(d.wrapping_mul(must_reduce.unwrap_u8() as u64));

--- a/consensus/enclave/impl/src/constant_time_division.rs
+++ b/consensus/enclave/impl/src/constant_time_division.rs
@@ -1,0 +1,145 @@
+//! This module contains an implementation of constant-time integer division.
+//! Only u64's are supported.
+//!
+//! The algorithm here is an adaptation of an algorithm described in Soatok's
+//! blog: https://soatok.blog/2020/08/27/soatoks-guide-to-side-channel-attacks/
+//! Note however, that this is basically just long division, for binary numbers.
+//!
+//! The blog post does not contain a proof of correctness for the algorithm,
+//! however, we will give our own exposition now.
+//!
+//! Unsigned integer division means, given a number and divisor (N and D),
+//! we want to produce quotient and remainder (Q and R) such that:
+//!
+//! N = Q * D + R
+//!
+//! where 0 <= R < Q ("R is fully reduced").
+//!
+//! This solution is unique for any N and D != 0.
+//!
+//! The idea of the algorithm is to look at the bit representation of N,
+//! and consider the sequence of "prefixes" of this number.
+//! So if N = 101101b for instance,
+//! we will consider the sequence.
+//! 1b
+//! 10b
+//! 101b
+//! 1011b
+//! 10110b
+//! 101101b
+//!
+//! At each step we will compute the quotient and remainder when divided by D.
+//! Let b_i denote the i'th bit of N.
+//!
+//! If at the i'th step, we have
+//!
+//! N_i = Q_i * D + R_i
+//!
+//! being fully reduced, then in the next step, we have
+//!
+//! N_{i+1} = 2 * N_i + b_i
+//!
+//! and we want to compute a fully reduced equation dividing N_{i+1} by D.
+//!
+//! Substituting for N_i and expanding, we have
+//!
+//! N_{i+1} = 2 * Q_i * D + 2 * R_i + b_i
+//!
+//! This looks almost like a division of N_{i+1} by D as required, but it may
+//! not be fully reduced, because we may have 2 * R_i + b_i > D.
+//!
+//! However, since R_i < D, we know that 2 * R_i + b_i < 2 * D.
+//! So to fully reduce the remainder, we have to subtract D at most once.
+//!
+//! We can compute 2 * R_i + b_i in constant time, and then in constant time
+//! test if it is less than D. Then we can subtract D, and conditionally assign
+//! it with the result. We can also conditionally add one to 2 * Q_i in that
+//! case. Once we have done this, we will have successfully divided N_{i+1} by
+//! D, and we can proceed to the next digit.
+//!
+//! On x86-64 we can assume that wrapping_sub and wrapping_add integer
+//! operations are constant time. We use the subtle crate for constant time
+//! comparisons and conditional assignment.
+
+use subtle::{ConditionallySelectable, ConstantTimeLess};
+
+/// Divide one u64 integer by another in constant time.
+///
+/// Arguments:
+/// * n: The number being divided
+/// * d: The divisor
+///
+/// Both n and d are considered secrets for constant time purposes.
+///
+/// Returns:
+/// * q: The quotient
+/// * r: The remainder
+///
+/// Preconditions: d is nonzero
+///
+/// Note: This function always takes the same number of operations on x86-64.
+///
+/// We estimate that it probably takes on the order of tens of thousands of
+/// cycles. The most expensive operation in the loop is ct_lt, which also crawls
+/// 64 bits, and we do the loop 64 times.
+///
+/// If this needs to be faster, some approaches are detailed here:
+/// https://stackoverflow.com/a/31718095/3598119
+/// * Use x86-64 specific stuff calling to clz or similar.
+/// * Use the de Brujin multiplication trick.
+///
+/// However it may take some work to implement those in a way that is actually
+/// constant time and is faster.
+pub fn ct_u64_divide(n: u64, d: u64) -> (u64, u64) {
+    assert!(d != 0, "division by zero");
+
+    let mut q = 0u64;
+    let mut r = 0u64;
+
+    for i in (0u64..64u64).rev() {
+        // This is a logical left shift and rust does not check for overflow.
+        // This is similar to an unchecked mul by 2 on x86.
+        q = q << 1;
+        r = r << 1;
+
+        // Select i'th bit of n using bitmasking, and add it to r
+        // Wrapping add is used to avoid any overflow checks.
+        r = r.wrapping_add((n >> i) & 1);
+
+        // Test if r >= d in constant time.
+        let must_reduce = !r.ct_lt(&d);
+
+        // Compute the difference in case it is necessary. No overflow checks.
+        let r_sub_d = r.wrapping_sub(d);
+
+        // If r needs to be reduced, then it becomes r_sub_d.
+        r.conditional_assign(&r_sub_d, must_reduce);
+
+        // If reduction happened, then we must add one to q.
+        q = q.wrapping_add(must_reduce.unwrap_u8() as u64);
+    }
+    (q, r)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ct_u64_divide() {
+        assert_eq!(ct_u64_divide(0, 1), (0, 0));
+        assert_eq!(ct_u64_divide(3, 1), (3, 0));
+        assert_eq!(ct_u64_divide(3, 2), (1, 1));
+        assert_eq!(ct_u64_divide(3, 4), (0, 3));
+        assert_eq!(ct_u64_divide(33, 4), (8, 1));
+        assert_eq!(ct_u64_divide(33, 5), (6, 3));
+        assert_eq!(ct_u64_divide(33, 6), (5, 3));
+        assert_eq!(ct_u64_divide(33, 7), (4, 5));
+        assert_eq!(ct_u64_divide(33, 8), (4, 1));
+        assert_eq!(ct_u64_divide(33, 9), (3, 6));
+        assert_eq!(ct_u64_divide(33, 10), (3, 3));
+        assert_eq!(ct_u64_divide(33, 11), (3, 0));
+        assert_eq!(ct_u64_divide(77, 100), (0, 77));
+        assert_eq!(ct_u64_divide(777, 100), (7, 77));
+    }
+}

--- a/consensus/enclave/impl/src/constant_time_division.rs
+++ b/consensus/enclave/impl/src/constant_time_division.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 //! This module contains an implementation of constant-time integer division.
 //! Only u64's are supported.
 //!

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1045,7 +1045,9 @@ mod tests {
                 .unwrap();
 
             // Check that the context we got back is correct.
-            let (expected_priority, _) = ct_u64_divide(tx.prefix.fee, Mob::MINIMUM_FEE / 128);
+            const SMALLEST_MINIMUM_FEE: u64 = 1 << SMALLEST_MINIMUM_FEE_LOG2;
+            let (expected_priority, _) =
+                ct_u64_divide(tx.prefix.fee, Mob::MINIMUM_FEE / SMALLEST_MINIMUM_FEE);
 
             assert_eq!(well_formed_tx_context.tx_hash(), &tx.tx_hash());
             assert_eq!(well_formed_tx_context.priority(), expected_priority);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -180,10 +180,11 @@ impl SgxConsensusEnclave {
         // We also want to allow that increments of ~1% of the minimum fee actually
         // affect the priority of your payment. So, we divide the min fee by 128,
         // before dividing the fee by this. Separately, the fee map enforces that
-        // the minimum fees are >= 128, and so we are not dividing by zero.
+        // the minimum fees are >= SMALLEST_MINIMUM_FEE, and so we are not dividing by
+        // zero.
         let (priority, _) = ct_u64_divide(tx.prefix.fee, min_fee >> SMALLEST_MINIMUM_FEE_LOG2);
 
-        WellFormedTxContext::new_from_tx(priority, tx)
+        WellFormedTxContext::from_tx(tx, priority)
     }
 
     fn decrypt_well_formed_tx(&self, encrypted: &WellFormedEncryptedTx) -> Result<WellFormedTx> {
@@ -1351,7 +1352,7 @@ mod tests {
             let blockchain_config = BlockchainConfig {
                 block_version,
                 fee_map: FeeMap::try_from_iter([
-                    (Mob::ID, 1000),
+                    (Mob::ID, 1000000),
                     (token_id1, 1000),
                     (token_id2, 1000),
                 ])

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -181,7 +181,7 @@ impl SgxConsensusEnclave {
         // the minimum fees are >= 128, and so we are not dividing by zero.
         let (priority, _) = ct_u64_divide(tx.prefix.fee, min_fee >> 7);
 
-        WellFormedTxContext::new_from_tx(priority, &tx)
+        WellFormedTxContext::new_from_tx(priority, tx)
     }
 
     fn decrypt_well_formed_tx(&self, encrypted: &WellFormedEncryptedTx) -> Result<WellFormedTx> {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -46,7 +46,7 @@ use mc_common::{
 use mc_consensus_enclave_api::{
     BlockchainConfig, BlockchainConfigWithDigest, ConsensusEnclave, Error, FeePublicKey,
     FormBlockInputs, LocallyEncryptedTx, Result, SealedBlockSigningKey, TxContext,
-    WellFormedEncryptedTx, WellFormedTxContext,
+    WellFormedEncryptedTx, WellFormedTxContext, SMALLEST_MINIMUM_FEE_LOG2,
 };
 use mc_crypto_ake_enclave::AkeEnclaveState;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
@@ -168,6 +168,8 @@ impl SgxConsensusEnclave {
         ))
     }
 
+    // Get a WellFormedTxContext for a Tx, given the minimum fee for its specified
+    // fee token.
     fn get_well_formed_tx_context(&self, tx: &Tx, min_fee: u64) -> WellFormedTxContext {
         // Compute the priority number to assign to this tx.
         //
@@ -179,7 +181,7 @@ impl SgxConsensusEnclave {
         // affect the priority of your payment. So, we divide the min fee by 128,
         // before dividing the fee by this. Separately, the fee map enforces that
         // the minimum fees are >= 128, and so we are not dividing by zero.
-        let (priority, _) = ct_u64_divide(tx.prefix.fee, min_fee >> 7);
+        let (priority, _) = ct_u64_divide(tx.prefix.fee, min_fee >> SMALLEST_MINIMUM_FEE_LOG2);
 
         WellFormedTxContext::new_from_tx(priority, tx)
     }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -200,9 +200,12 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         _block_index: u64,
         _proofs: Vec<TxOutMembershipProof>,
     ) -> Result<(WellFormedEncryptedTx, WellFormedTxContext)> {
-        let tx = mc_util_serial::decode(&locally_encrypted_tx.0)?;
+        let tx: Tx = mc_util_serial::decode(&locally_encrypted_tx.0)?;
         let well_formed_encrypted_tx = WellFormedEncryptedTx(locally_encrypted_tx.0);
-        let well_formed_tx_context = WellFormedTxContext::from(&tx);
+
+        // hack
+        let priority = tx.prefix.fee;
+        let well_formed_tx_context = WellFormedTxContext::new_from_tx(priority, &tx);
 
         Ok((well_formed_encrypted_tx, well_formed_tx_context))
     }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -205,7 +205,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
 
         // hack
         let priority = tx.prefix.fee;
-        let well_formed_tx_context = WellFormedTxContext::new_from_tx(priority, &tx);
+        let well_formed_tx_context = WellFormedTxContext::from_tx(&tx, priority);
 
         Ok((well_formed_encrypted_tx, well_formed_tx_context))
     }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -595,7 +595,7 @@ mod combine_tests {
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
-            let client_tx = WellFormedTxContext::from(&tx);
+            let client_tx = WellFormedTxContext::new_from_tx(0, &tx);
 
             // "Combining" a singleton set should return a vec containing the single
             // element.
@@ -679,7 +679,7 @@ mod combine_tests {
                         .unwrap();
 
                     let tx = transaction_builder.build(&mut rng).unwrap();
-                    WellFormedTxContext::from(&tx)
+                    WellFormedTxContext::new_from_tx(0, &tx)
                 };
                 transaction_set.push(client_tx);
             }
@@ -754,7 +754,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // Create another transaction that attempts to spend `tx_out`.
@@ -791,7 +791,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // This transaction spends a different TxOut, unrelated to `first_client_tx` and
@@ -854,7 +854,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // `combine` the set of transactions.
@@ -947,7 +947,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // Create another transaction that attempts to spend `tx_out2` but has the same
@@ -986,7 +986,7 @@ mod combine_tests {
 
                 let mut tx = transaction_builder.build(&mut rng).unwrap();
                 tx.prefix.outputs[0].public_key = first_client_tx.output_public_keys()[0].clone();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // This transaction spends a different TxOut, unrelated to `first_client_tx` and
@@ -1049,7 +1049,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::from(&tx)
+                WellFormedTxContext::new_from_tx(0, &tx)
             };
 
             // `combine` the set of transactions.

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -595,7 +595,7 @@ mod combine_tests {
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
-            let client_tx = WellFormedTxContext::new_from_tx(0, &tx);
+            let client_tx = WellFormedTxContext::from_tx(&tx, 0);
 
             // "Combining" a singleton set should return a vec containing the single
             // element.
@@ -679,7 +679,7 @@ mod combine_tests {
                         .unwrap();
 
                     let tx = transaction_builder.build(&mut rng).unwrap();
-                    WellFormedTxContext::new_from_tx(0, &tx)
+                    WellFormedTxContext::from_tx(&tx, 0)
                 };
                 transaction_set.push(client_tx);
             }
@@ -754,7 +754,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // Create another transaction that attempts to spend `tx_out`.
@@ -791,7 +791,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // This transaction spends a different TxOut, unrelated to `first_client_tx` and
@@ -854,7 +854,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // `combine` the set of transactions.
@@ -947,7 +947,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // Create another transaction that attempts to spend `tx_out2` but has the same
@@ -986,7 +986,7 @@ mod combine_tests {
 
                 let mut tx = transaction_builder.build(&mut rng).unwrap();
                 tx.prefix.outputs[0].public_key = first_client_tx.output_public_keys()[0].clone();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // This transaction spends a different TxOut, unrelated to `first_client_tx` and
@@ -1049,7 +1049,7 @@ mod combine_tests {
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
-                WellFormedTxContext::new_from_tx(0, &tx)
+                WellFormedTxContext::from_tx(&tx, 0)
             };
 
             // `combine` the set of transactions.

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -222,7 +222,7 @@ class Node:
                 { "token_id": 0, "minimum_fee": self.minimum_fee },
                 {
                     "token_id": 1,
-                    "minimum_fee": 1,
+                    "minimum_fee": 1000,
                     "master_minters": {
                         "signers": open(os.path.join(MINTING_KEYS_DIR, 'master-minter1.pub')).read(),
                         "threshold": 1
@@ -230,7 +230,7 @@ class Node:
                 },
                 {
                     "token_id": 2,
-                    "minimum_fee": 1,
+                    "minimum_fee": 1000,
                     "master_minters": {
                         "signers": open(os.path.join(MINTING_KEYS_DIR, 'master-minter2.pub')).read(),
                         "threshold": 1


### PR DESCRIPTION
```
    Make well-formed tx context hold a "priority" instead of fee.
    
    This commit:
    * Replaces the fee with priority in WellFormedTxContext
    * Makes the enclave compute priority by dividing the fee by
      minimum fee / 128, and discarding the remainder.
    
    Dividing the minium fee by 128 first ensures that if e.g.
    you pay minimum fee + 1%, that actually increases your
    priority, and minimum fee + 2% increases your priority more
    than that. Otherwise, minimum fee + 1% and minimum fee + 2%
    would get rounded to the same priority value, and there would
    be effectively no difference. If we don't dividie minimum fee
    by 128 first, then you have to increase your fee in increments
    of minimum fee to start actually seeing your transaction happen
    faster, which seems like it would be harmful to a fee market
    and lead to unnecessarily increased fees.
    
    * We impose a rule that minimum fee >= 128 as a u64, for all tokens.
      This should not be a problem. The rule is imposed in the
      fee map config structure.
    * We introduce a constant time u64 integer division routine in
      consensus enclave impl, and document and test it.
```