### PR TITLE
Move tx_hashes_to_block out of TxManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "grpcio",
  "hex",
  "lazy_static",
+ "mc-account-keys",
  "mc-attest-api",
  "mc-attest-core",
  "mc-attest-enclave-api",

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -263,8 +263,8 @@ impl SgxConsensusEnclave {
             return Err(Error::InvalidLocalMembershipProof);
         }
 
-        // Sanity check - since our caller (TxManager::tx_hashes_to_block) collects all
-        // proof of memberships and root element at a time the ledger is not
+        // Sanity check - since our caller (ByzantineLedgerWorker/TxManager) collects
+        // all proof of memberships and root element at a time the ledger is not
         // expected to change, we should end with the same root element for all
         // transactions.
         if root_element != &root_elements[0] {

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -61,6 +61,7 @@ serde_json = "1.0"
 mc-sgx-build = { path = "../../sgx/build" }
 
 [dev-dependencies]
+mc-account-keys = { path = "../../account-keys" }
 mc-common = { path = "../../common", features = ["loggers"] }
 mc-consensus-enclave-mock = { path = "../../consensus/enclave/mock" }
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -139,6 +139,7 @@ impl<
     /// * `highest_issued_msg` - Worker sets to highest consensus message issued
     ///   by this node.
     /// * `logger` - Logger instance.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         enclave: E,
         scp_node: Box<dyn ScpNode<ConsensusValue>>,

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -817,7 +817,7 @@ impl<
         let parent_block = self
             .ledger
             .get_block(num_blocks - 1)
-            .expect("Ledger must contain a block.");
+            .expect("Failed to get last block.");
 
         // Split externalized values into the different transaction types
         let mut tx_hashes = Vec::new();

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -810,14 +810,10 @@ impl<
         &self,
         externalized_values: Vec<ConsensusValue>,
     ) -> BlockData {
-        let num_blocks = self
-            .ledger
-            .num_blocks()
-            .expect("Ledger must contain a block.");
         let parent_block = self
             .ledger
-            .get_block(num_blocks - 1)
-            .expect("Failed to get last block.");
+            .get_latest_block()
+            .expect("Failed to get latest block.");
 
         // Split externalized values into the different transaction types
         let mut tx_hashes = Vec::new();

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -839,7 +839,7 @@ impl<
         // TODO
         let well_formed_encrypted_txs_with_proofs = self
             .tx_manager
-            .tx_hashes_to_block(&tx_hashes)
+            .tx_hashes_to_well_formed_encrypted_txs_and_proofs(&tx_hashes)
             .unwrap_or_else(|e| panic!("Failed to build block from {:?}: {:?}", tx_hashes, e));
 
         let root_element = self

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -835,17 +835,21 @@ impl<
             }
         }
 
-        // TODO
+        // Resolve hashes into well formed encrypted txs and associated proofs.
         let well_formed_encrypted_txs_with_proofs = self
             .tx_manager
             .tx_hashes_to_well_formed_encrypted_txs_and_proofs(&tx_hashes)
             .unwrap_or_else(|e| panic!("Failed to build block from {:?}: {:?}", tx_hashes, e));
 
+        // Get the root membership element, which is needed for validating the
+        // membership proofs (and also storing in the block for bookkeeping
+        // purposes).
         let root_element = self
             .ledger
             .get_root_tx_out_membership_element()
-            .expect("TODO");
+            .expect("Failed getting root tx out membership element");
 
+        // Request the enclave to form the next block.
         let (block, block_contents, mut signature) = self
             .enclave
             .form_block(
@@ -857,7 +861,7 @@ impl<
                 },
                 &root_element,
             )
-            .expect("TODO");
+            .expect("form_block failed");
 
         // The enclave cannot provide a timestamp, so this happens in untrusted.
         signature.set_signed_at(chrono::Utc::now().timestamp() as u64);

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 The MobileCoin Foundation
+// Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! The MobileCoin consensus service.
 
@@ -508,6 +508,7 @@ impl<
             .set(ByzantineLedger::new(
                 self.local_node_id.clone(),
                 self.config.network().quorum_set(),
+                self.enclave.clone(),
                 self.peer_manager.clone(),
                 self.ledger_db.clone(),
                 self.tx_manager.clone(),

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -737,7 +737,7 @@ mod tests {
         // All transactions must be in the cache.
         for tx_hash in &tx_hashes {
             let cache_entry = CacheEntry {
-                encrypted_tx: Default::default(),
+                encrypted_tx: WellFormedEncryptedTx(tx_hash.to_vec()),
                 context: Arc::new(Default::default()),
             };
             tx_manager.lock_cache().insert(*tx_hash, cache_entry);
@@ -748,7 +748,19 @@ mod tests {
             .unwrap();
         assert_eq!(well_formed_encrypted_txs_with_proofs.len(), tx_hashes.len());
 
-        // TODO validate encrypted txs match the provided hashes.
+        assert_eq!(
+            well_formed_encrypted_txs_with_proofs[0].0 .0,
+            tx_hashes[0].to_vec()
+        );
+        assert_eq!(
+            well_formed_encrypted_txs_with_proofs[1].0 .0,
+            tx_hashes[1].to_vec()
+        );
+
+        assert_eq!(
+            well_formed_encrypted_txs_with_proofs[2].0 .0,
+            tx_hashes[2].to_vec()
+        );
     }
 
     #[test_with_logger]

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -1,11 +1,12 @@
-// Copyright (c) 2018-2021 The MobileCoin Foundation
+// Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use crate::tx_manager::TxManagerResult;
 use mc_attest_enclave_api::{EnclaveMessage, PeerSession};
 use mc_common::HashSet;
 use mc_consensus_enclave::{TxContext, WellFormedEncryptedTx};
-use mc_peers::ConsensusValue;
-use mc_transaction_core::{tx::TxHash, Block, BlockContents, BlockSignature};
+use mc_transaction_core::{
+    tx::{TxHash, TxOutMembershipProof},
+};
 
 #[cfg(test)]
 use mockall::*;
@@ -40,9 +41,8 @@ pub trait TxManager: Send {
     // TODO rename since this is no longer specific to just hashes
     fn tx_hashes_to_block(
         &self,
-        value: Vec<ConsensusValue>,
-        parent_block: &Block,
-    ) -> TxManagerResult<(Block, BlockContents, BlockSignature)>;
+        value: &[TxHash],
+    ) -> TxManagerResult<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>>;
 
     /// Creates a message containing a set of transactions that are encrypted
     /// for a peer.

--- a/consensus/service/src/tx_manager/tx_manager_trait.rs
+++ b/consensus/service/src/tx_manager/tx_manager_trait.rs
@@ -4,9 +4,7 @@ use crate::tx_manager::TxManagerResult;
 use mc_attest_enclave_api::{EnclaveMessage, PeerSession};
 use mc_common::HashSet;
 use mc_consensus_enclave::{TxContext, WellFormedEncryptedTx};
-use mc_transaction_core::{
-    tx::{TxHash, TxOutMembershipProof},
-};
+use mc_transaction_core::tx::{TxHash, TxOutMembershipProof};
 
 #[cfg(test)]
 use mockall::*;
@@ -36,10 +34,13 @@ pub trait TxManager: Send {
     /// Combines the transactions that correspond to the given hashes.
     fn combine(&self, tx_hashes: &[TxHash]) -> TxManagerResult<Vec<TxHash>>;
 
-    /// Forms a Block containing the transactions that correspond to the given
-    /// hashes.
-    // TODO rename since this is no longer specific to just hashes
-    fn tx_hashes_to_block(
+    /// Get an array of well-formed encrypted transactions and membership proofs
+    /// that correspond to the provided tx hashes.
+    ///
+    /// # Arguments
+    /// * `tx_hashes` - Hashes of well-formed transactions that are valid w.r.t.
+    ///   the current ledger.
+    fn tx_hashes_to_well_formed_encrypted_txs_and_proofs(
         &self,
         value: &[TxHash],
     ) -> TxManagerResult<Vec<(WellFormedEncryptedTx, Vec<TxOutMembershipProof>)>>;

--- a/consensus/service/src/tx_manager/untrusted_interfaces.rs
+++ b/consensus/service/src/tx_manager/untrusted_interfaces.rs
@@ -2,7 +2,7 @@
 
 use mc_consensus_enclave::{TxContext, WellFormedTxContext};
 use mc_transaction_core::{
-    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipProof},
     validation::TransactionValidationResult,
 };
 use std::sync::Arc;
@@ -44,8 +44,4 @@ pub trait UntrustedInterfaces: Send + Sync {
         &self,
         indexes: &[u64],
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>>;
-
-    fn get_root_tx_out_membership_element(
-        &self,
-    ) -> TransactionValidationResult<TxOutMembershipElement>;
 }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -28,7 +28,7 @@ use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_ledger_db::Ledger;
 use mc_transaction_core::{
     ring_signature::KeyImage,
-    tx::{TxHash, TxOutMembershipElement, TxOutMembershipProof},
+    tx::{TxHash, TxOutMembershipProof},
     validation::{validate_tombstone, TransactionValidationError, TransactionValidationResult},
 };
 use std::{collections::HashSet, iter::FromIterator, sync::Arc};
@@ -167,14 +167,6 @@ impl<L: Ledger + Sync> TxManagerUntrustedInterfaces for DefaultTxManagerUntruste
     ) -> TransactionValidationResult<Vec<TxOutMembershipProof>> {
         self.ledger
             .get_tx_out_proof_of_memberships(indexes)
-            .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
-    }
-
-    fn get_root_tx_out_membership_element(
-        &self,
-    ) -> TransactionValidationResult<TxOutMembershipElement> {
-        self.ledger
-            .get_root_tx_out_membership_element()
             .map_err(|e| TransactionValidationError::Ledger(e.to_string()))
     }
 }


### PR DESCRIPTION
### Motivation

`tx_hashes_to_block` currently lives inside `TxManager`, which is the object that deals with tracking `Tx`s (the original transaction type, as opposed to the newer mint-related transactions). During the work on adding minting this function was repurposed to get a list of values, that are now either a `Tx`, or a `MintTx` or a `MintConfigTx` and then use the consensus enclave to form a block from them.
This is hacky, and gets in the way of follow-up work on `MintTx` verification that we want to do - specifically, we want to have the enclave validate `MintTx`s against active `MintConfigTx`s, which means the active `MintConfigTx` information needs to make its way to the enclave. `TxManager` has no access to that, and while it could be bolted on that is wrong and repurposing the original purpose of that object.

I think the right thing to do is to change `tx_hashes_to_block` to only deal with `Tx`s, as was originally intended, and move the actual block forming that combines all transaction types into `ByzantineLedgerWorker`, which is where we go from SCP externalized values into a block formed by the enclave and then into the ledger database.

### In this PR
* Add a method `form_block_from_externalized_values` to `ByzantineLedgerWorker` that deals with forming a new block using the enclave and inputs externalized from SCP
* Rename `tx_hashes_to_block` to `tx_hashes_to_well_formed_encrypted_txs_and_proofs` and remove block-forming functionality from it
* Test fixes/shuffling
* Remove no longer used method `get_root_tx_out_membership_element` from `TxManagerUntrustedInterfaces` 
