### PR TITLE
Move mc-consensus-service configuration into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,6 +3046,7 @@ dependencies = [
  "mc-consensus-enclave",
  "mc-consensus-enclave-mock",
  "mc-consensus-scp",
+ "mc-consensus-service-config",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-multisig",
@@ -3064,13 +3065,11 @@ dependencies = [
  "mc-util-logger-macros",
  "mc-util-metered-channel",
  "mc-util-metrics",
- "mc-util-parse",
  "mc-util-serial",
  "mc-util-telemetry",
  "mc-util-uri",
  "mockall",
  "once_cell",
- "pem",
  "protobuf",
  "rand 0.8.5",
  "rand_core 0.6.3",
@@ -3081,6 +3080,30 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempdir",
+]
+
+[[package]]
+name = "mc-consensus-service-config"
+version = "1.3.0-pre0"
+dependencies = [
+ "base64 0.13.0",
+ "clap 3.1.8",
+ "displaydoc",
+ "hex",
+ "mc-attest-core",
+ "mc-common",
+ "mc-consensus-enclave-api",
+ "mc-consensus-scp",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-transaction-core",
+ "mc-util-parse",
+ "mc-util-serial",
+ "mc-util-uri",
+ "pem",
+ "serde",
+ "serde_json",
  "toml 0.5.8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "consensus/scp",
     "consensus/scp/play",
     "consensus/service",
+    "consensus/service/config",
     "crypto/box",
     "crypto/digestible",
     "crypto/digestible/derive/test",

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -22,6 +22,7 @@ mc-connection = { path = "../../connection" }
 mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-enclave = { path = "../../consensus/enclave" }
 mc-consensus-scp = { path = "../../consensus/scp" }
+mc-consensus-service-config = { path = "config" }
 mc-crypto-digestible = { path = "../../crypto/digestible" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-crypto-multisig = { path = "../../crypto/multisig" }
@@ -35,7 +36,6 @@ mc-util-cli = { path = "../../util/cli" }
 mc-util-grpc = { path = "../../util/grpc" }
 mc-util-metered-channel = { path = "../../util/metered-channel" }
 mc-util-metrics = { path = "../../util/metrics" }
-mc-util-parse = { path = "../../util/parse" }
 mc-util-serial = { path = "../../util/serial" }
 mc-util-telemetry = { path = "../../util/telemetry", features = ["jaeger"] }
 mc-util-uri = { path = "../../util/uri" }
@@ -50,14 +50,12 @@ grpcio = "0.10.1"
 hex = "0.4"
 lazy_static = "1.4"
 once_cell = "1.10"
-pem = "1.0"
 protobuf = "2.27.1"
 rand = "0.8"
 rayon = "1.5"
 retry = "1.3"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"
-toml = "0.5"
 
 [build-dependencies]
 mc-sgx-build = { path = "../../sgx/build" }

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "mc-consensus-service-config"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+
+[dependencies]
+mc-attest-core = { path = "../../../attest/core" }
+mc-common = { path = "../../../common" }
+mc-consensus-enclave-api = { path = "../../enclave/api" }
+mc-consensus-scp = { path = "../../scp" }
+mc-crypto-digestible = { path = "../../../crypto/digestible", features = ["derive"] }
+mc-crypto-keys = { path = "../../../crypto/keys" }
+mc-crypto-multisig = { path = "../../../crypto/multisig" }
+mc-transaction-core = { path = "../../../transaction/core" }
+mc-util-parse = { path = "../../../util/parse" }
+mc-util-serial = { path = "../../../util/serial", features = ["std"] }
+mc-util-uri = { path = "../../../util/uri" }
+
+base64 = "0.13"
+clap = { version = "3.1", features = ["derive", "env"] }
+displaydoc = { version = "0.2", default-features = false }
+hex = "0.4"
+pem = "1.0"
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_json = "1.0"
+toml = "0.5"

--- a/consensus/service/config/src/error.rs
+++ b/consensus/service/config/src/error.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Configuration error data type
+
+use displaydoc::Display;
+use mc_consensus_enclave_api::{FeeMapError, MasterMintersMapError};
+use mc_transaction_core::TokenId;
+use serde_json::Error as JsonError;
+use std::io::Error as IoError;
+use toml::de::Error as TomlError;
+
+/// Configuration error data type
+#[derive(Debug, Display)]
+pub enum Error {
+    /// Missing minimum fee for token id {0}
+    MissingMinimumFee(TokenId),
+
+    /// Fee {0} for token id {1} is out of bounds
+    FeeOutOfBounds(u64, TokenId),
+
+    /// allow_any_fee cannot be used for token id {0}
+    AllowAnyFeeNotAllowed(TokenId),
+
+    /// Mint configuration is not allowed for token id {0}
+    MintConfigNotAllowed(TokenId),
+
+    /**
+     * Invalid mint configuration for token id {0}: must have at least one
+     * signer
+     */
+    NoSigners(TokenId),
+
+    /** Invalid mint configuration for token id {0}: signer set threshold
+     * exceeds number of signers
+     */
+    SignerSetThresholdExceedsSigners(TokenId),
+
+    /// Cannot figure out file extension
+    PathExtension,
+
+    /// Unrecognized file extension {0}
+    UnrecognizedExtension(String),
+
+    /// Duplicate token configuration
+    DuplicateTokenConfig,
+
+    /// Missing MOB token configuration
+    MissingMobConfig,
+
+    /// Missing minimum fee for token id {0}
+    MissingMininumFee(TokenId),
+
+    /// Fee map: {0}
+    FeeMap(FeeMapError),
+
+    /// Master minters map: {0}
+    MasterMintersMap(MasterMintersMapError),
+
+    /// JSON: {0}
+    Json(JsonError),
+
+    /// TOML: {0}
+    Toml(TomlError),
+
+    /// IO: {0}
+    Io(IoError),
+}
+
+impl From<IoError> for Error {
+    fn from(src: IoError) -> Self {
+        Self::Io(src)
+    }
+}
+
+impl From<FeeMapError> for Error {
+    fn from(src: FeeMapError) -> Self {
+        Self::FeeMap(src)
+    }
+}
+
+impl From<MasterMintersMapError> for Error {
+    fn from(src: MasterMintersMapError) -> Self {
+        Self::MasterMintersMap(src)
+    }
+}
+
+impl From<JsonError> for Error {
+    fn from(src: JsonError) -> Self {
+        Self::Json(src)
+    }
+}
+
+impl From<TomlError> for Error {
+    fn from(src: TomlError) -> Self {
+        Self::Toml(src)
+    }
+}

--- a/consensus/service/config/src/error.rs
+++ b/consensus/service/config/src/error.rs
@@ -3,8 +3,10 @@
 //! Configuration error data type
 
 use displaydoc::Display;
+use mc_common::ResponderId;
 use mc_consensus_enclave_api::{FeeMapError, MasterMintersMapError};
 use mc_transaction_core::TokenId;
+use mc_util_uri::UriConversionError;
 use serde_json::Error as JsonError;
 use std::io::Error as IoError;
 use toml::de::Error as TomlError;
@@ -64,6 +66,18 @@ pub enum Error {
 
     /// IO: {0}
     Io(IoError),
+
+    /// URI conversion of {0}: {1}
+    UriConversion(String, UriConversionError),
+
+    /// Duplicate responder id in network configuration
+    DuplicateResponderId(ResponderId),
+
+    /// Known peers should not contain our peer responder id ({0})
+    KnownPeersContainsSelf(ResponderId),
+
+    /// Missing tx_source_urls
+    MissingTxSourceUrls,
 }
 
 impl From<IoError> for Error {

--- a/consensus/service/config/src/error.rs
+++ b/consensus/service/config/src/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     /// URI conversion of {0}: {1}
     UriConversion(String, UriConversionError),
 
-    /// Duplicate responder id in network configuration
+    /// Duplicate responder id in network configuration: {0}
     DuplicateResponderId(ResponderId),
 
     /// Known peers should not contain our peer responder id ({0})

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -3,10 +3,12 @@
 //! Configuration parameters for the Consensus Service application.
 #![deny(missing_docs)]
 
+mod error;
 mod network;
 mod tokens;
 
-use crate::config::{network::NetworkConfig, tokens::TokensConfig};
+pub use crate::{error::Error, network::NetworkConfig, tokens::TokensConfig};
+
 use clap::Parser;
 use mc_attest_core::ProviderId;
 use mc_common::{NodeID, ResponderId};
@@ -172,7 +174,7 @@ fn parse_block_version(s: &str) -> Result<BlockVersion, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mc_consensus_enclave::FeeMap;
+    use mc_consensus_enclave_api::FeeMap;
     use mc_transaction_core::{tokens::Mob, Token};
 
     #[test]

--- a/consensus/service/config/src/network.rs
+++ b/consensus/service/config/src/network.rs
@@ -86,6 +86,7 @@ impl NetworkConfig {
         Ok(network)
     }
 
+    /// Construct a quorum set from the configuration.
     pub fn quorum_set(&self) -> QuorumSet {
         if !self.quorum_set.is_valid() {
             panic!("invalid quorum set: {:?}", self.quorum_set);
@@ -125,6 +126,7 @@ impl NetworkConfig {
         Self::resolve_quorum_set(&self.quorum_set, &peer_map)
     }
 
+    /// Get the list of peers we connect and broadcast messages to.
     pub fn broadcast_peers(&self) -> Vec<PeerUri> {
         self.broadcast_peers.clone()
     }

--- a/consensus/service/config/src/network.rs
+++ b/consensus/service/config/src/network.rs
@@ -2,6 +2,7 @@
 
 //! Consensus network configuration.
 
+use crate::error::Error;
 use mc_common::{HashMap, HashSet, NodeID, ResponderId};
 use mc_consensus_scp::{QuorumSet, QuorumSetMember};
 use mc_util_uri::{ConnectionUri, ConsensusPeerUri as PeerUri};
@@ -29,22 +30,18 @@ impl NetworkConfig {
     pub fn load_from_path(
         path: impl AsRef<Path>,
         peer_responder_id: &ResponderId,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, Error> {
         let path = path.as_ref();
 
         // Read configuration file.
-        let data = fs::read_to_string(path).unwrap_or_else(|err| err.to_string());
+        let data = fs::read_to_string(path)?;
 
         // Parse configuration file.
         let network: Self = match path.extension().and_then(|ext| ext.to_str()) {
-            None => Err("failed figuring out file extension".to_owned()),
-            Some("toml") => {
-                toml::from_str(&data).map_err(|err| format!("TOML parsing failed: {:?}", err))
-            }
-            Some("json") => {
-                serde_json::from_str(&data).map_err(|err| format!("JSON parsing failed: {:?}", err))
-            }
-            Some(ext) => Err(format!("Unrecognized extension '{}'", ext)),
+            None => Err(Error::PathExtension),
+            Some("toml") => toml::from_str(&data).map_err(Error::from),
+            Some("json") => serde_json::from_str(&data).map_err(Error::from),
+            Some(ext) => Err(Error::UnrecognizedExtension(ext.to_string())),
         }?;
 
         // Sanity tests:
@@ -59,27 +56,21 @@ impl NetworkConfig {
         for peer_uri in peer_uris {
             let responder_id = peer_uri
                 .responder_id()
-                .map_err(|e| format!("failed getting responder id for {:?}: {:?}", peer_uri, e))?;
+                .map_err(|err| Error::UriConversion(peer_uri.to_string(), err))?;
 
             if peer_responder_id == &responder_id {
-                return Err(format!(
-                    "Our peer responder id ({}) should not appear in broadcast_peers or known_peers!",
-                    responder_id
-                ));
+                return Err(Error::KnownPeersContainsSelf(responder_id));
             }
 
             if !spotted_responder_ids.insert(responder_id.clone()) {
-                return Err(format!(
-                    "Duplicate responder_id {} found in network configuration",
-                    responder_id
-                ));
+                return Err(Error::DuplicateResponderId(responder_id));
             }
         }
 
         // Sanity test: We should have at least one source of transactions, if we have
         // any peers configured.
         if !network.broadcast_peers.is_empty() && network.tx_source_urls.is_empty() {
-            return Err("Network configuration is missing tx_source_urls".to_owned());
+            return Err(Error::MissingTxSourceUrls);
         }
 
         // Success.

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -274,17 +274,6 @@ mod tests {
     use super::*;
     use std::convert::TryFrom;
 
-    // #[macro_export]
-    // macro_rules! assert_validation_error {
-    //     ($err:expr, $expected_err:pat) => {
-    //         match $err {
-    //             Err($expected_err) => (),
-    //             Err(err) => panic!("Unexpected error: {:?}, expected {:?}", err),
-    //             Ok(_) => panic!("Expected success, expected {:?}",
-    // $expected_err),         }
-    //     };
-    // }
-
     #[test]
     fn empty_config() {
         let input_toml: &str = r#"

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -2,9 +2,9 @@
 
 //! Tokens configuration.
 
-use crate::consensus_service::ConsensusServiceError;
+use crate::error::Error;
 use mc_common::HashSet;
-use mc_consensus_enclave::{FeeMap, MasterMintersMap};
+use mc_consensus_enclave_api::{FeeMap, MasterMintersMap};
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
 use mc_crypto_multisig::SignerSet;
 use mc_transaction_core::{tokens::Mob, Token, TokenId};
@@ -123,29 +123,22 @@ impl TokenConfig {
     }
 
     /// Check if the token configuration is valid.
-    pub fn validate(&self) -> Result<(), ConsensusServiceError> {
+    pub fn validate(&self) -> Result<(), Error> {
         // We must have a fee for every configured token.
         if self.minimum_fee_or_default().is_none() {
-            return Err(ConsensusServiceError::Configuration(
-                "missing minimum fee".to_string(),
-            ));
+            return Err(Error::MissingMinimumFee(self.token_id));
         }
 
         // By default, we restrict MOB minimum fee to a sane value.
         if self.token_id == Mob::ID {
             let mob_fee = self.minimum_fee_or_default().unwrap(); // We are guaranteed to have a minimum fee for MOB.
             if !self.allow_any_fee && !ACCEPTABLE_MOB_FEE_VALUES.contains(&mob_fee) {
-                return Err(ConsensusServiceError::Configuration(format!(
-                    "Fee {} picoMOB is out of bounds",
-                    mob_fee
-                )));
+                return Err(Error::FeeOutOfBounds(mob_fee, self.token_id));
             }
         } else {
             // allow_any_fee can only be used for MOB
             if self.allow_any_fee {
-                return Err(ConsensusServiceError::Configuration(
-                    "allow_any_fee can only be used for MOB".to_string(),
-                ));
+                return Err(Error::AllowAnyFeeNotAllowed(self.token_id));
             }
         }
 
@@ -153,22 +146,16 @@ impl TokenConfig {
         if let Some(master_minters) = &self.master_minters {
             // MOB cannot be minted.
             if self.token_id == TokenId::MOB {
-                return Err(ConsensusServiceError::Configuration(
-                    "MOB cannot have minting configuration".to_string(),
-                ));
+                return Err(Error::MintConfigNotAllowed(self.token_id));
             }
 
             // We must have at least one master minter.
             if master_minters.signers().is_empty() || master_minters.threshold() == 0 {
-                return Err(ConsensusServiceError::Configuration(
-                    "must have at least one signer".to_string(),
-                ));
+                return Err(Error::NoSigners(self.token_id));
             }
 
             if master_minters.threshold() as usize > master_minters.signers().len() {
-                return Err(ConsensusServiceError::Configuration(
-                    "signer set threshold is greater than the number of signers".to_string(),
-                ));
+                return Err(Error::SignerSetThresholdExceedsSigners(self.token_id));
             }
         }
 
@@ -199,29 +186,18 @@ impl Default for TokensConfig {
 
 impl TokensConfig {
     /// Get the tokens configuration by loading the tokens.toml/json file.
-    pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, ConsensusServiceError> {
+    pub fn load_from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
         let path = path.as_ref();
 
         // Read configuration file.
-        let data = fs::read_to_string(path).map_err(|err| {
-            ConsensusServiceError::Configuration(format!("error reading file: {}", err))
-        })?;
+        let data = fs::read_to_string(path)?;
 
         // Parse configuration file.
         let tokens_config: Self = match path.extension().and_then(|ext| ext.to_str()) {
-            None => Err(ConsensusServiceError::Configuration(
-                "failed figuring out file extension".to_owned(),
-            )),
-            Some("toml") => toml::from_str(&data).map_err(|err| {
-                ConsensusServiceError::Configuration(format!("TOML parsing: {:?}", err))
-            }),
-            Some("json") => serde_json::from_str(&data).map_err(|err| {
-                ConsensusServiceError::Configuration(format!("JSON parsing: {:?}", err))
-            }),
-            Some(ext) => Err(ConsensusServiceError::Configuration(format!(
-                "Unrecognized extension '{}'",
-                ext
-            ))),
+            None => Err(Error::PathExtension),
+            Some("toml") => toml::from_str(&data).map_err(Error::from),
+            Some("json") => serde_json::from_str(&data).map_err(Error::from),
+            Some(ext) => Err(Error::UnrecognizedExtension(ext.to_string())),
         }?;
 
         tokens_config.validate()?;
@@ -229,34 +205,21 @@ impl TokensConfig {
     }
 
     /// Validate the tokens configuration.
-    pub fn validate(&self) -> Result<(), ConsensusServiceError> {
+    pub fn validate(&self) -> Result<(), Error> {
         // Cannot have duplicate configuration for a single token.
         let unique_token_ids = HashSet::from_iter(self.tokens.iter().map(|token| token.token_id));
         if unique_token_ids.len() != self.tokens.len() {
-            return Err(ConsensusServiceError::Configuration(
-                "duplicate token configuration found".to_owned(),
-            ));
+            return Err(Error::DuplicateTokenConfig);
         }
 
         // Must have MOB.
         if self.get_token_config(&Mob::ID).is_none() {
-            return Err(ConsensusServiceError::Configuration(
-                "MOB token configuration not found".to_owned(),
-            ));
+            return Err(Error::MissingMobConfig);
         }
 
         // Validate the configuration of each token
         for token in self.tokens.iter() {
-            token.validate().map_err(|err| {
-                if let ConsensusServiceError::Configuration(msg) = err {
-                    ConsensusServiceError::Configuration(format!(
-                        "token id {}: {}",
-                        token.token_id, msg
-                    ))
-                } else {
-                    err
-                }
-            })?;
+            token.validate()?;
         }
 
         // Tokens configuration is valid.
@@ -269,26 +232,22 @@ impl TokensConfig {
     }
 
     /// Construct a FeeMap based on the configuration.
-    pub fn fee_map(&self) -> Result<FeeMap, ConsensusServiceError> {
+    pub fn fee_map(&self) -> Result<FeeMap, Error> {
         self.validate()?;
 
-        FeeMap::try_from_iter(
+        Ok(FeeMap::try_from_iter(
             self.tokens
                 .iter()
                 .map(|token_config| {
                     Ok((
                         token_config.token_id,
-                        token_config.minimum_fee_or_default().ok_or_else(|| {
-                            ConsensusServiceError::Configuration(format!(
-                                "missing minimum fee for token id {:?}",
-                                token_config.token_id
-                            ))
-                        })?,
+                        token_config
+                            .minimum_fee_or_default()
+                            .ok_or_else(|| Error::MissingMinimumFee(token_config.token_id))?,
                     ))
                 })
-                .collect::<Result<Vec<_>, ConsensusServiceError>>()?,
-        )
-        .map_err(|err| ConsensusServiceError::Configuration(format!("FeeMap: {}", err)))
+                .collect::<Result<Vec<_>, Error>>()?,
+        )?)
     }
     /// Get the entire set of configured tokens.
     pub fn tokens(&self) -> &[TokenConfig] {
@@ -296,16 +255,17 @@ impl TokensConfig {
     }
 
     /// Get a map of token id -> master minters.
-    pub fn token_id_to_master_minters(&self) -> Result<MasterMintersMap, ConsensusServiceError> {
+    pub fn token_id_to_master_minters(&self) -> Result<MasterMintersMap, Error> {
         self.validate()?;
 
-        MasterMintersMap::try_from_iter(self.tokens.iter().filter_map(|token_config| {
-            token_config
-                .master_minters
-                .as_ref()
-                .map(|master_minters| (token_config.token_id, master_minters.clone()))
-        }))
-        .map_err(|err| ConsensusServiceError::Configuration(format!("MasterMintersMap: {}", err)))
+        Ok(MasterMintersMap::try_from_iter(
+            self.tokens.iter().filter_map(|token_config| {
+                token_config
+                    .master_minters
+                    .as_ref()
+                    .map(|master_minters| (token_config.token_id, master_minters.clone()))
+            }),
+        )?)
     }
 }
 
@@ -314,13 +274,16 @@ mod tests {
     use super::*;
     use std::convert::TryFrom;
 
-    fn assert_validation_error(tokens: &TokensConfig, err: &str) {
-        match tokens.validate() {
-            Ok(_) => panic!("expected an error"),
-            Err(ConsensusServiceError::Configuration(msg)) => assert_eq!(msg, err),
-            Err(e) => panic!("Unexpected error: {}", e),
-        }
-    }
+    // #[macro_export]
+    // macro_rules! assert_validation_error {
+    //     ($err:expr, $expected_err:pat) => {
+    //         match $err {
+    //             Err($expected_err) => (),
+    //             Err(err) => panic!("Unexpected error: {:?}, expected {:?}", err),
+    //             Ok(_) => panic!("Expected success, expected {:?}",
+    // $expected_err),         }
+    //     };
+    // }
 
     #[test]
     fn empty_config() {
@@ -336,7 +299,7 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since MOB is not specified.
-        assert_validation_error(&tokens, "MOB token configuration not found");
+        assert!(matches!(tokens.validate(), Err(Error::MissingMobConfig)));
     }
 
     #[test]
@@ -357,7 +320,7 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since we must have the MOB token configured.
-        assert_validation_error(&tokens, "MOB token configuration not found");
+        assert!(matches!(tokens.validate(), Err(Error::MissingMobConfig)));
         assert!(tokens.fee_map().is_err());
     }
 
@@ -378,7 +341,7 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since we must have the MOB token configured.
-        assert_validation_error(&tokens, "MOB token configuration not found");
+        assert!(matches!(tokens.validate(), Err(Error::MissingMobConfig)));
         assert!(tokens.fee_map().is_err());
     }
 
@@ -567,7 +530,9 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since the minimum fee for the second token is unknown.
-        assert_validation_error(&tokens, "token id 6: missing minimum fee");
+        assert!(
+            matches!(tokens.validate(), Err(Error::MissingMinimumFee(token_id)) if token_id == TokenId::from(6))
+        );
 
         // Getting the fee map should also fail.
         assert!(tokens.fee_map().is_err());
@@ -596,9 +561,8 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since allow_any_fee cannot be used on non-MOB tokens.
-        assert_validation_error(
-            &tokens,
-            "token id 1: allow_any_fee can only be used for MOB",
+        assert!(
+            matches!(tokens.validate(), Err(Error::AllowAnyFeeNotAllowed(token_id)) if token_id == TokenId::from(1))
         );
     }
 
@@ -620,7 +584,9 @@ mod tests {
         assert_eq!(tokens, tokens2);
 
         // Validation should fail since the fee is outside the allowed eange.
-        assert_validation_error(&tokens, "token id 0: Fee 1 picoMOB is out of bounds");
+        assert!(
+            matches!(tokens.validate(), Err(Error::FeeOutOfBounds(fee, token_id)) if fee == 1 && token_id == Mob::ID)
+        );
     }
 
     #[test]
@@ -641,8 +607,10 @@ mod tests {
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
         assert_eq!(tokens, tokens2);
 
-        // Validation should fail since the fee is outside the allowed eange.
-        assert_validation_error(&tokens, "token id 0: Fee 1 picoMOB is out of bounds");
+        // Validation should fail since the fee is outside the allowed range.
+        assert!(
+            matches!(tokens.validate(), Err(Error::FeeOutOfBounds(fee, token_id)) if fee == 1 && token_id == Mob::ID)
+        );
     }
 
     #[test]
@@ -797,7 +765,9 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert_validation_error(&tokens, "token id 0: MOB cannot have minting configuration");
+        assert!(
+            matches!(tokens.validate(), Err(Error::MintConfigNotAllowed(token_id)) if token_id == Mob::ID)
+        );
     }
 
     #[test]
@@ -816,7 +786,9 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert_validation_error(&tokens, "token id 2: must have at least one signer");
+        assert!(
+            matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == TokenId::from(2))
+        );
     }
 
     #[test]
@@ -838,7 +810,9 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert_validation_error(&tokens, "token id 2: must have at least one signer");
+        assert!(
+            matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == TokenId::from(2))
+        );
     }
 
     #[test]
@@ -858,7 +832,10 @@ mod tests {
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         // Validation should fail since we must have the MOB token configured.
-        assert_validation_error(&tokens, "duplicate token configuration found");
+        assert!(matches!(
+            tokens.validate(),
+            Err(Error::DuplicateTokenConfig)
+        ));
         assert!(tokens.fee_map().is_err());
     }
 }

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -243,7 +243,7 @@ impl TokensConfig {
                         token_config.token_id,
                         token_config
                             .minimum_fee_or_default()
-                            .ok_or_else(|| Error::MissingMinimumFee(token_config.token_id))?,
+                            .ok_or(Error::MissingMinimumFee(token_config.token_id))?,
                     ))
                 })
                 .collect::<Result<Vec<_>, Error>>()?,

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -4,7 +4,6 @@
 
 use crate::{
     api::grpc_error::ConsensusGrpcError,
-    config::Config,
     consensus_service::ProposeTxCallback,
     counters,
     mint_tx_manager::MintTxManager,
@@ -19,6 +18,7 @@ use mc_consensus_api::{
     consensus_common::{ProposeTxResponse, ProposeTxResult},
 };
 use mc_consensus_enclave::ConsensusEnclave;
+use mc_consensus_service_config::Config;
 use mc_ledger_db::Ledger;
 use mc_peers::ConsensusValue;
 use mc_transaction_core::mint::{MintConfigTx, MintTx};
@@ -274,11 +274,11 @@ impl ConsensusClientApi for ClientApiService {
 mod client_api_tests {
     use crate::{
         api::client_api_service::{ClientApiService, PENDING_LIMIT},
-        config::Config,
         counters,
         mint_tx_manager::{MintTxManagerError, MockMintTxManager},
         tx_manager::{MockTxManager, TxManagerError},
     };
+    use mc_consensus_service_config::Config;
     use clap::Parser;
     use grpcio::{
         ChannelBuilder, Environment, Error as GrpcError, RpcStatusCode, Server, ServerBuilder,

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -278,7 +278,6 @@ mod client_api_tests {
         mint_tx_manager::{MintTxManagerError, MockMintTxManager},
         tx_manager::{MockTxManager, TxManagerError},
     };
-    use mc_consensus_service_config::Config;
     use clap::Parser;
     use grpcio::{
         ChannelBuilder, Environment, Error as GrpcError, RpcStatusCode, Server, ServerBuilder,
@@ -295,6 +294,7 @@ mod client_api_tests {
     };
     use mc_consensus_enclave::TxContext;
     use mc_consensus_enclave_mock::MockConsensusEnclave;
+    use mc_consensus_service_config::Config;
     use mc_crypto_keys::Ed25519Pair;
     use mc_ledger_db::MockLedger;
     use mc_peers::ConsensusValue;

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -10,13 +10,13 @@ use mc_common::{
     time::SystemTimeProvider,
 };
 use mc_consensus_enclave::{BlockchainConfig, ConsensusServiceSgxEnclave, ENCLAVE_FILE};
-use mc_consensus_service_config::Config;
 use mc_consensus_service::{
     consensus_service::{ConsensusService, ConsensusServiceError},
     mint_tx_manager::MintTxManagerImpl,
     tx_manager::TxManagerImpl,
     validators::DefaultTxManagerUntrustedInterfaces,
 };
+use mc_consensus_service_config::Config;
 use mc_ledger_db::LedgerDB;
 use mc_util_cli::ParserWithBuildInfo;
 use std::{

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -10,8 +10,8 @@ use mc_common::{
     time::SystemTimeProvider,
 };
 use mc_consensus_enclave::{BlockchainConfig, ConsensusServiceSgxEnclave, ENCLAVE_FILE};
+use mc_consensus_service_config::Config;
 use mc_consensus_service::{
-    config::Config,
     consensus_service::{ConsensusService, ConsensusServiceError},
     mint_tx_manager::MintTxManagerImpl,
     tx_manager::TxManagerImpl,

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -6,7 +6,6 @@ use crate::{
     api::{AttestedApiService, BlockchainApiService, ClientApiService, PeerApiService},
     background_work_queue::BackgroundWorkQueue,
     byzantine_ledger::ByzantineLedger,
-    config::Config,
     counters,
     mint_tx_manager::MintTxManager,
     peer_keepalive::PeerKeepalive,
@@ -27,6 +26,7 @@ use mc_common::{
 use mc_connection::{Connection, ConnectionManager};
 use mc_consensus_api::{consensus_client_grpc, consensus_common_grpc, consensus_peer_grpc};
 use mc_consensus_enclave::{ConsensusEnclave, Error as ConsensusEnclaveError};
+use mc_consensus_service_config::{Config, Error as ConfigError};
 use mc_crypto_keys::DistinguishedEncoding;
 use mc_ledger_db::{Error as LedgerDbError, Ledger, LedgerDB};
 use mc_peers::{ConsensusValue, PeerConnection, ThreadedBroadcaster, VerifiedConsensusMsg};
@@ -61,13 +61,18 @@ pub enum ConsensusServiceError {
     /// Report cache error: `{0}`
     ReportCache(ReportCacheError),
     /// Configuration: `{0}`
-    Configuration(String),
+    Config(ConfigError),
     /// Consensus enclave error: `{0}`
     ConsensusEnclave(ConsensusEnclaveError),
 }
 impl From<ReportCacheError> for ConsensusServiceError {
     fn from(src: ReportCacheError) -> Self {
         ConsensusServiceError::ReportCache(src)
+    }
+}
+impl From<ConfigError> for ConsensusServiceError {
+    fn from(src: ConfigError) -> Self {
+        ConsensusServiceError::Config(src)
     }
 }
 impl From<ConsensusEnclaveError> for ConsensusServiceError {

--- a/consensus/service/src/lib.rs
+++ b/consensus/service/src/lib.rs
@@ -7,7 +7,6 @@
 #[cfg(test)]
 extern crate test;
 
-pub mod config;
 pub mod consensus_service;
 pub mod mint_tx_manager;
 pub mod tx_manager;


### PR DESCRIPTION
### Motivation

We need to make part of the `mc-consensus-service` crate reusable - specifically, for building the master minters admin key signing utility: we are going to need a utility that can parse the `tokens.toml` configuration file and sign some part of it (the master minters configuration). We don't want to utility to have to depend on `mc-consensus-service` since that crate has a lot of dependencies including the ability to build an enclave, and as such the configuration part of it is being separated into its own small crate that can then be re-used.

### In this PR
* Moving consensus service configuration into its own crate
* Some more explicit error handling