### PR TITLE
backport TokenId u32 -> u64 change

### DIFF
--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -25,7 +25,7 @@ message LastBlockInfoResponse {
     uint64 mob_minimum_fee = 2 [deprecated = true];
 
     // A map of token id -> minimum fee
-    map<uint32, uint64> minimum_fees = 3;
+    map<uint64, uint64> minimum_fees = 3;
 
     // Current network_block version, appropriate for new transactions.
     //

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Clone, Copy, Debug, Deserialize, Digestible, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
-pub struct TokenId(u32);
+pub struct TokenId(u64);
 
-impl From<u32> for TokenId {
-    fn from(src: u32) -> Self {
+impl From<u64> for TokenId {
+    fn from(src: u64) -> Self {
         Self(src)
     }
 }
@@ -27,7 +27,7 @@ impl TokenId {
 }
 
 impl Deref for TokenId {
-    type Target = u32;
+    type Target = u64;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
this is desired because it prevents a breaking change in the consensus
proto file between 1.2.0 and 1.3.0 which would otherwise occur

The `TokenId` stuff is not active at this revision, but it is used
in the tokens.toml parsing which is used to configure consensus
at this revision, and would be hard to remove.