### PR TITLE
Fix Clippy warnings across the repo

### DIFF
--- a/api/src/convert/archive_block.rs
+++ b/api/src/convert/archive_block.rs
@@ -150,11 +150,11 @@ mod tests {
             let key_image = KeyImage::from(block_idx);
 
             let parent_block_id = last_block
-                .map(|block| block.id.clone())
+                .map(|block| block.id)
                 .unwrap_or_else(|| BlockID::try_from(&[1u8; 32][..]).unwrap());
 
             let block_contents = BlockContents {
-                key_images: vec![key_image.clone()],
+                key_images: vec![key_image],
                 outputs: vec![tx_out.clone()],
                 ..Default::default()
             };

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -56,12 +56,13 @@ mod tests {
             let minted_outputs: Vec<TxOut> = {
                 // Mint an initial collection of outputs, including one belonging to
                 // `sender_account`.
-                let mut recipient_and_amounts: Vec<(PublicAddress, u64)> = Vec::new();
-                recipient_and_amounts.push((alice.default_subaddress(), 65536));
+                let recipient_and_amounts: Vec<(PublicAddress, u64)> = vec![
+                    (alice.default_subaddress(), 65536),
+                    // Some outputs belonging to this account will be used as mix-ins.
+                    (charlie.default_subaddress(), 65536),
+                    (charlie.default_subaddress(), 65536),
+                ];
 
-                // Some outputs belonging to this account will be used as mix-ins.
-                recipient_and_amounts.push((charlie.default_subaddress(), 65536));
-                recipient_and_amounts.push((charlie.default_subaddress(), 65536));
                 mc_transaction_core_test_utils::get_outputs(
                     block_version,
                     &recipient_and_amounts,

--- a/api/src/convert/tx_out_membership_proof.rs
+++ b/api/src/convert/tx_out_membership_proof.rs
@@ -61,20 +61,12 @@ mod tests {
     fn test_membership_proof_from() {
         let index: u64 = 128_465;
         let highest_index: u64 = 781_384_772_994;
-        let mut hashes = Vec::<TxOutMembershipElement>::default();
-        // Add some arbitrary hashes.
-        hashes.push(TxOutMembershipElement::new(
-            Range::new(0, 1).unwrap(),
-            [2u8; 32],
-        ));
-        hashes.push(TxOutMembershipElement::new(
-            Range::new(0, 3).unwrap(),
-            [4u8; 32],
-        ));
-        hashes.push(TxOutMembershipElement::new(
-            Range::new(0, 7).unwrap(),
-            [8u8; 32],
-        ));
+        let hashes = vec![
+            // Add some arbitrary hashes.
+            TxOutMembershipElement::new(Range::new(0, 1).unwrap(), [2u8; 32]),
+            TxOutMembershipElement::new(Range::new(0, 3).unwrap(), [4u8; 32]),
+            TxOutMembershipElement::new(Range::new(0, 7).unwrap(), [8u8; 32]),
+        ];
         let tx_out_membership_proof =
             TxOutMembershipProof::new(index, highest_index, hashes.clone());
 

--- a/attest/core/src/nonce.rs
+++ b/attest/core/src/nonce.rs
@@ -229,7 +229,7 @@ mod test {
     /// Test that our hex decoding matches hex::decode
     fn test_string_from_and_hex_decoding() {
         let s = "029a2f3945a8f6bb1fb5b11a54283a40";
-        let ias_nonce = IasNonce::from_hex(&s).unwrap();
+        let ias_nonce = IasNonce::from_hex(s).unwrap();
         assert_eq!(
             [2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64],
             ias_nonce.0

--- a/attest/core/src/report.rs
+++ b/attest/core/src/report.rs
@@ -209,7 +209,7 @@ mod test {
 
     #[test]
     fn test_serde() {
-        let report: Report = TEST_REPORT1.clone().into();
+        let report: Report = TEST_REPORT1.into();
         let serialized = serialize(&report).expect("Could not serialize report");
         let report2: Report = deserialize(&serialized).expect("Could not deserialize report");
         assert_eq!(report, report2);
@@ -217,24 +217,24 @@ mod test {
 
     #[test]
     fn test_debug() {
-        let report: Report = TEST_REPORT1.clone().into();
+        let report: Report = TEST_REPORT1.into();
         let debug_str = format!("{:?}", &report);
         assert_eq!(&debug_str, TEST_REPORT_DEBUGSTR);
     }
 
     #[test]
     fn test_ord() {
-        let report1: Report = TEST_REPORT1.clone().into();
+        let report1: Report = TEST_REPORT1.into();
         let mut report2 = report1;
         assert_eq!(report1, report2);
-        assert!(!(report1 < report2));
+        assert!(report1 >= report2);
 
         let orig_value = report2.0.key_id.id[0];
         report2.0.key_id.id[0] = 255;
         assert!(report1 < report2);
         report2.0.key_id.id[0] = orig_value;
         assert_eq!(report1, report2);
-        assert!(!(report1 < report2));
+        assert!(report1 >= report2);
     }
 
     #[test]

--- a/attest/core/src/types/report_body.rs
+++ b/attest/core/src/types/report_body.rs
@@ -455,7 +455,7 @@ mod test {
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_ord() {
-        let body1: ReportBody = REPORT_BODY_SRC.clone().into();
+        let body1: ReportBody = REPORT_BODY_SRC.into();
         let mut body2 = body1;
 
         let orig_value = body2.0.cpu_svn.svn[0];
@@ -541,7 +541,7 @@ mod test {
     fn test_serde() {
         assert_eq!(REPORT_BODY_SIZE, size_of::<sgx_report_body_t>());
 
-        let body: ReportBody = REPORT_BODY_SRC.clone().into();
+        let body: ReportBody = REPORT_BODY_SRC.into();
         let serialized = serialize(&body).expect("Error serializing report.");
         let body2: ReportBody = deserialize(&serialized).expect("Error deserializing report");
         assert_eq!(body, body2);

--- a/attest/core/src/types/report_data.rs
+++ b/attest/core/src/types/report_data.rs
@@ -85,7 +85,7 @@ mod test {
 
     #[test]
     fn test_serde() {
-        let data: ReportData = REPORT_DATA_TEST.clone().into();
+        let data: ReportData = REPORT_DATA_TEST.into();
         let serialized = serialize(&data).expect("Could not serialize report_data");
         let data2: ReportData =
             deserialize(&serialized).expect("Could not deserialize report_data");
@@ -102,7 +102,7 @@ mod test {
 
         let mask = ReportDataMask::new_with_mask(&REPORT_DATA_TEST.d[..], &bitmask[..])
             .expect("Could not create mask structure");
-        let data: ReportData = REPORT_DATA_TEST.clone().into();
+        let data: ReportData = REPORT_DATA_TEST.into();
 
         assert!(mask.eq(&data));
     }

--- a/attest/core/src/types/target_info.rs
+++ b/attest/core/src/types/target_info.rs
@@ -240,7 +240,7 @@ mod test {
 
     #[test]
     fn test_bad_ffi_write_len() {
-        let ti: TargetInfo = TARGET_INFO_SAMPLE.clone().into();
+        let ti: TargetInfo = TARGET_INFO_SAMPLE.into();
         let mut outbuf = vec![0u8; size_of::<TargetInfo>() - 1];
 
         assert_eq!(
@@ -251,7 +251,7 @@ mod test {
 
     #[test]
     fn test_bad_ffi_read_len() {
-        let ti: TargetInfo = TARGET_INFO_SAMPLE.clone().into();
+        let ti: TargetInfo = TARGET_INFO_SAMPLE.into();
         let mut outbuf = vec![0u8; size_of::<TargetInfo>() - 1];
 
         assert_eq!(
@@ -262,7 +262,7 @@ mod test {
 
     #[test]
     fn test_target_info_serde() {
-        let ti1: TargetInfo = TARGET_INFO_SAMPLE.clone().into();
+        let ti1: TargetInfo = TARGET_INFO_SAMPLE.into();
         let ti1ser = serialize(&ti1).expect("TargetInfo serialization failure");
         let ti2 = deserialize(&ti1ser).expect("TargetInfo deserialization failure");
         assert_eq!(ti1, ti2);

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2256,14 +2256,10 @@ mod tests {
             let output1 = block_contents
                 .outputs
                 .iter()
-                .find(|output| {
-                    output
-                        .view_key_match(&recipient1.view_private_key())
-                        .is_ok()
-                })
+                .find(|output| output.view_key_match(recipient1.view_private_key()).is_ok())
                 .unwrap();
             let (amount, _) = output1
-                .view_key_match(&recipient1.view_private_key())
+                .view_key_match(recipient1.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, 12);
             assert_eq!(amount.token_id, token_id1);
@@ -2271,14 +2267,10 @@ mod tests {
             let output2 = block_contents
                 .outputs
                 .iter()
-                .find(|output| {
-                    output
-                        .view_key_match(&recipient2.view_private_key())
-                        .is_ok()
-                })
+                .find(|output| output.view_key_match(recipient2.view_private_key()).is_ok())
                 .unwrap();
             let (amount, _) = output2
-                .view_key_match(&recipient2.view_private_key())
+                .view_key_match(recipient2.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, 200);
             assert_eq!(amount.token_id, token_id2);
@@ -2813,14 +2805,10 @@ mod tests {
             let output1 = block_contents
                 .outputs
                 .iter()
-                .find(|output| {
-                    output
-                        .view_key_match(&recipient1.view_private_key())
-                        .is_ok()
-                })
+                .find(|output| output.view_key_match(recipient1.view_private_key()).is_ok())
                 .unwrap();
             let (amount, _) = output1
-                .view_key_match(&recipient1.view_private_key())
+                .view_key_match(recipient1.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, 12);
             assert_eq!(amount.token_id, token_id1);
@@ -2828,14 +2816,10 @@ mod tests {
             let output2 = block_contents
                 .outputs
                 .iter()
-                .find(|output| {
-                    output
-                        .view_key_match(&recipient2.view_private_key())
-                        .is_ok()
-                })
+                .find(|output| output.view_key_match(recipient2.view_private_key()).is_ok())
                 .unwrap();
             let (amount, _) = output2
-                .view_key_match(&recipient2.view_private_key())
+                .view_key_match(recipient2.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, 200);
             assert_eq!(amount.token_id, token_id2);

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -2388,8 +2388,8 @@ mod nominate_protocol_tests {
                 .expect("No message emitted");
 
             let expected = Msg::new(
-                local_node.0.clone(),
-                local_node.1.clone(),
+                local_node.0,
+                local_node.1,
                 slot_index,
                 Topic::Nominate(NominatePayload {
                     X: btreeset! { 777, 1000, 2000, 4242},
@@ -2437,11 +2437,11 @@ mod ballot_protocol_tests {
             .expect("No message emitted.");
 
         let expected = Msg::new(
-            local_node.0.clone(),
-            local_node.1.clone(),
+            local_node.0,
+            local_node.1,
             slot_index,
             Topic::Externalize(ExternalizePayload {
-                C: Ballot::new(1, &vec![1234, 1337, 1338, 5678]),
+                C: Ballot::new(1, &[1234, 1337, 1338, 5678]),
                 HN: 1,
             }),
         );
@@ -3433,7 +3433,7 @@ mod ballot_protocol_tests {
 
         // Not quorum; the local node emits its initial statement.
         for msg in msgs.iter().take(3) {
-            let emitted_msg = slot.handle_message(&msg);
+            let emitted_msg = slot.handle_message(msg);
             assert!(emitted_msg.unwrap().is_none());
         }
 

--- a/consensus/scp/tests/mock_network/metamesh_topology.rs
+++ b/consensus/scp/tests/mock_network/metamesh_topology.rs
@@ -73,8 +73,7 @@ pub fn metamesh(
                 .cloned()
                 .collect::<Vec<QuorumSet>>();
 
-            let mut inner_quorum_sets = Vec::<QuorumSet>::new();
-            inner_quorum_sets.push(inner_quorum_set_for_this_org);
+            let mut inner_quorum_sets = vec![inner_quorum_set_for_this_org];
             inner_quorum_sets.append(&mut inner_quorum_sets_for_other_orgs);
 
             // connect this node to all other nodes

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -251,7 +251,7 @@ impl SCPNetwork {
 
         for peer_id in peers {
             nodes_map
-                .get_mut(&peer_id)
+                .get_mut(peer_id)
                 .expect("failed to get peer from nodes_map")
                 .send_msg(amsg.clone());
         }
@@ -531,24 +531,28 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
     let node_ids: Vec<NodeID> = network_config.nodes.iter().map(|n| n.id.clone()).collect();
 
     // check that all ledgers start empty
-    for n in 0..network_config.nodes.len() {
-        assert!(simulation.get_ledger_size(&node_ids[n]) == 0);
+    for node_id in node_ids.iter().take(network_config.nodes.len()) {
+        assert!(simulation.get_ledger_size(node_id) == 0);
     }
 
     // push values
     let mut last_log = Instant::now();
-    for i in 0..test_options.values_to_submit {
+    for (i, value) in values
+        .iter()
+        .take(test_options.values_to_submit)
+        .enumerate()
+    {
         let start = Instant::now();
 
         if test_options.submit_in_parallel {
             // simulate broadcast of values to all nodes in parallel
-            for n in 0..network_config.nodes.len() {
-                simulation.push_value(&node_ids[n], &values[i]);
+            for node_id in node_ids.iter().take(network_config.nodes.len()) {
+                simulation.push_value(node_id, value);
             }
         } else {
             // submit values to nodes in sequence
             let n = i % network_config.nodes.len();
-            simulation.push_value(&node_ids[n], &values[i]);
+            simulation.push_value(&node_ids[n], value);
         }
 
         if last_log.elapsed().as_millis() > 999 {
@@ -596,7 +600,7 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
                 panic!("test failed due to timeout");
             }
 
-            let num_externalized_values = simulation.get_ledger_size(&node_id);
+            let num_externalized_values = simulation.get_ledger_size(node_id);
             if num_externalized_values >= test_options.values_to_submit {
                 // if the validity_fn does not enforce unique values, we can end up
                 // with values that appear in multiple slots. This is not a problem
@@ -644,7 +648,7 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
         // check that all submitted values are externalized at least once
         // duplicate values are possible depending on validity_fn
         let externalized_values_hashset = simulation
-            .get_ledger(&node_id)
+            .get_ledger(node_id)
             .iter()
             .flatten()
             .cloned()
@@ -681,7 +685,7 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
     // Check that all of the externalized ledgers match block-by-block
     let first_node_ledger = simulation.get_ledger(&node_ids[0]);
     for node_id in node_ids.iter().skip(1) {
-        let other_node_ledger = simulation.get_ledger(&node_id);
+        let other_node_ledger = simulation.get_ledger(node_id);
 
         if first_node_ledger.len() != other_node_ledger.len() {
             log::error!(

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -566,7 +566,7 @@ mod tests {
 
         // Validation should fail since the minimum fee for the second token is unknown.
         assert!(
-            matches!(tokens.validate(), Err(Error::MissingMinimumFee(token_id)) if token_id == TokenId::from(6))
+            matches!(tokens.validate(), Err(Error::MissingMinimumFee(token_id)) if token_id == 6)
         );
 
         // Getting the fee map should also fail.
@@ -597,7 +597,7 @@ mod tests {
 
         // Validation should fail since allow_any_fee cannot be used on non-MOB tokens.
         assert!(
-            matches!(tokens.validate(), Err(Error::AllowAnyFeeNotAllowed(token_id)) if token_id == TokenId::from(1))
+            matches!(tokens.validate(), Err(Error::AllowAnyFeeNotAllowed(token_id)) if token_id == 1)
         );
     }
 
@@ -806,7 +806,7 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 0
-            
+
             [tokens.governors]
             signers = """
             -----BEGIN PUBLIC KEY-----
@@ -828,7 +828,7 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 0 # Must have MOB
-            
+
             [[tokens]]
             token_id = 2
             minimum_fee = 1
@@ -839,9 +839,7 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert!(
-            matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == TokenId::from(2))
-        );
+        assert!(matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == 2));
     }
 
     #[test]
@@ -863,9 +861,7 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert!(
-            matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == TokenId::from(2))
-        );
+        assert!(matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == 2));
     }
 
     #[test]
@@ -929,8 +925,8 @@ mod tests {
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         // The governors signature should've decoded successfully.
-        assert!(!tokens
+        assert!(tokens
             .verify_governors_signature(&Ed25519Public::from(&minting_trust_root_private_key))
-            .is_ok());
+            .is_err());
     }
 }

--- a/consensus/service/src/api/attested_api_service.rs
+++ b/consensus/service/src/api/attested_api_service.rs
@@ -182,7 +182,7 @@ mod peer_tests {
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(err @ _) => {
+            Err(err) => {
                 panic!("Unexpected error {:?}", err);
             }
         }
@@ -250,7 +250,7 @@ mod client_tests {
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(err @ _) => {
+            Err(err) => {
                 panic!("Unexpected error {:?}", err);
             }
         }

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -282,7 +282,7 @@ mod tests {
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(err @ _) => {
+            Err(err) => {
                 panic!("Unexpected error {:?}", err);
             }
         }
@@ -440,7 +440,7 @@ mod tests {
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(err @ _) => {
+            Err(err) => {
                 panic!("Unexpected error {:?}", err);
             }
         }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -359,8 +359,10 @@ mod client_api_tests {
         let mut consensus_enclave = MockConsensusEnclave::new();
         {
             // Return a TxContext that contains some KeyImages.
-            let mut tx_context = TxContext::default();
-            tx_context.key_images = vec![KeyImage::default(), KeyImage::default()];
+            let tx_context = TxContext {
+                key_images: vec![KeyImage::default(), KeyImage::default()],
+                ..Default::default()
+            };
 
             consensus_enclave
                 .expect_client_tx_propose()
@@ -428,8 +430,10 @@ mod client_api_tests {
         let mut consensus_enclave = MockConsensusEnclave::new();
         {
             // Return a TxContext that contains some KeyImages.
-            let mut tx_context = TxContext::default();
-            tx_context.key_images = vec![KeyImage::default(), KeyImage::default()];
+            let tx_context = TxContext {
+                key_images: vec![KeyImage::default(), KeyImage::default()],
+                ..Default::default()
+            };
 
             consensus_enclave
                 .expect_client_tx_propose()
@@ -503,8 +507,10 @@ mod client_api_tests {
         let mut consensus_enclave = MockConsensusEnclave::new();
 
         // Return a TxContext that contains some KeyImages.
-        let mut tx_context = TxContext::default();
-        tx_context.key_images = vec![KeyImage::default(), KeyImage::default()];
+        let tx_context = TxContext {
+            key_images: vec![KeyImage::default(), KeyImage::default()],
+            ..Default::default()
+        };
 
         consensus_enclave
             .expect_client_tx_propose()
@@ -709,7 +715,7 @@ mod client_api_tests {
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(err @ _) => {
+            Err(err) => {
                 panic!("Unexpected error {:?}", err);
             }
         };

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -494,7 +494,7 @@ mod tests {
             get_incoming_consensus_msgs_sender_ok(),
             get_scp_client_value_sender(),
             get_fetch_latest_msg_fn(),
-            known_responder_ids.clone(),
+            known_responder_ids,
             logger,
         );
 
@@ -524,7 +524,7 @@ mod tests {
             let mut ledger = MockLedger::new();
             ledger
                 .expect_get_block()
-                .return_const(Ok(Block::new_origin_block(&vec![])));
+                .return_const(Ok(Block::new_origin_block(&[])));
             mc_peers::ConsensusMsg::from_scp_msg(&ledger, scp_msg, &node_x_signer_key).unwrap()
         };
 
@@ -598,7 +598,7 @@ mod tests {
             let mut ledger = MockLedger::new();
             ledger
                 .expect_get_block()
-                .return_const(Ok(Block::new_origin_block(&vec![])));
+                .return_const(Ok(Block::new_origin_block(&[])));
             mc_peers::ConsensusMsg::from_scp_msg(&ledger, scp_msg, &node_a_signer_key).unwrap()
         };
 
@@ -716,7 +716,7 @@ mod tests {
             let mut ledger = MockLedger::new();
             ledger
                 .expect_get_block()
-                .return_const(Ok(Block::new_origin_block(&vec![])));
+                .return_const(Ok(Block::new_origin_block(&[])));
             mc_peers::ConsensusMsg::from_scp_msg(&ledger, scp_msg, &wrong_signer_key).unwrap()
         };
 

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -177,7 +177,7 @@ mod tests {
         let ledger_path = TempDir::new("ledger").unwrap();
         setup_ledger_dir(
             &Some(origin_block_path.path().to_path_buf()),
-            &ledger_path.path().to_path_buf(),
+            ledger_path.path(),
         );
     }
 
@@ -196,7 +196,7 @@ mod tests {
 
         setup_ledger_dir(
             &Some(origin_block_path.path().to_path_buf()),
-            &ledger_path.path().to_path_buf(),
+            ledger_path.path(),
         );
 
         let new_data_path = ledger_path.path().join("data.mdb");
@@ -219,7 +219,7 @@ mod tests {
 
         setup_ledger_dir(
             &Some(origin_block_path.path().to_path_buf()),
-            &ledger_path.path().to_path_buf(),
+            ledger_path.path(),
         );
 
         let new_data_path = ledger_path.path().join("data.mdb");
@@ -247,7 +247,7 @@ mod tests {
 
         setup_ledger_dir(
             &Some(origin_block_path.path().to_path_buf()),
-            &ledger_path.path().to_path_buf(),
+            ledger_path.path(),
         );
 
         let mut data_file = File::open(&ledger_data_path).unwrap();

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -319,7 +319,7 @@ mod tests {
         tx_manager::{MockTxManager, TxManagerImpl},
         validators::DefaultTxManagerUntrustedInterfaces,
     };
-    use hex;
+
     use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::ConsensusServiceMockEnclave;
     use mc_consensus_scp::{core_types::Ballot, msg::*, SlotIndex};
@@ -366,7 +366,7 @@ mod tests {
     // Get the local node's NodeID and message signer key.
     pub fn get_local_node_config(node_id: u32) -> (NodeID, ConsensusPeerUri, Arc<Ed25519Pair>) {
         let secret_key = Ed25519Private::try_from_der(
-            &base64::decode("MC4CAQAwBQYDK2VwBCIEIC50QXQll2Y9qxztvmsUgcBBIxkmk7EQjxzQTa926bKo")
+            base64::decode("MC4CAQAwBQYDK2VwBCIEIC50QXQll2Y9qxztvmsUgcBBIxkmk7EQjxzQTa926bKo")
                 .unwrap()
                 .as_slice(),
         )
@@ -470,22 +470,22 @@ mod tests {
         let broadcaster = Arc::new(Mutex::new(MockBroadcast::new()));
 
         let byzantine_ledger = ByzantineLedger::new(
-            local_node_id.clone(),
-            local_quorum_set.clone(),
+            local_node_id,
+            local_quorum_set,
             enclave,
             peer_manager,
             ledger.clone(),
-            tx_manager.clone(),
+            tx_manager,
             mint_tx_manager,
             broadcaster,
-            msg_signer_key.clone(),
+            msg_signer_key,
             Vec::new(),
             None,
             logger.clone(),
         );
 
         // Initially, byzantine_ledger is not behind.
-        assert_eq!(byzantine_ledger.is_behind(), false);
+        assert!(!byzantine_ledger.is_behind());
     }
 
     // Initially, ByzantineLedger should emit the normal SCPStatements from
@@ -697,7 +697,7 @@ mod tests {
                 }
             }
 
-            thread::sleep(Duration::from_millis(100 as u64));
+            thread::sleep(Duration::from_millis(100_u64));
         }
 
         {
@@ -801,7 +801,7 @@ mod tests {
                 break;
             }
 
-            thread::sleep(Duration::from_millis(100 as u64));
+            thread::sleep(Duration::from_millis(100_u64));
         }
 
         let mut emitted_msgs = mock_peer_state
@@ -1032,7 +1032,7 @@ mod tests {
                 }
             }
 
-            thread::sleep(Duration::from_millis(100 as u64));
+            thread::sleep(Duration::from_millis(100_u64));
         }
 
         {
@@ -1115,7 +1115,7 @@ mod tests {
                 break;
             }
 
-            thread::sleep(Duration::from_millis(100 as u64));
+            thread::sleep(Duration::from_millis(100_u64));
         }
 
         let mut emitted_msgs = mock_peer_state
@@ -1136,9 +1136,9 @@ mod tests {
                         C: Ballot::new(
                             55,
                             &[
-                                ConsensusValue::MintTx(tx1.clone()),
-                                ConsensusValue::MintTx(tx2.clone()),
-                                ConsensusValue::MintTx(tx3.clone()),
+                                ConsensusValue::MintTx(tx1),
+                                ConsensusValue::MintTx(tx2),
+                                ConsensusValue::MintTx(tx3),
                             ]
                         ),
                         HN: 66,

--- a/consensus/service/src/byzantine_ledger/pending_values.rs
+++ b/consensus/service/src/byzantine_ledger/pending_values.rs
@@ -180,36 +180,33 @@ mod tests {
         // `validate` should be called one for each pending value.
         tx_manager
             .expect_validate()
-            .with(eq(values[0].clone()))
+            .with(eq(values[0]))
             .return_const(Ok(()));
         // This transaction has expired.
         tx_manager
             .expect_validate()
-            .with(eq(values[1].clone()))
+            .with(eq(values[1]))
             .return_const(Err(TxManagerError::TransactionValidation(
                 TransactionValidationError::TombstoneBlockExceeded,
             )));
         tx_manager
             .expect_validate()
-            .with(eq(values[2].clone()))
+            .with(eq(values[2]))
             .return_const(Ok(()));
 
         let mut pending_values =
             PendingValues::new(Arc::new(tx_manager), Arc::new(mint_tx_manager));
-        assert!(pending_values.push(values[0].clone().into(), None));
-        assert!(!pending_values.push(values[1].clone().into(), None));
-        assert!(pending_values.push(values[2].clone().into(), None));
+        assert!(pending_values.push(values[0].into(), None));
+        assert!(!pending_values.push(values[1].into(), None));
+        assert!(pending_values.push(values[2].into(), None));
 
         assert_eq!(
             pending_values.pending_values,
-            vec![values[0].clone().into(), values[2].clone().into()]
+            vec![values[0].into(), values[2].into()]
         );
         assert_eq!(
             pending_values.pending_values_map,
-            HashMap::from_iter(vec![
-                (values[0].clone().into(), None),
-                (values[2].clone().into(), None)
-            ])
+            HashMap::from_iter(vec![(values[0].into(), None), (values[2].into(), None)])
         );
     }
 
@@ -268,18 +265,18 @@ mod tests {
         // `validate` should be called one for each pending value.
         tx_manager
             .expect_validate()
-            .with(eq(tx_hashes[0].clone()))
+            .with(eq(tx_hashes[0]))
             .return_const(Ok(()));
         // This transaction has expired.
         tx_manager
             .expect_validate()
-            .with(eq(tx_hashes[1].clone()))
+            .with(eq(tx_hashes[1]))
             .return_const(Err(TxManagerError::TransactionValidation(
                 TransactionValidationError::TombstoneBlockExceeded,
             )));
         tx_manager
             .expect_validate()
-            .with(eq(tx_hashes[2].clone()))
+            .with(eq(tx_hashes[2]))
             .return_const(Ok(()));
 
         // Create new PendingValues and forcefully shove the pending tx_hashes into it

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -1188,7 +1188,7 @@ mod tests {
         // The worker must be behind.
         let first_sync_at = Instant::now();
         worker.ledger_sync_state = LedgerSyncState::IsBehind {
-            attempt_sync_at: first_sync_at.clone(),
+            attempt_sync_at: first_sync_at,
             num_sync_attempts: 7,
         };
 
@@ -1249,7 +1249,7 @@ mod tests {
         // The worker must be behind.
         let first_sync_at = Instant::now();
         worker.ledger_sync_state = LedgerSyncState::IsBehind {
-            attempt_sync_at: first_sync_at.clone(),
+            attempt_sync_at: first_sync_at,
             num_sync_attempts: 7,
         };
 
@@ -1296,7 +1296,7 @@ mod tests {
         for tx_hash in &tx_hashes[0..100] {
             tx_manager
                 .expect_validate()
-                .with(eq(tx_hash.clone()))
+                .with(eq(*tx_hash))
                 .return_const(Ok(()));
         }
 
@@ -1304,7 +1304,7 @@ mod tests {
         for tx_hash in &tx_hashes[100..103] {
             tx_manager
                 .expect_validate()
-                .with(eq(tx_hash.clone()))
+                .with(eq(*tx_hash))
                 .return_const(Err(TxManagerError::TransactionValidation(
                     TransactionValidationError::TombstoneBlockExceeded,
                 )));
@@ -1314,14 +1314,14 @@ mod tests {
         for tx_hash in &tx_hashes[103..] {
             tx_manager
                 .expect_validate()
-                .with(eq(tx_hash.clone()))
+                .with(eq(*tx_hash))
                 .return_const(Ok(()));
         }
 
         let connection_manager = get_connection_manager(&node_id, &peers, &logger);
         let (task_sender, task_receiver) = get_channel();
 
-        let previous_block = Block::new_origin_block(&vec![]);
+        let previous_block = Block::new_origin_block(&[]);
         ledger
             .expect_get_block()
             .times(1)
@@ -1348,11 +1348,11 @@ mod tests {
         );
 
         // Should return true when the task queue is empty.
-        assert_eq!(worker.receive_tasks(), true);
+        assert!(worker.receive_tasks());
 
         // Should return false when a StopTrigger is consumed.
         task_sender.send(TaskMessage::StopTrigger).unwrap();
-        assert_eq!(worker.receive_tasks(), false);
+        assert!(!worker.receive_tasks());
 
         for tx_hash in &tx_hashes {
             task_sender
@@ -1364,7 +1364,7 @@ mod tests {
         }
         // Initially, pending_values should be empty.
         assert!(worker.pending_values.is_empty());
-        assert_eq!(worker.receive_tasks(), true);
+        assert!(worker.receive_tasks());
         // Should maintain the invariant that pending_values only contains tx_hashes
         // corresponding to transactions that are valid w.r.t. the current ledger.
         assert_eq!(worker.pending_values.len(), tx_hashes.len() - 3);
@@ -1380,7 +1380,7 @@ mod tests {
 
         // Initially, pending_consensus_msgs should be empty.
         assert_eq!(worker.pending_consensus_msgs, vec![]);
-        assert_eq!(worker.receive_tasks(), true);
+        assert!(worker.receive_tasks());
         // The message from the task queue should now be pending.
         assert_eq!(worker.pending_consensus_msgs.len(), 1);
     }
@@ -1410,7 +1410,7 @@ mod tests {
         for tx_hash in &tx_hashes {
             tx_manager
                 .expect_validate()
-                .with(eq(tx_hash.clone()))
+                .with(eq(*tx_hash))
                 .return_const(Err(TxManagerError::TransactionValidation(
                     TransactionValidationError::TombstoneBlockExceeded,
                 )));
@@ -1446,7 +1446,7 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(worker.receive_tasks(), true);
+        assert!(worker.receive_tasks());
         // Should maintain the invariant that pending_values and pending_values map
         // only contain tx_hashes corresponding to transactions that are valid w.r.t the
         // current ledger.
@@ -1616,7 +1616,7 @@ mod tests {
         ledger_sync.expect_is_behind().return_const(false);
         scp_node
             .expect_max_externalized_slots()
-            .return_const(5 as usize);
+            .return_const(5_usize);
         scp_node.expect_process_timeouts().return_const(Vec::new());
         scp_node.expect_get_externalized_values().return_const(vec![
             ConsensusValue::TxHash(hash_tx1),

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -455,14 +455,14 @@ mod mint_config_tx_tests {
             mint_tx_manager.combine_mint_config_txs(
                 &[
                     mint_config_tx3.clone(),
-                    mint_config_tx4.clone(),
+                    mint_config_tx4,
                     mint_config_tx1.clone(),
                     mint_config_tx3.clone(),
-                    mint_config_tx3.clone(),
+                    mint_config_tx3,
                     mint_config_tx2.clone(),
                     mint_config_tx1.clone(),
-                    mint_config_tx1.clone(),
-                    mint_config_tx2.clone(),
+                    mint_config_tx1,
+                    mint_config_tx2,
                 ],
                 100
             ),
@@ -511,15 +511,15 @@ mod mint_config_tx_tests {
             mint_tx_manager.combine_mint_config_txs(
                 &[
                     mint_config_tx3.clone(),
-                    mint_config_tx4.clone(),
+                    mint_config_tx4,
                     mint_config_tx1.clone(),
-                    mint_config_tx5.clone(),
-                    mint_config_tx3.clone(),
+                    mint_config_tx5,
+                    mint_config_tx3,
                     mint_config_tx2.clone(),
                     mint_config_tx1.clone(),
-                    mint_config_tx1.clone(),
-                    mint_config_tx2.clone(),
-                    mint_config_tx6.clone(),
+                    mint_config_tx1,
+                    mint_config_tx2,
+                    mint_config_tx6,
                 ],
                 3
             ),

--- a/consensus/service/src/tx_manager/mod.rs
+++ b/consensus/service/src/tx_manager/mod.rs
@@ -360,7 +360,7 @@ mod tests {
         let well_formed_encrypted_tx = WellFormedEncryptedTx::default();
         let well_formed_tx_context = WellFormedTxContext::new(
             0,
-            tx_hash.clone(),
+            tx_hash,
             Default::default(),
             Default::default(),
             Default::default(),
@@ -375,7 +375,7 @@ mod tests {
         let tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
         assert_eq!(tx_manager.num_entries(), 0);
 
-        assert!(tx_manager.insert(tx_context.clone()).is_ok());
+        assert!(tx_manager.insert(tx_context).is_ok());
         assert_eq!(tx_manager.num_entries(), 1);
         assert!(tx_manager.lock_cache().contains_key(&tx_hash));
     }
@@ -401,7 +401,7 @@ mod tests {
         let well_formed_encrypted_tx = WellFormedEncryptedTx::default();
         let well_formed_tx_context = WellFormedTxContext::new(
             0,
-            tx_hash.clone(),
+            tx_hash,
             Default::default(),
             Default::default(),
             Default::default(),
@@ -421,7 +421,7 @@ mod tests {
         assert!(tx_manager.lock_cache().contains_key(&tx_hash));
 
         // Re-inserting should also be Ok.
-        assert!(tx_manager.insert(tx_context.clone()).is_ok());
+        assert!(tx_manager.insert(tx_context).is_ok());
         assert_eq!(tx_manager.num_entries(), 1);
         assert!(tx_manager.lock_cache().contains_key(&tx_hash));
     }
@@ -444,7 +444,7 @@ mod tests {
         let mock_enclave = MockConsensusEnclave::new();
 
         let tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert!(tx_manager.insert(tx_context.clone()).is_err());
+        assert!(tx_manager.insert(tx_context).is_err());
         assert_eq!(tx_manager.num_entries(), 0);
     }
 
@@ -470,7 +470,7 @@ mod tests {
             .return_const(Err(EnclaveError::Signature));
 
         let tx_manager = TxManagerImpl::new(mock_enclave, mock_untrusted, logger.clone());
-        assert!(tx_manager.insert(tx_context.clone()).is_err());
+        assert!(tx_manager.insert(tx_context).is_err());
         assert_eq!(tx_manager.num_entries(), 0);
     }
 
@@ -501,7 +501,7 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
 
         assert_eq!(tx_manager.num_entries(), 14);
@@ -562,7 +562,7 @@ mod tests {
             .cache
             .lock()
             .unwrap()
-            .insert(tx_context.tx_hash.clone(), cache_entry);
+            .insert(tx_context.tx_hash, cache_entry);
 
         assert!(tx_manager.validate(&tx_context.tx_hash).is_ok());
     }
@@ -614,7 +614,7 @@ mod tests {
             .cache
             .lock()
             .unwrap()
-            .insert(tx_context.tx_hash.clone(), cache_entry);
+            .insert(tx_context.tx_hash, cache_entry);
 
         match tx_manager.validate(&tx_context.tx_hash) {
             Err(TxManagerError::TransactionValidation(
@@ -643,7 +643,7 @@ mod tests {
         for tx_hash in &tx_hashes {
             let context = WellFormedTxContext::new(
                 Default::default(),
-                tx_hash.clone(),
+                *tx_hash,
                 Default::default(),
                 Default::default(),
                 Default::default(),
@@ -659,7 +659,7 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
         assert_eq!(tx_manager.num_entries(), tx_hashes.len());
 
@@ -686,7 +686,7 @@ mod tests {
         for tx_hash in &tx_hashes[2..] {
             let context = WellFormedTxContext::new(
                 Default::default(),
-                tx_hash.clone(),
+                *tx_hash,
                 Default::default(),
                 Default::default(),
                 Default::default(),
@@ -702,13 +702,10 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
 
-        match tx_manager.combine(&tx_hashes) {
-            Ok(_combined) => panic!(),
-            _ => {} // This is expected.
-        }
+        assert!(tx_manager.combine(&tx_hashes).is_err());
     }
 
     // TODO: tx_hashed_to_block should provide correct proofs for highest indices
@@ -786,7 +783,7 @@ mod tests {
 
         // This transaction is not in the cache.
         let not_in_cache = TxHash([66u8; 32]);
-        tx_hashes.insert(2, not_in_cache.clone());
+        tx_hashes.insert(2, not_in_cache);
 
         match tx_manager.tx_hashes_to_well_formed_encrypted_txs_and_proofs(&tx_hashes[..]) {
             Ok(_) => {
@@ -819,7 +816,7 @@ mod tests {
         for tx_hash in &tx_hashes {
             let context = WellFormedTxContext::new(
                 Default::default(),
-                tx_hash.clone(),
+                *tx_hash,
                 Default::default(),
                 Default::default(),
                 Default::default(),
@@ -835,7 +832,7 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
         assert_eq!(tx_manager.num_entries(), tx_hashes.len());
 
@@ -883,7 +880,7 @@ mod tests {
         for tx_hash in &tx_hashes {
             let context = WellFormedTxContext::new(
                 Default::default(),
-                tx_hash.clone(),
+                *tx_hash,
                 Default::default(),
                 Default::default(),
                 Default::default(),
@@ -899,7 +896,7 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
         assert_eq!(tx_manager.num_entries(), tx_hashes.len());
 
@@ -930,7 +927,7 @@ mod tests {
             .cache
             .lock()
             .unwrap()
-            .insert(tx_hash.clone(), cache_entry);
+            .insert(tx_hash, cache_entry);
 
         // Get something that is in the cache.
         assert_eq!(
@@ -957,7 +954,7 @@ mod tests {
         for tx_hash in &tx_hashes {
             let context = WellFormedTxContext::new(
                 Default::default(),
-                tx_hash.clone(),
+                *tx_hash,
                 Default::default(),
                 Default::default(),
                 Default::default(),
@@ -973,7 +970,7 @@ mod tests {
                 .cache
                 .lock()
                 .unwrap()
-                .insert(context.tx_hash().clone(), cache_entry);
+                .insert(*context.tx_hash(), cache_entry);
         }
         assert_eq!(tx_manager.num_entries(), tx_hashes.len());
     }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -234,8 +234,10 @@ pub mod well_formed_tests {
 
         // This tx_context contains highest_indices that exceed the number of TxOuts in
         // the ledger.
-        let mut tx_context = TxContext::default();
-        tx_context.highest_indices = vec![99, 10002, 445];
+        let tx_context = TxContext {
+            highest_indices: vec![99, 10002, 445],
+            ..Default::default()
+        };
 
         match untrusted.well_formed_check(&tx_context) {
             Ok((_cur_block_index, _membership_proofs)) => {
@@ -977,7 +979,7 @@ mod combine_tests {
                     .unwrap();
 
                 let mut tx = transaction_builder.build(&mut rng).unwrap();
-                tx.prefix.outputs[0].public_key = first_client_tx.output_public_keys()[0].clone();
+                tx.prefix.outputs[0].public_key = first_client_tx.output_public_keys()[0];
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 

--- a/crypto/box/src/lib.rs
+++ b/crypto/box/src/lib.rs
@@ -53,7 +53,7 @@ mod test {
                         algo.decrypt(&a, &ciphertext).expect("decryption failed!");
                     assert_eq!(plaintext.len(), decrypted.len());
                     assert_eq!(plaintext, &&decrypted[..]);
-                    assert_eq!(bool::from(success), true);
+                    assert!(bool::from(success));
                 }
             }
         });
@@ -75,7 +75,7 @@ mod test {
                 for _reps in 0..50 {
                     let ciphertext = algo.encrypt(&mut rng, &a_pub, plaintext).unwrap();
                     let (success, _decrypted) = algo.decrypt(&not_a, &ciphertext).unwrap();
-                    assert_eq!(bool::from(success), false);
+                    assert!(!bool::from(success));
                 }
             }
         });
@@ -100,7 +100,7 @@ mod test {
                         .decrypt_fixed_length(&a, &ciphertext)
                         .expect("decryption failed!");
                     assert_eq!(plaintext, &decrypted);
-                    assert_eq!(bool::from(success), true);
+                    assert!(bool::from(success));
                 }
             }
         });

--- a/crypto/digestible/derive/test/tests/behavior.rs
+++ b/crypto/digestible/derive/test/tests/behavior.rs
@@ -408,8 +408,8 @@ fn bar2() {
 #[test]
 fn generic_example_struct1() {
     let arg = GenericExampleStruct {
-        a: 123 as u32,
-        b: 456 as u32,
+        a: 123u32,
+        b: 456u32,
     };
 
     let expected_ast = ASTNode::from(ASTAggregate {
@@ -439,8 +439,8 @@ fn generic_example_struct1() {
     );
 
     let arg2 = GenericExampleStruct {
-        a: Some(123 as u32),
-        b: Some(456 as u32),
+        a: Some(123u32),
+        b: Some(456u32),
     };
 
     digestible_test_case_ast("genfoo1", &arg2, expected_ast);
@@ -458,8 +458,8 @@ fn generic_example_struct1() {
 #[test]
 fn generic_example_struct2() {
     let arg = GenericExampleStruct {
-        a: 123 as i32,
-        b: 456 as i32,
+        a: 123i32,
+        b: 456i32,
     };
 
     let expected_ast = ASTNode::from(ASTAggregate {
@@ -489,8 +489,8 @@ fn generic_example_struct2() {
     );
 
     let arg2 = GenericExampleStruct {
-        a: Some(123 as i32),
-        b: Some(456 as i32),
+        a: Some(123i32),
+        b: Some(456i32),
     };
 
     digestible_test_case_ast("genfoo2", &arg2, expected_ast);

--- a/crypto/digestible/derive/test/tests/schema_evolution.rs
+++ b/crypto/digestible/derive/test/tests/schema_evolution.rs
@@ -310,7 +310,7 @@ fn struct_schema_evolution() {
             b: Some(99),
             c: Default::default(),
             d: 0,
-            e: vec!['a' as u8]
+            e: vec![b'a']
         }
         .digest32::<MerlinTranscript>(b"test"),
         ThingV7 {

--- a/crypto/digestible/test-utils/tests/sanity.rs
+++ b/crypto/digestible/test-utils/tests/sanity.rs
@@ -166,7 +166,7 @@ fn digest_aggregate_append_bytes() {
     let seq3 = ASTNode::from(ASTAggregate {
         context: b"stuff3",
         name: b"blob".to_vec(),
-        elems: vec![prim1.clone(), prim2.clone()],
+        elems: vec![prim1, prim2],
         is_completed: true,
     });
 

--- a/crypto/sig/src/lib.rs
+++ b/crypto/sig/src/lib.rs
@@ -243,7 +243,7 @@ mod tests {
 
             let sig = sign(b"test", &seckey2, b"foobar");
             let result = verify(b"test", &pubkey, b"foobar", &sig);
-            assert!(!result.is_ok());
+            assert!(result.is_err());
         })
     }
     // Expected failure when message is different
@@ -255,7 +255,7 @@ mod tests {
 
             let sig = sign(b"test", &seckey, b"foobar");
             let result = verify(b"test", &pubkey, b"foobarbaz", &sig);
-            assert!(!result.is_ok());
+            assert!(result.is_err());
         })
     }
 
@@ -268,7 +268,7 @@ mod tests {
 
             let sig = sign(b"test", &seckey, b"foobar");
             let result = verify(b"prod", &pubkey, b"foobar", &sig);
-            assert!(!result.is_ok());
+            assert!(result.is_err());
         })
     }
 }

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -262,9 +262,11 @@ fn check_key_images_response_round_trip() {
     }
 
     run_with_several_seeds(|mut rng| {
-        let mut test_val = mc_fog_types::ledger::CheckKeyImagesResponse::default();
-        test_val.num_blocks = rng.next_u32() as u64;
-        test_val.global_txo_count = rng.next_u32() as u64;
+        let mut test_val = mc_fog_types::ledger::CheckKeyImagesResponse {
+            num_blocks: rng.next_u32() as u64,
+            global_txo_count: rng.next_u32() as u64,
+            ..Default::default()
+        };
         for _ in 0..20 {
             test_val
                 .results
@@ -401,39 +403,39 @@ impl Sample for [u8; 32] {
 
 impl Sample for KexRngPubkey {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let mut result = KexRngPubkey::default();
-        result.public_key = <[u8; 32]>::sample(rng).to_vec();
-        result.version = rng.next_u32();
-        result
+        Self {
+            public_key: <[u8; 32]>::sample(rng).to_vec(),
+            version: rng.next_u32(),
+        }
     }
 }
 
 impl Sample for mc_fog_types::view::RngRecord {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let mut result = Self::default();
-        result.ingest_invocation_id = rng.next_u64() as i64;
-        result.pubkey = <KexRngPubkey>::sample(rng);
-        result.start_block = rng.next_u64();
-        result
+        Self {
+            ingest_invocation_id: rng.next_u64() as i64,
+            pubkey: KexRngPubkey::sample(rng),
+            start_block: rng.next_u64(),
+        }
     }
 }
 
 impl Sample for mc_fog_types::view::DecommissionedIngestInvocation {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let mut result = Self::default();
-        result.ingest_invocation_id = rng.next_u64() as i64;
-        result.last_ingested_block = rng.next_u64();
-        result
+        Self {
+            ingest_invocation_id: rng.next_u64() as i64,
+            last_ingested_block: rng.next_u64(),
+        }
     }
 }
 
 impl Sample for mc_fog_types::view::TxOutSearchResult {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let mut result = Self::default();
-        result.search_key = <[u8; 32]>::sample(rng).to_vec();
-        result.ciphertext = <[u8; 32]>::sample(rng).to_vec();
-        result.result_code = 1;
-        result
+        Self {
+            search_key: <[u8; 32]>::sample(rng).to_vec(),
+            ciphertext: <[u8; 32]>::sample(rng).to_vec(),
+            result_code: 1,
+        }
     }
 }
 

--- a/fog/ingest/client/tests/get_ingress_key_records.rs
+++ b/fog/ingest/client/tests/get_ingress_key_records.rs
@@ -36,21 +36,18 @@ fn test_get_ingress_key_records(logger: Logger) {
             .arg("0")
             .assert()
             .success()
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.active_ingress_pubkey.get_data(),
             )))
             .stdout(
-                predicate::str::contains(format!(
-                    "{}",
-                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                predicate::str::contains(hex::encode(
+                    &ingest_server_set_up_data.retired_ingress_pubkey.get_data(),
                 ))
                 .not(),
             )
             .stdout(
-                predicate::str::contains(format!(
-                    "{}",
-                    hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+                predicate::str::contains(hex::encode(
+                    &ingest_server_set_up_data.lost_ingress_pubkey.get_data(),
                 ))
                 .not(),
             );
@@ -66,20 +63,17 @@ fn test_get_ingress_key_records(logger: Logger) {
             .arg("--include-lost")
             .assert()
             .success()
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.active_ingress_pubkey.get_data(),
             )))
             .stdout(
-                predicate::str::contains(format!(
-                    "{}",
-                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                predicate::str::contains(hex::encode(
+                    &ingest_server_set_up_data.retired_ingress_pubkey.get_data(),
                 ))
                 .not(),
             )
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.lost_ingress_pubkey.get_data(),
             )));
     }
 
@@ -94,18 +88,15 @@ fn test_get_ingress_key_records(logger: Logger) {
             .arg("--include-retired")
             .assert()
             .success()
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.active_ingress_pubkey.get_data(),
             )))
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.retired_ingress_pubkey.get_data(),
             )))
             .stdout(
-                predicate::str::contains(format!(
-                    "{}",
-                    hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+                predicate::str::contains(hex::encode(
+                    &ingest_server_set_up_data.lost_ingress_pubkey.get_data(),
                 ))
                 .not(),
             );
@@ -124,17 +115,14 @@ fn test_get_ingress_key_records(logger: Logger) {
             .arg("--include-retired")
             .assert()
             .success()
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.active_ingress_pubkey.get_data(),
             )))
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.retired_ingress_pubkey.get_data(),
             )))
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.lost_ingress_pubkey.get_data(),
             )));
     }
     // Test that the "--start-block-at-least" option works correctly.
@@ -151,20 +139,17 @@ fn test_get_ingress_key_records(logger: Logger) {
             .arg("--include-retired")
             .assert()
             .success()
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.active_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.active_ingress_pubkey.get_data(),
             )))
             .stdout(
-                predicate::str::contains(format!(
-                    "{}",
-                    hex::encode(&ingest_server_set_up_data.retired_ingress_pubkey.get_data())
+                predicate::str::contains(hex::encode(
+                    &ingest_server_set_up_data.retired_ingress_pubkey.get_data(),
                 ))
                 .not(),
             )
-            .stdout(predicate::str::contains(format!(
-                "{}",
-                hex::encode(&ingest_server_set_up_data.lost_ingress_pubkey.get_data())
+            .stdout(predicate::str::contains(hex::encode(
+                &ingest_server_set_up_data.lost_ingress_pubkey.get_data(),
             )));
     }
 }
@@ -202,7 +187,7 @@ fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
     db.new_ingress_key(&ingress_key3, 789).unwrap();
 
     db.retire_ingress_key(&ingress_key1, true).unwrap();
-    db.report_lost_ingress_key(ingress_key2.clone()).unwrap();
+    db.report_lost_ingress_key(ingress_key2).unwrap();
 
     let ingest_server_client_uri = &format!("insecure-fog-ingest://0.0.0.0:{}/", BASE_PORT + 4);
     let ingest_server = {
@@ -213,10 +198,10 @@ fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
 
         let config = IngestServerConfig {
             ias_spid: Default::default(),
-            local_node_id: local_node_id.clone(),
-            client_listen_uri: FogIngestUri::from_str(&ingest_server_client_uri).unwrap(),
+            local_node_id,
+            client_listen_uri: FogIngestUri::from_str(ingest_server_client_uri).unwrap(),
             peer_listen_uri: igp_uri.clone(),
-            peers: btreeset![igp_uri.clone()],
+            peers: btreeset![igp_uri],
             fog_report_id: Default::default(),
             max_transactions: 10_000,
             pubkey_expiry_window: 100,
@@ -239,14 +224,7 @@ fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
         let ledger_db = LedgerDB::open(ledger_db_path.path()).unwrap();
 
         let ra_client = AttestClient::new("").expect("Could not create IAS client");
-        let mut node = IngestServer::new(
-            config,
-            ra_client,
-            db.clone(),
-            watcher,
-            ledger_db,
-            logger.clone(),
-        );
+        let mut node = IngestServer::new(config, ra_client, db, watcher, ledger_db, logger.clone());
         node.start().expect("Could not start Ingest Service");
 
         node
@@ -254,12 +232,12 @@ fn set_up_ingest_servers(logger: Logger) -> IngestServerSetUpData {
 
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
-    return IngestServerSetUpData {
+    IngestServerSetUpData {
         _ingest_server: ingest_server,
         _db_test_context: db_test_context,
         ingest_server_client_uri: ingest_server_client_uri.to_owned(),
         retired_ingress_pubkey: external::CompressedRistretto::from(&ingress_key1),
         lost_ingress_pubkey: external::CompressedRistretto::from(&ingress_key2),
         active_ingress_pubkey: external::CompressedRistretto::from(&ingress_key3),
-    };
+    }
 }

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -143,8 +143,10 @@ fn test_ingest_enclave(logger: Logger) {
 
         // Check that Alice cannot decrypt the payloads for each tx row
         let alice_fog_credential = UserPrivate::from(&alice_account);
-        for idx in 0..10 {
-            if let Ok(_) = alice_fog_credential.decrypt_tx_out_result(tx_rows[idx].payload.clone())
+        for tx_row in tx_rows.iter().take(10) {
+            if alice_fog_credential
+                .decrypt_tx_out_result(tx_row.payload.clone())
+                .is_ok()
             {
                 panic!("Alice should not have been able to decrypt the tx row!");
             }
@@ -157,10 +159,10 @@ fn make_malformed_fog_hint<T: RngCore + CryptoRng>(
     ingress_pubkey: &RistrettoPublic,
     rng: &mut T,
 ) -> EncryptedFogHint {
-    let mut plaintext = PlaintextArray::default();
+    let plaintext = PlaintextArray::default();
 
     let bytes = VersionedCryptoBox::default()
-        .encrypt_fixed_length(rng, ingress_pubkey, &mut plaintext)
+        .encrypt_fixed_length(rng, ingress_pubkey, &plaintext)
         .expect("cryptobox encryption failed unexpectedly");
     EncryptedFogHint::from(bytes)
 }
@@ -181,7 +183,7 @@ fn make_malformed_fog_hint2<T: RngCore + CryptoRng>(
     }
 
     let bytes = VersionedCryptoBox::default()
-        .encrypt_fixed_length(rng, ingress_pubkey, &mut plaintext)
+        .encrypt_fixed_length(rng, ingress_pubkey, &plaintext)
         .expect("cryptobox encryption failed unexpectedly");
     EncryptedFogHint::from(bytes)
 }
@@ -461,7 +463,7 @@ fn test_ingest_enclave_overflow(logger: Logger) {
             .iter()
             .map(|kex_rng_pubkey| {
                 VersionedKexRng::try_from_kex_pubkey(
-                    &kex_rng_pubkey,
+                    kex_rng_pubkey,
                     alice_fog_credential.get_view_key(),
                 )
                 .expect("Could not form kex rng")
@@ -472,7 +474,7 @@ fn test_ingest_enclave_overflow(logger: Logger) {
             .iter()
             .map(|kex_rng_pubkey| {
                 VersionedKexRng::try_from_kex_pubkey(
-                    &kex_rng_pubkey,
+                    kex_rng_pubkey,
                     bob_fog_credential.get_view_key(),
                 )
                 .expect("Could not form kex rng")

--- a/fog/ingest/server/tests/key_sharing_on_activate.rs
+++ b/fog/ingest/server/tests/key_sharing_on_activate.rs
@@ -61,7 +61,7 @@ fn make_node(
         pubkey_expiry_window: 100,
         peer_checkup_period: None,
         watcher_timeout: Duration::default(),
-        state_file: Some(StateFile::new(state_file.clone())),
+        state_file: Some(StateFile::new(state_file)),
         enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
         omap_capacity: OMAP_CAPACITY,
     };
@@ -155,19 +155,19 @@ fn test_key_sharing_on_activate(logger: Logger) {
     assert_eq!(node0_key, node4_key);
 
     assert!(
-        !node1.activate().is_ok(),
+        node1.activate().is_err(),
         "node1 should not have been able to activate"
     );
     assert!(
-        !node2.activate().is_ok(),
+        node2.activate().is_err(),
         "node2 should not have been able to activate"
     );
     assert!(
-        !node3.activate().is_ok(),
+        node3.activate().is_err(),
         "node3 should not have been able to activate"
     );
     assert!(
-        !node4.activate().is_ok(),
+        node4.activate().is_err(),
         "node4 should not have been able to activate"
     );
 
@@ -192,19 +192,19 @@ fn test_key_sharing_on_activate(logger: Logger) {
         "node0 didn't get the old key back after node1 was activated"
     );
     assert!(
-        !node0.activate().is_ok(),
+        node0.activate().is_err(),
         "node1 should not have been able to activate"
     );
     assert!(
-        !node2.activate().is_ok(),
+        node2.activate().is_err(),
         "node2 should not have been able to activate"
     );
     assert!(
-        !node3.activate().is_ok(),
+        node3.activate().is_err(),
         "node3 should not have been able to activate"
     );
     assert!(
-        !node4.activate().is_ok(),
+        node4.activate().is_err(),
         "node4 should not have been able to activate"
     );
 

--- a/fog/ingest/server/tests/sealed_key.rs
+++ b/fog/ingest/server/tests/sealed_key.rs
@@ -36,14 +36,14 @@ fn test_ingest_sealed_key_recovery(logger: Logger) {
 
     let config = IngestServerConfig {
         ias_spid: Default::default(),
-        local_node_id: local_node_id.clone(),
+        local_node_id,
         client_listen_uri: FogIngestUri::from_str(&format!(
             "insecure-fog-ingest://0.0.0.0:{}/",
             base_port + 4
         ))
         .unwrap(),
         peer_listen_uri: igp_uri.clone(),
-        peers: btreeset![igp_uri.clone()],
+        peers: btreeset![igp_uri],
         fog_report_id: Default::default(),
         max_transactions: 10_000,
         pubkey_expiry_window: 100,
@@ -101,14 +101,7 @@ fn test_ingest_sealed_key_recovery(logger: Logger) {
     drop(std::fs::remove_file(&state_file));
 
     let ra_client = AttestClient::new("").expect("Could not create IAS client");
-    let node = IngestServer::new(
-        config.clone(),
-        ra_client,
-        db.clone(),
-        watcher.clone(),
-        ledger_db.clone(),
-        logger.clone(),
-    );
+    let node = IngestServer::new(config, ra_client, db, watcher, ledger_db, logger.clone());
 
     let summary3 = node.get_ingest_summary();
     assert_ne!(

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -219,12 +219,9 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
     WatcherDB::create(&watcher_path).unwrap();
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");
@@ -433,12 +430,9 @@ fn three_node_cluster_fencing(logger: Logger) {
     WatcherDB::create(&watcher_path).unwrap();
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
         // add test KeyImageData record to ledger oram
         let v_result1 = key_image_store.add_record(&rec.key_image, rec.block_index, rec.timestamp);
 
-        assert!(v_result1.is_ok() && !v_result1.is_err());
+        assert!(v_result1.is_ok());
 
         //query the ledger oram for the record using the key_image
         let v = key_image_store.find_record(&rec.key_image);
@@ -250,7 +250,7 @@ mod tests {
         let v_result2 =
             key_image_store.add_record(&rec2.key_image, rec2.block_index, rec2.timestamp);
 
-        assert!(v_result2.is_ok() && !v_result2.is_err());
+        assert!(v_result2.is_ok());
 
         //query the ledger oram for the record using the key_image
         let v2 = key_image_store.find_record(&rec2.key_image);
@@ -266,7 +266,7 @@ mod tests {
         let v_result3 =
             key_image_store.add_record(&rec3.key_image, rec3.block_index, rec3.timestamp);
 
-        assert!(v_result3.is_ok() && !v_result3.is_err());
+        assert!(v_result3.is_ok());
         //we can add the record even if the key image is all zero bytes
         let rec3 = KeyImageData {
             key_image: KeyImage::from(0),
@@ -278,7 +278,7 @@ mod tests {
             key_image_store.add_record(&rec3.key_image, rec3.block_index, rec3.timestamp);
 
         // we should not get back "invalid key" error
-        assert!(!v_result.is_err());
+        assert!(v_result.is_ok());
 
         //query the ledger oram for the record using the key_image
         let v3 = key_image_store.find_record(&rec3.key_image);

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -92,7 +92,7 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
     // Initialize an OverSeerService object
     let mut overseer_service = OverseerService::new(
         vec![client_listen_uri0, client_listen_uri1, client_listen_uri2],
-        recovery_db.clone(),
+        recovery_db,
         logger.clone(),
     );
     overseer_service.start().unwrap();

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -42,12 +42,9 @@ fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_an
 
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -42,12 +42,9 @@ fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_
 
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/overseer/server/tests/one_active_node.rs
+++ b/fog/overseer/server/tests/one_active_node.rs
@@ -34,12 +34,9 @@ fn one_active_node_cluster_state_does_not_change(logger: Logger) {
 
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let _watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let _watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -96,7 +96,7 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
     // Initialize an OverSeerService object
     let mut overseer_service = OverseerService::new(
         vec![client_listen_uri0, client_listen_uri1, client_listen_uri2],
-        recovery_db.clone(),
+        recovery_db,
         logger.clone(),
     );
     overseer_service.start().unwrap();

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -42,12 +42,9 @@ fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_
 
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -40,12 +40,9 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
 
     // Open the watcher db
     let tx_source_url = Url::from_str("https://localhost").unwrap();
-    let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
-        &watcher_path,
-        &[tx_source_url.clone()],
-        logger.clone(),
-    )
-    .expect("Could not create watcher_db");
+    let watcher =
+        mc_watcher::watcher_db::WatcherDB::open_rw(&watcher_path, &[tx_source_url], logger.clone())
+            .expect("Could not create watcher_db");
 
     // Set up an empty ledger db.
     let ledger_db_path = blockchain_path.path().join("ledger_db");

--- a/fog/report/server/tests/grpc_apis.rs
+++ b/fog/report/server/tests/grpc_apis.rs
@@ -37,8 +37,7 @@ fn report_server_grpc_tests(logger: Logger) {
     let env = Arc::new(grpcio::EnvBuilder::new().build());
 
     let report_client = {
-        let ch = ChannelBuilder::default_channel_builder(env.clone())
-            .connect_to_uri(&client_uri, &logger);
+        let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&client_uri, &logger);
         report_grpc::ReportApiClient::new(ch)
     };
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -1534,7 +1534,7 @@ mod tests {
             egress_key1.version
         );
         assert_eq!(ingest_invocations[0].start_block, 0);
-        assert_eq!(ingest_invocations[0].decommissioned, false);
+        assert!(!ingest_invocations[0].decommissioned);
 
         assert_eq!(
             IngestInvocationId::from(ingest_invocations[1].id),
@@ -1550,7 +1550,7 @@ mod tests {
             egress_key2.version
         );
         assert_eq!(ingest_invocations[1].start_block, 100);
-        assert_eq!(ingest_invocations[1].decommissioned, false);
+        assert!(!ingest_invocations[1].decommissioned);
     }
 
     #[test_with_logger]
@@ -1575,7 +1575,7 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         // Add an ingested block and see that last_ingested_block gets updated.
@@ -1588,7 +1588,7 @@ mod tests {
             assert_eq!(ranges.len(), 1);
             assert_eq!(ranges[0].id, invoc_id1);
             assert_eq!(ranges[0].start_block, 123);
-            assert_eq!(ranges[0].decommissioned, false);
+            assert!(!ranges[0].decommissioned);
             assert_eq!(ranges[0].last_ingested_block, Some(block_index));
         }
 
@@ -1602,12 +1602,12 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, Some(129));
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 1020);
-        assert_eq!(ranges[1].decommissioned, false);
+        assert!(!ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
 
         // Decomission the first ingest invocation and validate the returned data.
@@ -1618,12 +1618,12 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, true);
+        assert!(ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, Some(129));
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 1020);
-        assert_eq!(ranges[1].decommissioned, false);
+        assert!(!ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
 
         // Decomission the second ingest invocation and validate the returned data.
@@ -1634,12 +1634,12 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, true);
+        assert!(ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, Some(129));
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 1020);
-        assert_eq!(ranges[1].decommissioned, true);
+        assert!(ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
     }
 
@@ -1666,12 +1666,12 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 456);
-        assert_eq!(ranges[1].decommissioned, false);
+        assert!(!ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
 
         // Ensure we do not have any decommissioning events.
@@ -1679,13 +1679,7 @@ mod tests {
         assert_eq!(
             events
                 .iter()
-                .filter(
-                    |event| if let FogUserEvent::DecommissionIngestInvocation(_) = event {
-                        true
-                    } else {
-                        false
-                    }
-                )
+                .filter(|event| matches!(event, FogUserEvent::DecommissionIngestInvocation(_)))
                 .count(),
             0
         );
@@ -1698,12 +1692,12 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 456);
-        assert_eq!(ranges[1].decommissioned, true);
+        assert!(ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
 
         // We should have one decommissioning event.
@@ -1741,17 +1735,17 @@ mod tests {
 
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, true);
+        assert!(ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         assert_eq!(ranges[1].id, invoc_id2);
         assert_eq!(ranges[1].start_block, 456);
-        assert_eq!(ranges[1].decommissioned, true);
+        assert!(ranges[1].decommissioned);
         assert_eq!(ranges[1].last_ingested_block, None);
 
         assert_eq!(ranges[2].id, invoc_id3);
         assert_eq!(ranges[2].start_block, 456);
-        assert_eq!(ranges[2].decommissioned, false);
+        assert!(!ranges[2].decommissioned);
         assert_eq!(ranges[2].last_ingested_block, None);
 
         // We should have one decommissioning event and one new ingest invocation event.
@@ -1810,8 +1804,8 @@ mod tests {
                 .order_by(schema::ingest_invocations::dsl::id)
                 .load(&conn)
                 .unwrap();
-        let mut invoc1_orig_last_active_at = invocs_last_active_at[0].clone();
-        let invoc2_orig_last_active_at = invocs_last_active_at[1].clone();
+        let mut invoc1_orig_last_active_at = invocs_last_active_at[0];
+        let invoc2_orig_last_active_at = invocs_last_active_at[1];
 
         // Sleep a second so that the timestamp update would show if it happens.
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -1857,7 +1851,7 @@ mod tests {
         assert!(invocs_last_active_at[0] > invoc1_orig_last_active_at);
         assert_eq!(invocs_last_active_at[1], invoc2_orig_last_active_at);
 
-        invoc1_orig_last_active_at = invocs_last_active_at[0].clone();
+        invoc1_orig_last_active_at = invocs_last_active_at[0];
 
         // Sleep so that timestamp change is noticeable if it happens
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -2426,7 +2420,7 @@ mod tests {
 
         assert_eq!(
             db.get_all_reports().unwrap(),
-            vec![(report_id2.into(), report2.clone())]
+            vec![(report_id2.into(), report2)]
         );
 
         // Retire the ingress public key
@@ -2493,7 +2487,7 @@ mod tests {
             )
             .unwrap(),
             vec![IngressPublicKeyRecord {
-                key: ingress_key1.clone(),
+                key: ingress_key1,
                 status: IngressPublicKeyStatus {
                     start_block: 123,
                     pubkey_expiry: 0,
@@ -2522,7 +2516,7 @@ mod tests {
             ),
             HashSet::from_iter(vec![
                 IngressPublicKeyRecord {
-                    key: ingress_key1.clone(),
+                    key: ingress_key1,
                     status: IngressPublicKeyStatus {
                         start_block: 123,
                         pubkey_expiry: 0,
@@ -2532,7 +2526,7 @@ mod tests {
                     last_scanned_block: None,
                 },
                 IngressPublicKeyRecord {
-                    key: ingress_key2.clone(),
+                    key: ingress_key2,
                     status: IngressPublicKeyStatus {
                         start_block: 456,
                         pubkey_expiry: 0,
@@ -2568,7 +2562,7 @@ mod tests {
                 ),
                 HashSet::from_iter(vec![
                     IngressPublicKeyRecord {
-                        key: ingress_key1.clone(),
+                        key: ingress_key1,
                         status: IngressPublicKeyStatus {
                             start_block: 123,
                             pubkey_expiry: 0,
@@ -2578,7 +2572,7 @@ mod tests {
                         last_scanned_block: Some(block_id),
                     },
                     IngressPublicKeyRecord {
-                        key: ingress_key2.clone(),
+                        key: ingress_key2,
                         status: IngressPublicKeyStatus {
                             start_block: 456,
                             pubkey_expiry: 0,
@@ -2609,7 +2603,7 @@ mod tests {
             ),
             HashSet::from_iter(vec![
                 IngressPublicKeyRecord {
-                    key: ingress_key1.clone(),
+                    key: ingress_key1,
                     status: IngressPublicKeyStatus {
                         start_block: 123,
                         pubkey_expiry: 0,
@@ -2619,7 +2613,7 @@ mod tests {
                     last_scanned_block: Some(130),
                 },
                 IngressPublicKeyRecord {
-                    key: ingress_key2.clone(),
+                    key: ingress_key2,
                     status: IngressPublicKeyStatus {
                         start_block: 456,
                         pubkey_expiry: 0,
@@ -2648,7 +2642,7 @@ mod tests {
             ),
             HashSet::from_iter(vec![
                 IngressPublicKeyRecord {
-                    key: ingress_key1.clone(),
+                    key: ingress_key1,
                     status: IngressPublicKeyStatus {
                         start_block: 123,
                         pubkey_expiry: 0,
@@ -2658,7 +2652,7 @@ mod tests {
                     last_scanned_block: Some(130),
                 },
                 IngressPublicKeyRecord {
-                    key: ingress_key2.clone(),
+                    key: ingress_key2,
                     status: IngressPublicKeyStatus {
                         start_block: 456,
                         pubkey_expiry: 0,
@@ -2696,7 +2690,7 @@ mod tests {
             ),
             HashSet::from_iter(vec![
                 IngressPublicKeyRecord {
-                    key: ingress_key1.clone(),
+                    key: ingress_key1,
                     status: IngressPublicKeyStatus {
                         start_block: 123,
                         pubkey_expiry: 0,
@@ -2706,7 +2700,7 @@ mod tests {
                     last_scanned_block: Some(130),
                 },
                 IngressPublicKeyRecord {
-                    key: ingress_key2.clone(),
+                    key: ingress_key2,
                     status: IngressPublicKeyStatus {
                         start_block: 456,
                         pubkey_expiry: 888,
@@ -2747,7 +2741,7 @@ mod tests {
                 ),
                 HashSet::from_iter(vec![
                     IngressPublicKeyRecord {
-                        key: ingress_key1.clone(),
+                        key: ingress_key1,
                         status: IngressPublicKeyStatus {
                             start_block: 123,
                             pubkey_expiry: 0,
@@ -2757,7 +2751,7 @@ mod tests {
                         last_scanned_block: Some(130),
                     },
                     IngressPublicKeyRecord {
-                        key: ingress_key2.clone(),
+                        key: ingress_key2,
                         status: IngressPublicKeyStatus {
                             start_block: 456,
                             pubkey_expiry: 888,
@@ -2782,7 +2776,7 @@ mod tests {
             )
             .unwrap(),
             vec![IngressPublicKeyRecord {
-                key: ingress_key2.clone(),
+                key: ingress_key2,
                 status: IngressPublicKeyStatus {
                     start_block: 456,
                     pubkey_expiry: 888,
@@ -2831,7 +2825,7 @@ mod tests {
             )
             .unwrap(),
             vec![IngressPublicKeyRecord {
-                key: ingress_key1.clone(),
+                key: ingress_key1,
                 status: IngressPublicKeyStatus {
                     start_block: 123,
                     pubkey_expiry: 0,
@@ -2894,7 +2888,7 @@ mod tests {
             )
             .unwrap(),
             vec![IngressPublicKeyRecord {
-                key: ingress_key1.clone(),
+                key: ingress_key1,
                 status: IngressPublicKeyStatus {
                     start_block: 123,
                     pubkey_expiry: 0,
@@ -2964,7 +2958,7 @@ mod tests {
             ),
             HashSet::<IngressPublicKeyRecord>::from_iter(vec![
                 IngressPublicKeyRecord {
-                    key: ingress_key1.clone(),
+                    key: ingress_key1,
                     status: IngressPublicKeyStatus {
                         start_block: 123,
                         pubkey_expiry: 0,
@@ -2974,7 +2968,7 @@ mod tests {
                     last_scanned_block: None,
                 },
                 IngressPublicKeyRecord {
-                    key: ingress_key2.clone(),
+                    key: ingress_key2,
                     status: IngressPublicKeyStatus {
                         start_block: 456,
                         pubkey_expiry: 0,
@@ -3062,7 +3056,7 @@ mod tests {
         let ranges = db.get_ingestable_ranges().unwrap();
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         // This makes last_scanned_block equal 10.
@@ -3097,7 +3091,7 @@ mod tests {
             .unwrap();
 
         let expected = IngressPublicKeyRecord {
-            key: ingress_key1.clone(),
+            key: ingress_key1,
             status: IngressPublicKeyStatus {
                 start_block: 0,
                 pubkey_expiry: 20,
@@ -3299,7 +3293,7 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         // This makes last_scanned_block equal 10.
@@ -3374,7 +3368,7 @@ mod tests {
         assert_eq!(ranges.len(), 1);
         assert_eq!(ranges[0].id, invoc_id1);
         assert_eq!(ranges[0].start_block, 123);
-        assert_eq!(ranges[0].decommissioned, false);
+        assert!(!ranges[0].decommissioned);
         assert_eq!(ranges[0].last_ingested_block, None);
 
         // This makes last_scanned_block equal 10.
@@ -3409,7 +3403,7 @@ mod tests {
             .unwrap();
 
         let expected = IngressPublicKeyRecord {
-            key: ingress_key1.clone(),
+            key: ingress_key1,
             status: IngressPublicKeyStatus {
                 start_block: 0,
                 pubkey_expiry: 15,

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -86,7 +86,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogLedgerUri::from_str("fog-ledger://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
@@ -94,7 +94,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogLedgerUri::from_str("fog-ledger://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -102,7 +102,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogLedgerUri::from_str("insecure-fog-ledger://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:3223");
@@ -110,7 +110,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri =
             FogLedgerUri::from_str("insecure-fog-ledger://node1.test.mobilecoin.com/").unwrap();
@@ -119,7 +119,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri =
             FogLedgerUri::from_str("insecure-fog-ledger://node1.test.mobilecoin.com:666/").unwrap();
@@ -128,7 +128,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogViewUri::from_str("fog-view://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
@@ -185,7 +185,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogViewUri::from_str("fog-view://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -193,7 +193,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogViewUri::from_str("insecure-fog-view://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:3225");
@@ -201,7 +201,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:3225").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri = FogViewUri::from_str("insecure-fog-view://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
@@ -209,7 +209,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri =
             FogViewUri::from_str("insecure-fog-view://node1.test.mobilecoin.com:666/").unwrap();
@@ -218,7 +218,7 @@ mod tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
     }
 
     #[test]

--- a/fog/view/enclave/tests/basic.rs
+++ b/fog/view/enclave/tests/basic.rs
@@ -13,13 +13,12 @@ use std::str::FromStr;
 const VIEW_OMAP_CAPACITY: u64 = 1024 * 1024;
 
 fn get_enclave(logger: Logger) -> SgxViewEnclave {
-    let sgx_enclave = SgxViewEnclave::new(
+    SgxViewEnclave::new(
         get_enclave_path(mc_fog_view_enclave::ENCLAVE_FILE),
         ResponderId::from_str("abc:123").unwrap(),
         VIEW_OMAP_CAPACITY,
         logger.clone(),
-    );
-    sgx_enclave
+    )
 }
 
 #[test_with_logger]

--- a/fog/view/server/src/block_tracker.rs
+++ b/fog/view/server/src/block_tracker.rs
@@ -326,7 +326,7 @@ mod tests {
         // Now, we have scanned everything we have promised to scan, next blocks should
         // return empty.
         let expected_state = HashMap::from_iter(vec![]);
-        assert_eq!(block_tracker.next_blocks(&[rec.clone()]), expected_state);
+        assert_eq!(block_tracker.next_blocks(&[rec]), expected_state);
     }
 
     // Single ingestable range (decommissioned, scanned some blocks)
@@ -396,7 +396,7 @@ mod tests {
         // last-scanned block
         let expected_state = HashMap::from_iter(vec![]);
 
-        assert_eq!(block_tracker.next_blocks(&[rec.clone()]), expected_state);
+        assert_eq!(block_tracker.next_blocks(&[rec]), expected_state);
     }
 
     // Single key (lost, but scanned some blocks)
@@ -445,7 +445,7 @@ mod tests {
         block_tracker.block_processed(rec.key, rec.status.start_block + 20);
 
         let expected_state = HashMap::from_iter(vec![]);
-        assert_eq!(block_tracker.next_blocks(&[rec.clone()]), expected_state);
+        assert_eq!(block_tracker.next_blocks(&[rec]), expected_state);
     }
 
     // Two ingestable ranges should advance independently of eachother
@@ -503,10 +503,7 @@ mod tests {
             (rec2.key, rec2.status.start_block),
         ]);
 
-        assert_eq!(
-            block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
-            expected_state
-        );
+        assert_eq!(block_tracker.next_blocks(&[rec1, rec2]), expected_state);
     }
 
     // highest_fully_processed_block_count behaves as expected
@@ -537,7 +534,7 @@ mod tests {
         };
 
         assert_eq!(
-            block_tracker.highest_fully_processed_block_count(&[rec.clone()]),
+            block_tracker.highest_fully_processed_block_count(&[rec]),
             (0, None),
         );
     }
@@ -652,7 +649,7 @@ mod tests {
         // The highest processed block is still 15, but the reason we are blocked is now
         // None, and not the record, because the record was marked lost.
         assert_eq!(
-            block_tracker.highest_fully_processed_block_count(&[rec.clone()]),
+            block_tracker.highest_fully_processed_block_count(&[rec]),
             (15, None)
         );
         // When the reason is None, that is supposed to mean that highest fully
@@ -753,7 +750,7 @@ mod tests {
         rec1.status.lost = true;
         let expected = (40, None);
         assert_eq!(
-            block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
+            block_tracker.highest_fully_processed_block_count(&[rec1, rec2]),
             expected,
         );
     }
@@ -870,7 +867,7 @@ mod tests {
         // progress all the way to rec2
         let expected = (40, None);
         assert_eq!(
-            block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
+            block_tracker.highest_fully_processed_block_count(&[rec1, rec2]),
             expected,
         );
     }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -403,7 +403,7 @@ mod tests {
             assert_eq!(
                 ingress_keys,
                 vec![IngressPublicKeyRecord {
-                    key: ingress_key.clone(),
+                    key: ingress_key,
                     status: IngressPublicKeyStatus {
                         start_block: 10,
                         pubkey_expiry: 0,
@@ -462,7 +462,7 @@ mod tests {
         assert_eq!(
             ingress_keys,
             vec![IngressPublicKeyRecord {
-                key: ingress_key.clone(),
+                key: ingress_key,
                 status: IngressPublicKeyStatus {
                     start_block: 10,
                     pubkey_expiry: 0,
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(
             ingress_keys,
             vec![IngressPublicKeyRecord {
-                key: ingress_key.clone(),
+                key: ingress_key,
                 status: IngressPublicKeyStatus {
                     start_block: 10,
                     pubkey_expiry: 0,
@@ -540,7 +540,7 @@ mod tests {
         assert_eq!(
             ingress_keys,
             vec![IngressPublicKeyRecord {
-                key: ingress_key.clone(),
+                key: ingress_key,
                 status: IngressPublicKeyStatus {
                     start_block: 10,
                     pubkey_expiry: 0,
@@ -653,7 +653,7 @@ mod tests {
         // Sort to make comparing easier
         fetched_records.sort_by_key(|fr| (fr.ingress_key, fr.block_index));
         blocks_and_records
-            .sort_by_key(|(ingress_key, block, _records)| (ingress_key.clone(), block.index));
+            .sort_by_key(|(ingress_key, block, _records)| (*ingress_key, block.index));
 
         for (i, fetched_record) in fetched_records.iter().enumerate() {
             assert_eq!(fetched_record.ingress_key, blocks_and_records[i].0);
@@ -717,7 +717,7 @@ mod tests {
         // Sort to make comparing easier
         fetched_records.sort_by_key(|fr| (fr.ingress_key, fr.block_index));
         blocks_and_records
-            .sort_by_key(|(ingress_key, block, _records)| (ingress_key.clone(), block.index));
+            .sort_by_key(|(ingress_key, block, _records)| (*ingress_key, block.index));
 
         for (i, fetched_record) in fetched_records.iter().enumerate() {
             assert_eq!(fetched_record.ingress_key, blocks_and_records[i].0);

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -91,7 +91,7 @@ fn get_test_environment(
         let mut server = ViewServer::new(
             config,
             enclave,
-            db.clone(),
+            db,
             ra_client,
             SystemTimeProvider::default(),
             logger.clone(),
@@ -109,7 +109,7 @@ fn get_test_environment(
         let mut verifier = Verifier::default();
         verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
 
-        FogViewGrpcClient::new(uri, GRPC_RETRY_CONFIG, verifier, grpcio_env.clone(), logger)
+        FogViewGrpcClient::new(uri, GRPC_RETRY_CONFIG, verifier, grpcio_env, logger)
     };
 
     (db_test_context, server, client)

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -1884,7 +1884,7 @@ mod ledger_db_test {
             key_images: key_images2,
             outputs: outputs2,
             validated_mint_config_txs: vec![to_validated(&mint_config_tx3)],
-            mint_txs: vec![mint_tx1.clone(), mint_tx2.clone()],
+            mint_txs: vec![mint_tx1, mint_tx2],
         };
         let block2 = Block::new_with_parent(
             BLOCK_VERSION,
@@ -2117,7 +2117,7 @@ mod ledger_db_test {
         );
 
         let block_contents3 = BlockContents {
-            mint_txs: vec![mint_tx2.clone(), mint_tx1.clone()],
+            mint_txs: vec![mint_tx2, mint_tx1],
             outputs: vec![create_test_tx_out(&mut rng), create_test_tx_out(&mut rng)],
             ..Default::default()
         };
@@ -2185,7 +2185,7 @@ mod ledger_db_test {
         );
 
         let block_contents2 = BlockContents {
-            mint_txs: vec![mint_tx1.clone()],
+            mint_txs: vec![mint_tx1],
             outputs: vec![create_test_tx_out(&mut rng)],
             ..Default::default()
         };
@@ -2282,7 +2282,7 @@ mod ledger_db_test {
         );
 
         let block_contents3 = BlockContents {
-            mint_txs: vec![mint_tx2.clone()],
+            mint_txs: vec![mint_tx2],
             outputs: vec![create_test_tx_out(&mut rng)],
             ..Default::default()
         };
@@ -2331,7 +2331,7 @@ mod ledger_db_test {
         let mint_tx3 = create_mint_tx(token_id1, &signers1, 11, &mut rng);
 
         let block_contents3 = BlockContents {
-            mint_txs: vec![mint_tx3.clone()],
+            mint_txs: vec![mint_tx3],
             outputs: vec![create_test_tx_out(&mut rng)],
             ..Default::default()
         };
@@ -2602,7 +2602,7 @@ mod ledger_db_test {
 
         // The ledger should each key image.
         for key_image in &key_images {
-            assert!(ledger_db.contains_key_image(&key_image).unwrap());
+            assert!(ledger_db.contains_key_image(key_image).unwrap());
         }
     }
 
@@ -2900,7 +2900,7 @@ mod ledger_db_test {
             let tx_out = create_test_tx_out(&mut rng);
             let outputs = vec![tx_out];
             BlockContents {
-                key_images: block_one_key_images.clone(),
+                key_images: block_one_key_images,
                 outputs,
                 ..Default::default()
             }
@@ -2939,7 +2939,7 @@ mod ledger_db_test {
 
         let block_one_contents = {
             let mut tx_out = create_test_tx_out(&mut rng);
-            tx_out.public_key = existing_tx_out.public_key.clone();
+            tx_out.public_key = existing_tx_out.public_key;
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
             BlockContents {

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -427,14 +427,14 @@ mod membership_proof_tests {
     fn test_is_valid_singleton() {
         let tx_outs = get_tx_outs(1);
         let tx_out = tx_outs.get(0).unwrap();
-        let hash = hash_leaf(&tx_out);
+        let hash = hash_leaf(tx_out);
         let elems = vec![TxOutMembershipElement {
             range: Range::new(0, 0).unwrap(),
             hash: hash.into(),
         }];
         let proof = TxOutMembershipProof::new(0, 0, elems);
 
-        assert!(is_membership_proof_valid(&tx_out, &proof, &hash).unwrap());
+        assert!(is_membership_proof_valid(tx_out, &proof, &hash).unwrap());
     }
 
     #[test]
@@ -461,7 +461,7 @@ mod membership_proof_tests {
             .unwrap();
 
         assert!(is_membership_proof_valid(
-            &tx_outs.get(5).unwrap(),
+            tx_outs.get(5).unwrap(),
             &proof_of_five,
             &known_root_hash
         )
@@ -472,7 +472,7 @@ mod membership_proof_tests {
             .unwrap();
 
         assert!(is_membership_proof_valid(
-            &tx_outs.get(3).unwrap(),
+            tx_outs.get(3).unwrap(),
             &proof_of_three,
             &known_root_hash
         )
@@ -511,7 +511,7 @@ mod membership_proof_tests {
                         3
                     )
                 ),
-                is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash)
+                is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash)
             );
         }
 
@@ -525,7 +525,7 @@ mod membership_proof_tests {
             proof.index = 6;
             assert_eq!(
                 Err(MembershipProofError::HighestIndexMismatch),
-                is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash)
+                is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash)
             );
         }
     }
@@ -570,7 +570,7 @@ mod membership_proof_tests {
             proof.highest_index = 2;
             assert_eq!(
                 Err(MembershipProofError::HighestIndexMismatch),
-                is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash)
+                is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash)
             );
         }
 
@@ -586,7 +586,7 @@ mod membership_proof_tests {
             proof.highest_index = 8;
             assert_eq!(
                 Err(MembershipProofError::HighestIndexMismatch),
-                is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash)
+                is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash)
             );
         }
     }
@@ -622,7 +622,7 @@ mod membership_proof_tests {
             };
             assert_eq!(
                 Err(MembershipProofError::UnexpectedMembershipElement(3)),
-                is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash)
+                is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash)
             );
         }
     }
@@ -660,7 +660,7 @@ mod membership_proof_tests {
             .unwrap();
 
         assert!(
-            is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof, &known_root_hash).unwrap()
+            is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof, &known_root_hash).unwrap()
         );
 
         let mut proof1 = proof.clone();
@@ -668,15 +668,15 @@ mod membership_proof_tests {
 
         assert_eq!(
             Err(MembershipProofError::MissingLeafHash(5)),
-            is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof1, &known_root_hash)
+            is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof1, &known_root_hash)
         );
 
-        let mut proof2 = proof.clone();
+        let mut proof2 = proof;
         proof2.elements.remove(1);
 
         assert_eq!(
             Err(MembershipProofError::UnexpectedMembershipElement(2)),
-            is_membership_proof_valid(&tx_outs.get(5).unwrap(), &proof2, &known_root_hash)
+            is_membership_proof_valid(tx_outs.get(5).unwrap(), &proof2, &known_root_hash)
         );
     }
 
@@ -707,7 +707,7 @@ mod membership_proof_tests {
         let rederived_proof = derive_proof_at_index(&proof).unwrap();
         // The rederived proof must be a valid proof.
         assert!(is_membership_proof_valid(
-            &tx_outs.get(5).unwrap(),
+            tx_outs.get(5).unwrap(),
             &rederived_proof,
             &known_root_hash
         )
@@ -768,7 +768,7 @@ mod membership_proof_tests {
 
         // The rederived proof must be a valid proof.
         assert!(is_membership_proof_valid(
-            &tx_outs.get(16).unwrap(),
+            tx_outs.get(16).unwrap(),
             &rederived_proof,
             &known_root_hash
         )
@@ -1152,7 +1152,7 @@ pub mod tx_out_store_tests {
                                        tx_out_0
         */
         let tx_out_zero: &TxOut = tx_outs.get(0).unwrap();
-        let leaf_hash_zero = hash_leaf(&tx_out_zero);
+        let leaf_hash_zero = hash_leaf(tx_out_zero);
         {
             // The first root hash should be the leaf hash fn applied to the single TxOut.
             let _index = tx_out_store.push(tx_out_zero, &mut rw_transaction).unwrap();
@@ -1170,7 +1170,7 @@ pub mod tx_out_store_tests {
                              tx_out_0                tx_out_1
         */
         let tx_out_one: &TxOut = tx_outs.get(1).unwrap();
-        let leaf_hash_one = hash_leaf(&tx_out_one);
+        let leaf_hash_one = hash_leaf(tx_out_one);
         let root_hash_one = {
             // The second root hash should be the internal hash fn applied to the leaf hash
             // fn of tx_out_zero and tx_out_one.
@@ -1193,10 +1193,10 @@ pub mod tx_out_store_tests {
                  tx_out_0                tx_out_1              tx_out_2
         */
         let tx_out_two: &TxOut = tx_outs.get(2).unwrap();
-        let leaf_hash_two = hash_leaf(&tx_out_two);
+        let leaf_hash_two = hash_leaf(tx_out_two);
         {
             let _index = tx_out_store.push(tx_out_two, &mut rw_transaction).unwrap();
-            let right = hash_nodes(&hash_leaf(&tx_out_two), &NIL_HASH);
+            let right = hash_nodes(&hash_leaf(tx_out_two), &NIL_HASH);
             let expected_root_hash = hash_nodes(&root_hash_one, &right);
             let root_hash = tx_out_store.get_root_merkle_hash(&rw_transaction).unwrap();
             assert_eq!(expected_root_hash, root_hash);
@@ -1214,7 +1214,7 @@ pub mod tx_out_store_tests {
              tx_out_0                tx_out_1              tx_out_2               tx_out_3
         */
         let tx_out_three: &TxOut = tx_outs.get(3).unwrap();
-        let leaf_hash_three = hash_leaf(&tx_out_three);
+        let leaf_hash_three = hash_leaf(tx_out_three);
         {
             let _index = tx_out_store
                 .push(tx_out_three, &mut rw_transaction)

--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -886,7 +886,7 @@ mod tests {
         let sync_service =
             LedgerSyncService::new(ledger, conn_manager, transactions_fetcher, logger.clone());
 
-        assert_eq!(sync_service.is_behind(&network_state), false);
+        assert!(!sync_service.is_behind(&network_state));
     }
 
     // A blocking set of peers on a higher slot isn't enough to consider this node
@@ -928,7 +928,7 @@ mod tests {
             ));
         }
 
-        assert_eq!(sync_service.is_behind(&network_state), false);
+        assert!(!sync_service.is_behind(&network_state));
 
         // Now Node B also externalizes a higher slot.
         // The set {Node A, Node B} is blocking, and {Node A, Node B} \union {local
@@ -946,7 +946,7 @@ mod tests {
             ));
         }
 
-        assert_eq!(sync_service.is_behind(&network_state), true);
+        assert!(sync_service.is_behind(&network_state));
     }
 
     #[test_with_logger]
@@ -1024,7 +1024,7 @@ mod tests {
 
         let transactions_by_block = get_block_contents(
             transactions_fetcher,
-            &responder_ids.as_slice(),
+            responder_ids.as_slice(),
             &blocks,
             Duration::from_secs(1),
             &logger,
@@ -1103,7 +1103,7 @@ mod tests {
 
         let transactions_by_block = get_block_contents(
             transactions_fetcher,
-            &responder_ids.as_slice(),
+            responder_ids.as_slice(),
             &blocks,
             Duration::from_secs(1),
             &logger,
@@ -1443,7 +1443,7 @@ mod tests {
         let (block_two, mut contents_two) = blocks_and_contents.get(2).unwrap().clone();
         contents_two
             .key_images
-            .push(contents_one.key_images.get(0).unwrap().clone());
+            .push(*contents_one.key_images.get(0).unwrap());
         potentially_safe_blocks_and_contents.push((block_two, contents_two));
 
         let safe_blocks: Vec<(Block, BlockContents)> = identify_safe_blocks(
@@ -1480,7 +1480,7 @@ mod tests {
         let (block_two, mut contents_two) = blocks_and_contents.get(2).unwrap().clone();
         contents_two
             .key_images
-            .push(contents_one.key_images.get(0).unwrap().clone());
+            .push(*contents_one.key_images.get(0).unwrap());
         potentially_safe_blocks_and_contents.push((block_two, contents_two));
 
         let safe_blocks: Vec<(Block, BlockContents)> = identify_safe_blocks(

--- a/ledger/sync/src/network_state/scp_network_state.rs
+++ b/ledger/sync/src/network_state/scp_network_state.rs
@@ -215,7 +215,7 @@ mod tests {
             assert_eq!(network_state.peer_to_current_slot().len(), 1);
             assert_eq!(
                 *network_state.id_to_current_slot.get(&sender_id).unwrap(),
-                4 as SlotIndex
+                4_u64
             );
         }
 
@@ -236,7 +236,7 @@ mod tests {
             assert_eq!(network_state.peer_to_current_slot().len(), 1);
             assert_eq!(
                 *network_state.id_to_current_slot.get(&sender_id).unwrap(),
-                4 as SlotIndex
+                4_u64
             );
         }
 
@@ -256,7 +256,7 @@ mod tests {
             assert_eq!(network_state.peer_to_current_slot().len(), 1);
             assert_eq!(
                 *network_state.id_to_current_slot.get(&sender_id).unwrap(),
-                4 as SlotIndex
+                4_u64
             );
         }
     }
@@ -287,7 +287,7 @@ mod tests {
             assert_eq!(network_state.peer_to_current_slot().len(), 1);
             assert_eq!(
                 *network_state.id_to_current_slot.get(&sender_id).unwrap(),
-                5 as SlotIndex
+                5_u64
             );
         }
     }
@@ -326,7 +326,7 @@ mod tests {
         assert_eq!(network_state.peer_to_current_slot().len(), 1);
         assert_eq!(
             *network_state.id_to_current_slot.get(&sender_id).unwrap(),
-            8 as SlotIndex
+            8_u64
         );
     }
 
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(network_state.peer_to_current_slot().len(), 1);
         assert_eq!(
             *network_state.id_to_current_slot.get(&sender_a_id).unwrap(),
-            4 as SlotIndex
+            4_u64
         );
 
         // A Commit from sender B.
@@ -382,7 +382,7 @@ mod tests {
 
         assert_eq!(
             *network_state.id_to_current_slot.get(&sender_b_id).unwrap(),
-            5 as SlotIndex
+            5_u64
         );
     }
 
@@ -423,7 +423,7 @@ mod tests {
             QuorumSet::new_with_node_ids(1, vec![test_node_id(5), test_node_id(7)]);
 
         // Initially, we are not behind.
-        assert_eq!(network_state.is_behind(local_block), false);
+        assert!(!network_state.is_behind(local_block));
 
         // Send a message from node 2. Nothing should change.
         network_state.push(Msg::<&str>::new(
@@ -435,7 +435,7 @@ mod tests {
                 HN: 0,
             }),
         ));
-        assert_eq!(network_state.is_behind(local_block), false);
+        assert!(!network_state.is_behind(local_block));
 
         // Send a message from node 3, so we have a blocking set but no quorum.
         network_state.push(Msg::<&str>::new(
@@ -447,7 +447,7 @@ mod tests {
                 HN: 0,
             }),
         ));
-        assert_eq!(network_state.is_behind(local_block), false);
+        assert!(!network_state.is_behind(local_block));
 
         // Send a message from node 5, not forming quorum.
         network_state.push(Msg::<&str>::new(
@@ -459,7 +459,7 @@ mod tests {
                 HN: 0,
             }),
         ));
-        assert_eq!(network_state.is_behind(local_block), false);
+        assert!(!network_state.is_behind(local_block));
 
         // Send a message from node 6, we now have a blocking set and quorum.
         network_state.push(Msg::<&str>::new(
@@ -471,7 +471,7 @@ mod tests {
                 HN: 0,
             }),
         ));
-        assert_eq!(network_state.is_behind(local_block), true);
+        assert!(network_state.is_behind(local_block));
     }
 
     // A quorum set with a single node is blocking and quorum when that node has
@@ -483,30 +483,20 @@ mod tests {
             QuorumSet::new_with_node_ids(1, vec![test_node_id(2)]);
         let network_state = SCPNetworkState::new(local_node_id, local_node_quorum_set);
 
-        assert_eq!(
-            network_state
-                .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(0).responder_id])),
-            false,
-        );
+        assert!(!network_state
+            .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(0).responder_id])));
 
-        assert_eq!(
-            network_state
-                .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(1).responder_id])),
-            false,
-        );
+        assert!(!network_state
+            .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(1).responder_id])));
 
-        assert_eq!(
-            network_state
-                .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(2).responder_id])),
-            true
-        );
+        assert!(network_state
+            .is_blocking_and_quorum(&HashSet::from_iter(vec![test_node_id(2).responder_id])));
 
-        assert_eq!(
+        assert!(
             network_state.is_blocking_and_quorum(&HashSet::from_iter(vec![
                 test_node_id(0).responder_id,
                 test_node_id(2).responder_id
-            ])),
-            true
+            ]))
         );
     }
 

--- a/mint-auditor/src/db.rs
+++ b/mint-auditor/src/db.rs
@@ -610,7 +610,7 @@ mod tests {
             Err(Error::UnexpectedBlockIndex(2, 1)) => {
                 // Expected
             }
-            err @ _ => {
+            err => {
                 panic!("Unexpected result: {:?}", err);
             }
         }
@@ -646,7 +646,7 @@ mod tests {
             Err(Error::UnexpectedBlockIndex(0, 1)) => {
                 // Expected
             }
-            err @ _ => {
+            err => {
                 panic!("Unexpected result: {:?}", err);
             }
         }
@@ -686,7 +686,7 @@ mod tests {
             Err(Error::UnexpectedBlockIndex(0, 3)) => {
                 // Expected
             }
-            err @ _ => {
+            err => {
                 panic!("Unexpected result: {:?}", err);
             }
         }

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -213,7 +213,7 @@ mod test {
         let rust = UnspentTxOut {
             tx_out: tx_out.clone(),
             subaddress_index,
-            key_image: key_image.clone(),
+            key_image,
             value,
             attempted_spend_height,
             attempted_spend_tombstone,
@@ -303,9 +303,9 @@ mod test {
             let attempted_spend_tombstone = 1234;
 
             UnspentTxOut {
-                tx_out: tx_out.clone(),
+                tx_out,
                 subaddress_index,
-                key_image: key_image.clone(),
+                key_image,
                 value,
                 attempted_spend_height,
                 attempted_spend_tombstone,
@@ -316,7 +316,7 @@ mod test {
         let outlay = {
             let public_addr = AccountKey::random(&mut rng).default_subaddress();
             Outlay {
-                receiver: public_addr.clone(),
+                receiver: public_addr,
                 value: 1234,
             }
         };

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -368,7 +368,7 @@ mod test {
             .to_str()
             .expect("Could not get path as string");
 
-        let mobilecoind_db = Database::new(mobilecoind_db_path.to_string(), logger.clone())
+        let mobilecoind_db = Database::new(mobilecoind_db_path, logger.clone())
             .expect("failed creating new mobilecoind db");
 
         // The db starts unencrypted.
@@ -377,7 +377,7 @@ mod test {
 
         // We should be able to insert a monitor at this point.
         let monitor_data = MonitorData::new(
-            account_key.clone(),
+            account_key,
             0,  // first_subaddress
             10, // num_subaddresses
             0,  // first_block
@@ -392,7 +392,7 @@ mod test {
         // We should be able to get our monitor.
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Re-encrypting with an empty password should not affect things.
@@ -403,7 +403,7 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Checking an empty password should not affect anything.
@@ -414,7 +414,7 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Checking a non-empty password should error and not affect things.
@@ -425,7 +425,7 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Set a password.
@@ -436,11 +436,11 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Re-open the db.
-        let mobilecoind_db = Database::new(mobilecoind_db_path.to_string(), logger.clone())
+        let mobilecoind_db = Database::new(mobilecoind_db_path, logger.clone())
             .expect("failed creating new mobilecoind db");
 
         // This time we're encrypted and locked.
@@ -469,13 +469,13 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Re-encrypt and repeat the test.
         mobilecoind_db.re_encrypt(&[11; 32]).unwrap();
 
-        let mobilecoind_db = Database::new(mobilecoind_db_path.to_string(), logger.clone())
+        let mobilecoind_db = Database::new(mobilecoind_db_path, logger.clone())
             .expect("failed creating new mobilecoind db");
 
         assert!(mobilecoind_db.is_db_encrypted());
@@ -499,14 +499,14 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data.clone())])
         );
 
         // Remove password and try again.
         mobilecoind_db.re_encrypt(&[]).unwrap();
 
-        let mobilecoind_db = Database::new(mobilecoind_db_path.to_string(), logger)
-            .expect("failed creating new mobilecoind db");
+        let mobilecoind_db =
+            Database::new(mobilecoind_db_path, logger).expect("failed creating new mobilecoind db");
 
         assert!(!mobilecoind_db.is_db_encrypted());
         assert!(mobilecoind_db.is_unlocked());
@@ -515,7 +515,7 @@ mod test {
 
         assert_eq!(
             mobilecoind_db.get_monitor_map().unwrap(),
-            HashMap::from_iter(vec![(monitor_id.clone(), monitor_data.clone())])
+            HashMap::from_iter(vec![(monitor_id, monitor_data)])
         );
     }
 
@@ -527,7 +527,7 @@ mod test {
 
         // Set up a db with 3 random recipients and 10 blocks.
         let (_ledger_db, mobilecoind_db) =
-            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger.clone(), &mut rng);
 
         // A test accouunt.
         let account_key = AccountKey::random(&mut rng);

--- a/mobilecoind/src/lib.rs
+++ b/mobilecoind/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2018-2021 The MobileCoin Foundation
 
+#![feature(assert_matches)]
+
 extern crate alloc;
 
 pub mod config;

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -518,8 +518,7 @@ mod test {
                 .expect("block_processed failed");
 
             let monitor_data2 = MonitorData::new(
-                account.clone(),
-                30, // first_subaddress
+                account, 30, // first_subaddress
                 20, // num_subaddresses
                 0,  // first_block
                 "", // name

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1953,6 +1953,7 @@ build_api! {
 }
 
 #[cfg(test)]
+#[allow(clippy::needless_collect)]
 mod test {
     use super::*;
     use crate::{
@@ -1999,7 +2000,7 @@ mod test {
 
         // Three random recipients and no monitors.
         let (ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Create request for adding a new monitor.
         let data = MonitorData::new(
@@ -2052,14 +2053,7 @@ mod test {
 
         // 10 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(
-                BLOCK_VERSION,
-                10,
-                &vec![],
-                &vec![],
-                logger.clone(),
-                &mut rng,
-            );
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
 
         let monitors_map = mobilecoind_db.get_monitor_map().unwrap();
         assert_eq!(0, monitors_map.len());
@@ -2103,14 +2097,7 @@ mod test {
 
         // 10 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(
-                BLOCK_VERSION,
-                10,
-                &vec![],
-                &vec![],
-                logger.clone(),
-                &mut rng,
-            );
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
 
         // Add some new monitors directly to the database.
         let monitors_to_add = 10;
@@ -2162,14 +2149,7 @@ mod test {
 
         // 10 random recipients and no monitors.
         let (ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(
-                BLOCK_VERSION,
-                10,
-                &vec![],
-                &vec![],
-                logger.clone(),
-                &mut rng,
-            );
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
 
         let data = MonitorData::new(
             AccountKey::random(&mut rng),
@@ -2240,8 +2220,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![account_key.default_subaddress()],
-                &vec![],
+                &[account_key.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -2369,11 +2349,7 @@ mod test {
         assert_eq!(utxos.len(), 1);
         assert_eq!(
             HashSet::from_iter(utxos.iter()),
-            HashSet::from_iter(
-                expected_utxos
-                    .iter()
-                    .filter(|utxo| utxo.token_id == TokenId::from(2))
-            )
+            HashSet::from_iter(expected_utxos.iter().filter(|utxo| utxo.token_id == 2))
         );
     }
 
@@ -2383,7 +2359,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // call get entropy
         let response = client
@@ -2400,7 +2376,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // call get entropy
         let response = client
@@ -2423,7 +2399,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Use mnemonic to construct AccountKey.
         let mnemonic_str =
@@ -2461,7 +2437,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Use root entropy to construct AccountKey.
         let root_entropy = [123u8; 32];
@@ -2503,7 +2479,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Insert into database.
         let id = mobilecoind_db.add_monitor(&data).unwrap();
@@ -2551,7 +2527,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get ledger info.
         let response = client
@@ -2567,7 +2543,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get block info for a valid block.
         let mut request = mc_mobilecoind_api::GetBlockInfoRequest::new();
@@ -2590,7 +2566,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get block info for a valid block.
         let mut request = mc_mobilecoind_api::GetBlockRequest::new();
@@ -2613,7 +2589,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Insert a block with some key images in it.
         let recipient = AccountKey::random(&mut rng).default_subaddress();
@@ -2859,7 +2835,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // A call with an invalid hash should fail
         {
@@ -2949,12 +2925,7 @@ mod test {
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
 
-        add_txos_to_ledger_db(
-            BLOCK_VERSION,
-            &mut ledger_db,
-            &vec![tx_out.clone()],
-            &mut rng,
-        );
+        add_txos_to_ledger_db(BLOCK_VERSION, &mut ledger_db, &[tx_out.clone()], &mut rng);
 
         // A request with a valid confirmation number and monitor ID should return
         // Verified
@@ -3026,8 +2997,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![account_key.default_subaddress()],
-                &vec![],
+                &[account_key.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3265,8 +3236,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3319,8 +3290,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3330,8 +3301,7 @@ mod test {
         // A list of outputs to exclude.
         let to_exclude: Vec<TxOut> = {
             let data = MonitorData::new(
-                sender.clone(),
-                0,  // first_subaddress
+                sender, 0,  // first_subaddress
                 20, // num_subaddresses
                 0,  // first_block
                 "", // name
@@ -3394,8 +3364,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3445,8 +3415,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3522,8 +3492,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3768,8 +3738,7 @@ mod test {
             // Unrecognized monitor id
             let sender = AccountKey::random(&mut rng);
             let data = MonitorData::new(
-                sender.clone(),
-                0,  // first_subaddress
+                sender, 0,  // first_subaddress
                 20, // num_subaddresses
                 0,  // first_block
                 "", // name
@@ -3837,7 +3806,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Grab the first TxOut of each block in the database and verify its index.
         for block_index in 0..test_utils::GET_TESTING_ENVIRONMENT_NUM_BLOCKS as u64 {
@@ -3873,8 +3842,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -3909,7 +3878,7 @@ mod test {
         {
             let tx_proposal = TxProposal::try_from(response.get_tx_proposal()).unwrap();
             let key_images = tx_proposal.tx.key_images();
-            let outputs = tx_proposal.tx.prefix.outputs.clone();
+            let outputs = tx_proposal.tx.prefix.outputs;
             let block_contents = BlockContents {
                 key_images,
                 outputs,
@@ -3975,8 +3944,7 @@ mod test {
         let sender = AccountKey::random(&mut rng);
         let sender_default_subaddress = sender.default_subaddress();
         let data = MonitorData::new(
-            sender.clone(),
-            0,  // first_subaddress
+            sender, 0,  // first_subaddress
             20, // num_subaddresses
             0,  // first_block
             "", // name
@@ -3991,8 +3959,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 num_random_recipients as u32,
-                &vec![sender_default_subaddress.clone()],
-                &vec![],
+                &[sender_default_subaddress.clone()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4094,8 +4062,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4162,8 +4130,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4311,7 +4279,7 @@ mod test {
 
                 let public_key =
                     GenericArray::<u8, U32>::from_slice(receipt.get_tx_public_key().get_data());
-                assert!(tx_out_public_keys.contains(&public_key));
+                assert!(tx_out_public_keys.contains(public_key));
             }
 
             // Check that attempted_spend_height got updated for the relevant utxos.
@@ -4352,8 +4320,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![account_key.default_subaddress()],
-                &vec![],
+                &[account_key.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4420,8 +4388,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4554,7 +4522,7 @@ mod test {
 
             let public_key =
                 GenericArray::<u8, U32>::from_slice(receipt.get_tx_public_key().get_data());
-            assert!(tx_out_public_keys.contains(&public_key));
+            assert!(tx_out_public_keys.contains(public_key));
         }
 
         // Check that attempted_spend_height got updated for the relevant utxos.
@@ -4593,14 +4561,7 @@ mod test {
 
         // 1 known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(
-                BLOCK_VERSION,
-                10,
-                &vec![],
-                &vec![],
-                logger.clone(),
-                &mut rng,
-            );
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
 
         // Add a few utxos to our recipient, such that all of them are required to
         // create the test transaction.
@@ -4632,7 +4593,7 @@ mod test {
 
         let utxos_by_keyimage: HashMap<KeyImage, UnspentTxOut> = utxos
             .iter()
-            .map(|utxo| (utxo.key_image.clone(), utxo.clone()))
+            .map(|utxo| (utxo.key_image, utxo.clone()))
             .collect();
 
         // Generate two random recipients.
@@ -4748,7 +4709,7 @@ mod test {
         let (ledger_db, mobilecoind_db) = test_utils::get_test_databases(
             BLOCK_VERSION,
             3,
-            &vec![sender.default_subaddress()],
+            &[sender.default_subaddress()],
             test_utils::GET_TESTING_ENVIRONMENT_NUM_BLOCKS,
             logger.clone(),
             &mut rng,
@@ -4891,8 +4852,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -4958,8 +4919,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -5023,8 +4984,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );
@@ -5099,7 +5060,7 @@ mod test {
             let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
 
             let subaddress_spk = SubaddressSPKId::from(&recover_public_subaddress_spend_key(
-                &sender.view_private_key(),
+                sender.view_private_key(),
                 &tx_out_target_key,
                 &tx_public_key,
             ));
@@ -5137,7 +5098,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Random receiver address.
         let receiver = AccountKey::random(&mut rng).default_subaddress();
@@ -5256,7 +5217,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // a valid transfer code must reference a tx_public_key that appears in the
         // ledger that is controlled by the root_entropy included in the code
@@ -5281,12 +5242,7 @@ mod test {
             )
             .unwrap();
 
-        add_txos_to_ledger_db(
-            BLOCK_VERSION,
-            &mut ledger_db,
-            &vec![tx_out.clone()],
-            &mut rng,
-        );
+        add_txos_to_ledger_db(BLOCK_VERSION, &mut ledger_db, &[tx_out.clone()], &mut rng);
 
         let tx_public_key = tx_out.public_key;
 
@@ -5373,7 +5329,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // a valid transfer code must reference a tx_public_key that appears in the
         // ledger that is controlled by the bip39_entropy included in the code
@@ -5398,12 +5354,7 @@ mod test {
             )
             .unwrap();
 
-        add_txos_to_ledger_db(
-            BLOCK_VERSION,
-            &mut ledger_db,
-            &vec![tx_out.clone()],
-            &mut rng,
-        );
+        add_txos_to_ledger_db(BLOCK_VERSION, &mut ledger_db, &[tx_out.clone()], &mut rng);
 
         let tx_public_key = tx_out.public_key;
 
@@ -5484,7 +5435,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         {
             // Random receiver address.
@@ -5551,7 +5502,7 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
 
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &vec![], &vec![], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         let network_status = client
             .get_network_status(&mc_mobilecoind_api::Empty::new())
@@ -5587,8 +5538,8 @@ mod test {
             get_testing_environment(
                 BLOCK_VERSION,
                 3,
-                &vec![sender.default_subaddress()],
-                &vec![],
+                &[sender.default_subaddress()],
+                &[],
                 logger.clone(),
                 &mut rng,
             );

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -591,7 +591,7 @@ mod test {
                 value: DEFAULT_PER_RECIPIENT_AMOUNT,
                 token_id: Mob::ID,
             },
-            &[utxos[0].key_image.clone()],
+            &[utxos[0].key_image],
             &mut rng,
         );
 
@@ -662,7 +662,7 @@ mod test {
                 value: 0,
                 token_id: Mob::ID,
             },
-            &[utxos[0].key_image.clone()],
+            &[utxos[0].key_image],
             &mut rng,
         );
 

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -442,7 +442,7 @@ mod test {
     ) -> (Arc<Environment>, LedgerDB, UtxoStore, Vec<UnspentTxOut>) {
         // Set up a db with 3 random recipients and 10 blocks.
         let (ledger_db, _mobilecoind_db) =
-            get_test_databases(BlockVersion::ZERO, 3, &vec![], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger.clone(), &mut rng);
 
         // Get a few TxOuts to play with, and use them to construct UnspentTxOuts.
         let utxos: Vec<UnspentTxOut> = (0..5)
@@ -708,7 +708,7 @@ mod test {
     fn test_remove_utxos_by_key_images(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let (env, _ledger_db, utxo_store, mut utxos) = setup_test_utxo_store(&mut rng, &logger);
-        let key_images: Vec<KeyImage> = utxos.iter().map(|utxo| utxo.key_image.clone()).collect();
+        let key_images: Vec<KeyImage> = utxos.iter().map(|utxo| utxo.key_image).collect();
 
         // Some random monitor ids to play with
         let (_monitor_data, monitor_id0) = get_test_monitor_data_and_id(&mut rng);
@@ -835,12 +835,8 @@ mod test {
                 .remove_utxos_by_key_images(&mut db_txn, &monitor_id0, &key_images)
                 .unwrap();
             assert_eq!(
-                HashSet::from_iter(removed_utxos.iter().map(|utxo| utxo.key_image.clone())),
-                HashSet::from_iter(vec![
-                    key_images[0].clone(),
-                    key_images[1].clone(),
-                    key_images[2].clone()
-                ])
+                HashSet::from_iter(removed_utxos.iter().map(|utxo| utxo.key_image)),
+                HashSet::from_iter(vec![key_images[0], key_images[1], key_images[2]])
             );
 
             assert_eq!(

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -218,7 +218,7 @@ mod tests {
         let num_blocks = 10;
         let ledger = get_mock_ledger(num_blocks);
 
-        let msg = ConsensusMsg::from_scp_msg(
+        ConsensusMsg::from_scp_msg(
             &ledger,
             Msg::new(
                 local_node_id,
@@ -233,8 +233,7 @@ mod tests {
             ),
             &local_signer_key,
         )
-        .unwrap();
-        msg
+        .unwrap()
     }
 
     // Correctly-constructed signature should verify.

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -453,9 +453,9 @@ mod threaded_broadcaster_tests {
                 &local_signer_key,
             );
 
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
 
             broadcaster.barrier();
 
@@ -478,9 +478,9 @@ mod threaded_broadcaster_tests {
                 &local_signer_key,
             );
 
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
 
             broadcaster.barrier();
 
@@ -544,9 +544,9 @@ mod threaded_broadcaster_tests {
                 &node2_signer_key,
             );
 
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
 
             broadcaster.barrier();
 
@@ -564,9 +564,9 @@ mod threaded_broadcaster_tests {
             let msg2 =
                 create_consensus_msg(&ledger, node2, quorum_set, 1, "msg2", &node2_signer_key);
 
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
 
             broadcaster.barrier();
 
@@ -629,9 +629,9 @@ mod threaded_broadcaster_tests {
                 &local_signer_key,
             );
 
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg1, &msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg1, msg1.issuer_responder_id());
 
             broadcaster.barrier();
 
@@ -663,9 +663,9 @@ mod threaded_broadcaster_tests {
                 &local_signer_key,
             );
 
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
-            broadcaster.broadcast_consensus_msg(&msg2, &msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
+            broadcaster.broadcast_consensus_msg(&msg2, msg2.issuer_responder_id());
 
             broadcaster.barrier();
 

--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -282,7 +282,7 @@ mod amount_tests {
                     let amount = Amount { value, token_id: token_id.into() };
                     let amount = MaskedAmount::new(amount, &shared_secret).unwrap();
                     let blinding = get_blinding(&shared_secret);
-                    let expected_commitment = CompressedCommitment::new(value, blinding.into(), &generators(token_id));
+                    let expected_commitment = CompressedCommitment::new(value, blinding, &generators(token_id));
                     assert_eq!(amount.commitment, expected_commitment);
             }
 
@@ -308,7 +308,7 @@ mod amount_tests {
                 token_id in any::<u64>(),
                 shared_secret in arbitrary_ristretto_public()) {
                 let amount = Amount { value, token_id: token_id.into() };
-                let masked_amount = MaskedAmount::new(amount.clone(), &shared_secret).unwrap();
+                let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
                 let result = masked_amount.get_value(&shared_secret);
                 let blinding = get_blinding(&shared_secret);
                 let expected = Ok((amount, blinding));

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -238,15 +238,15 @@ mod tests {
         let key2 = RistrettoPublic::from_random(&mut rng);
 
         let memo1 = MemoPayload::default();
-        let e_memo1 = memo1.clone().encrypt(&key1);
+        let e_memo1 = memo1.encrypt(&key1);
         assert_eq!(memo1, e_memo1.decrypt(&key1), "roundtrip failed");
 
         let memo2 = MemoPayload::new([1u8, 2u8], [47u8; 64]);
-        let e_memo2 = memo2.clone().encrypt(&key1);
+        let e_memo2 = memo2.encrypt(&key1);
         assert_eq!(memo2, e_memo2.decrypt(&key1), "roundtrip failed");
 
         let memo1 = MemoPayload::default();
-        let e_memo1 = memo1.clone().encrypt(&key1);
+        let e_memo1 = memo1.encrypt(&key1);
         assert_ne!(
             memo1,
             e_memo1.decrypt(&key2),
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let memo2 = MemoPayload::new([1u8, 2u8], [47u8; 64]);
-        let e_memo2 = memo2.clone().encrypt(&key2);
+        let e_memo2 = memo2.encrypt(&key2);
         assert_ne!(
             memo2,
             e_memo2.decrypt(&key1),

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -166,7 +166,7 @@ mod tests {
         );
 
         assert_eq!(
-            validate_configs(1.into(), &[mint_config1.clone(), mint_config2.clone()]),
+            validate_configs(1.into(), &[mint_config1, mint_config2]),
             Err(Error::InvalidTokenId(123.into()))
         );
     }
@@ -225,7 +225,7 @@ mod tests {
 
         let prefix = MintConfigTxPrefix {
             token_id: *token_id,
-            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            configs: vec![mint_config1, mint_config2],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
             total_mint_limit: 100,
@@ -342,7 +342,7 @@ mod tests {
 
         let prefix = MintConfigTxPrefix {
             token_id: *token_id,
-            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            configs: vec![mint_config1, mint_config2],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
             total_mint_limit: 100,
@@ -373,10 +373,7 @@ mod tests {
 
         // Tamper with the tombstone block.
         let signature = MultiSig::new(vec![governor_1.try_sign(message.as_ref()).unwrap()]);
-        let mut tx = MintConfigTx {
-            prefix: prefix.clone(),
-            signature,
-        };
+        let mut tx = MintConfigTx { prefix, signature };
         tx.prefix.tombstone_block += 1;
         assert_eq!(
             validate_signature(
@@ -420,7 +417,7 @@ mod tests {
 
         let prefix = MintConfigTxPrefix {
             token_id: *token_id,
-            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            configs: vec![mint_config1, mint_config2],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
             total_mint_limit: 100,
@@ -467,10 +464,7 @@ mod tests {
             governor_1.try_sign(message.as_ref()).unwrap(),
             governor_2.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = MintConfigTx {
-            prefix: prefix.clone(),
-            signature,
-        };
+        let tx = MintConfigTx { prefix, signature };
         assert_eq!(
             validate_signature(
                 &tx,
@@ -506,7 +500,7 @@ mod tests {
 
         let prefix = MintConfigTxPrefix {
             token_id: *token_id,
-            configs: vec![mint_config1.clone(), mint_config2.clone()],
+            configs: vec![mint_config1, mint_config2],
             nonce: vec![2u8; NONCE_LENGTH],
             tombstone_block: 123,
             total_mint_limit: 100,
@@ -518,10 +512,7 @@ mod tests {
             governor_1.try_sign(message.as_ref()).unwrap(),
             governor_1.try_sign(message.as_ref()).unwrap(),
         ]);
-        let tx = MintConfigTx {
-            prefix: prefix.clone(),
-            signature,
-        };
+        let tx = MintConfigTx { prefix, signature };
         assert_eq!(
             validate_signature(
                 &tx,

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -103,7 +103,7 @@ mod tests {
         let signer_3 = Ed25519Pair::from_random(&mut rng);
 
         let mint_config = MintConfig {
-            token_id: token_id,
+            token_id,
             signer_set: SignerSet::new(
                 vec![
                     signer_1.public_key(),
@@ -116,7 +116,7 @@ mod tests {
         };
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: 100,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -142,7 +142,7 @@ mod tests {
         let signer_3 = Ed25519Pair::from_random(&mut rng);
 
         let mint_config = MintConfig {
-            token_id: token_id,
+            token_id,
             signer_set: SignerSet::new(
                 vec![
                     signer_1.public_key(),
@@ -184,7 +184,7 @@ mod tests {
         let signer_3 = Ed25519Pair::from_random(&mut rng);
 
         let mint_config = MintConfig {
-            token_id: token_id,
+            token_id,
             signer_set: SignerSet::new(
                 vec![
                     signer_1.public_key(),
@@ -197,7 +197,7 @@ mod tests {
         };
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: mint_config.mint_limit + 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -226,7 +226,7 @@ mod tests {
         let signer_3 = Ed25519Pair::from_random(&mut rng);
 
         let mint_config = MintConfig {
-            token_id: token_id,
+            token_id,
             signer_set: SignerSet::new(
                 vec![
                     signer_1.public_key(),
@@ -239,7 +239,7 @@ mod tests {
         };
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -265,7 +265,7 @@ mod tests {
         let signer_1 = Ed25519Pair::from_random(&mut rng);
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: 10,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -289,7 +289,7 @@ mod tests {
         let signer_2 = Ed25519Pair::from_random(&mut rng);
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -315,7 +315,7 @@ mod tests {
         let signer_1 = Ed25519Pair::from_random(&mut rng);
 
         let prefix = MintTxPrefix {
-            token_id: token_id,
+            token_id,
             amount: 1,
             view_public_key: RistrettoPublic::from_random(&mut rng),
             spend_public_key: RistrettoPublic::from_random(&mut rng),
@@ -354,7 +354,7 @@ mod tests {
             Err(Error::InvalidSignature)
         );
 
-        let mut prefix3 = prefix.clone();
+        let mut prefix3 = prefix;
         prefix3.nonce.push(5);
         let tx = MintTx {
             prefix: prefix3,

--- a/transaction/core/src/onetime_keys.rs
+++ b/transaction/core/src/onetime_keys.rs
@@ -207,8 +207,8 @@ mod tests {
         tx_private_key: &RistrettoPrivate,
         recipient: &PublicAddress,
     ) -> (RistrettoPublic, RistrettoPublic) {
-        let tx_target_key = create_tx_out_target_key(&tx_private_key, recipient);
-        let tx_public_key = create_tx_out_public_key(&tx_private_key, recipient.spend_public_key());
+        let tx_target_key = create_tx_out_target_key(tx_private_key, recipient);
+        let tx_public_key = create_tx_out_public_key(tx_private_key, recipient.spend_public_key());
         (tx_target_key, tx_public_key)
     }
 
@@ -245,7 +245,7 @@ mod tests {
         assert_eq!(
             recipient.spend_public_key(),
             &recover_public_subaddress_spend_key(
-                &account.view_private_key(), // (a, D_0)
+                account.view_private_key(), // (a, D_0)
                 &tx_target_key,
                 &tx_public_key
             )
@@ -255,7 +255,7 @@ mod tests {
         assert_ne!(
             other_account.default_subaddress().spend_public_key(),
             &recover_public_subaddress_spend_key(
-                &other_account.view_private_key(),
+                other_account.view_private_key(),
                 &tx_target_key,
                 &tx_public_key
             ),

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -160,7 +160,7 @@ pub mod tests {
             generate_range_proofs(&values, &blindings, &generators(0), &mut rng).unwrap();
 
         // Modify a commitment.
-        let mut wrong_commitments = commitments.clone();
+        let mut wrong_commitments = commitments;
         wrong_commitments[0] = RistrettoPoint::random(&mut rng).compress();
 
         match check_range_proofs(&proof, &wrong_commitments, &generators(0), &mut rng) {

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -611,7 +611,7 @@ mod mlsag_tests {
 
             // Sign with an input blinding that differs from the real input's amount commitment.
             {
-                let mut params = params.clone();
+                let mut params = params;
                 let wrong_blinding = Scalar::random(&mut rng);
 
                 params.blinding = wrong_blinding;
@@ -808,7 +808,7 @@ mod mlsag_tests {
 
             // Modify the signature to have too many responses.
             {
-                let mut invalid_signature = signature.clone();
+                let mut invalid_signature = signature;
                 invalid_signature.responses.push(CurveScalar::from_random(&mut rng));
 
                 let result =

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -750,7 +750,7 @@ mod rct_bulletproofs_tests {
             // Modify an output value
             {
                 let index = rng.next_u64() as usize % (num_inputs);
-                let (_value, blinding) = params.output_values_and_blindings[index].clone();
+                let (_value, blinding) = params.output_values_and_blindings[index];
                 params.output_values_and_blindings[index] = (rng.next_u64(), blinding);
             }
 
@@ -826,8 +826,8 @@ mod rct_bulletproofs_tests {
 
             // Duplicate one of the rings.
             params.rings[2] = params.rings[3].clone();
-            params.output_values_and_blindings[2] = params.output_values_and_blindings[3].clone();
-            params.input_secrets[2] = params.input_secrets[3].clone();
+            params.output_values_and_blindings[2] = params.output_values_and_blindings[3];
+            params.input_secrets[2] = params.input_secrets[3];
             params.real_input_indices[2] = params.real_input_indices[3];
 
             let signature = params.sign(fee, &mut rng).unwrap();

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -799,7 +799,7 @@ mod tests {
                 &bob_addr,
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(Some(memo_val.clone())),
+                |_| Ok(Some(memo_val)),
             )
             .unwrap();
 
@@ -835,7 +835,7 @@ mod tests {
                 &bob.change_subaddress(),
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(Some(memo_val.clone())),
+                |_| Ok(Some(memo_val)),
             )
             .unwrap();
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -614,7 +614,7 @@ mod tests {
 
         assert!(tx_out.e_memo.is_none());
         assert_eq!(
-            validate_memo_exists(&tx_out),
+            validate_memo_exists(tx_out),
             Err(TransactionValidationError::MissingMemo)
         );
 
@@ -622,7 +622,7 @@ mod tests {
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(tx_out.e_memo.is_some());
-        assert_eq!(validate_memo_exists(&tx_out), Ok(()));
+        assert_eq!(validate_memo_exists(tx_out), Ok(()));
     }
 
     #[test]
@@ -632,14 +632,14 @@ mod tests {
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(tx_out.e_memo.is_none());
-        assert_eq!(validate_no_memo_exists(&tx_out), Ok(()));
+        assert_eq!(validate_no_memo_exists(tx_out), Ok(()));
 
         let (tx, _) = create_test_tx(BlockVersion::ONE);
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(tx_out.e_memo.is_some());
         assert_eq!(
-            validate_no_memo_exists(&tx_out),
+            validate_no_memo_exists(tx_out),
             Err(TransactionValidationError::MemosNotAllowed)
         );
     }
@@ -653,7 +653,7 @@ mod tests {
 
         assert!(tx_out.masked_amount.masked_token_id.is_empty());
         assert_eq!(
-            validate_masked_token_id_exists(&tx_out),
+            validate_masked_token_id_exists(tx_out),
             Err(TransactionValidationError::MissingMaskedTokenId)
         );
 
@@ -661,7 +661,7 @@ mod tests {
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(!tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(validate_memo_exists(&tx_out), Ok(()));
+        assert_eq!(validate_memo_exists(tx_out), Ok(()));
     }
 
     #[test]
@@ -671,14 +671,14 @@ mod tests {
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(validate_no_masked_token_id_exists(&tx_out), Ok(()));
+        assert_eq!(validate_no_masked_token_id_exists(tx_out), Ok(()));
 
         let (tx, _) = create_test_tx(BlockVersion::TWO);
         let tx_out = tx.prefix.outputs.first().unwrap();
 
         assert!(!tx_out.masked_amount.masked_token_id.is_empty());
         assert_eq!(
-            validate_no_masked_token_id_exists(&tx_out),
+            validate_no_masked_token_id_exists(tx_out),
             Err(TransactionValidationError::MaskedTokenIdNotAllowed)
         );
     }
@@ -1149,7 +1149,7 @@ mod tests {
         for block_version in BlockVersion::iterator() {
             let (mut tx, _ledger) = create_test_tx(block_version);
 
-            tx.prefix.fee = tx.prefix.fee + 1;
+            tx.prefix.fee += 1;
 
             match validate_signature(block_version, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
@@ -1169,7 +1169,7 @@ mod tests {
         for _ in 0..3 {
             let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
 
-            tx.prefix.token_id = tx.prefix.token_id + 1;
+            tx.prefix.token_id += 1;
 
             match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -673,7 +673,7 @@ pub mod transaction_builder_tests {
 
         let onetime_private_key = recover_onetime_private_key(
             &RistrettoPublic::try_from(&real_output.public_key).unwrap(),
-            &account.view_private_key(),
+            account.view_private_key(),
             &account.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
         );
 
@@ -807,13 +807,13 @@ pub mod transaction_builder_tests {
 
             // The output should belong to the correct recipient.
             assert!(
-                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()
+                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, output).unwrap()
             );
 
             // The output should have the correct value and confirmation number
             {
                 let public_key = RistrettoPublic::try_from(&output.public_key).unwrap();
-                assert!(confirmation.validate(&public_key, &recipient.view_private_key()));
+                assert!(confirmation.validate(&public_key, recipient.view_private_key()));
             }
 
             // The transaction should have a valid signature.
@@ -888,13 +888,13 @@ pub mod transaction_builder_tests {
 
             // The output should belong to the correct recipient.
             assert!(
-                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()
+                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, output).unwrap()
             );
 
             // The output should have the correct value and confirmation number
             {
                 let public_key = RistrettoPublic::try_from(&output.public_key).unwrap();
-                assert!(confirmation.validate(&public_key, &recipient.view_private_key()));
+                assert!(confirmation.validate(&public_key, recipient.view_private_key()));
             }
 
             // The output's fog hint should contain the correct public key.
@@ -973,7 +973,7 @@ pub mod transaction_builder_tests {
 
             // The output should belong to the correct recipient.
             assert!(
-                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &output).unwrap()
+                subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, output).unwrap()
             );
 
             // The output's fog hint should contain the correct public key.
@@ -1168,17 +1168,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1194,7 +1194,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         assert_eq!(memo, MemoPayload::default());
                     }
                 }
@@ -1225,7 +1225,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         assert_eq!(memo, MemoPayload::default());
                     }
                 }
@@ -1344,17 +1344,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1370,7 +1370,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::AuthenticatedSender(memo) => {
                                 assert_eq!(
@@ -1409,7 +1409,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Destination(memo) => {
                                 assert_eq!(
@@ -1501,17 +1501,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1527,7 +1527,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::AuthenticatedSender(memo) => {
                                 assert_eq!(
@@ -1566,7 +1566,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Destination(memo) => {
                                 assert_eq!(
@@ -1658,17 +1658,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1684,7 +1684,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::AuthenticatedSenderWithPaymentRequestId(memo) => {
                                 assert_eq!(
@@ -1724,7 +1724,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Destination(memo) => {
                                 assert_eq!(
@@ -1815,17 +1815,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1841,7 +1841,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::AuthenticatedSenderWithPaymentRequestId(memo) => {
                                 assert_eq!(
@@ -1881,7 +1881,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Unused(_) => {}
                             _ => {
@@ -1960,17 +1960,17 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, &change)
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
                         .unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, &output)
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
                         .unwrap()
                 );
 
@@ -1986,7 +1986,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Unused(_) => {}
                             _ => {
@@ -2008,7 +2008,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Destination(memo) => {
                                 assert_eq!(
@@ -2129,24 +2129,20 @@ pub mod transaction_builder_tests {
                 validate_tx_out(block_version, change).unwrap();
 
                 assert!(
-                    !subaddress_matches_tx_out(&bob, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&bob, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&alice, DEFAULT_SUBADDRESS_INDEX, &change).unwrap()
+                    !subaddress_matches_tx_out(&alice, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&alice, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
+                    !subaddress_matches_tx_out(&alice, CHANGE_SUBADDRESS_INDEX, output).unwrap()
+                );
+                assert!(!subaddress_matches_tx_out(&bob, CHANGE_SUBADDRESS_INDEX, output).unwrap());
+                assert!(
+                    !subaddress_matches_tx_out(&charlie, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
                 );
                 assert!(
-                    !subaddress_matches_tx_out(&bob, CHANGE_SUBADDRESS_INDEX, &output).unwrap()
-                );
-                assert!(
-                    !subaddress_matches_tx_out(&charlie, DEFAULT_SUBADDRESS_INDEX, &change)
-                        .unwrap()
-                );
-                assert!(
-                    !subaddress_matches_tx_out(&charlie, DEFAULT_SUBADDRESS_INDEX, &output)
-                        .unwrap()
+                    !subaddress_matches_tx_out(&charlie, DEFAULT_SUBADDRESS_INDEX, output).unwrap()
                 );
 
                 // The 1st output should belong to the correct recipient and have correct amount
@@ -2161,7 +2157,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = output.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::AuthenticatedSender(memo) => {
                                 assert_eq!(
@@ -2197,7 +2193,7 @@ pub mod transaction_builder_tests {
                     assert_eq!(amount.token_id, token_id);
 
                     if block_version.e_memo_feature_is_supported() {
-                        let memo = change.e_memo.clone().unwrap().decrypt(&ss);
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                             MemoType::Destination(memo) => {
                                 assert_eq!(
@@ -2341,7 +2337,7 @@ pub mod transaction_builder_tests {
 
             let onetime_private_key = recover_onetime_private_key(
                 &RistrettoPublic::try_from(&real_output.public_key).unwrap(),
-                &alice.view_private_key(),
+                alice.view_private_key(),
                 &alice.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
             );
 
@@ -2568,8 +2564,7 @@ pub mod transaction_builder_tests {
                 !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &burn_tx_out).unwrap()
             );
             assert!(
-                subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &change_tx_out)
-                    .unwrap()
+                subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, change_tx_out).unwrap()
             );
 
             // Test that view key matching works with the burn tx out with burn address view
@@ -2586,12 +2581,12 @@ pub mod transaction_builder_tests {
             // Test that view key matching works with the change tx out with sender's view
             // key
             let (amount, _) = change_tx_out
-                .view_key_match(&sender.view_private_key())
+                .view_key_match(sender.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, change_value);
 
             assert!(burn_tx_out
-                .view_key_match(&sender.view_private_key())
+                .view_key_match(sender.view_private_key())
                 .is_err());
         }
     }

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -197,7 +197,7 @@ mod tests {
         let hint_slice = "Vaccine 90% effective";
         let output = create_output(
             &account_key.subaddress(0),
-            amount.clone(),
+            amount,
             &mut fixed_rng,
             Some(hint_slice),
             &logger,
@@ -210,7 +210,7 @@ mod tests {
         let hint_slice = "Covid-19 Vaccine 90% Up to 90% Effective in Late-Stage Trials - LONDON — the University of Oxford added their vaccine candidate to a growing list of shots showing promising effectiveness against Covid-19 — setting in motion disparate regulatory and distribution tracks that executives and researchers hope will result in the start of widespread vaccinations by the end of the year.";
         let output = create_output(
             &account_key.subaddress(0),
-            amount.clone(),
+            amount,
             &mut fixed_rng,
             Some(hint_slice),
             &logger,

--- a/util/keyfile/tests/b58-length.rs
+++ b/util/keyfile/tests/b58-length.rs
@@ -15,12 +15,7 @@ fn test_b58pub_length<T: RngCore + CryptoRng>(
     num_trials: usize,
     rng: &mut T,
 ) -> bool {
-    let url = format!(
-        "fog://{}",
-        std::iter::repeat("a")
-            .take(domain_length)
-            .collect::<String>()
-    );
+    let url = format!("fog://{}", "a".repeat(domain_length));
     for _ in 0..num_trials {
         let root_id = RootIdentity::random_with_fog(
             rng,
@@ -43,7 +38,7 @@ fn test_b58pub_length<T: RngCore + CryptoRng>(
             return true;
         }
     }
-    return false;
+    false
 }
 
 #[test]

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -135,7 +135,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -145,7 +145,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -155,7 +155,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -165,7 +165,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -175,7 +175,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("localhost:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -185,7 +185,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("localhost:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -195,7 +195,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -205,7 +205,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "");
 
@@ -216,7 +216,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "coiner");
         assert_eq!(uri.password(), "");
 
@@ -227,7 +227,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "");
         assert_eq!(uri.password(), "passw0rd");
 
@@ -238,7 +238,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "abc");
         assert_eq!(uri.password(), "def");
 
@@ -249,7 +249,7 @@ mod consensus_client_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
         assert_eq!(uri.username(), "abc");
         assert_eq!(uri.password(), "def:1:2:3");
     }
@@ -313,23 +313,23 @@ mod consensus_peer_uri_tests {
     fn test_valid_peer_uris() {
         let uri = PeerUri::from_str("mcp://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:8443");
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = PeerUri::from_str("mcp://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:8443");
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = PeerUri::from_str("mcp://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = PeerUri::from_str("insecure-mcp://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:8080");
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri = PeerUri::from_str("insecure-mcp://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:8080");
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri = PeerUri::from_str("insecure-mcp://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -349,7 +349,7 @@ mod consensus_peer_uri_tests {
                 public_key: signer_key.public_key(),
             }
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         // Base64 encoded with '+' -> '-', '/' -> '_'
         let uri = PeerUri::from_str(
@@ -369,7 +369,7 @@ mod consensus_peer_uri_tests {
                 .unwrap(),
             }
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
     }
 
     #[test]
@@ -397,7 +397,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogUri::from_str("fog://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
@@ -405,7 +405,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogUri::from_str("fog://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -413,7 +413,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), true);
+        assert!(uri.use_tls());
 
         let uri = FogUri::from_str("insecure-fog://127.0.0.1/").unwrap();
         assert_eq!(uri.addr(), "127.0.0.1:3225");
@@ -421,7 +421,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("127.0.0.1:3225").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri = FogUri::from_str("insecure-fog://node1.test.mobilecoin.com/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
@@ -429,7 +429,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
 
         let uri = FogUri::from_str("insecure-fog://node1.test.mobilecoin.com:666/").unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:666");
@@ -437,7 +437,7 @@ mod fog_uri_tests {
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
         );
-        assert_eq!(uri.use_tls(), false);
+        assert!(!uri.use_tls());
     }
 
     #[test]

--- a/watcher/src/block_data_store.rs
+++ b/watcher/src/block_data_store.rs
@@ -394,7 +394,7 @@ mod tests {
                 .get_block_data_map(block_datas[0].block().index)
                 .unwrap(),
             HashMap::from_iter(vec![
-                (tx_src_url1.clone(), block_datas[0].clone()),
+                (tx_src_url1, block_datas[0].clone()),
                 (tx_src_url2.clone(), block_datas[0].clone()),
             ])
         );
@@ -402,7 +402,7 @@ mod tests {
             watcher_db
                 .get_block_data_map(block_datas[1].block().index)
                 .unwrap(),
-            HashMap::from_iter(vec![(tx_src_url2.clone(), block_datas[1].clone()),])
+            HashMap::from_iter(vec![(tx_src_url2, block_datas[1].clone()),])
         );
     }
 }

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -392,7 +392,7 @@ mod tests {
 
         pub fn current_expected_report(node_url: &ConsensusClientUri) -> VerificationReport {
             let report_version_map = REPORT_VERSION.lock().unwrap();
-            let report_version = report_version_map.get(&node_url).map(|v| *v).unwrap_or(1);
+            let report_version = report_version_map.get(node_url).copied().unwrap_or(1);
 
             VerificationReport {
                 sig: VerificationSignature::from(vec![report_version; 32]),
@@ -629,14 +629,14 @@ mod tests {
         let signed_block_c1 =
             BlockSignature::from_block_and_keypair(&blocks[0].0, &signer3).unwrap();
         watcher_db
-            .add_block_signature(&tx_src_url3, 1, signed_block_c1, filename.clone())
+            .add_block_signature(&tx_src_url3, 1, signed_block_c1, filename)
             .unwrap();
 
         let mut tries = 30;
         let expected_reports_signer2 = HashMap::from_iter(vec![
-            (tx_src_url1.clone(), vec![None]),
+            (tx_src_url1, vec![None]),
             (
-                tx_src_url2.clone(),
+                tx_src_url2,
                 vec![Some(TestNodeClient::current_expected_report(&node2_url))],
             ),
         ]);

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -1803,7 +1803,7 @@ pub mod tests {
 
             // Unless it is added to a url we have not encountered before.
             watcher_db
-                .add_block_signature(&url3, 2, signed_block_b2, filename.clone())
+                .add_block_signature(&url3, 2, signed_block_b2, filename)
                 .unwrap();
 
             assert_eq!(
@@ -1850,7 +1850,7 @@ pub mod tests {
 
             assert_eq!(
                 watcher_db.get_verification_report_poll_queue().unwrap(),
-                HashMap::from_iter(vec![(url3.clone(), vec![signing_key_b.public_key()]),])
+                HashMap::from_iter(vec![(url3, vec![signing_key_b.public_key()]),])
             );
         })
     }
@@ -2019,11 +2019,8 @@ pub mod tests {
             assert_eq!(
                 last_synced,
                 HashMap::from_iter(vec![
-                    (url1.clone(), None),
-                    (
-                        url2.clone(),
-                        Some(block_datas.last().unwrap().block().index)
-                    ),
+                    (url1, None),
+                    (url2, Some(block_datas.last().unwrap().block().index)),
                 ])
             );
         })


### PR DESCRIPTION
… when running with `--all-targets`, so that we have a baseline without warnings for #1693