### PR TITLE
mc-consensus-mint-client improvements for offline/HSM flows

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -57,20 +57,16 @@ fn main() {
         }
 
         Commands::HashMintConfigTx { params } => {
-            let generated_nonce = params.nonce.is_none();
-
             let tx_prefix = params
                 .try_into_mint_config_tx_prefix(|| panic!("missing tombstone block"))
                 .expect("failed creating tx prefix");
 
-            // If we generated a nonce then we should output it, otherwise there is no way
-            // to reconstruct the tx prefix that is being hashed.
-            if generated_nonce {
-                println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
-            }
+            // Print the nonce, since if we generated it randomlly then there is no way to
+            // reconstruct the tx prefix that is being hashed without it.
+            println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
 
             let hash = tx_prefix.hash();
-            println!("{}", hex::encode(hash));
+            println!("Hash: {}", hex::encode(hash));
         }
 
         Commands::SubmitMintConfigTx { node, tx_filenames } => {
@@ -137,20 +133,16 @@ fn main() {
         }
 
         Commands::HashMintTx { params } => {
-            let generated_nonce = params.nonce.is_none();
-
             let tx_prefix = params
                 .try_into_mint_tx_prefix(|| panic!("missing tombstone block"))
                 .expect("failed creating tx prefix");
 
-            // If we generated a nonce then we should output it, otherwise there is no way
-            // to reconstruct the tx prefix that is being hashed.
-            if generated_nonce {
-                println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
-            }
+            // Print the nonce, since if we generated it randomlly then there is no way to
+            // reconstruct the tx prefix that is being hashed without it.
+            println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
 
             let hash = tx_prefix.hash();
-            println!("{}", hex::encode(hash));
+            println!("Hash: {}", hex::encode(hash));
         }
 
         Commands::SubmitMintTx { node, tx_filenames } => {

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -56,6 +56,23 @@ fn main() {
             fs::write(out, json).expect("failed writing output file");
         }
 
+        Commands::HashMintConfigTx { params } => {
+            let generated_nonce = params.nonce.is_none();
+
+            let tx_prefix = params
+                .try_into_mint_config_tx_prefix(|| panic!("missing tombstone block"))
+                .expect("failed creating tx prefix");
+
+            // If we generated a nonce then we should output it, otherwise there is no way
+            // to reconstruct the tx prefix that is being hashed.
+            if generated_nonce {
+                println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
+            }
+
+            let hash = tx_prefix.hash();
+            println!("{}", hex::encode(hash));
+        }
+
         Commands::SubmitMintConfigTx { node, tx_filenames } => {
             // Load all txs.
             let txs: Vec<MintConfigTx> = load_json_files(&tx_filenames);

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -136,6 +136,23 @@ fn main() {
             fs::write(out, json).expect("failed writing output file");
         }
 
+        Commands::HashMintTx { params } => {
+            let generated_nonce = params.nonce.is_none();
+
+            let tx_prefix = params
+                .try_into_mint_tx_prefix(|| panic!("missing tombstone block"))
+                .expect("failed creating tx prefix");
+
+            // If we generated a nonce then we should output it, otherwise there is no way
+            // to reconstruct the tx prefix that is being hashed.
+            if generated_nonce {
+                println!("Nonce: {}", hex::encode(&tx_prefix.nonce));
+            }
+
+            let hash = tx_prefix.hash();
+            println!("{}", hex::encode(hash));
+        }
+
         Commands::SubmitMintTx { node, tx_filenames } => {
             // Load all txs.
             let txs: Vec<MintTx> = load_json_files(&tx_filenames);

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -6,7 +6,9 @@ use clap::{Args, Parser, Subcommand};
 use hex::FromHex;
 use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
-use mc_crypto_keys::{DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, Signer};
+use mc_crypto_keys::{
+    DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, Signer,
+};
 use mc_crypto_multisig::{MultiSig, SignerSet};
 use mc_transaction_core::mint::{
     constants::NONCE_LENGTH, MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx, MintTxPrefix,
@@ -16,22 +18,18 @@ use rand::{thread_rng, RngCore};
 use std::{convert::TryFrom, fs, path::PathBuf};
 
 #[derive(Args)]
-pub struct MintConfigTxParams {
-    /// The key(s) to sign the transaction with.
-    #[clap(long = "signing-key", required =true, use_value_delimiter = true, parse(try_from_str = load_key_from_pem), env = "MC_MINTING_SIGNING_KEYS")]
-    signing_keys: Vec<Ed25519Private>,
-
+pub struct MintConfigTxPrefixParams {
     /// The token id we are minting.
     #[clap(long, env = "MC_MINTING_TOKEN_ID")]
-    token_id: u32,
+    pub token_id: u32,
 
     /// Tombstone block.
     #[clap(long, env = "MC_MINTING_TOMBSTONE")]
-    tombstone: Option<u64>,
+    pub tombstone: Option<u64>,
 
     /// Nonce.
     #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_NONCE")]
-    nonce: Option<[u8; NONCE_LENGTH]>,
+    pub nonce: Option<[u8; NONCE_LENGTH]>,
 
     /// Mint configs. Each configuration must be of the format: <mint
     /// limit>:<signing threshold>:<signer 1 public keyfile>[:<signer 2
@@ -41,22 +39,22 @@ pub struct MintConfigTxParams {
     /// out of 3 signers.
     #[clap(long = "config", parse(try_from_str = parse_mint_config), required = true, use_value_delimiter = true, env = "MC_MINTING_CONFIGS")]
     // Tuple of (mint limit, SignerSet)
-    configs: Vec<(u64, SignerSet<Ed25519Public>)>,
+    pub configs: Vec<(u64, SignerSet<Ed25519Public>)>,
 
     /// Total mint limit, shared amongst all configs.
     #[clap(long, env = "MC_MINTING_TOTAL_LIMIT")]
-    total_mint_limit: u64,
+    pub total_mint_limit: u64,
 }
 
-impl MintConfigTxParams {
-    pub fn try_into_mint_config_tx(
+impl MintConfigTxPrefixParams {
+    pub fn try_into_mint_config_tx_prefix(
         self,
         fallback_tombstone_block: impl Fn() -> u64,
-    ) -> Result<MintConfigTx, String> {
+    ) -> Result<MintConfigTxPrefix, String> {
         let tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
         let nonce = get_or_generate_nonce(self.nonce);
         let token_id = self.token_id;
-        let prefix = MintConfigTxPrefix {
+        Ok(MintConfigTxPrefix {
             token_id,
             configs: self
                 .configs
@@ -70,19 +68,55 @@ impl MintConfigTxParams {
             nonce,
             tombstone_block,
             total_mint_limit: self.total_mint_limit,
-        };
+        })
+    }
+}
 
+#[derive(Args)]
+pub struct MintConfigTxParams {
+    /// The key(s) to sign the transaction with.
+    #[clap(
+        long = "signing-key",
+        use_value_delimiter = true,
+        parse(try_from_str = load_key_from_pem),
+        required_unless_present = "signatures",
+        env = "MC_MINTING_SIGNING_KEYS"
+)]
+    signing_keys: Vec<Ed25519Private>,
+
+    /// Pre-generated signatures to use.
+    #[clap(long = "signature", use_value_delimiter = true, parse(try_from_str = parse_ed25519_signature), env = "MC_MINTING_SIGNATURES")]
+    signatures: Vec<Ed25519Signature>,
+
+    #[clap(flatten)]
+    prefix_params: MintConfigTxPrefixParams,
+}
+
+impl MintConfigTxParams {
+    pub fn try_into_mint_config_tx(
+        self,
+        fallback_tombstone_block: impl Fn() -> u64,
+    ) -> Result<MintConfigTx, String> {
+        let prefix = self
+            .prefix_params
+            .try_into_mint_config_tx_prefix(fallback_tombstone_block)?;
         let message = prefix.hash();
-        let signature = MultiSig::new(
-            self.signing_keys
-                .into_iter()
-                .map(|signer| {
-                    Ed25519Pair::from(signer)
-                        .try_sign(message.as_ref())
-                        .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {}", e))
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        );
+
+        let mut signatures = self
+            .signing_keys
+            .into_iter()
+            .map(|signer| {
+                Ed25519Pair::from(signer)
+                    .try_sign(message.as_ref())
+                    .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {}", e))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        signatures.extend(self.signatures);
+
+        signatures.sort();
+        signatures.dedup();
+
+        let signature = MultiSig::new(signatures);
         Ok(MintConfigTx { prefix, signature })
     }
 }
@@ -90,7 +124,7 @@ impl MintConfigTxParams {
 #[derive(Args)]
 pub struct MintTxParams {
     /// The key(s) to sign the transaction with.
-    #[clap(long = "signing-key", required =true, use_value_delimiter = true, parse(try_from_str = load_key_from_pem), env = "MC_MINTING_SIGNING_KEYS")]
+    #[clap(long = "signing-key", use_value_delimiter = true, parse(try_from_str = load_key_from_pem), env = "MC_MINTING_SIGNING_KEYS")]
     signing_keys: Vec<Ed25519Private>,
 
     /// The b58 address we are minting to.
@@ -166,6 +200,12 @@ pub enum Commands {
 
         #[clap(flatten)]
         params: MintConfigTxParams,
+    },
+
+    // Produce a hash of a MintConfigTx transaction. This is useful for offline/HSM signing.
+    HashMintConfigTx {
+        #[clap(flatten)]
+        params: MintConfigTxPrefixParams,
     },
 
     // Submit json-encoded MintConfigTx(s). If multiple transactions are provided, signatures will
@@ -245,6 +285,14 @@ pub fn load_key_from_pem(filename: &str) -> Result<Ed25519Private, String> {
 
     Ed25519Private::try_from_der(&parsed_pem.contents[..])
         .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))
+}
+
+pub fn parse_ed25519_signature(hex_signature: &str) -> Result<Ed25519Signature, String> {
+    let bytes = hex::decode(hex_signature)
+        .map_err(|err| format!("Failed decoding hex signature: {}", err))?;
+
+    Ed25519Signature::try_from(&bytes[..])
+        .map_err(|err| format!("Failed parsing Ed25519 signature: {}", err))
 }
 
 fn parse_public_address(b58: &str) -> Result<PublicAddress, String> {

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -370,13 +370,16 @@ impl Verifier<Ed25519Signature> for Ed25519Pair {
 pub struct Ed25519Signature(Signature);
 
 impl Ed25519Signature {
+    /// Signature length in bytes.
+    pub const BYTE_SIZE: usize = Signature::BYTE_SIZE;
+
     /// Create a new signature from a byte array
-    pub fn new(bytes: [u8; Signature::BYTE_SIZE]) -> Self {
+    pub fn new(bytes: [u8; Self::BYTE_SIZE]) -> Self {
         Self(Signature::from(bytes))
     }
 
     /// Return the inner byte array
-    pub fn to_bytes(&self) -> [u8; Signature::BYTE_SIZE] {
+    pub fn to_bytes(&self) -> [u8; Self::BYTE_SIZE] {
         self.0.to_bytes()
     }
 }
@@ -422,7 +425,7 @@ impl Hash for Ed25519Signature {
 // This is needed to implement prost::Message
 impl Default for Ed25519Signature {
     fn default() -> Self {
-        Self::new([0; Signature::BYTE_SIZE])
+        Self::new([0; Self::BYTE_SIZE])
     }
 }
 


### PR DESCRIPTION
`mc-consensus-mint-client` is used to generate and sign `MintConfigTx`s and `MintTx`s. Prior to this PR, this requires having the private key(s) used for signing inside PEM file that is readable by the utility. This PR enables a new flow where the data to be signed (the hash of the tx prefix) can be generated, and then that hash can be signed offline or by an HSM. The produced signature, in hex bytes, can be fed back into the utility to generate a transaction.

Example usage:
1) Generate a hash for a `MintConfigTx`: `mc-consensus-mint-client hash-mint-config-tx --token-id 10 --config 10:1:minting1-public.pem --total-mint-limit 40 --tombstone 123 --nonce 33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333`
2) Take the generated hash (presented as hex-encoded bytes) and sign it with an HSM
3) Take the signature (as hex-encoded bytes) and use it to generate and submit a `MintConfigTx`: `mc-consensus-mint-client generate-and-submit-mint-config-tx --node mc://node1.eran.mobilecoin.com/ --token-id 10 --config 10:1:minting1-public.pem --total-mint-limit 40 --tombstone 123 --nonce 33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333 --signature 263f5c3da1f1e6d988ab2fb9c366e21f8a218d6c88c85add50e417d93dc9ef8f66ac4099aeea5b69adb2685569e34ffd07b7ab5b092a06d8901aec663ed3360e`
