### PR TITLE
allow transactions with "mixed" token types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5087,6 +5093,7 @@ name = "mc-transaction-core"
 version = "1.3.0-pre0"
 dependencies = [
  "aes",
+ "assert_matches",
  "bulletproofs-og",
  "crc",
  "curve25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "strsim 0.10.0",
+ "syn 1.0.91",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote 1.0.18",
+ "syn 1.0.91",
+]
+
+[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -2079,6 +2114,12 @@ dependencies = [
  "tokio 1.16.1",
  "tokio-rustls 0.23.2",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -4794,6 +4835,7 @@ dependencies = [
  "rocket_contrib",
  "serde",
  "serde_derive",
+ "serde_with",
 ]
 
 [[package]]
@@ -7317,6 +7359,29 @@ dependencies = [
  "itoa 1.0.1",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -48,7 +48,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockVersion, CompressedCommitment, MaskedAmount, Token,
+    Amount, BlockVersion, CompressedCommitment, MaskedAmount, Token,
 };
 
 use mc_transaction_std::{
@@ -1692,12 +1692,19 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
 
             let value = jni_big_int_to_u64(env, value)?;
 
+            // TODO: If you want to support mixed transactions, use something other
+            // than fee_token_id here.
+            let amount = Amount {
+                value: value as u64,
+                token_id: tx_builder.get_fee_token_id(),
+            };
+
             let recipient: MutexGuard<PublicAddress> =
                 env.get_rust_field(recipient, RUST_OBJ_FIELD)?;
 
             let mut rng = McRng::default();
             let (tx_out, confirmation_number) =
-                tx_builder.add_output(value as u64, &recipient, &mut rng)?;
+                tx_builder.add_output(amount, &recipient, &mut rng)?;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
                 if len as usize >= confirmation_number.to_vec().len() {

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1693,7 +1693,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
 
             let value = jni_big_int_to_u64(env, value)?;
 
-            // TODO: If you want to support mixed transactions, use something other
+            // TODO: If you want to do mixed transactions, use something other
             // than fee_token_id here.
             let amount = Amount {
                 value: value as u64,
@@ -1751,8 +1751,15 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 ChangeDestination::from(&*source_account_key);
             let mut rng = McRng::default();
 
+            // TODO: If you want to do mixed transactions, use something other
+            // than fee_token_id here.
+            let amount = Amount {
+                value: value as u64,
+                token_id: tx_builder.get_fee_token_id(),
+            };
+
             let (tx_out, confirmation_number) =
-                tx_builder.add_change_output(value, &change_destination, &mut rng)?;
+                tx_builder.add_change_output(amount, &change_destination, &mut rng)?;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
                 if len as usize >= confirmation_number.to_vec().len() {

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1693,7 +1693,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
 
             let value = jni_big_int_to_u64(env, value)?;
 
-            // TODO: If you want to do mixed transactions, use something other
+            // TODO (GH #1867): If you want to do mixed transactions, use something other
             // than fee_token_id here.
             let amount = Amount {
                 value: value as u64,
@@ -1751,7 +1751,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 ChangeDestination::from(&*source_account_key);
             let mut rng = McRng::default();
 
-            // TODO: If you want to do mixed transactions, use something other
+            // TODO (GH #1867): If you want to do mixed transactions, use something other
             // than fee_token_id here.
             let amount = Amount {
                 value: value as u64,

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1603,12 +1603,13 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
         // FIXME #1595: The token id should be a parameter and not hard coded to Mob
         // here
         let token_id = Mob::ID;
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
         let tx_builder = TransactionBuilder::new_with_box(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver.clone(),
             memo_builder_box,
-        );
+        )?;
 
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, tx_builder)?)
     })

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -242,8 +242,8 @@ message TxPrefix {
     // The block index at which this transaction is no longer valid.
     uint64 tombstone_block = 4;
 
-    // Token id for this transaction
-    fixed64 token_id = 5;
+    // Token id for the fee of this transaction
+    fixed64 fee_token_id = 5;
 }
 
 message RingMLSAG {
@@ -255,7 +255,10 @@ message RingMLSAG {
 message SignatureRctBulletproofs {
     repeated RingMLSAG ring_signatures = 1;
     repeated CompressedRistretto pseudo_output_commitments = 2;
-    bytes range_proofs = 3;
+    bytes range_proof_bytes = 3;
+    repeated bytes range_proofs = 4;
+    repeated fixed64 pseudo_output_token_ids = 5;
+    repeated fixed64 output_token_ids = 6;
 }
 
 message Tx {

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -246,18 +246,44 @@ message TxPrefix {
     fixed64 fee_token_id = 5;
 }
 
+// A ring mlsag is a group-ring signature conferring spending authority of one TxOut
+// which is part of a TxIn.
 message RingMLSAG {
+    // The initial challenge value for the ring signature
     CurveScalar c_zero = 1;
+    // The "responses", one for each input which is signed
     repeated CurveScalar responses = 2;
+    // The key image is a hash unique to the "true" spent input. This cannot
+    // be linked back to determine the true spent input, but the input cannot be
+    // spent again without producing the same key image value, so this is used to
+    // prevent double-spends.
     KeyImage key_image = 3;
 }
 
 message SignatureRctBulletproofs {
+    // A ring-signature, one for each TxIn, producing one pseudo-output and key image.
     repeated RingMLSAG ring_signatures = 1;
+    // The amount commitments for each pseudo-output.
+    // There must be one of these for each TxIn.
     repeated CompressedRistretto pseudo_output_commitments = 2;
+    // Before mixed transactions feature, there is one range proof for all pseudo-output
+    // and output commitments, whose serialized bytes appear here.
+    // After mixed transactions feature, this field is empty.
     bytes range_proof_bytes = 3;
+    // Before mixed transactions feature, this field is empty.
+    // After mixed transactions feature, this field contains one range proof for each
+    // token id which appears in the transaction, in sorted order of token ids.
+    // It range-proofs the pseudo-outputs and outputs with that token id, in the order
+    // that they appear in the transaction.
     repeated bytes range_proofs = 4;
+    // The token ids of each pseudo ouptut. There must be one of these for each TxIn.
+    // Before mixed transactions feature, this field is empty, and the token ids of
+    // all pseudo-outputs are inferred from the tx.prefix.fee_token_id.
     repeated fixed64 pseudo_output_token_ids = 5;
+    // The token ids of each output. There must be one of these for each output of the Tx.
+    // (tx.prefix.outputs).
+    // Before mixed transactions feature, this field is empty, and the token ids of
+    // all outputs are inferred from the tx.prefix.fee_token_id.
     repeated fixed64 output_token_ids = 6;
 }
 

--- a/api/src/convert/signature_rct_bulletproofs.rs
+++ b/api/src/convert/signature_rct_bulletproofs.rs
@@ -5,6 +5,7 @@ use mc_transaction_core::{
     ring_signature::{RingMLSAG, SignatureRctBulletproofs},
     CompressedCommitment,
 };
+use protobuf::RepeatedField;
 use std::convert::TryFrom;
 
 impl From<&SignatureRctBulletproofs> for external::SignatureRctBulletproofs {
@@ -25,7 +26,10 @@ impl From<&SignatureRctBulletproofs> for external::SignatureRctBulletproofs {
             .collect();
         signature.set_pseudo_output_commitments(pseudo_output_commitments.into());
 
-        signature.set_range_proofs(source.range_proof_bytes.clone());
+        signature.set_range_proof_bytes(source.range_proof_bytes.clone());
+        signature.set_range_proofs(RepeatedField::from_vec(source.range_proofs.clone()));
+        signature.set_pseudo_output_token_ids(source.pseudo_output_token_ids.clone());
+        signature.set_output_token_ids(source.output_token_ids.clone());
 
         signature
     }
@@ -46,12 +50,18 @@ impl TryFrom<&external::SignatureRctBulletproofs> for SignatureRctBulletproofs {
                 .push(CompressedCommitment::try_from(pseudo_output_commitment)?);
         }
 
-        let range_proof_bytes = source.get_range_proofs().to_vec();
+        let range_proof_bytes = source.get_range_proof_bytes().to_vec();
+        let range_proofs = source.get_range_proofs().to_vec();
+        let pseudo_output_token_ids = source.get_pseudo_output_token_ids().to_vec();
+        let output_token_ids = source.get_output_token_ids().to_vec();
 
         Ok(SignatureRctBulletproofs {
             ring_signatures,
             pseudo_output_commitments,
             range_proof_bytes,
+            range_proofs,
+            pseudo_output_token_ids,
+            output_token_ids,
         })
     }
 }

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -34,7 +34,7 @@ mod tests {
         onetime_keys::recover_onetime_private_key,
         tokens::Mob,
         tx::{Tx, TxOut, TxOutMembershipProof},
-        BlockVersion, Token,
+        Amount, BlockVersion, Token,
     };
     use mc_transaction_core_test_utils::MockFogResolver;
     use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
@@ -106,7 +106,14 @@ mod tests {
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
-                .add_output(65536, &bob.default_subaddress(), &mut rng)
+                .add_output(
+                    Amount {
+                        value: 65536,
+                        token_id: Mob::ID,
+                    },
+                    &bob.default_subaddress(),
+                    &mut rng,
+                )
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -107,10 +107,7 @@ mod tests {
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
                 .add_output(
-                    Amount {
-                        value: 65536,
-                        token_id: Mob::ID,
-                    },
+                    Amount::new(65536, Mob::ID),
                     &bob.default_subaddress(),
                     &mut rng,
                 )

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -72,10 +72,11 @@ mod tests {
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                Mob::ID,
+                Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 MockFogResolver::default(),
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
 
             let ring: Vec<TxOut> = minted_outputs.clone();
             let public_key = RistrettoPublic::try_from(&minted_outputs[0].public_key).unwrap();

--- a/api/src/convert/tx_prefix.rs
+++ b/api/src/convert/tx_prefix.rs
@@ -18,7 +18,7 @@ impl From<&tx::TxPrefix> for external::TxPrefix {
 
         tx_prefix.set_fee(source.fee);
 
-        tx_prefix.set_token_id(source.token_id);
+        tx_prefix.set_fee_token_id(source.fee_token_id);
 
         tx_prefix.set_tombstone_block(source.tombstone_block);
 
@@ -47,7 +47,7 @@ impl TryFrom<&external::TxPrefix> for tx::TxPrefix {
             inputs,
             outputs,
             fee: source.get_fee(),
-            token_id: source.get_token_id(),
+            fee_token_id: source.get_fee_token_id(),
             tombstone_block: source.get_tombstone_block(),
         };
         Ok(tx_prefix)

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -236,7 +236,7 @@ impl SgxConsensusEnclave {
         // We need to make sure all transactions are valid. We also ensure they all
         // point at the same root membership element.
         for (tx, proofs) in transactions_with_proofs.iter() {
-            let token_id = TokenId::from(tx.prefix.token_id);
+            let token_id = TokenId::from(tx.prefix.fee_token_id);
 
             let minimum_fee = ct_min_fees
                 .get(&token_id)
@@ -685,7 +685,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             .decrypt_bytes(locally_encrypted_tx.0)?;
         let tx: Tx = mc_util_serial::decode(&decrypted_bytes)?;
 
-        let token_id = TokenId::from(tx.prefix.token_id);
+        let token_id = TokenId::from(tx.prefix.fee_token_id);
 
         // Validate.
         let mut csprng = McRng::default();
@@ -782,7 +782,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Compute the total fees for each known token id, for tx's in this block.
         let mut total_fees: CtTokenMap<u128> = ct_min_fee_map.keys().cloned().collect();
         for tx in transactions.iter() {
-            let token_id = TokenId::from(tx.prefix.token_id);
+            let token_id = TokenId::from(tx.prefix.fee_token_id);
             total_fees.add(&token_id, tx.prefix.fee as u128);
         }
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -236,10 +236,10 @@ impl SgxConsensusEnclave {
         // We need to make sure all transactions are valid. We also ensure they all
         // point at the same root membership element.
         for (tx, proofs) in transactions_with_proofs.iter() {
-            let token_id = TokenId::from(tx.prefix.fee_token_id);
+            let fee_token_id = TokenId::from(tx.prefix.fee_token_id);
 
             let minimum_fee = ct_min_fees
-                .get(&token_id)
+                .get(&fee_token_id)
                 .ok_or(TransactionValidationError::TokenNotYetConfigured)?;
 
             mc_transaction_core::validation::validate(
@@ -685,12 +685,12 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             .decrypt_bytes(locally_encrypted_tx.0)?;
         let tx: Tx = mc_util_serial::decode(&decrypted_bytes)?;
 
-        let token_id = TokenId::from(tx.prefix.fee_token_id);
+        let fee_token_id = TokenId::from(tx.prefix.fee_token_id);
 
         // Validate.
         let mut csprng = McRng::default();
         let minimum_fee = ct_min_fee_map
-            .get(&token_id)
+            .get(&fee_token_id)
             .ok_or(TransactionValidationError::TokenNotYetConfigured)?;
         mc_transaction_core::validation::validate(
             &tx,
@@ -782,8 +782,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Compute the total fees for each known token id, for tx's in this block.
         let mut total_fees: CtTokenMap<u128> = ct_min_fee_map.keys().cloned().collect();
         for tx in transactions.iter() {
-            let token_id = TokenId::from(tx.prefix.fee_token_id);
-            total_fees.add(&token_id, tx.prefix.fee as u128);
+            let fee_token_id = TokenId::from(tx.prefix.fee_token_id);
+            total_fees.add(&fee_token_id, tx.prefix.fee as u128);
         }
 
         // Sort the token ids which did not appear to the end.

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -575,10 +575,11 @@ mod combine_tests {
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                Mob::ID,
+                Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 MockFogResolver::default(),
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
@@ -634,10 +635,11 @@ mod combine_tests {
 
                     let mut transaction_builder = TransactionBuilder::new(
                         block_version,
-                        Mob::ID,
+                        Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                         MockFogResolver::default(),
                         EmptyMemoBuilder::default(),
-                    );
+                    )
+                    .unwrap();
 
                     // Create InputCredentials to spend the TxOut.
                     let onetime_private_key = recover_onetime_private_key(
@@ -739,10 +741,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -780,10 +783,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -844,10 +848,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -935,10 +940,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -977,10 +983,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -1042,10 +1049,11 @@ mod combine_tests {
 
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -585,7 +585,14 @@ mod combine_tests {
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
-                .add_output(123, &bob.default_subaddress(), &mut rng)
+                .add_output(
+                    Amount {
+                        value: 123,
+                        token_id: Mob::ID,
+                    },
+                    &bob.default_subaddress(),
+                    &mut rng,
+                )
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).unwrap();
@@ -669,7 +676,14 @@ mod combine_tests {
                     transaction_builder.add_input(input_credentials);
                     transaction_builder.set_fee(0).unwrap();
                     transaction_builder
-                        .add_output(88, &bob.default_subaddress(), &mut rng)
+                        .add_output(
+                            Amount {
+                                value: 88,
+                                token_id: Mob::ID,
+                            },
+                            &bob.default_subaddress(),
+                            &mut rng,
+                        )
                         .unwrap();
 
                     let tx = transaction_builder.build(&mut rng).unwrap();
@@ -744,7 +758,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &bob.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &bob.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
@@ -781,7 +802,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &recipient_account.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &recipient_account.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
@@ -844,7 +872,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &recipient_account.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &recipient_account.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
@@ -937,7 +972,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &bob.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &bob.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();
@@ -975,7 +1017,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &recipient_account.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &recipient_account.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let mut tx = transaction_builder.build(&mut rng).unwrap();
@@ -1039,7 +1088,14 @@ mod combine_tests {
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
-                    .add_output(123, &recipient_account.default_subaddress(), &mut rng)
+                    .add_output(
+                        Amount {
+                            value: 123,
+                            token_id: Mob::ID,
+                        },
+                        &recipient_account.default_subaddress(),
+                        &mut rng,
+                    )
                     .unwrap();
 
                 let tx = transaction_builder.build(&mut rng).unwrap();

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -625,10 +625,7 @@ mod combine_tests {
                     let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
                     let tx_out = TxOut::new(
-                        Amount {
-                            value: 88,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(88, Mob::ID),
                         &alice.default_subaddress(),
                         &tx_secret_key_for_txo,
                         Default::default(),
@@ -677,10 +674,7 @@ mod combine_tests {
                     transaction_builder.set_fee(0).unwrap();
                     transaction_builder
                         .add_output(
-                            Amount {
-                                value: 88,
-                                token_id: Mob::ID,
-                            },
+                            Amount::new(88, Mob::ID),
                             &bob.default_subaddress(),
                             &mut rng,
                         )
@@ -759,10 +753,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &bob.default_subaddress(),
                         &mut rng,
                     )
@@ -803,10 +794,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &recipient_account.default_subaddress(),
                         &mut rng,
                     )
@@ -824,10 +812,7 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
-                    Amount {
-                        value: 123,
-                        token_id: Mob::ID,
-                    },
+                    Amount::new(123, Mob::ID),
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
                     Default::default(),
@@ -873,10 +858,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &recipient_account.default_subaddress(),
                         &mut rng,
                     )
@@ -909,10 +891,7 @@ mod combine_tests {
 
             // Create two TxOuts that were sent to Alice.
             let tx_out1 = TxOut::new(
-                Amount {
-                    value: 123,
-                    token_id: Mob::ID,
-                },
+                Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -920,10 +899,7 @@ mod combine_tests {
             .unwrap();
 
             let tx_out2 = TxOut::new(
-                Amount {
-                    value: 123,
-                    token_id: Mob::ID,
-                },
+                Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
                 Default::default(),
@@ -973,10 +949,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &bob.default_subaddress(),
                         &mut rng,
                     )
@@ -1018,10 +991,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &recipient_account.default_subaddress(),
                         &mut rng,
                     )
@@ -1040,10 +1010,7 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
-                    Amount {
-                        value: 123,
-                        token_id: Mob::ID,
-                    },
+                    Amount::new(123, Mob::ID),
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
                     Default::default(),
@@ -1089,10 +1056,7 @@ mod combine_tests {
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
                     .add_output(
-                        Amount {
-                            value: 123,
-                            token_id: Mob::ID,
-                        },
+                        Amount::new(123, Mob::ID),
                         &recipient_account.default_subaddress(),
                         &mut rng,
                     )

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -583,10 +583,7 @@ mod combine_tests {
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
                 .add_output(
-                    Amount {
-                        value: 123,
-                        token_id: Mob::ID,
-                    },
+                    Amount::new(123, Mob::ID),
                     &bob.default_subaddress(),
                     &mut rng,
                 )

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -536,10 +536,7 @@ mod combine_tests {
             let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
             let tx_out = TxOut::new(
-                Amount {
-                    value: 123,
-                    token_id: Mob::ID,
-                },
+                Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &tx_secret_key_for_txo,
                 Default::default(),

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -814,7 +814,7 @@ fn build_tx(
             let target_address = to_account.default_subaddress();
 
             tx_builder
-                .add_output(value, &target_address, &mut rng)
+                .add_output(Amount { value, token_id }, &target_address, &mut rng)
                 .expect("failed to add output");
         }
     }

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -715,17 +715,18 @@ fn build_tx(
     // Use token id for first spendable tx out
     let token_id = spendable_txouts.first().unwrap().amount.token_id;
 
+    // FIXME: This needs to be the fee for the current token, not MOB.
+    // However, bootstrapping non MOB tokens is not supported right now.
+    let fee_amount = Amount::new(MOB_FEE.load(Ordering::SeqCst), token_id);
+
     // Create tx_builder.
     let mut tx_builder = TransactionBuilder::new(
         block_version,
-        token_id,
+        fee_amount,
         fog_resolver,
         EmptyMemoBuilder::default(),
-    );
-
-    // FIXME: This needs to be the fee for the current token, not MOB.
-    // However, bootstrapping non MOB tokens is not supported right now.
-    tx_builder.set_fee(MOB_FEE.load(Ordering::SeqCst)).unwrap();
+    )
+    .unwrap();
 
     // Unzip each vec of tuples into a tuple of vecs.
     let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -707,10 +707,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
 
     tx_builder
         .add_change_output(
-            Amount {
-                value: change,
-                token_id: amount.token_id,
-            },
+            Amount::new(change, amount.token_id),
             &change_destination,
             rng,
         )

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -606,9 +606,13 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         memo_builder.set_sender_credential(SenderMemoCredential::from(source_account_key));
         memo_builder.enable_destination_memo();
 
-        TransactionBuilder::new(block_version, amount.token_id, fog_resolver, memo_builder)
+        TransactionBuilder::new(
+            block_version,
+            Amount::new(fee, amount.token_id),
+            fog_resolver,
+            memo_builder,
+        )?
     };
-    tx_builder.set_fee(fee)?;
 
     let input_amount = inputs
         .iter()

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -700,13 +700,20 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
     // Resolve account server key if the receiver specifies an account service in
     // their public address
     tx_builder
-        .add_output(amount.value, target_address, rng)
+        .add_output(amount, target_address, rng)
         .map_err(Error::AddOutput)?;
 
     let change_destination = ChangeDestination::from(source_account_key);
 
     tx_builder
-        .add_change_output(change, &change_destination, rng)
+        .add_change_output(
+            Amount {
+                value: change,
+                token_id: amount.token_id,
+            },
+            &change_destination,
+            rng,
+        )
         .map_err(|err| {
             log::error!(logger, "Could not add change due to {:?}", err);
             Error::AddOutput(err)

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -378,14 +378,12 @@ pub extern "C" fn mc_transaction_builder_create(
 
         let mut transaction_builder = TransactionBuilder::new_with_box(
             block_version,
-            token_id,
+            Amount::new(fee, token_id),
             fog_resolver,
             memo_builder_box,
-        );
+        )
+        .expect("Could not create transaction builder");
 
-        transaction_builder
-            .set_fee(fee)
-            .expect("failure not expected");
         transaction_builder.set_tombstone_block(tombstone_block);
         Some(transaction_builder)
     })

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -19,7 +19,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockVersion, CompressedCommitment, EncryptedMemo, MaskedAmount, Token,
+    Amount, BlockVersion, CompressedCommitment, EncryptedMemo, MaskedAmount, Token,
 };
 
 use mc_transaction_std::{
@@ -498,6 +498,13 @@ pub extern "C" fn mc_transaction_builder_add_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
+        // TODO: If you want to support mixed transactions, use something other
+        // than fee_token_id here.
+        let amount = Amount {
+            value: amount,
+            token_id: transaction_builder.get_fee_token_id(),
+        };
+
         let (tx_out, confirmation) =
             transaction_builder.add_output(amount, &recipient_address, &mut rng)?;
 
@@ -540,6 +547,13 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .into_mut()
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
+
+        // TODO: If you want to support mixed transactions, use something other
+        // than fee_token_id here.
+        let amount = Amount {
+            value: amount,
+            token_id: transaction_builder.get_fee_token_id(),
+        };
 
         let (tx_out, confirmation) =
             transaction_builder.add_change_output(amount, &change_destination, &mut rng)?;

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -496,8 +496,8 @@ pub extern "C" fn mc_transaction_builder_add_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        // TODO: If you want to support mixed transactions, use something other
-        // than fee_token_id here.
+        // TODO (GH #1867): If you want to support mixed transactions, use something
+        // other than fee_token_id here.
         let amount = Amount {
             value: amount,
             token_id: transaction_builder.get_fee_token_id(),
@@ -546,8 +546,8 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        // TODO: If you want to support mixed transactions, use something other
-        // than fee_token_id here.
+        // TODO (GH #1867): If you want to support mixed transactions, use something
+        // other than fee_token_id here.
         let amount = Amount {
             value: amount,
             token_id: transaction_builder.get_fee_token_id(),

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -22,6 +22,7 @@ rocket = { version = "0.4.10", default-features = false }
 rocket_contrib = { version = "0.4.10", default-features = false, features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
+serde_with = "1.12"
 
 [dev-dependencies]
 mc-crypto-keys = { path = "../crypto/keys" }

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -296,11 +296,7 @@ fn create_request_code(
     let mut req = mc_mobilecoind_api::CreateRequestCodeRequest::new();
     req.set_receiver(receiver);
     if let Some(value) = request.value.clone() {
-        req.set_value(
-            value
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse value field: {}", err))?,
-        );
+        req.set_value(u64::from(value));
     }
     if let Some(memo) = request.memo.clone() {
         req.set_memo(memo);
@@ -409,11 +405,7 @@ fn build_and_submit(
     req.set_max_input_utxo_value(max_input_utxo_value);
     if let Some(subaddress) = transfer.change_subaddress.as_ref() {
         req.set_override_change_subaddress(true);
-        req.set_change_subaddress(
-            subaddress
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse change subaddress: {}", err))?,
-        )
+        req.set_change_subaddress(u64::from(subaddress))
     }
 
     let resp = state
@@ -447,10 +439,9 @@ fn pay_address_code(
     // Get max_input_utxo_value.
     let max_input_utxo_value = transfer
         .max_input_utxo_value
-        .clone()
-        .unwrap_or_else(|| "0".to_owned()) // A value of 0 disables the max limit.
-        .parse::<u64>()
-        .map_err(|err| format!("Failed to parse max_input_utxo_value: {}", err))?;
+        .as_ref()
+        .map(u64::from)
+        .unwrap_or(0);
 
     // Send the pay address code request
     let mut req = mc_mobilecoind_api::PayAddressCodeRequest::new();
@@ -461,11 +452,7 @@ fn pay_address_code(
     req.set_max_input_utxo_value(max_input_utxo_value);
     if let Some(subaddress) = transfer.change_subaddress.as_ref() {
         req.set_override_change_subaddress(true);
-        req.set_change_subaddress(
-            subaddress
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse change subaddress: {}", err))?,
-        )
+        req.set_change_subaddress(u64::from(subaddress))
     }
 
     let resp = state

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -392,21 +392,14 @@ fn build_and_submit(
     // Generate an outlay
     let mut outlay = mc_mobilecoind_api::Outlay::new();
     outlay.set_receiver(public_address);
-    outlay.set_value(
-        transfer
-            .request_data
-            .value
-            .parse::<u64>()
-            .map_err(|err| format!("Failed to parse request_code.amount: {}", err))?,
-    );
+    outlay.set_value(transfer.request_data.value.into());
 
     // Get max_input_utxo_value.
     let max_input_utxo_value = transfer
         .max_input_utxo_value
-        .clone()
-        .unwrap_or_else(|| "0".to_owned()) // A value of 0 disables the max limit.
-        .parse::<u64>()
-        .map_err(|err| format!("Failed to parse max_input_utxo_value: {}", err))?;
+        .as_ref()
+        .map(u64::from)
+        .unwrap_or(0);
 
     // Send the payment request
     let mut req = mc_mobilecoind_api::SendPaymentRequest::new();
@@ -449,10 +442,7 @@ fn pay_address_code(
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
     // Get amount.
-    let amount = transfer
-        .value
-        .parse::<u64>()
-        .map_err(|err| format!("Failed parsing amount: {}", err))?;
+    let amount = u64::from(transfer.value);
 
     // Get max_input_utxo_value.
     let max_input_utxo_value = transfer
@@ -509,13 +499,7 @@ fn generate_request_code_transaction(
     // Generate an outlay
     let mut outlay = mc_mobilecoind_api::Outlay::new();
     outlay.set_receiver(public_address);
-    outlay.set_value(
-        request
-            .transfer
-            .value
-            .parse::<u64>()
-            .map_err(|err| format!("Failed to parse amount: {}", err))?,
-    );
+    outlay.set_value(request.transfer.value.into());
 
     let inputs: Vec<mc_mobilecoind_api::UnspentTxOut> = request
         .input_list

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -295,7 +295,7 @@ fn create_request_code(
     // Generate b58 code
     let mut req = mc_mobilecoind_api::CreateRequestCodeRequest::new();
     req.set_receiver(receiver);
-    if let Some(value) = request.value.clone() {
+    if let Some(value) = request.value {
         req.set_value(u64::from(value));
     }
     if let Some(memo) = request.memo.clone() {

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -921,7 +921,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
         signature.set_ring_signatures(RepeatedField::from_vec(ring_sigs));
         signature.set_pseudo_output_commitments(RepeatedField::from_vec(commitments));
         let range_proof_bytes = hex::decode(&src.range_proof_bytes)
-            .map_err(|err| format!("Could not decode from hex: {}", err))?;
+            .map_err(|err| format!("Could not decode top-level range proof from hex '{}': {}", &src.range_proof_bytes, err))?;
         signature.set_range_proof_bytes(range_proof_bytes);
         let range_proofs: Vec<Vec<u8>> = src
             .range_proofs

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -937,6 +937,9 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             .collect::<Result<Vec<Vec<u8>>, String>>()?;
         signature.set_range_proofs(RepeatedField::from(range_proofs));
 
+        signature.set_pseudo_output_token_ids(signature.pseudo_output_token_ids.clone());
+        signature.set_output_token_ids(signature.output_token_ids.clone());
+
         Ok(signature)
     }
 }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -927,7 +927,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             .range_proofs
             .iter()
             .map(|hex_str| {
-                hex::decode(hex_str).map_err(|err| format!("Could not decode from hex: {}", err))
+                hex::decode(hex_str).map_err(|err| format!("Could not decode range proof from hex '{}': {}", hex_str, err))
             })
             .collect::<Result<Vec<Vec<u8>>, String>>()?;
         signature.set_range_proofs(RepeatedField::from(range_proofs));

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -11,6 +11,35 @@ use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
+// Represents u64 using string, when serializing to Json
+// Javascript integers are not 64 bit, and so it is not really proper json.
+// Using string avoids issues with some json parsers not handling large numbers
+// well.
+//
+// This does not rely on the serde-json arbitrary precision feature, which
+// (we fear) might break other things (e.g. https://github.com/serde-rs/json/issues/505)
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct JsonU64(#[serde(with = "serde_with::rust::display_fromstr")] pub u64);
+
+impl From<&u64> for JsonU64 {
+    fn from(src: &u64) -> Self {
+        Self(*src)
+    }
+}
+
+impl From<&JsonU64> for u64 {
+    fn from(src: &JsonU64) -> u64 {
+        src.0
+    }
+}
+
+impl From<JsonU64> for u64 {
+    fn from(src: JsonU64) -> u64 {
+        src.0
+    }
+}
+
 #[derive(Deserialize, Default, Debug)]
 pub struct JsonPasswordRequest {
     pub password: String,
@@ -148,7 +177,7 @@ pub struct JsonUnspentTxOut {
     pub tx_out: JsonTxOut,
     pub subaddress_index: u64,
     pub key_image: String,
-    pub value: String, // Needs to be String since Javascript ints are not 64 bit.
+    pub value: JsonU64,
     pub attempted_spend_height: u64,
     pub attempted_spend_tombstone: u64,
     pub monitor_id: String,
@@ -160,7 +189,7 @@ impl From<&mc_mobilecoind_api::UnspentTxOut> for JsonUnspentTxOut {
             tx_out: src.get_tx_out().into(),
             subaddress_index: src.get_subaddress_index(),
             key_image: hex::encode(&src.get_key_image().get_data()),
-            value: src.value.to_string(),
+            value: JsonU64(src.value),
             attempted_spend_height: src.get_attempted_spend_height(),
             attempted_spend_tombstone: src.get_attempted_spend_tombstone(),
             monitor_id: hex::encode(&src.get_monitor_id()),
@@ -187,11 +216,7 @@ impl TryFrom<&JsonUnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
         );
         utxo.set_subaddress_index(src.subaddress_index);
         utxo.set_key_image(key_image);
-        utxo.set_value(
-            src.value
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
-        );
+        utxo.set_value(src.value.into());
         utxo.set_attempted_spend_height(src.attempted_spend_height);
         utxo.set_attempted_spend_tombstone(src.attempted_spend_tombstone);
         utxo.set_monitor_id(
@@ -340,7 +365,7 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct JsonParseRequestCodeResponse {
     pub receiver: JsonPublicAddress,
-    pub value: String,
+    pub value: JsonU64,
     pub memo: String,
 }
 
@@ -348,7 +373,7 @@ impl From<&mc_mobilecoind_api::ParseRequestCodeResponse> for JsonParseRequestCod
     fn from(src: &mc_mobilecoind_api::ParseRequestCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
-            value: src.get_value().to_string(),
+            value: JsonU64(src.get_value()),
             memo: src.get_memo().to_string(),
         }
     }
@@ -428,7 +453,7 @@ impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub struct JsonSendPaymentRequest {
     pub request_data: JsonParseRequestCodeResponse,
-    pub max_input_utxo_value: Option<String>, // String due to u64 limitation.
+    pub max_input_utxo_value: Option<JsonU64>,
     pub change_subaddress: Option<String>,
 }
 
@@ -454,21 +479,21 @@ impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonSendPaymentResponse 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct JsonPayAddressCodeRequest {
     pub receiver_b58_address_code: String,
-    pub value: String,
+    pub value: JsonU64,
     pub max_input_utxo_value: Option<String>,
     pub change_subaddress: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonOutlay {
-    pub value: String,
+    pub value: JsonU64,
     pub receiver: JsonPublicAddress,
 }
 
 impl From<&mc_mobilecoind_api::Outlay> for JsonOutlay {
     fn from(src: &mc_mobilecoind_api::Outlay) -> Self {
         Self {
-            value: src.get_value().to_string(),
+            value: JsonU64(src.get_value()),
             receiver: src.get_receiver().into(),
         }
     }
@@ -479,11 +504,7 @@ impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
 
     fn try_from(src: &JsonOutlay) -> Result<mc_mobilecoind_api::Outlay, String> {
         let mut outlay = mc_mobilecoind_api::Outlay::new();
-        outlay.set_value(
-            src.value
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
-        );
+        outlay.set_value(src.value.into());
         outlay.set_receiver(
             PublicAddress::try_from(&src.receiver)
                 .map_err(|err| format!("Could not convert receiver: {}", err))?,
@@ -496,7 +517,7 @@ impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonMaskedAmount {
     pub commitment: String,
-    pub masked_value: String,
+    pub masked_value: JsonU64,
     pub masked_token_id: String,
 }
 
@@ -504,7 +525,7 @@ impl From<&MaskedAmount> for JsonMaskedAmount {
     fn from(src: &MaskedAmount) -> Self {
         Self {
             commitment: hex::encode(src.get_commitment().get_data()),
-            masked_value: src.get_masked_value().to_string(),
+            masked_value: JsonU64(src.get_masked_value()),
             masked_token_id: hex::encode(src.get_masked_token_id()),
         }
     }
@@ -543,12 +564,7 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
         );
         let mut masked_amount = MaskedAmount::new();
         masked_amount.set_commitment(commitment);
-        masked_amount.set_masked_value(
-            src.masked_amount
-                .masked_value
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from value: {}", err))?,
-        );
+        masked_amount.set_masked_value(src.masked_amount.masked_value.into());
         masked_amount.set_masked_token_id(
             hex::decode(&src.masked_amount.masked_token_id)
                 .map_err(|err| format!("Failed to decode masked token id hex: {}", err))?,
@@ -589,8 +605,8 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonRange {
-    pub from: String,
-    pub to: String,
+    pub from: JsonU64,
+    pub to: JsonU64,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
@@ -603,8 +619,8 @@ impl From<&TxOutMembershipElement> for JsonTxOutMembershipElement {
     fn from(src: &TxOutMembershipElement) -> Self {
         Self {
             range: JsonRange {
-                from: src.get_range().get_from().to_string(),
-                to: src.get_range().get_to().to_string(),
+                from: JsonU64(src.get_range().get_from()),
+                to: JsonU64(src.get_range().get_to()),
             },
             hash: hex::encode(src.get_hash().get_data()),
         }
@@ -613,16 +629,16 @@ impl From<&TxOutMembershipElement> for JsonTxOutMembershipElement {
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonTxOutMembershipProof {
-    pub index: String,
-    pub highest_index: String,
+    pub index: JsonU64,
+    pub highest_index: JsonU64,
     pub elements: Vec<JsonTxOutMembershipElement>,
 }
 
 impl From<&TxOutMembershipProof> for JsonTxOutMembershipProof {
     fn from(src: &TxOutMembershipProof) -> Self {
         Self {
-            index: src.get_index().to_string(),
-            highest_index: src.get_highest_index().to_string(),
+            index: JsonU64(src.get_index()),
+            highest_index: JsonU64(src.get_highest_index()),
             elements: src
                 .get_elements()
                 .iter()
@@ -639,20 +655,8 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
         let mut elements: Vec<TxOutMembershipElement> = Vec::new();
         for element in &src.elements {
             let mut range = mc_api::external::Range::new();
-            range.set_from(
-                element
-                    .range
-                    .from
-                    .parse::<u64>()
-                    .map_err(|err| format!("Failed to parse u64 from range.from: {}", err))?,
-            );
-            range.set_to(
-                element
-                    .range
-                    .to
-                    .parse::<u64>()
-                    .map_err(|err| format!("Failed to parse u64 from range.to: {}", err))?,
-            );
+            range.set_from(element.range.from.into());
+            range.set_to(element.range.to.into());
 
             let mut hash = TxOutMembershipHash::new();
             hash.set_data(
@@ -667,16 +671,8 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
         }
 
         let mut proof = TxOutMembershipProof::new();
-        proof.set_index(
-            src.index
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from index: {}", err))?,
-        );
-        proof.set_highest_index(
-            src.highest_index
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from highest_index: {}", err))?,
-        );
+        proof.set_index(src.index.into());
+        proof.set_highest_index(src.highest_index.into());
         proof.set_elements(RepeatedField::from_vec(elements));
 
         Ok(proof)
@@ -765,8 +761,8 @@ impl TryFrom<&JsonTxIn> for TxIn {
 pub struct JsonTxPrefix {
     pub inputs: Vec<JsonTxIn>,
     pub outputs: Vec<JsonTxOut>,
-    pub fee: String,
-    tombstone_block: String,
+    pub fee: JsonU64,
+    tombstone_block: JsonU64,
 }
 
 impl From<&TxPrefix> for JsonTxPrefix {
@@ -774,8 +770,8 @@ impl From<&TxPrefix> for JsonTxPrefix {
         Self {
             inputs: src.get_inputs().iter().map(JsonTxIn::from).collect(),
             outputs: src.get_outputs().iter().map(JsonTxOut::from).collect(),
-            fee: src.get_fee().to_string(),
-            tombstone_block: src.get_tombstone_block().to_string(),
+            fee: JsonU64(src.get_fee()),
+            tombstone_block: JsonU64(src.get_tombstone_block()),
         }
     }
 }
@@ -801,16 +797,8 @@ impl TryFrom<&JsonTxPrefix> for TxPrefix {
         let mut prefix = TxPrefix::new();
         prefix.set_inputs(RepeatedField::from_vec(inputs));
         prefix.set_outputs(RepeatedField::from_vec(outputs));
-        prefix.set_fee(
-            src.fee
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from fee: {}", err))?,
-        );
-        prefix.set_tombstone_block(
-            src.tombstone_block
-                .parse::<u64>()
-                .map_err(|err| format!("Failed to parse u64 from tombstone_block: {}", err))?,
-        );
+        prefix.set_fee(src.fee.into());
+        prefix.set_tombstone_block(src.tombstone_block.into());
 
         Ok(prefix)
     }
@@ -837,33 +825,14 @@ impl From<&RingMLSAG> for JsonRingMLSAG {
     }
 }
 
-// Representa TokenId (u64) using string, when serializing to Json
-// This does not rely on the serde-json arbitrary precision feature, which
-// (we fear) might break other things
-#[derive(Deserialize, Serialize, Default, Debug, Clone)]
-#[serde(transparent)]
-pub struct JsonTokenId(#[serde(with = "serde_with::rust::display_fromstr")] pub u64);
-
-impl From<&u64> for JsonTokenId {
-    fn from(src: &u64) -> Self {
-        Self(*src)
-    }
-}
-
-impl From<&JsonTokenId> for u64 {
-    fn from(src: &JsonTokenId) -> u64 {
-        src.0
-    }
-}
-
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]
 pub struct JsonSignatureRctBulletproofs {
     pub ring_signatures: Vec<JsonRingMLSAG>,
     pub pseudo_output_commitments: Vec<String>,
     pub range_proof_bytes: String,
     pub range_proofs: Vec<String>,
-    pub pseudo_output_token_ids: Vec<JsonTokenId>,
-    pub output_token_ids: Vec<JsonTokenId>,
+    pub pseudo_output_token_ids: Vec<JsonU64>,
+    pub output_token_ids: Vec<JsonU64>,
 }
 
 impl From<&SignatureRctBulletproofs> for JsonSignatureRctBulletproofs {
@@ -1226,30 +1195,30 @@ impl From<&mc_mobilecoind_api::GetTxStatusAsReceiverResponse> for JsonStatusResp
 
 #[derive(Serialize, Default, Debug)]
 pub struct JsonLedgerInfoResponse {
-    pub block_count: String,
-    pub txo_count: String,
+    pub block_count: JsonU64,
+    pub txo_count: JsonU64,
 }
 
 impl From<&mc_mobilecoind_api::GetLedgerInfoResponse> for JsonLedgerInfoResponse {
     fn from(src: &mc_mobilecoind_api::GetLedgerInfoResponse) -> Self {
         Self {
-            block_count: src.block_count.to_string(),
-            txo_count: src.txo_count.to_string(),
+            block_count: JsonU64(src.block_count),
+            txo_count: JsonU64(src.txo_count),
         }
     }
 }
 
 #[derive(Serialize, Default, Debug)]
 pub struct JsonBlockInfoResponse {
-    pub key_image_count: String,
-    pub txo_count: String,
+    pub key_image_count: JsonU64,
+    pub txo_count: JsonU64,
 }
 
 impl From<&mc_mobilecoind_api::GetBlockInfoResponse> for JsonBlockInfoResponse {
     fn from(src: &mc_mobilecoind_api::GetBlockInfoResponse) -> Self {
         Self {
-            key_image_count: src.key_image_count.to_string(),
-            txo_count: src.txo_count.to_string(),
+            key_image_count: JsonU64(src.key_image_count),
+            txo_count: JsonU64(src.txo_count),
         }
     }
 }
@@ -1259,8 +1228,8 @@ pub struct JsonBlockDetailsResponse {
     pub block_id: String,
     pub version: u32,
     pub parent_id: String,
-    pub index: String,
-    pub cumulative_txo_count: String,
+    pub index: JsonU64,
+    pub cumulative_txo_count: JsonU64,
     pub contents_hash: String,
     pub key_images: Vec<String>,
     pub txos: Vec<JsonTxOut>,
@@ -1274,8 +1243,8 @@ impl From<&mc_mobilecoind_api::GetBlockResponse> for JsonBlockDetailsResponse {
             block_id: hex::encode(&block.get_id().get_data()),
             version: block.get_version(),
             parent_id: hex::encode(&block.get_parent_id().get_data()),
-            index: block.get_index().to_string(),
-            cumulative_txo_count: block.get_cumulative_txo_count().to_string(),
+            index: JsonU64(block.get_index()),
+            cumulative_txo_count: JsonU64(block.get_cumulative_txo_count()),
             contents_hash: hex::encode(&block.get_contents_hash().get_data()),
             key_images: src
                 .get_key_images()
@@ -1293,7 +1262,7 @@ pub struct JsonProcessedTxOut {
     pub subaddress_index: u64,
     pub public_key: String,
     pub key_image: String,
-    pub value: String, // Needs to be String since Javascript ints are not 64 bit.
+    pub value: JsonU64,
     pub direction: String,
 }
 
@@ -1310,7 +1279,7 @@ impl From<&mc_mobilecoind_api::ProcessedTxOut> for JsonProcessedTxOut {
             subaddress_index: src.subaddress_index,
             public_key: hex::encode(&src.get_public_key().get_data()),
             key_image: hex::encode(&src.get_key_image().get_data()),
-            value: src.value.to_string(),
+            value: JsonU64(src.value),
             direction: direction_str.to_owned(),
         }
     }

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -864,7 +864,7 @@ impl From<&SignatureRctBulletproofs> for JsonSignatureRctBulletproofs {
             range_proofs: src
                 .get_range_proofs()
                 .iter()
-                .map(|bytes| hex::encode(bytes))
+                .map(hex::encode)
                 .collect(),
             pseudo_output_token_ids: src.pseudo_output_token_ids.clone(),
             output_token_ids: src.output_token_ids.clone(),

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -923,7 +923,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             )
         })?;
         signature.set_range_proof_bytes(range_proof_bytes);
-        let range_proofs: Vec<Vec<u8>> = src
+        let range_proofs = src
             .range_proofs
             .iter()
             .map(|hex_str| {

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -934,8 +934,8 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
                     )
                 })
             })
-            .collect::<Result<Vec<Vec<u8>>, String>>()?;
-        signature.set_range_proofs(RepeatedField::from(range_proofs));
+            .collect::<Result<_, _>>()?;
+        signature.set_range_proofs(range_proofs);
 
         signature.set_pseudo_output_token_ids(src.pseudo_output_token_ids.clone());
         signature.set_output_token_ids(src.output_token_ids.clone());

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -937,8 +937,8 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             .collect::<Result<Vec<Vec<u8>>, String>>()?;
         signature.set_range_proofs(RepeatedField::from(range_proofs));
 
-        signature.set_pseudo_output_token_ids(signature.pseudo_output_token_ids.clone());
-        signature.set_output_token_ids(signature.output_token_ids.clone());
+        signature.set_pseudo_output_token_ids(src.pseudo_output_token_ids.clone());
+        signature.set_output_token_ids(src.output_token_ids.clone());
 
         Ok(signature)
     }
@@ -1473,8 +1473,23 @@ mod test {
             proto2.get_tx().get_signature().pseudo_output_commitments
         );
         assert_eq!(
+            proto_proposal.get_tx().get_signature().range_proof_bytes,
+            proto2.get_tx().get_signature().range_proof_bytes,
+        );
+        assert_eq!(
             proto_proposal.get_tx().get_signature().range_proofs,
             proto2.get_tx().get_signature().range_proofs
+        );
+        assert_eq!(
+            proto_proposal
+                .get_tx()
+                .get_signature()
+                .pseudo_output_token_ids,
+            proto2.get_tx().get_signature().pseudo_output_token_ids,
+        );
+        assert_eq!(
+            proto_proposal.get_tx().get_signature().output_token_ids,
+            proto2.get_tx().get_signature().output_token_ids,
         );
 
         assert_eq!(proto_proposal.get_tx().signature, proto2.get_tx().signature);

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -248,7 +248,7 @@ impl From<&mc_mobilecoind_api::GetUnspentTxOutListResponse> for JsonUtxosRespons
 #[derive(Deserialize, Default, Debug)]
 pub struct JsonCreateRequestCodeRequest {
     pub receiver: JsonPublicAddress,
-    pub value: Option<String>,
+    pub value: Option<JsonU64>,
     pub memo: Option<String>,
 }
 
@@ -454,7 +454,7 @@ impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
 pub struct JsonSendPaymentRequest {
     pub request_data: JsonParseRequestCodeResponse,
     pub max_input_utxo_value: Option<JsonU64>,
-    pub change_subaddress: Option<String>,
+    pub change_subaddress: Option<JsonU64>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
@@ -480,8 +480,8 @@ impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonSendPaymentResponse 
 pub struct JsonPayAddressCodeRequest {
     pub receiver_b58_address_code: String,
     pub value: JsonU64,
-    pub max_input_utxo_value: Option<String>,
-    pub change_subaddress: Option<String>,
+    pub max_input_utxo_value: Option<JsonU64>,
+    pub change_subaddress: Option<JsonU64>,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone)]

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -861,11 +861,7 @@ impl From<&SignatureRctBulletproofs> for JsonSignatureRctBulletproofs {
                 .map(|x| hex::encode(x.get_data()))
                 .collect(),
             range_proof_bytes: hex::encode(src.get_range_proof_bytes()),
-            range_proofs: src
-                .get_range_proofs()
-                .iter()
-                .map(hex::encode)
-                .collect(),
+            range_proofs: src.get_range_proofs().iter().map(hex::encode).collect(),
             pseudo_output_token_ids: src.pseudo_output_token_ids.clone(),
             output_token_ids: src.output_token_ids.clone(),
         }
@@ -920,14 +916,23 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
         let mut signature = SignatureRctBulletproofs::new();
         signature.set_ring_signatures(RepeatedField::from_vec(ring_sigs));
         signature.set_pseudo_output_commitments(RepeatedField::from_vec(commitments));
-        let range_proof_bytes = hex::decode(&src.range_proof_bytes)
-            .map_err(|err| format!("Could not decode top-level range proof from hex '{}': {}", &src.range_proof_bytes, err))?;
+        let range_proof_bytes = hex::decode(&src.range_proof_bytes).map_err(|err| {
+            format!(
+                "Could not decode top-level range proof from hex '{}': {}",
+                &src.range_proof_bytes, err
+            )
+        })?;
         signature.set_range_proof_bytes(range_proof_bytes);
         let range_proofs: Vec<Vec<u8>> = src
             .range_proofs
             .iter()
             .map(|hex_str| {
-                hex::decode(hex_str).map_err(|err| format!("Could not decode range proof from hex '{}': {}", hex_str, err))
+                hex::decode(hex_str).map_err(|err| {
+                    format!(
+                        "Could not decode range proof from hex '{}': {}",
+                        hex_str, err
+                    )
+                })
             })
             .collect::<Result<Vec<Vec<u8>>, String>>()?;
         signature.set_range_proofs(RepeatedField::from(range_proofs));

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -869,17 +869,16 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         // TODO: Use RTH memo builder, optionally?
 
+        let fee_amount = Amount::new(fee, token_id);
+
         // Create tx_builder.
         let mut tx_builder = TransactionBuilder::new(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver,
             EmptyMemoBuilder::default(),
-        );
-
-        tx_builder
-            .set_fee(fee)
-            .map_err(|err| Error::TxBuild(format!("Error setting fee: {}", err)))?;
+        )
+        .map_err(|err| Error::TxBuild(format!("Error creating transaction builder: {}", err)))?;
 
         // Unzip each vec of tuples into a tuple of vecs.
         let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -988,20 +988,24 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
         let change = input_value - total_value - tx_builder.get_fee();
 
-        // TODO: If you want to support mixed transactions, use outlay-specific token id
-        // here
-        let change_amount = Amount {
-            value: change,
-            token_id,
-        };
+        // If we do have nonzero change, add an output for that as well.
+        // TODO: Should the exchange write destination memos?
+        // If so then we must always write a change output, even if the change is zero
+        if change > 0 {
+            // TODO: If you want to support mixed transactions, use outlay-specific token id
+            // here
+            let change_amount = Amount {
+                value: change,
+                token_id,
+            };
 
-        // If we do, add an output for that as well.
-        let change_dest =
-            ChangeDestination::from_subaddress_index(from_account_key, change_subaddress);
+            let change_dest =
+                ChangeDestination::from_subaddress_index(from_account_key, change_subaddress);
 
-        tx_builder
-            .add_change_output(change_amount, &change_dest, rng)
-            .map_err(|err| Error::TxBuild(format!("failed adding output (change): {}", err)))?;
+            tx_builder
+                .add_change_output(change_amount, &change_dest, rng)
+                .map_err(|err| Error::TxBuild(format!("failed adding output (change): {}", err)))?;
+        }
 
         // Set tombstone block.
         tx_builder.set_tombstone_block(tombstone_block);

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -867,7 +867,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             fog_resolver_factory(&fog_uris).map_err(Error::Fog)?
         };
 
-        // TODO: Use RTH memo builder, optionally?
+        // TODO (GH #1522): Use RTH memo builder, optionally?
 
         let fee_amount = Amount::new(fee, token_id);
 
@@ -962,8 +962,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_out_to_outlay_index = HashMap::default();
         let mut outlay_confirmation_numbers = Vec::default();
         for (i, outlay) in destinations.iter().enumerate() {
-            // TODO: If you want to support mixed transactions, use outlay-specific token id
-            // here
+            // TODO (GH #1867): If you want to support mixed transactions, use
+            // outlay-specific token id here
             let amount = Amount {
                 value: outlay.value,
                 token_id,
@@ -988,7 +988,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let change = input_value - total_value - tx_builder.get_fee();
 
         // If we do have nonzero change, add an output for that as well.
-        // TODO: Should the exchange write destination memos?
+        // TODO (GH #1522): Should the exchange write destination memos?
         // If so then we must always write a change output, even if the change is zero
         if change > 0 {
             // TODO: If you want to support mixed transactions, use outlay-specific token id

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2922,14 +2922,7 @@ mod test {
             EmptyMemoBuilder::default(),
         );
         let (tx_out, tx_confirmation) = transaction_builder
-            .add_output(
-                Amount {
-                    value: 10,
-                    token_id: Mob::ID,
-                },
-                &receiver.subaddress(0),
-                &mut rng,
-            )
+            .add_output(Amount::new(10, Mob::ID), &receiver.subaddress(0), &mut rng)
             .unwrap();
 
         add_txos_to_ledger_db(BLOCK_VERSION, &mut ledger_db, &[tx_out.clone()], &mut rng);
@@ -5243,10 +5236,7 @@ mod test {
         );
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
-                Amount {
-                    value: 10,
-                    token_id: Mob::ID,
-                },
+                Amount::new(10, Mob::ID),
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
                 &mut rng,
             )
@@ -5358,10 +5348,7 @@ mod test {
         );
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
-                Amount {
-                    value: 10,
-                    token_id: Mob::ID,
-                },
+                Amount::new(10, Mob::ID),
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
                 &mut rng,
             )

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2922,7 +2922,14 @@ mod test {
             EmptyMemoBuilder::default(),
         );
         let (tx_out, tx_confirmation) = transaction_builder
-            .add_output(10, &receiver.subaddress(0), &mut rng)
+            .add_output(
+                Amount {
+                    value: 10,
+                    token_id: Mob::ID,
+                },
+                &receiver.subaddress(0),
+                &mut rng,
+            )
             .unwrap();
 
         add_txos_to_ledger_db(BLOCK_VERSION, &mut ledger_db, &[tx_out.clone()], &mut rng);
@@ -5236,7 +5243,10 @@ mod test {
         );
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
-                10,
+                Amount {
+                    value: 10,
+                    token_id: Mob::ID,
+                },
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
                 &mut rng,
             )
@@ -5348,7 +5358,10 @@ mod test {
         );
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
-                10,
+                Amount {
+                    value: 10,
+                    token_id: Mob::ID,
+                },
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
                 &mut rng,
             )

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2917,10 +2917,11 @@ mod test {
         let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, tx_confirmation) = transaction_builder
             .add_output(Amount::new(10, Mob::ID), &receiver.subaddress(0), &mut rng)
             .unwrap();
@@ -5230,10 +5231,11 @@ mod test {
 
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 Amount::new(10, Mob::ID),
@@ -5342,10 +5344,11 @@ mod test {
 
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 Amount::new(10, Mob::ID),

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -52,6 +52,7 @@ features = ["default-code-coverage"]
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "u64_backend"] }
 
 [dev-dependencies]
+assert_matches = "1.5"
 rand = "0.8"
 rand_hc = "0.3"
 tempdir = "0.3"

--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -41,6 +41,13 @@ pub struct Amount {
     pub token_id: TokenId,
 }
 
+impl Amount {
+    /// Create a new amount
+    pub fn new(value: u64, token_id: TokenId) -> Self {
+        Self { value, token_id }
+    }
+}
+
 /// A commitment to an amount of MobileCoin or a related token, as it appears on
 /// the blockchain. This is a "blinded" commitment, and only the sender and
 /// receiver know the value and token id.

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -57,7 +57,7 @@ impl FromStr for BlockVersion {
 impl BlockVersion {
     /// The maximum value of block_version that this build of
     /// mc-transaction-core has support for
-    pub const MAX: Self = Self(2);
+    pub const MAX: Self = Self(3);
 
     /// Refers to the block version number at network launch.
     pub const ZERO: Self = Self(0);
@@ -67,6 +67,9 @@ impl BlockVersion {
 
     /// Constant for block version two
     pub const TWO: Self = Self(2);
+
+    /// Constant for block version two
+    pub const THREE: Self = Self(3);
 
     /// Iterator over block versions from one up to max, inclusive. For use in
     /// tests.
@@ -101,6 +104,12 @@ impl BlockVersion {
     /// in block version 2 and higher. This is described in MCIP #25.
     pub fn mlsags_sign_extended_message_digest(&self) -> bool {
         self.0 >= 2
+    }
+
+    /// Mixed transactions [MCIP #31](https://github.com/mobilecoinfoundation/mcips/pull/31)
+    /// are introduced in block version 3
+    pub fn mixed_transactions_are_supported(&self) -> bool {
+        self.0 >= 3
     }
 }
 

--- a/transaction/core/src/blockchain/block_version.rs
+++ b/transaction/core/src/blockchain/block_version.rs
@@ -68,7 +68,7 @@ impl BlockVersion {
     /// Constant for block version two
     pub const TWO: Self = Self(2);
 
-    /// Constant for block version two
+    /// Constant for block version three
     pub const THREE: Self = Self(3);
 
     /// Iterator over block versions from one up to max, inclusive. For use in

--- a/transaction/core/src/range_proofs/error.rs
+++ b/transaction/core/src/range_proofs/error.rs
@@ -6,7 +6,7 @@ use bulletproofs_og::ProofError;
 use displaydoc::Display;
 
 /// An error which can occur in connection to a range proof
-#[derive(Debug, Display, PartialEq)]
+#[derive(Debug, Clone, Eq, Display, PartialEq)]
 pub enum Error {
     /// ProofError: `{0:?}`
     ProofError(ProofError),

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -2,7 +2,7 @@
 
 //! Errors which can occur in connection to ring signatures
 
-use crate::range_proofs::error::Error as RangeProofError;
+use crate::{range_proofs::error::Error as RangeProofError, TokenId};
 use alloc::string::{String, ToString};
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
@@ -81,6 +81,9 @@ pub enum Error {
 
     /// Missing expected range proofs (expected: {0}, found: {1})
     MissingRangeProofs(usize, usize),
+
+    /// No commitments were found for {0}, this is a logic error
+    NoCommitmentsForTokenId(TokenId),
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 
 /// An error which can occur in connection to a ring signature
-#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum Error {
     /// Incorrect length for array copy, provided `{0}`, required `{1}`.
     LengthMismatch(usize, usize),

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -50,10 +50,10 @@ pub enum Error {
     ValueNotConserved,
 
     /// Invalid RangeProof: {0}
-    RangeProofError(String),
+    RangeProof(String),
 
     /// RangeProof Deserialization failed
-    RangeProofDeserializationError,
+    RangeProofDeserialization,
 
     /// TokenId is not allowed at this block version
     TokenIdNotAllowed,
@@ -91,6 +91,6 @@ impl From<mc_util_repr_bytes::LengthMismatch> for Error {
 
 impl From<RangeProofError> for Error {
     fn from(src: RangeProofError) -> Self {
-        Error::RangeProofError(src.to_string())
+        Error::RangeProof(src.to_string())
     }
 }

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -2,13 +2,13 @@
 
 //! Errors which can occur in connection to ring signatures
 
+use crate::range_proofs::error::Error as RangeProofError;
+use alloc::string::{String, ToString};
 use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 
 /// An error which can occur in connection to a ring signature
-#[derive(
-    Clone, Copy, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum Error {
     /// Incorrect length for array copy, provided `{0}`, required `{1}`.
     LengthMismatch(usize, usize),
@@ -49,8 +49,8 @@ pub enum Error {
      */
     ValueNotConserved,
 
-    /// Invalid RangeProof
-    RangeProofError,
+    /// Invalid RangeProof: {0}
+    RangeProofError(String),
 
     /// RangeProof Deserialization failed
     RangeProofDeserializationError,
@@ -86,5 +86,11 @@ pub enum Error {
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {
     fn from(src: mc_util_repr_bytes::LengthMismatch) -> Self {
         Error::LengthMismatch(src.found, src.expected)
+    }
+}
+
+impl From<RangeProofError> for Error {
+    fn from(src: RangeProofError) -> Self {
+        Error::RangeProofError(src.to_string())
     }
 }

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -52,8 +52,35 @@ pub enum Error {
     /// Invalid RangeProof
     RangeProofError,
 
+    /// RangeProof Deserialization failed
+    RangeProofDeserializationError,
+
     /// TokenId is not allowed at this block version
     TokenIdNotAllowed,
+
+    /// Missing pseudo-output token ids
+    MissingPseudoOutputTokenIds,
+
+    /// Missing output token ids
+    MissingOutputTokenIds,
+
+    /// Pseudo-output token ids not allowed at this block version
+    PseudoOutputTokenIdsNotAllowed,
+
+    /// Output token ids not allowed at this block version
+    OutputTokenIdsNotAllowed,
+
+    /// Mixed token ids in transactions not allowed at this block version
+    MixedTransactionsNotAllowed,
+
+    /// Too many range proofs for the block version
+    TooManyRangeProofs,
+
+    /// Unexpected range proof for the block version
+    UnexpectedRangeProof,
+
+    /// Missing expected range proofs (expected: {0}, found: {1})
+    MissingRangeProofs(usize, usize),
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {

--- a/transaction/core/src/ring_signature/generator_cache.rs
+++ b/transaction/core/src/ring_signature/generator_cache.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The MobileCoin Foundation
+// Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! A simple generator cache
 

--- a/transaction/core/src/ring_signature/generator_cache.rs
+++ b/transaction/core/src/ring_signature/generator_cache.rs
@@ -1,0 +1,25 @@
+//! A simple generator cache
+
+use super::{generators, PedersenGens};
+use crate::TokenId;
+use alloc::collections::BTreeMap;
+
+/// GeneratorCache is a simple object which caches computations of
+/// generator: TokenId -> RistrettoPoint
+///
+/// This is intended just to be used in the scope of a single transaction,
+/// and we therefore don't require it to be constant-time.
+#[derive(Default, Clone)]
+pub struct GeneratorCache {
+    cache: BTreeMap<TokenId, PedersenGens>,
+}
+
+impl GeneratorCache {
+    /// Get (and if necessary, cache) the Pedersen Generators corresponding to
+    /// a particular token id.
+    pub fn get(&mut self, token_id: TokenId) -> &PedersenGens {
+        self.cache
+            .entry(token_id)
+            .or_insert_with(|| generators(*token_id))
+    }
+}

--- a/transaction/core/src/ring_signature/generator_cache.rs
+++ b/transaction/core/src/ring_signature/generator_cache.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
 //! A simple generator cache
 
 use super::{generators, PedersenGens};
@@ -5,7 +7,7 @@ use crate::TokenId;
 use alloc::collections::BTreeMap;
 
 /// GeneratorCache is a simple object which caches computations of
-/// generator: TokenId -> RistrettoPoint
+/// generator: TokenId -> PedersenGens
 ///
 /// This is intended just to be used in the scope of a single transaction,
 /// and we therefore don't require it to be constant-time.

--- a/transaction/core/src/ring_signature/generator_cache.rs
+++ b/transaction/core/src/ring_signature/generator_cache.rs
@@ -9,8 +9,8 @@ use alloc::collections::BTreeMap;
 /// GeneratorCache is a simple object which caches computations of
 /// generator: TokenId -> PedersenGens
 ///
-/// This is intended just to be used in the scope of a single transaction,
-/// and we therefore don't require it to be constant-time.
+/// This is intended just to be used in the scope of constructing or validating
+/// a single transaction, and we therefore don't require it to be constant-time.
 #[derive(Default, Clone)]
 pub struct GeneratorCache {
     cache: BTreeMap<TokenId, PedersenGens>,

--- a/transaction/core/src/ring_signature/mod.rs
+++ b/transaction/core/src/ring_signature/mod.rs
@@ -14,12 +14,14 @@ use mc_crypto_keys::RistrettoPublic;
 
 mod curve_scalar;
 mod error;
+mod generator_cache;
 mod key_image;
 mod mlsag;
 mod rct_bulletproofs;
 
 pub use curve_scalar::*;
 pub use error::Error;
+pub use generator_cache::*;
 pub use key_image::*;
 pub use mlsag::*;
 pub use rct_bulletproofs::*;

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -66,7 +66,7 @@ pub struct SignatureRctBulletproofs {
     /// struct may derive Default, which is a requirement for serializing
     /// with Prost.
     ///
-    /// Note: This is EMPTY if mixed transactions is enabled
+    /// Note: This is EMPTY if mixed transactions are enabled
     #[prost(bytes, tag = "3")]
     #[digestible(never_omit)]
     pub range_proof_bytes: Vec<u8>,

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -510,10 +510,9 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
                 }))
                 .unzip();
 
-            assert!(
-                !values.is_empty(),
-                "logic error when accumulating commitments for token id"
-            );
+            if values.is_empty() {
+                return Err(Error::NoCommitmentsForTokenId(token_id));
+            }
 
             let (range_proof, _commitments) =
                 generate_range_proofs(&values, &blindings, generator, rng)?;

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -251,7 +251,7 @@ impl SignatureRctBulletproofs {
                 .collect();
 
             let range_proof = RangeProof::from_bytes(&self.range_proof_bytes)
-                .map_err(|_e| Error::RangeProofDeserializationError)?;
+                .map_err(|_e| Error::RangeProofDeserialization)?;
 
             check_range_proofs(&range_proof, &commitments, generator, rng)?
         } else {
@@ -293,7 +293,7 @@ impl SignatureRctBulletproofs {
                 );
 
                 let range_proof = RangeProof::from_bytes(range_proof)
-                    .map_err(|_e| Error::RangeProofDeserializationError)?;
+                    .map_err(|_e| Error::RangeProofDeserialization)?;
 
                 check_range_proofs(&range_proof, &commitments, generator, rng)?
             }

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -8,7 +8,9 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
+use alloc::vec;
+
+use alloc::{collections::BTreeSet, vec::Vec};
 use bulletproofs_og::RangeProof;
 use core::convert::TryFrom;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
@@ -23,9 +25,33 @@ use crate::{
     constants::FEE_BLINDING,
     domain_separators::EXTENDED_MESSAGE_DOMAIN_TAG,
     range_proofs::{check_range_proofs, generate_range_proofs},
-    ring_signature::{generators, mlsag::RingMLSAG, Error, KeyImage, Scalar},
-    BlockVersion, Commitment, CompressedCommitment,
+    ring_signature::{mlsag::RingMLSAG, Error, GeneratorCache, KeyImage, Scalar},
+    BlockVersion, Commitment, CompressedCommitment, TokenId,
 };
+
+/// The secrets corresponding to an input needed to create a signature
+#[derive(Clone, Debug)]
+pub struct InputSecret {
+    /// The one-time private key for the output we are trying to spend
+    pub onetime_private_key: RistrettoPrivate,
+    /// The value of the output we are trying to spend
+    pub value: u64,
+    /// The token id of the output we are trying to spend
+    pub token_id: TokenId,
+    /// The blinding factor of the output we are trying to spend
+    pub blinding: Scalar,
+}
+
+/// The secrets corresponding to an output needed to create a signature
+#[derive(Clone, Debug)]
+pub struct OutputSecret {
+    /// The value of the output we are creating
+    pub value: u64,
+    /// The token id of the output we are creating
+    pub token_id: TokenId,
+    /// The blinding factor of the output we are creating
+    pub blinding: Scalar,
+}
 
 /// An RCT_TYPE_BULLETPROOFS_2 signature
 #[derive(Clone, Digestible, Eq, PartialEq, Serialize, Deserialize, Message)]
@@ -42,9 +68,27 @@ pub struct SignatureRctBulletproofs {
     /// This contains range_proof.to_bytes(). It is stored this way so that this
     /// struct may derive Default, which is a requirement for serializing
     /// with Prost.
+    ///
+    /// Note: This is EMPTY if mixed transactions is enabled
     #[prost(bytes, tag = "3")]
     #[digestible(never_omit)]
     pub range_proof_bytes: Vec<u8>,
+
+    /// A range proof, one for each token id that is used in the transaction.
+    ///
+    /// The range proofs correspond to the sorted order of token ids used.
+    #[prost(bytes, repeated, tag = "4")]
+    pub range_proofs: Vec<Vec<u8>>,
+
+    /// Token id for each pseudo_output. This must have the same length as
+    /// `pseudo_output_commitments`, after mixed transactions feature.
+    #[prost(fixed64, repeated, tag = "5")]
+    pub pseudo_output_token_ids: Vec<u64>,
+
+    /// Token id for each output. This must have the same length as
+    /// `prefix.outputs`, after mixed transactions feature
+    #[prost(fixed64, repeated, tag = "6")]
+    pub output_token_ids: Vec<u64>,
 }
 
 impl SignatureRctBulletproofs {
@@ -67,10 +111,10 @@ impl SignatureRctBulletproofs {
         message: &[u8; 32],
         rings: &[Vec<(CompressedRistrettoPublic, CompressedCommitment)>],
         real_input_indices: &[usize],
-        input_secrets: &[(RistrettoPrivate, u64, Scalar)],
-        output_values_and_blindings: &[(u64, Scalar)],
+        input_secrets: &[InputSecret],
+        output_secrets: &[OutputSecret],
         fee: u64,
-        token_id: u64,
+        fee_token_id: TokenId,
         rng: &mut CSPRNG,
     ) -> Result<Self, Error> {
         sign_with_balance_check(
@@ -79,9 +123,9 @@ impl SignatureRctBulletproofs {
             rings,
             real_input_indices,
             input_secrets,
-            output_values_and_blindings,
+            output_secrets,
             fee,
-            token_id,
+            fee_token_id,
             true,
             rng,
         )
@@ -96,7 +140,8 @@ impl SignatureRctBulletproofs {
     ///   commitments.
     /// * `output_commitments` - Output amount commitments.
     /// * `fee` - Value of the implicit fee output.
-    /// * `token id` - This determines the pedersen generator for commitments
+    /// * `fee_token id` - This determines the pedersen generator for fee
+    ///   commitment
     /// * `rng` - randomness
     pub fn verify<CSPRNG: RngCore + CryptoRng>(
         &self,
@@ -105,10 +150,10 @@ impl SignatureRctBulletproofs {
         rings: &[Vec<(CompressedRistrettoPublic, CompressedCommitment)>],
         output_commitments: &[CompressedCommitment],
         fee: u64,
-        token_id: u64,
+        fee_token_id: TokenId,
         rng: &mut CSPRNG,
     ) -> Result<(), Error> {
-        if !block_version.masked_token_id_feature_is_supported() && token_id != 0 {
+        if !block_version.masked_token_id_feature_is_supported() && fee_token_id != 0 {
             return Err(Error::TokenIdNotAllowed);
         }
 
@@ -126,6 +171,23 @@ impl SignatureRctBulletproofs {
                 rings.len(),
                 self.pseudo_output_commitments.len(),
             ));
+        }
+
+        // pseudo output token ids must be provided if mixed transactions is enabled
+        if block_version.mixed_transactions_are_supported() {
+            if self.pseudo_output_commitments.len() != self.pseudo_output_token_ids.len() {
+                return Err(Error::MissingPseudoOutputTokenIds);
+            }
+            if output_commitments.len() != self.output_token_ids.len() {
+                return Err(Error::MissingOutputTokenIds);
+            }
+        } else {
+            if !self.pseudo_output_token_ids.is_empty() {
+                return Err(Error::PseudoOutputTokenIdsNotAllowed);
+            }
+            if !self.output_token_ids.is_empty() {
+                return Err(Error::OutputTokenIdsNotAllowed);
+            }
         }
 
         // Key images must be unique.
@@ -155,11 +217,32 @@ impl SignatureRctBulletproofs {
             decompressed_pseudo_output_commitments.push(commitment);
         }
 
-        // Compute the pedersen generators for this token_id
-        let generator = generators(token_id);
+        // Collect list of of unique token ids
+        let token_ids = {
+            let mut token_ids = BTreeSet::default();
+            token_ids.insert(fee_token_id);
+            for token_id in &self.output_token_ids {
+                token_ids.insert(token_id.into());
+            }
+            for token_id in &self.pseudo_output_token_ids {
+                token_ids.insert(token_id.into());
+            }
+            token_ids
+        };
+
+        // Get a generator cache
+        let mut generator_cache = GeneratorCache::default();
 
         // pseudo_output_commitments and output commitments must be in [0, 2^64).
-        {
+        // this is done differently depending on if mixed transactions are supported
+        if !block_version.mixed_transactions_are_supported() {
+            // Before mixed transactions, we expect the range proof to appear in
+            // self.range_proof_bytes, not self.range_proofs
+            if !self.range_proofs.is_empty() {
+                return Err(Error::TooManyRangeProofs);
+            }
+
+            let generator = generator_cache.get(fee_token_id);
             let commitments: Vec<CompressedRistretto> = self
                 .pseudo_output_commitments
                 .iter()
@@ -168,10 +251,54 @@ impl SignatureRctBulletproofs {
                 .collect();
 
             let range_proof = RangeProof::from_bytes(&self.range_proof_bytes)
-                .map_err(|_e| Error::RangeProofError)?;
+                .map_err(|_e| Error::RangeProofDeserializationError)?;
 
-            check_range_proofs(&range_proof, &commitments, &generator, rng)
+            check_range_proofs(&range_proof, &commitments, generator, rng)
                 .map_err(|_e| Error::RangeProofError)?;
+        } else {
+            // When mixed transactions are supported, self.range_proofs should contain
+            // a range proof correspond to each token id used in the transaction, in sorted
+            // order. range_proof_bytes should be empty
+            if !self.range_proof_bytes.is_empty() {
+                return Err(Error::UnexpectedRangeProof);
+            }
+            if token_ids.len() != self.range_proofs.len() {
+                return Err(Error::MissingRangeProofs(
+                    token_ids.len(),
+                    self.range_proofs.len(),
+                ));
+            }
+
+            // For each used token id, and range proof, we have to pick out the matching
+            // outputs and pseudo outputs and verify the range proof.
+            for (token_id, range_proof) in token_ids.iter().zip(self.range_proofs.iter()) {
+                let generator = generator_cache.get(*token_id);
+
+                let commitments: Vec<CompressedRistretto> = self
+                    .pseudo_output_commitments
+                    .iter()
+                    .zip(self.pseudo_output_token_ids.iter())
+                    .chain(output_commitments.iter().zip(self.output_token_ids.iter()))
+                    .filter_map(|(compressed_commitment, this_token_id)| {
+                        if token_id == this_token_id {
+                            Some(compressed_commitment.point)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+                assert!(
+                    !commitments.is_empty(),
+                    "logic error when accumulating commitments for token id"
+                );
+
+                let range_proof = RangeProof::from_bytes(range_proof)
+                    .map_err(|_e| Error::RangeProofDeserializationError)?;
+
+                check_range_proofs(&range_proof, &commitments, generator, rng)
+                    .map_err(|_e| Error::RangeProofError)?;
+            }
         }
 
         // Compute sum of pseudo outputs
@@ -189,6 +316,7 @@ impl SignatureRctBulletproofs {
                 .sum();
 
             // The implicit fee output.
+            let generator = generator_cache.get(fee_token_id);
             let fee_commitment = generator.commit(Scalar::from(fee), *FEE_BLINDING);
             let difference =
                 sum_of_output_commitments + fee_commitment - sum_of_pseudo_output_commitments;
@@ -203,6 +331,7 @@ impl SignatureRctBulletproofs {
             message,
             &self.pseudo_output_commitments,
             &self.range_proof_bytes,
+            &self.range_proofs,
         );
 
         // Each MLSAG must be valid.
@@ -232,11 +361,11 @@ impl SignatureRctBulletproofs {
 /// * `message` - The messages to be signed, e.g. Hash(TxPrefix).
 /// * `rings` - One or more rings of one-time addresses and amount commitments.
 /// * `real_input_indices` - The index of the real input in each ring.
-/// * `input_secrets` - One-time private key, amount value, and amount blinding
-///   for each real input.
-/// * `output_values_and_blindings` - Value and blinding for each output amount
+/// * `input_secrets` - Input secret for each real input.
+/// * `output_values_and_blindings` - Output secret for each output amount
 ///   commitment.
 /// * `fee` - Value of the implicit fee output.
+/// * `fee_token_id` - Token id of the fee output.
 /// * `check_value_is_preserved` - If true, check that the value of inputs
 /// * `rng` - randomness
 fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
@@ -244,15 +373,29 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     message: &[u8; 32],
     rings: &[Vec<(CompressedRistrettoPublic, CompressedCommitment)>],
     real_input_indices: &[usize],
-    input_secrets: &[(RistrettoPrivate, u64, Scalar)],
-    output_values_and_blindings: &[(u64, Scalar)],
+    input_secrets: &[InputSecret],
+    output_secrets: &[OutputSecret],
     fee: u64,
-    token_id: u64,
+    fee_token_id: TokenId,
     check_value_is_preserved: bool,
     rng: &mut CSPRNG,
 ) -> Result<SignatureRctBulletproofs, Error> {
-    if !block_version.masked_token_id_feature_is_supported() && token_id != 0 {
+    if !block_version.masked_token_id_feature_is_supported() && fee_token_id != 0 {
         return Err(Error::TokenIdNotAllowed);
+    }
+
+    // input and output token ids must match fee_token_id if mixed transactions is
+    // not enabled
+    if !block_version.mixed_transactions_are_supported() {
+        if input_secrets.iter().any(|sec| sec.token_id != fee_token_id) {
+            return Err(Error::MixedTransactionsNotAllowed);
+        }
+        if output_secrets
+            .iter()
+            .any(|sec| sec.token_id != fee_token_id)
+        {
+            return Err(Error::MixedTransactionsNotAllowed);
+        }
     }
 
     if rings.is_empty() {
@@ -295,10 +438,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     //
     // Note: This implicit fee output is not the same as the accumulated fee output
     // produced by the enclave -- the blinding of that output is not zero.
-    let sum_of_output_blindings: Scalar = output_values_and_blindings
-        .iter()
-        .map(|(_, blinding)| blinding)
-        .sum();
+    let sum_of_output_blindings: Scalar = output_secrets.iter().map(|secret| secret.blinding).sum();
 
     let sum_of_pseudo_output_blindings: Scalar = pseudo_output_blindings.iter().sum();
     let last_blinding: Scalar = sum_of_output_blindings - sum_of_pseudo_output_blindings;
@@ -308,35 +448,112 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     let pseudo_output_values_and_blindings: Vec<(u64, Scalar)> = input_secrets
         .iter()
         .zip(pseudo_output_blindings.iter())
-        .map(|((_, value, _), blinding)| (*value, *blinding))
+        .map(|(secret, blinding)| (secret.value, *blinding))
         .collect();
 
-    // Compute the pedersen generators for this token_id
-    let generator = generators(token_id);
+    // Create a pedersen generator cache
+    let mut generator_cache = GeneratorCache::default();
 
-    let (range_proof, commitments) = {
+    // Range proof is present when mixed transactions are not supported, the set of
+    // range proofs is present when they are.
+    let (range_proof, range_proofs) = if !block_version.mixed_transactions_are_supported() {
         // The implicit fee output is omitted from the range proof because it is known.
+        let generator = generator_cache.get(fee_token_id);
 
         let (values, blindings): (Vec<_>, Vec<_>) = pseudo_output_values_and_blindings
             .iter()
-            .chain(output_values_and_blindings.iter())
-            .map(|(value, blinding)| (*value, *blinding))
+            .cloned()
+            .chain(
+                output_secrets
+                    .iter()
+                    .map(|secret| (secret.value, secret.blinding)),
+            )
             .unzip();
-        generate_range_proofs(&values, &blindings, &generator, rng)
-            .map_err(|_e| Error::RangeProofError)?
+        let (range_proof, _commitments) =
+            generate_range_proofs(&values, &blindings, generator, rng)
+                .map_err(|_e| Error::RangeProofError)?;
+
+        (range_proof.to_bytes().to_vec(), vec![])
+    } else {
+        let mut range_proofs = Vec::default();
+
+        // Collect list of of unique token ids
+        let token_ids = {
+            let mut token_ids = BTreeSet::default();
+            token_ids.insert(fee_token_id);
+            for secret in input_secrets {
+                token_ids.insert(secret.token_id);
+            }
+            for secret in output_secrets {
+                token_ids.insert(secret.token_id);
+            }
+            token_ids
+        };
+
+        for token_id in token_ids {
+            let generator = generator_cache.get(token_id);
+
+            // The input blinding is not the same as corresponding pseudo-output blinding
+            let (values, blindings): (Vec<_>, Vec<_>) = input_secrets
+                .iter()
+                .zip(pseudo_output_blindings.iter())
+                .filter_map(|(secret, blinding)| {
+                    if secret.token_id == token_id {
+                        Some((secret.value, *blinding))
+                    } else {
+                        None
+                    }
+                })
+                .chain(output_secrets.iter().filter_map(|secret| {
+                    if secret.token_id == token_id {
+                        Some((secret.value, secret.blinding))
+                    } else {
+                        None
+                    }
+                }))
+                .unzip();
+
+            assert!(
+                !values.is_empty(),
+                "logic error when accumulating commitments for token id"
+            );
+
+            let (range_proof, _commitments) =
+                generate_range_proofs(&values, &blindings, generator, rng)
+                    .map_err(|_e| Error::RangeProofError)?;
+
+            range_proofs.push(range_proof.to_bytes());
+        }
+
+        (Default::default(), range_proofs)
     };
 
+    // The actual pseudo output commitments use the blindings from
+    // `pseudo_output_blinding` and not the original true input.
+    let pseudo_output_commitments: Vec<RistrettoPoint> = input_secrets
+        .iter()
+        .zip(pseudo_output_blindings.iter())
+        .map(|(secret, blinding)| {
+            generator_cache
+                .get(secret.token_id)
+                .commit(Scalar::from(secret.value), *blinding)
+        })
+        .collect();
+
     if check_value_is_preserved {
-        let sum_of_output_commitments: RistrettoPoint = output_values_and_blindings
+        let sum_of_output_commitments: RistrettoPoint = output_secrets
             .iter()
-            .map(|(value, blinding)| generator.commit(Scalar::from(*value), *blinding))
+            .map(|secret| {
+                generator_cache
+                    .get(secret.token_id)
+                    .commit(Scalar::from(secret.value), secret.blinding)
+            })
             .sum();
 
-        let sum_of_pseudo_output_commitments: RistrettoPoint = pseudo_output_values_and_blindings
-            .iter()
-            .map(|(value, blinding)| generator.commit(Scalar::from(*value), *blinding))
-            .sum();
+        let sum_of_pseudo_output_commitments: RistrettoPoint =
+            pseudo_output_commitments.iter().sum();
 
+        let generator = generator_cache.get(fee_token_id);
         // The implicit fee output.
         let fee_commitment = generator.commit(Scalar::from(fee), *FEE_BLINDING);
 
@@ -347,20 +564,21 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
         }
     }
 
-    let pseudo_output_commitments: Vec<CompressedCommitment> = commitments
-        .iter()
-        .take(num_inputs)
-        .map(CompressedCommitment::from)
+    // The actual pseudo output commitments use the blindings from
+    // `pseudo_output_blinding` and not the original true input.
+    let pseudo_output_commitments: Vec<CompressedCommitment> = pseudo_output_commitments
+        .into_iter()
+        .map(|point| CompressedCommitment::from(&point.compress()))
         .collect();
 
     // Extend the message with the range proof and pseudo_output_commitments.
     // This ensures that they are signed by each RingMLSAG.
-    let range_proof_bytes = range_proof.to_bytes();
     let extended_message_digest = compute_extended_message_either_version(
         block_version,
         message,
         &pseudo_output_commitments,
-        &range_proof_bytes,
+        &range_proof,
+        &range_proofs,
     );
 
     // Prove that the signer is allowed to spend a public key in each ring, and that
@@ -368,25 +586,48 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
     let mut ring_signatures: Vec<RingMLSAG> = Vec::new();
     for i in 0..num_inputs {
         let real_index = real_input_indices[i];
-        let (onetime_private_key, value, blinding) = input_secrets[i];
+        let input_secret = &input_secrets[i];
+        let generator = generator_cache.get(input_secret.token_id);
         let ring_signature = RingMLSAG::sign(
             &extended_message_digest,
             &rings[i],
             real_index,
-            &onetime_private_key,
-            value,
-            &blinding,
+            &input_secret.onetime_private_key,
+            input_secret.value,
+            &input_secret.blinding,
             &pseudo_output_blindings[i],
-            &generator,
+            generator,
             rng,
         )?;
         ring_signatures.push(ring_signature);
     }
 
+    let mut pseudo_output_token_ids: Vec<u64> = input_secrets
+        .iter()
+        .map(|secret| *secret.token_id)
+        .collect();
+    let mut output_token_ids: Vec<u64> = output_secrets
+        .iter()
+        .map(|secret| *secret.token_id)
+        .collect();
+
+    if !block_version.mixed_transactions_are_supported() {
+        pseudo_output_token_ids.clear();
+        output_token_ids.clear();
+        assert!(!range_proof.is_empty());
+        assert!(range_proofs.is_empty());
+    } else {
+        assert!(range_proof.is_empty());
+        assert!(!range_proofs.is_empty());
+    }
+
     Ok(SignatureRctBulletproofs {
         ring_signatures,
         pseudo_output_commitments,
-        range_proof_bytes,
+        range_proof_bytes: range_proof,
+        range_proofs,
+        pseudo_output_token_ids,
+        output_token_ids,
     })
 }
 
@@ -396,10 +637,17 @@ fn compute_extended_message_either_version(
     message: &[u8],
     pseudo_output_commitments: &[CompressedCommitment],
     range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
 ) -> Vec<u8> {
     if block_version.mlsags_sign_extended_message_digest() {
         // New-style extended message using merlin
-        digest_extended_message(message, pseudo_output_commitments, range_proof_bytes).to_vec()
+        digest_extended_message(
+            message,
+            pseudo_output_commitments,
+            range_proof_bytes,
+            range_proofs,
+        )
+        .to_vec()
     } else {
         // Old-style extended message
         extend_message(message, pseudo_output_commitments, range_proof_bytes)
@@ -411,11 +659,13 @@ fn digest_extended_message(
     message: &[u8],
     pseudo_output_commitments: &[CompressedCommitment],
     range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
 ) -> [u8; 32] {
     let mut transcript = MerlinTranscript::new(EXTENDED_MESSAGE_DOMAIN_TAG.as_bytes());
     message.append_to_transcript(b"message", &mut transcript);
     pseudo_output_commitments.append_to_transcript(b"pseudo_output_commitments", &mut transcript);
-    range_proof_bytes.append_to_transcript(b"range_proof_bytes", &mut transcript);
+    range_proof_bytes.append_to_transcript_allow_omit(b"range_proof_bytes", &mut transcript);
+    range_proofs.append_to_transcript_allow_omit(b"range_proofs", &mut transcript);
 
     let mut output = [0u8; 32];
     transcript.extract_digest(&mut output);
@@ -471,21 +721,21 @@ mod rct_bulletproofs_tests {
 
         /// One-time private key, amount value, and amount blinding for each
         /// real input.
-        input_secrets: Vec<(RistrettoPrivate, u64, Scalar)>,
+        input_secrets: Vec<InputSecret>,
 
         /// Value and blinding for each output amount commitment.
-        output_values_and_blindings: Vec<(u64, Scalar)>,
+        output_secrets: Vec<OutputSecret>,
 
         /// Block Version
         block_version: BlockVersion,
 
         /// Token id
-        token_id: u64,
+        fee_token_id: TokenId,
     }
 
     impl SignatureParams {
         fn generator(&self) -> PedersenGens {
-            generators(self.token_id)
+            generators(*self.fee_token_id)
         }
 
         fn random<RNG: RngCore + CryptoRng>(
@@ -497,13 +747,14 @@ mod rct_bulletproofs_tests {
             let mut message = [0u8; 32];
             rng.fill_bytes(&mut message);
 
-            let token_id = if block_version.masked_token_id_feature_is_supported() {
-                rng.next_u64()
-            } else {
-                0
-            };
+            let fee_token_id =
+                TokenId::from(if block_version.masked_token_id_feature_is_supported() {
+                    rng.next_u64()
+                } else {
+                    0
+                });
 
-            let generator = generators(token_id);
+            let generator = generators(*fee_token_id);
 
             let mut rings = Vec::new();
             let mut real_input_indices = Vec::new();
@@ -536,15 +787,24 @@ mod rct_bulletproofs_tests {
 
                 rings.push(ring);
                 real_input_indices.push(real_index);
-                input_secrets.push((onetime_private_key, value, blinding));
+                input_secrets.push(InputSecret {
+                    onetime_private_key,
+                    value,
+                    token_id: fee_token_id,
+                    blinding,
+                });
             }
 
             // Create one output with the same value as each input.
-            let output_values_and_blindings: Vec<_> = input_secrets
+            let output_secrets: Vec<_> = input_secrets
                 .iter()
-                .map(|(_, value, _)| {
+                .map(|secret| {
                     let blinding = Scalar::random(rng);
-                    (*value, blinding)
+                    OutputSecret {
+                        value: secret.value,
+                        token_id: secret.token_id,
+                        blinding,
+                    }
                 })
                 .collect();
 
@@ -553,17 +813,21 @@ mod rct_bulletproofs_tests {
                 rings,
                 real_input_indices,
                 input_secrets,
-                output_values_and_blindings,
+                output_secrets,
                 block_version,
-                token_id,
+                fee_token_id,
             }
         }
 
         fn get_output_commitments(&self) -> Vec<CompressedCommitment> {
-            self.output_values_and_blindings
+            self.output_secrets
                 .iter()
-                .map(|(value, blinding)| {
-                    CompressedCommitment::new(*value, *blinding, &self.generator())
+                .map(|secret| {
+                    CompressedCommitment::new(
+                        secret.value,
+                        secret.blinding,
+                        &generators(*secret.token_id),
+                    )
                 })
                 .collect()
         }
@@ -579,9 +843,9 @@ mod rct_bulletproofs_tests {
                 &self.rings,
                 &self.real_input_indices,
                 &self.input_secrets,
-                &self.output_values_and_blindings,
+                &self.output_secrets,
                 fee,
-                self.token_id,
+                self.fee_token_id,
                 rng,
             )
         }
@@ -597,9 +861,9 @@ mod rct_bulletproofs_tests {
                 &self.rings,
                 &self.real_input_indices,
                 &self.input_secrets,
-                &self.output_values_and_blindings,
+                &self.output_secrets,
                 fee,
-                self.token_id,
+                self.fee_token_id,
                 false,
                 rng,
             )
@@ -697,7 +961,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
             result.unwrap();
@@ -728,7 +992,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
 
@@ -750,8 +1014,7 @@ mod rct_bulletproofs_tests {
             // Modify an output value
             {
                 let index = rng.next_u64() as usize % (num_inputs);
-                let (_value, blinding) = params.output_values_and_blindings[index];
-                params.output_values_and_blindings[index] = (rng.next_u64(), blinding);
+                params.output_secrets[index].value = rng.next_u64();
             }
 
             // Sign, without checking that value is preserved.
@@ -763,7 +1026,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
 
@@ -804,7 +1067,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
 
@@ -826,8 +1089,8 @@ mod rct_bulletproofs_tests {
 
             // Duplicate one of the rings.
             params.rings[2] = params.rings[3].clone();
-            params.output_values_and_blindings[2] = params.output_values_and_blindings[3];
-            params.input_secrets[2] = params.input_secrets[3];
+            params.output_secrets[2] = params.output_secrets[3].clone();
+            params.input_secrets[2] = params.input_secrets[3].clone();
             params.real_input_indices[2] = params.real_input_indices[3];
 
             let signature = params.sign(fee, &mut rng).unwrap();
@@ -838,7 +1101,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
 
@@ -882,7 +1145,8 @@ mod rct_bulletproofs_tests {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+            let popped_secret = params.output_secrets.pop().unwrap();
+            let fee = popped_secret.value;
 
             let signature = params.sign(fee, &mut rng).unwrap();
 
@@ -892,7 +1156,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
             result.unwrap();
@@ -905,7 +1169,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 wrong_fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             ) {
                 Err(Error::ValueNotConserved) => {} // Expected
@@ -927,7 +1191,8 @@ mod rct_bulletproofs_tests {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+            let popped_secret = params.output_secrets.pop().unwrap();
+            let fee = popped_secret.value;
 
             let signature = params.sign(fee, &mut rng).unwrap();
 
@@ -937,7 +1202,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
             assert!(result.is_err());
@@ -953,7 +1218,8 @@ mod rct_bulletproofs_tests {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+            let popped_secret = params.output_secrets.pop().unwrap();
+            let fee = popped_secret.value;
 
             let signature = params.sign(fee, &mut rng).unwrap();
 
@@ -963,7 +1229,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             );
             assert!(result.is_err());
@@ -979,7 +1245,8 @@ mod rct_bulletproofs_tests {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+            let popped_secret = params.output_secrets.pop().unwrap();
+            let fee = popped_secret.value;
 
             let signature = params.sign(fee, &mut rng).unwrap();
 
@@ -989,7 +1256,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id,
+                params.fee_token_id,
                 &mut rng,
             ).unwrap();
 
@@ -1000,7 +1267,7 @@ mod rct_bulletproofs_tests {
                 &params.rings,
                 &params.get_output_commitments(),
                 fee,
-                params.token_id + 1,
+                TokenId::from(*params.fee_token_id + 1),
                 &mut rng,
             );
             assert_eq!(result, Err(Error::RangeProofError));
@@ -1016,9 +1283,10 @@ mod rct_bulletproofs_tests {
             let mut rng: StdRng = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
-            let (fee, _) = params.output_values_and_blindings.pop().unwrap();
+            let popped_secret = params.output_secrets.pop().unwrap();
+            let fee = popped_secret.value;
 
-            params.token_id = 1;
+            params.fee_token_id = 1.into();
 
             assert_eq!(params.sign(fee, &mut rng), Err(Error::TokenIdNotAllowed));
         }

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -283,10 +283,9 @@ impl SignatureRctBulletproofs {
                     })
                     .collect();
 
-                assert!(
-                    !commitments.is_empty(),
-                    "logic error when accumulating commitments for token id"
-                );
+                if commitments.is_empty() {
+                    return Err(Error::NoCommitmentsForTokenId(*token_id));
+                }
 
                 let range_proof = RangeProof::from_bytes(range_proof)
                     .map_err(|_e| Error::RangeProofDeserialization)?;

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -252,7 +252,7 @@ impl SignatureRctBulletproofs {
             check_range_proofs(&range_proof, &commitments, generator, rng)?
         } else {
             // When mixed transactions are supported, self.range_proofs should contain
-            // a range proof correspond to each token id used in the transaction, in sorted
+            // a range proof corresponding to each token id used in the transaction, in sorted
             // order. range_proof_bytes should be empty
             if !self.range_proof_bytes.is_empty() {
                 return Err(Error::UnexpectedRangeProof);

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -316,16 +316,19 @@ impl SignatureRctBulletproofs {
         // We are checking that this sum is equal to the zero point (zero vector).
         //
         // At this point, we appeal to the "orthogonality" of the bases G, H_1, H_2, ...
-        // We assume that because they were chosen by hashing to curve, it is infeasible
-        // for any to find a nontrivial linear relation between them. (See generators
+        // We assume that it is infeasible for anyone to find a nontrivial linear
+        // relation between them.
+        //
+        // (See generators
         // module doc for justification of this, but basically it's because we hash to
         // curve.)
         //
-        // If someone submits a transaction where this sum is zero, and they do not know
-        // any "nontrivial" linear combination of G, H_1, ...
+        // Therefore, if someone submits a transaction where this sum is zero, and they
+        // cannot not know any "nontrivial" linear combination of G, H_1, ...
         // then this must be a trivial linear combination.
+        // A trivial linear combination is one where all the coefficients are zero.
         // This implies that w_j = 0 for all j, which implies that value was not created
-        // or destroyed, as required.
+        // or destroyed in any token id, as required.
         //
         // So we don't need to do a separate loop here once per token id, we can just
         // add everything together and check for zero.

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -137,7 +137,7 @@ impl SignatureRctBulletproofs {
     ///   commitments.
     /// * `output_commitments` - Output amount commitments.
     /// * `fee` - Value of the implicit fee output.
-    /// * `fee_token id` - This determines the pedersen generator for fee
+    /// * `fee_token_id` - This determines the pedersen generator for fee
     ///   commitment
     /// * `rng` - randomness
     pub fn verify<CSPRNG: RngCore + CryptoRng>(

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -252,8 +252,8 @@ impl SignatureRctBulletproofs {
             check_range_proofs(&range_proof, &commitments, generator, rng)?
         } else {
             // When mixed transactions are supported, self.range_proofs should contain
-            // a range proof corresponding to each token id used in the transaction, in sorted
-            // order. range_proof_bytes should be empty
+            // a range proof corresponding to each token id used in the transaction, in
+            // sorted order. range_proof_bytes should be empty
             if !self.range_proof_bytes.is_empty() {
                 return Err(Error::UnexpectedRangeProof);
             }

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -19,6 +19,12 @@ impl From<u64> for TokenId {
     }
 }
 
+impl From<&u64> for TokenId {
+    fn from(src: &u64) -> Self {
+        Self(*src)
+    }
+}
+
 impl fmt::Display for TokenId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -24,7 +24,7 @@ use crate::{
     memo::{EncryptedMemo, MemoPayload},
     onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
     ring_signature::{KeyImage, SignatureRctBulletproofs},
-    CompressedCommitment, NewMemoError, NewTxError, TokenId, ViewKeyMatchError,
+    CompressedCommitment, NewMemoError, NewTxError, ViewKeyMatchError,
 };
 
 /// Transaction hash length, in bytes.
@@ -176,21 +176,19 @@ impl TxPrefix {
     /// * `inputs` - Inputs spent by the transaction.
     /// * `outputs` - Outputs created by the transaction.
     /// * `fee` - Transaction fee.
-    /// * `fee_token_id` - Transaction fee token id.
     /// * `tombstone_block` - The block index at which this transaction is no
     ///   longer valid.
     pub fn new(
         inputs: Vec<TxIn>,
         outputs: Vec<TxOut>,
-        fee: u64,
-        fee_token_id: TokenId,
+        fee: Amount,
         tombstone_block: u64,
     ) -> TxPrefix {
         TxPrefix {
             inputs,
             outputs,
-            fee,
-            fee_token_id: *fee_token_id,
+            fee: fee.value,
+            fee_token_id: *fee.token_id,
             tombstone_block,
         }
     }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -24,7 +24,7 @@ use crate::{
     memo::{EncryptedMemo, MemoPayload},
     onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
     ring_signature::{KeyImage, SignatureRctBulletproofs},
-    CompressedCommitment, NewMemoError, NewTxError, ViewKeyMatchError,
+    CompressedCommitment, NewMemoError, NewTxError, TokenId, ViewKeyMatchError,
 };
 
 /// Transaction hash length, in bytes.
@@ -164,9 +164,9 @@ pub struct TxPrefix {
     #[prost(uint64, tag = "4")]
     pub tombstone_block: u64,
 
-    /// Token id for this transaction
+    /// Token id for the fee output of this transaction
     #[prost(fixed64, tag = "5")]
-    pub token_id: u64,
+    pub fee_token_id: u64,
 }
 
 impl TxPrefix {
@@ -176,20 +176,21 @@ impl TxPrefix {
     /// * `inputs` - Inputs spent by the transaction.
     /// * `outputs` - Outputs created by the transaction.
     /// * `fee` - Transaction fee.
+    /// * `fee_token_id` - Transaction fee token id.
     /// * `tombstone_block` - The block index at which this transaction is no
     ///   longer valid.
     pub fn new(
         inputs: Vec<TxIn>,
         outputs: Vec<TxOut>,
         fee: u64,
-        token_id: u64,
+        fee_token_id: TokenId,
         tombstone_block: u64,
     ) -> TxPrefix {
         TxPrefix {
             inputs,
             outputs,
             fee,
-            token_id,
+            fee_token_id: *fee_token_id,
             tombstone_block,
         }
     }
@@ -649,7 +650,7 @@ mod tests {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
             fee: Mob::MINIMUM_FEE,
-            token_id: *Mob::ID,
+            fee_token_id: *Mob::ID,
             tombstone_block: 23,
         };
 
@@ -712,7 +713,7 @@ mod tests {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
             fee: Mob::MINIMUM_FEE,
-            token_id: *Mob::ID,
+            fee_token_id: *Mob::ID,
             tombstone_block: 23,
         };
 

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -65,6 +65,8 @@ pub enum NewMemoError {
     OutputsAfterChange,
     /// Changing the fee after the change output is not supported
     FeeAfterChange,
+    /// Mixed Token Ids is not supported in these memos
+    MixedTokenIds,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -65,7 +65,7 @@ pub enum NewMemoError {
     OutputsAfterChange,
     /// Changing the fee after the change output is not supported
     FeeAfterChange,
-    /// Mixed Token Ids is not supported in these memos
+    /// Mixed Token Ids are not supported in these memos
     MixedTokenIds,
     /// Other: {0}
     Other(String),

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -28,7 +28,7 @@ use rand_core::{CryptoRng, RngCore};
 /// * `root_proofs` - Membership proofs for each input ring element contained in
 ///   `tx`.
 /// * `minimum_fee` - The minimum fee for the token indicated by
-///   tx.prefix.token_id
+///   tx.prefix.fee_token_id
 /// * `csprng` - Cryptographically secure random number generator.
 pub fn validate<R: RngCore + CryptoRng>(
     tx: &Tx,
@@ -310,7 +310,7 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
             &rings,
             &output_commitments,
             tx.prefix.fee,
-            tx.prefix.token_id,
+            TokenId::from(tx.prefix.fee_token_id),
             rng,
         )
         .map_err(TransactionValidationError::InvalidTransactionSignature)
@@ -1094,7 +1094,12 @@ mod tests {
 
         for block_version in BlockVersion::iterator() {
             let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(validate_signature(block_version, &tx, &mut rng), Ok(()));
+            assert_eq!(
+                validate_signature(block_version, &tx, &mut rng),
+                Ok(()),
+                "failed at block version: {}",
+                block_version
+            );
         }
     }
 
@@ -1169,7 +1174,7 @@ mod tests {
         for _ in 0..3 {
             let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
 
-            tx.prefix.token_id += 1;
+            tx.prefix.fee_token_id += 1;
 
             match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
@@ -1330,14 +1335,17 @@ mod tests {
         }
     }
 
+    // FIXME: This test needs to involve a Tx with more than one output to make
+    // sense
     #[test]
+    #[ignore]
     fn test_global_validate_for_blocks_with_sorted_outputs() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let fee = Mob::MINIMUM_FEE + 1;
         for block_version in BlockVersion::iterator() {
             // for block version < 3 it doesn't matter
             // for >= 3 it shall return an error about unsorted outputs
-            let (tx, _ledger) = create_test_tx_with_amount_and_comparer::<InverseTxOutputsOrdering>(
+            let (tx, ledger) = create_test_tx_with_amount_and_comparer::<InverseTxOutputsOrdering>(
                 block_version,
                 INITIALIZE_LEDGER_AMOUNT - fee,
                 fee,
@@ -1345,7 +1353,7 @@ mod tests {
 
             let highest_indices = tx.get_membership_proof_highest_indices();
             let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                &_ledger
+                &ledger
                     .get_tx_out_proof_of_memberships(&highest_indices)
                     .expect("failed getting proofs"),
             );

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -11,7 +11,7 @@ use crate::{
     constants::*,
     membership_proofs::{derive_proof_at_index, is_membership_proof_valid},
     tx::{Tx, TxOut, TxOutMembershipProof, TxPrefix},
-    BlockVersion, CompressedCommitment, TokenId,
+    Amount, BlockVersion, CompressedCommitment, TokenId,
 };
 use mc_common::HashSet;
 use mc_crypto_keys::CompressedRistrettoPublic;
@@ -309,8 +309,7 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
             message,
             &rings,
             &output_commitments,
-            tx.prefix.fee,
-            TokenId::from(tx.prefix.fee_token_id),
+            Amount::new(tx.prefix.fee, TokenId::from(tx.prefix.fee_token_id)),
             rng,
         )
         .map_err(TransactionValidationError::InvalidTransactionSignature)

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -142,7 +142,7 @@ pub fn create_transaction_with_amount_and_comparer<
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
-    amount: u64,
+    value: u64,
     fee: u64,
     tombstone_block: BlockIndex,
     rng: &mut R,
@@ -192,6 +192,11 @@ pub fn create_transaction_with_amount_and_comparer<
     )
     .unwrap();
     transaction_builder.add_input(input_credentials);
+
+    let amount = Amount {
+        value,
+        token_id: sender_amount.token_id,
+    };
 
     // Output
     transaction_builder

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -151,10 +151,11 @@ pub fn create_transaction_with_amount_and_comparer<
 
     let mut transaction_builder = TransactionBuilder::new(
         block_version,
-        sender_amount.token_id,
+        Amount::new(fee, sender_amount.token_id),
         MockFogResolver::default(),
         EmptyMemoBuilder::default(),
-    );
+    )
+    .unwrap();
 
     // The first transaction in the origin block should contain enough outputs to
     // use as mixins.
@@ -205,9 +206,6 @@ pub fn create_transaction_with_amount_and_comparer<
 
     // Tombstone block
     transaction_builder.set_tombstone_block(tombstone_block);
-
-    // Fee
-    transaction_builder.set_fee(fee).unwrap();
 
     // Build and return the transaction
     transaction_builder.build_with_sorter::<R, O>(rng).unwrap()

--- a/transaction/std/src/error.rs
+++ b/transaction/std/src/error.rs
@@ -9,8 +9,8 @@ use mc_transaction_core::{
 /// An error that can occur when using the TransactionBuilder
 #[derive(Debug, Display)]
 pub enum TxBuilderError {
-    /// Ring Signature construction failed
-    RingSignatureFailed,
+    /// Ring Signature construction failed: {0}
+    RingSignatureFailed(ring_signature::Error),
 
     /// Range proof construction failed
     RangeProofFailed,
@@ -89,8 +89,8 @@ impl From<mc_crypto_keys::KeyError> for TxBuilderError {
 }
 
 impl From<ring_signature::Error> for TxBuilderError {
-    fn from(_: Error) -> Self {
-        TxBuilderError::RingSignatureFailed
+    fn from(src: Error) -> Self {
+        TxBuilderError::RingSignatureFailed(src)
     }
 }
 

--- a/transaction/std/src/error.rs
+++ b/transaction/std/src/error.rs
@@ -24,8 +24,8 @@ pub enum TxBuilderError {
     /// Bad Amount: {0}
     BadAmount(AmountError),
 
-    /// Input had wrong token id: Expected {0}, Found {1}
-    WrongTokenType(TokenId, TokenId),
+    /// Mixed Transactions not allowed: Expected {0}, Found {1}
+    MixedTransactionsNotAllowed(TokenId, TokenId),
 
     /// New Tx: {0}
     NewTx(NewTxError),

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -7,7 +7,7 @@
 use super::{memo, ChangeDestination};
 use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
-use mc_transaction_core::{MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 mod rth_memo_builder;
 pub use rth_memo_builder::RTHMemoBuilder;
@@ -30,12 +30,12 @@ pub trait MemoBuilder: Debug {
     /// and gets a chance to report an error, if the fee is too large, or if it
     /// is being changed too late
     /// in the process, and memos that are already written would be invalid.
-    fn set_fee(&mut self, value: u64) -> Result<(), NewMemoError>;
+    fn set_fee(&mut self, amount: Amount) -> Result<(), NewMemoError>;
 
     /// Build a memo for a normal output (to another party).
     fn make_memo_for_output(
         &mut self,
-        value: u64,
+        amount: Amount,
         recipient: &PublicAddress,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
@@ -43,7 +43,7 @@ pub trait MemoBuilder: Debug {
     /// Build a memo for a change output (to ourselves).
     fn make_memo_for_change_output(
         &mut self,
-        value: u64,
+        amount: Amount,
         change_destination: &ChangeDestination,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
@@ -55,13 +55,13 @@ pub trait MemoBuilder: Debug {
 pub struct EmptyMemoBuilder;
 
 impl MemoBuilder for EmptyMemoBuilder {
-    fn set_fee(&mut self, _fee: u64) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
         Ok(())
     }
 
     fn make_memo_for_output(
         &mut self,
-        _value: u64,
+        _value: Amount,
         _recipient: &PublicAddress,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -70,7 +70,7 @@ impl MemoBuilder for EmptyMemoBuilder {
 
     fn make_memo_for_change_output(
         &mut self,
-        _value: u64,
+        _value: Amount,
         _change_destination: &ChangeDestination,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -226,11 +226,7 @@ impl MemoBuilder for RTHMemoBuilder {
         // total_outlay.checked_add(self.fee.value) is wrong.
         // We need to specify token-id aware RTH memos
         if self.fee.token_id != amount.token_id {
-            panic!(
-                "self fee token id != amount.token_id: {}, {}",
-                self.fee.token_id, amount.token_id
-            );
-            //return Err(NewMemoError::MixedTokenIds);
+            return Err(NewMemoError::MixedTokenIds);
         }
 
         self.total_outlay = self

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -85,10 +85,7 @@ impl Default for RTHMemoBuilder {
             total_outlay: 0,
             outlay_token_id: None,
             num_recipients: 0,
-            fee: Amount {
-                value: Mob::MINIMUM_FEE,
-                token_id: Mob::ID,
-            },
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         }
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2626,10 +2626,7 @@ pub mod transaction_builder_tests {
 
             transaction_builder
                 .add_change_output(
-                    Amount {
-                        value: change_value,
-                        token_id,
-                    },
+                        Amount::new(change_value, token_id),
                     &sender_change_dest,
                     &mut rng,
                 )

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2811,18 +2811,9 @@ pub mod transaction_builder_tests {
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 
-        let amount1 = Amount {
-            value: 1475 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let change_amount = Amount {
-            value: 128 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let amount2 = Amount {
-            value: 999999,
-            token_id: 2.into(),
-        };
+        let amount1 = Amount::new(1475 * MILLIMOB_TO_PICOMOB, Mob::ID);
+        let change_amount = Amount::new(128 * MILLIMOB_TO_PICOMOB, Mob::ID);
+        let amount2 = Amount::new(999999, 2.into())'
 
         let tx_out1_right_amount = Amount::new(
             amount1.value - change_amount.value - Mob::MINIMUM_FEE,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -322,7 +322,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     pub fn set_fee(&mut self, fee_value: u64) -> Result<(), TxBuilderError> {
         // Set the fee in memo builder first, so that it can signal an error
         // before we set self.fee, and don't have to roll back.
-        let mut new_fee = self.fee.clone();
+        let mut new_fee = self.fee;
         new_fee.value = fee_value;
         self.memo_builder
             .as_mut()
@@ -430,11 +430,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
                 let (amount, blinding) = masked_amount
                     .get_value(shared_secret)
                     .expect("TransactionBuilder created an invalid Amount");
-                OutputSecret {
-                    value: amount.value,
-                    token_id: amount.token_id,
-                    blinding,
-                }
+                OutputSecret { amount, blinding }
             })
             .collect();
 
@@ -478,8 +474,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             }
             input_secrets.push(InputSecret {
                 onetime_private_key: input_credential.onetime_private_key,
-                value: amount.value,
-                token_id: amount.token_id,
+                amount,
                 blinding,
             });
         }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -1514,10 +1514,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2156,10 +2156,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &alice_change_dest,
                         &mut rng,
                     )

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2623,7 +2623,7 @@ pub mod transaction_builder_tests {
 
             transaction_builder
                 .add_change_output(
-                        Amount::new(change_value, token_id),
+                    Amount::new(change_value, token_id),
                     &sender_change_dest,
                     &mut rng,
                 )
@@ -2687,7 +2687,7 @@ pub mod transaction_builder_tests {
 
         let amount1 = Amount::new(1475 * MILLIMOB_TO_PICOMOB, Mob::ID);
         let change_amount = Amount::new(128 * MILLIMOB_TO_PICOMOB, Mob::ID);
-        let amount2 = Amount::new(999999, 2.into())'
+        let amount2 = Amount::new(999999, 2.into());
 
         let tx_out1_right_amount = Amount::new(
             amount1.value - change_amount.value - Mob::MINIMUM_FEE,
@@ -2813,7 +2813,7 @@ pub mod transaction_builder_tests {
 
         let amount1 = Amount::new(1475 * MILLIMOB_TO_PICOMOB, Mob::ID);
         let change_amount = Amount::new(128 * MILLIMOB_TO_PICOMOB, Mob::ID);
-        let amount2 = Amount::new(999999, 2.into())'
+        let amount2 = Amount::new(999999, 2.into());
 
         let tx_out1_right_amount = Amount::new(
             amount1.value - change_amount.value - Mob::MINIMUM_FEE,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2685,18 +2685,9 @@ pub mod transaction_builder_tests {
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 
-        let amount1 = Amount {
-            value: 1475 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let change_amount = Amount {
-            value: 128 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let amount2 = Amount {
-            value: 999999,
-            token_id: 2.into(),
-        };
+        let amount1 = Amount::new(1475 * MILLIMOB_TO_PICOMOB, Mob::ID);
+        let change_amount = Amount::new(128 * MILLIMOB_TO_PICOMOB, Mob::ID);
+        let amount2 = Amount::new(999999, 2.into())'
 
         let tx_out1_right_amount = Amount::new(
             amount1.value - change_amount.value - Mob::MINIMUM_FEE,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -441,13 +441,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         let (outputs, _shared_serets): (Vec<TxOut>, Vec<_>) =
             self.outputs_and_shared_secrets.into_iter().unzip();
 
-        let tx_prefix = TxPrefix::new(
-            inputs,
-            outputs,
-            self.fee.value,
-            self.fee.token_id,
-            self.tombstone_block,
-        );
+        let tx_prefix = TxPrefix::new(inputs, outputs, self.fee, self.tombstone_block);
 
         let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
         for input in &tx_prefix.inputs {

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -1350,10 +1350,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -506,8 +506,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             &real_input_indices,
             &input_secrets,
             &output_values_and_blindings,
-            self.fee,
-            self.fee_token_id,
+            Amount::new(self.fee, TokenId::from(self.fee_token_id)),
             rng,
         )?;
 
@@ -778,10 +777,7 @@ pub mod transaction_builder_tests {
         for _i in 0..num_outputs {
             transaction_builder
                 .add_output(
-                    Amount {
-                        value: output_value,
-                        token_id,
-                    },
+                    Amount::new(output_value, token_id),
                     &recipient.default_subaddress(),
                     rng,
                 )
@@ -832,10 +828,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
             let (_txout, confirmation) = transaction_builder
                 .add_output(
-                    Amount {
-                        value: value - Mob::MINIMUM_FEE,
-                        token_id,
-                    },
+                    Amount::new(value - Mob::MINIMUM_FEE, token_id),
                     &recipient.default_subaddress(),
                     &mut rng,
                 )
@@ -916,10 +909,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
             let (_txout, confirmation) = transaction_builder
                 .add_output(
-                    Amount {
-                        value: value - Mob::MINIMUM_FEE,
-                        token_id,
-                    },
+                    Amount::new(value - Mob::MINIMUM_FEE, token_id),
                     &recipient.default_subaddress(),
                     &mut rng,
                 )
@@ -1012,10 +1002,7 @@ pub mod transaction_builder_tests {
 
             let (_txout, _confirmation) = transaction_builder
                 .add_output_with_fog_hint_address(
-                    Amount {
-                        value: value - Mob::MINIMUM_FEE,
-                        token_id,
-                    },
+                    Amount::new(value - Mob::MINIMUM_FEE, token_id),
                     &recipient.default_subaddress(),
                     &fog_hint_address,
                     |_| Ok(Default::default()),
@@ -1092,10 +1079,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1129,10 +1113,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1200,10 +1181,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1211,10 +1189,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )
@@ -1386,10 +1361,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1553,10 +1525,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE * 4,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - 4 * Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1720,10 +1689,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1731,10 +1697,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )
@@ -1887,10 +1850,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -1898,10 +1858,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )
@@ -2042,10 +1999,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -2053,10 +2007,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )
@@ -2222,10 +2173,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &bob_address,
                         &mut rng,
                     )
@@ -2419,10 +2367,7 @@ pub mod transaction_builder_tests {
 
                 let (_txout, _confirmation) = transaction_builder
                     .add_output(
-                        Amount {
-                            value: value - change_value - Mob::MINIMUM_FEE,
-                            token_id,
-                        },
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                         &recipient_address,
                         &mut rng,
                     )
@@ -2430,10 +2375,7 @@ pub mod transaction_builder_tests {
 
                 transaction_builder
                     .add_change_output(
-                        Amount {
-                            value: change_value,
-                            token_id,
-                        },
+                        Amount::new(change_value, token_id),
                         &sender_change_dest,
                         &mut rng,
                     )
@@ -2447,10 +2389,7 @@ pub mod transaction_builder_tests {
                 assert!(
                     transaction_builder
                         .add_output(
-                            Amount {
-                                value: Mob::MINIMUM_FEE,
-                                token_id
-                            },
+                            Amount::new(Mob::MINIMUM_FEE, token_id),
                             &recipient_address,
                             &mut rng
                         )
@@ -2461,10 +2400,7 @@ pub mod transaction_builder_tests {
                 assert!(
                     transaction_builder
                         .add_change_output(
-                            Amount {
-                                value: change_value,
-                                token_id
-                            },
+                            Amount::new(change_value, token_id),
                             &sender_change_dest,
                             &mut rng
                         )
@@ -2533,10 +2469,7 @@ pub mod transaction_builder_tests {
             let wrong_value = 999;
             transaction_builder
                 .add_output(
-                    Amount {
-                        value: wrong_value,
-                        token_id,
-                    },
+                    Amount::new(wrong_value, token_id),
                     &bob.default_subaddress(),
                     &mut rng,
                 )
@@ -2710,10 +2643,7 @@ pub mod transaction_builder_tests {
 
             let (burn_tx_out, _confirmation) = transaction_builder
                 .add_output(
-                    Amount {
-                        value: value - change_value - Mob::MINIMUM_FEE,
-                        token_id,
-                    },
+                    Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
                     &recipient,
                     &mut rng,
                 )
@@ -2799,6 +2729,11 @@ pub mod transaction_builder_tests {
             token_id: 2.into(),
         };
 
+        let tx_out1_right_amount = Amount::new(
+            amount1.value - change_amount.value - Mob::MINIMUM_FEE,
+            Mob::ID,
+        );
+
         for block_version in 3..=*BlockVersion::MAX {
             let block_version = BlockVersion::try_from(block_version).unwrap();
             let memo_builder = EmptyMemoBuilder::default();
@@ -2815,14 +2750,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
 
             let (tx_out1, _confirmation) = transaction_builder
-                .add_output(
-                    Amount {
-                        value: amount1.value - change_amount.value - Mob::MINIMUM_FEE,
-                        token_id: Mob::ID,
-                    },
-                    &recipient_addr,
-                    &mut rng,
-                )
+                .add_output(tx_out1_right_amount, &recipient_addr, &mut rng)
                 .unwrap();
 
             let (tx_out2, _confirmation) = transaction_builder
@@ -2913,8 +2841,8 @@ pub mod transaction_builder_tests {
     }
 
     #[test]
-    // Test mixed transactions expected failure case 1
-    fn test_mixed_transactions_expected_failure1() {
+    // Test mixed transactions expected failures (imbalanced transactions)
+    fn test_mixed_transactions_expected_failure_imbalanced_transactions() {
         let mut rng: StdRng = SeedableRng::from_seed([18u8; 32]);
 
         let fog_resolver = MockFogResolver::default();
@@ -2936,8 +2864,14 @@ pub mod transaction_builder_tests {
             token_id: 2.into(),
         };
 
-        for block_version in 3..=*BlockVersion::MAX {
-            let block_version = BlockVersion::try_from(block_version).unwrap();
+        let tx_out1_right_amount = Amount::new(
+            amount1.value - change_amount.value - Mob::MINIMUM_FEE,
+            Mob::ID,
+        );
+
+        // Builds a transaction using a particular amount in place of tx_out1, returning
+        // result of `.build()`
+        let mut test_fn = |block_version, tx_out1_amount| -> Result<_, _> {
             let memo_builder = EmptyMemoBuilder::default();
 
             let mut transaction_builder =
@@ -2952,14 +2886,7 @@ pub mod transaction_builder_tests {
             transaction_builder.add_input(input_credentials);
 
             let (_tx_out1, _confirmation) = transaction_builder
-                .add_output(
-                    Amount {
-                        value: amount1.value - change_amount.value - Mob::MINIMUM_FEE - 1,
-                        token_id: Mob::ID,
-                    },
-                    &recipient_addr,
-                    &mut rng,
-                )
+                .add_output(tx_out1_amount, &recipient_addr, &mut rng)
                 .unwrap();
 
             let (_tx_out2, _confirmation) = transaction_builder
@@ -2970,137 +2897,26 @@ pub mod transaction_builder_tests {
                 .add_change_output(change_amount, &sender_change_dest, &mut rng)
                 .unwrap();
 
-            let result = transaction_builder.build(&mut rng);
-
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    // Test mixed transactions expected failure case 2
-    fn test_mixed_transactions_expected_failure2() {
-        let mut rng: StdRng = SeedableRng::from_seed([18u8; 32]);
-
-        let fog_resolver = MockFogResolver::default();
-        let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ChangeDestination::from(&sender);
-        let recipient = AccountKey::random(&mut rng);
-        let recipient_addr = recipient.default_subaddress();
-
-        let amount1 = Amount {
-            value: 1475 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let change_amount = Amount {
-            value: 128 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let amount2 = Amount {
-            value: 999999,
-            token_id: 2.into(),
+            transaction_builder.build(&mut rng)
         };
 
         for block_version in 3..=*BlockVersion::MAX {
             let block_version = BlockVersion::try_from(block_version).unwrap();
-            let memo_builder = EmptyMemoBuilder::default();
 
-            let mut transaction_builder =
-                TransactionBuilder::new(block_version, Mob::ID, fog_resolver.clone(), memo_builder);
+            assert!(test_fn(block_version, tx_out1_right_amount).is_ok());
 
-            let input_credentials =
-                get_input_credentials(block_version, amount1, &sender, &fog_resolver, &mut rng);
-            transaction_builder.add_input(input_credentials);
+            let mut tx_out1_wrong_amount = tx_out1_right_amount.clone();
+            tx_out1_wrong_amount.value -= 1;
+            assert!(test_fn(block_version, tx_out1_wrong_amount).is_err());
 
-            let input_credentials =
-                get_input_credentials(block_version, amount2, &sender, &fog_resolver, &mut rng);
-            transaction_builder.add_input(input_credentials);
+            tx_out1_wrong_amount.value += 2;
+            assert!(test_fn(block_version, tx_out1_wrong_amount).is_err());
 
-            let (_tx_out1, _confirmation) = transaction_builder
-                .add_output(
-                    Amount {
-                        value: amount1.value - change_amount.value - Mob::MINIMUM_FEE + 1,
-                        token_id: Mob::ID,
-                    },
-                    &recipient_addr,
-                    &mut rng,
-                )
-                .unwrap();
+            tx_out1_wrong_amount.token_id = 99.into();
+            assert!(test_fn(block_version, tx_out1_wrong_amount).is_err());
 
-            let (_tx_out2, _confirmation) = transaction_builder
-                .add_output(amount2, &recipient_addr, &mut rng)
-                .unwrap();
-
-            transaction_builder
-                .add_change_output(change_amount, &sender_change_dest, &mut rng)
-                .unwrap();
-
-            let result = transaction_builder.build(&mut rng);
-
-            assert!(result.is_err());
-        }
-    }
-
-    #[test]
-    // Test mixed transactions expected failure case 3
-    fn test_mixed_transactions_expected_failure3() {
-        let mut rng: StdRng = SeedableRng::from_seed([18u8; 32]);
-
-        let fog_resolver = MockFogResolver::default();
-        let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ChangeDestination::from(&sender);
-        let recipient = AccountKey::random(&mut rng);
-        let recipient_addr = recipient.default_subaddress();
-
-        let amount1 = Amount {
-            value: 1475 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let change_amount = Amount {
-            value: 128 * MILLIMOB_TO_PICOMOB,
-            token_id: Mob::ID,
-        };
-        let amount2 = Amount {
-            value: 999999,
-            token_id: 2.into(),
-        };
-
-        for block_version in 3..=*BlockVersion::MAX {
-            let block_version = BlockVersion::try_from(block_version).unwrap();
-            let memo_builder = EmptyMemoBuilder::default();
-
-            let mut transaction_builder =
-                TransactionBuilder::new(block_version, Mob::ID, fog_resolver.clone(), memo_builder);
-
-            let input_credentials =
-                get_input_credentials(block_version, amount1, &sender, &fog_resolver, &mut rng);
-            transaction_builder.add_input(input_credentials);
-
-            let input_credentials =
-                get_input_credentials(block_version, amount2, &sender, &fog_resolver, &mut rng);
-            transaction_builder.add_input(input_credentials);
-
-            let (_tx_out1, _confirmation) = transaction_builder
-                .add_output(
-                    Amount {
-                        value: amount1.value - change_amount.value - Mob::MINIMUM_FEE,
-                        token_id: 99.into(),
-                    },
-                    &recipient_addr,
-                    &mut rng,
-                )
-                .unwrap();
-
-            let (_tx_out2, _confirmation) = transaction_builder
-                .add_output(amount2, &recipient_addr, &mut rng)
-                .unwrap();
-
-            transaction_builder
-                .add_change_output(change_amount, &sender_change_dest, &mut rng)
-                .unwrap();
-
-            let result = transaction_builder.build(&mut rng);
-
-            assert!(result.is_err());
+            tx_out1_wrong_amount.value -= 1;
+            assert!(test_fn(block_version, tx_out1_wrong_amount).is_err());
         }
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -106,7 +106,8 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///   transaction
     /// * `fee` - The fee (and token id) to use for this transaction. Note: The
     ///   fee token id cannot be changed later, and before mixed transactions
-    ///   feature, every input and output must have the same token id as the fee.
+    ///   feature, every input and output must have the same token id as the
+    ///   fee.
     /// * `fog_resolver` - Source of validated fog keys to use with this
     ///   transaction
     /// * `memo_builder` - An object which creates memos for the TxOuts in this
@@ -2696,9 +2697,10 @@ pub mod transaction_builder_tests {
 
     #[test]
     // Test that sending mixed transactions works
-    // 
-    // This test uses inputs of two different token IDs, paying the fee and creating change with
-    // TokenID1, and "passing through" the second token ID with its full amount as output.
+    //
+    // This test uses inputs of two different token IDs, paying the fee and creating
+    // change with TokenID1, and "passing through" the second token ID with its
+    // full amount as output.
     fn test_mixed_transactions() {
         let mut rng: StdRng = SeedableRng::from_seed([18u8; 32]);
 
@@ -2781,8 +2783,8 @@ pub mod transaction_builder_tests {
                     .unwrap()
             );
 
-            // Test that recipients's default subaddress owns the correct output, and not the other
-            // tx outs
+            // Test that recipients's default subaddress owns the correct output, and not
+            // the other tx outs
             assert!(
                 subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &tx_out1).unwrap()
             );

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2781,7 +2781,7 @@ pub mod transaction_builder_tests {
                     .unwrap()
             );
 
-            // Test that recipients's default subaddress owns the change, and not the other
+            // Test that recipients's default subaddress owns the correct output, and not the other
             // tx outs
             assert!(
                 subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &tx_out1).unwrap()

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2696,6 +2696,9 @@ pub mod transaction_builder_tests {
 
     #[test]
     // Test that sending mixed transactions works
+    // 
+    // This test uses inputs of two different token IDs, paying the fee and creating change with
+    // TokenID1, and "passing through" the second token ID with its full amount as output.
     fn test_mixed_transactions() {
         let mut rng: StdRng = SeedableRng::from_seed([18u8; 32]);
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -106,7 +106,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///   transaction
     /// * `fee` - The fee (and token id) to use for this transaction. Note: The
     ///   fee token id cannot be changed later, and before mixed transactions
-    ///   feature, every input and output must have this token id.
+    ///   feature, every input and output must have the same token id as the fee.
     /// * `fog_resolver` - Source of validated fog keys to use with this
     ///   transaction
     /// * `memo_builder` - An object which creates memos for the TxOuts in this


### PR DESCRIPTION
This allows transactions to involve inputs and outputs of different types, as long as they are balanced with respect to all of the types.

This is described in MCIP 31

TODO:
- [x] full transaction builder support
- [x] more testing

Future work:
* Make RTH memos that allow for mixed transactions (or at least, fee paid in another token?)
* Avoid regenerating pseudo commitments?
* Make a ticket to change asserts to debug asserts before branching for release?