### PR TITLE
updated the comment for BlockVersion.validate_transaction_outputs_are…

### DIFF
--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -86,7 +86,8 @@ impl BlockVersion {
         self.0 >= 2
     }
 
-    /// transactions shall be sorted after version 2
+    /// Tht transaction's outputs shall be sorted [MCIP #34](https://github.com/mobilecoinfoundation/mcips/pull/34)
+    /// feature is introduced in block version 3 and higher
     pub fn validate_transaction_outputs_are_sorted(&self) -> bool {
         self.0 > 2
     }


### PR DESCRIPTION
…_sorted

### Motivation

added a comment to clarify the BlockVersion.validate_transaction_outputs_are_sorted property

### In this PR
* new comment

#1695 

### Future Work
* < Out of scope non-goals for this PR >
* < These should be links to tickets. If the tickets do not exist, make them. >

