### PR TITLE
Add missing flag in tools/fog-local-network/README.md

### DIFF
--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -33,7 +33,7 @@ In order to use it, the following steps are necessary.
 
 3) Bootstrap a ledger:
     ```
-    cargo run mc-util-generate-sample-ledger --release -- --txs 100
+    cargo run -p mc-util-generate-sample-ledger --release -- --txs 100
     ```
 
 4) Start a local network, for example:


### PR DESCRIPTION
### Motivation

Make it easier for users to follow the readme instructions.

### In this PR

* Adds a missing flag in the `tools/fog-local-network/README.md` so that users can just copy and paste the command.


