### PR TITLE
Add utility method `get_active_mint_configs_map` to LedgerDB

### DIFF
--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -196,6 +196,10 @@ impl Ledger for MockLedger {
         unimplemented!()
     }
 
+    fn get_active_mint_configs_map(&self) -> Result<HashMap<TokenId, ActiveMintConfigs>, Error> {
+        unimplemented!()
+    }
+
     fn check_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }

--- a/ledger/db/src/ledger_trait.rs
+++ b/ledger/db/src/ledger_trait.rs
@@ -4,7 +4,7 @@ use crate::{
     mint_config_store::{ActiveMintConfig, ActiveMintConfigs},
     Error,
 };
-use mc_common::Hash;
+use mc_common::{Hash, HashMap};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     mint::MintTx,
@@ -100,6 +100,9 @@ pub trait Ledger: Send {
         &self,
         token_id: TokenId,
     ) -> Result<Option<ActiveMintConfigs>, Error>;
+
+    /// Return the full map of TokenId -> ActiveMintConfigs.
+    fn get_active_mint_configs_map(&self) -> Result<HashMap<TokenId, ActiveMintConfigs>, Error>;
 
     /// Checks if the ledger contains a given MintConfigTx nonce.
     /// If so, returns the index of the block in which it entered the ledger.

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -889,15 +889,6 @@ pub fn key_bytes_to_u64(bytes: &[u8]) -> u64 {
     u64::from_be_bytes(bytes.try_into().unwrap())
 }
 
-pub fn u32_to_key_bytes(value: u32) -> [u8; 4] {
-    value.to_be_bytes()
-}
-
-pub fn key_bytes_to_u32(bytes: &[u8]) -> u32 {
-    assert_eq!(4, bytes.len());
-    u32::from_be_bytes(bytes.try_into().unwrap())
-}
-
 #[cfg(test)]
 mod ledger_db_test {
     use super::*;

--- a/ledger/db/src/lib.rs
+++ b/ledger/db/src/lib.rs
@@ -23,7 +23,7 @@ use lmdb::{
     Database, DatabaseFlags, Environment, EnvironmentFlags, RoTransaction, RwTransaction,
     Transaction, WriteFlags,
 };
-use mc_common::logger::global_log;
+use mc_common::{logger::global_log, HashMap};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_transaction_core::{
     membership_proofs::Range,
@@ -384,6 +384,13 @@ impl Ledger for LedgerDB {
         let db_transaction = self.env.begin_ro_txn()?;
         self.mint_config_store
             .get_active_mint_configs(token_id, &db_transaction)
+    }
+
+    /// Return the full map of TokenId -> ActiveMintConfigs.
+    fn get_active_mint_configs_map(&self) -> Result<HashMap<TokenId, ActiveMintConfigs>, Error> {
+        let db_transaction = self.env.begin_ro_txn()?;
+        self.mint_config_store
+            .get_active_mint_configs_map(&db_transaction)
     }
 
     /// Checks if the ledger contains a given MintConfigTx nonce.
@@ -884,6 +891,11 @@ pub fn key_bytes_to_u64(bytes: &[u8]) -> u64 {
 
 pub fn u32_to_key_bytes(value: u32) -> [u8; 4] {
     value.to_be_bytes()
+}
+
+pub fn key_bytes_to_u32(bytes: &[u8]) -> u32 {
+    assert_eq!(4, bytes.len());
+    u32::from_be_bytes(bytes.try_into().unwrap())
 }
 
 #[cfg(test)]

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -201,6 +201,10 @@ impl Ledger for MockLedger {
         unimplemented!()
     }
 
+    fn get_active_mint_configs_map(&self) -> Result<HashMap<TokenId, ActiveMintConfigs>, Error> {
+        unimplemented!()
+    }
+
     fn check_mint_config_tx_nonce(&self, _nonce: &[u8]) -> Result<Option<BlockIndex>, Error> {
         unimplemented!()
     }


### PR DESCRIPTION
### Motivation

We're going to want to add an API endpoint to consensus that exposes the current minting configuration.
As part of that, it would be helpful to include a map of each configured token id and the associated mint config that is in the ledger.
This can be done by iterating over all configured token ids, but having a utility method that just returns a map with all the information that is in the database seems handy.

I built this in a different PR but then realized I don't need it there, however I will need it for the new configuration API endpoint.

### In this PR
* Add `LedgerDB::.get_active_mint_configs_map`
* Remove  method that is no longer used anywhere.