### PR TITLE
add get_minting_trust_root to consensus enclave

### DIFF
--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -268,8 +268,11 @@ pub trait ConsensusEnclave: ReportableEnclave {
     /// Retrieve the block signing public key from the enclave.
     fn get_signer(&self) -> Result<Ed25519Public>;
 
-    /// Retrieve the fee public key from the enclave
+    /// Retrieve the fee public key from the enclave.
     fn get_fee_recipient(&self) -> Result<FeePublicKey>;
+
+    /// Retrieve the minting trust root public key from the enclave.
+    fn get_minting_trust_root(&self) -> Result<Ed25519Public>;
 
     // CLIENT-FACING METHODS
 

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -75,6 +75,11 @@ pub enum EnclaveCall {
     /// Retrieves the fee recipient (FeePublicKey) for the enclave.
     GetFeeRecipient,
 
+    /// The [ConsensusEnclave::get_minting_trust_root()] method.
+    ///
+    /// Retrieves the minting trust root (Ed25519 public key) of an enclave.
+    GetMintingTrustRoot,
+
     /// The [ConsensusEnclave::new_ereport()] method.
     ///
     /// Creates a new report for the enclave with the provided target info.

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -536,6 +536,11 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         })
     }
 
+    fn get_minting_trust_root(&self) -> Result<Ed25519Public> {
+        Ed25519Public::try_from(&MINTING_TRUST_ROOT_PUBLIC_KEY[..])
+            .map_err(Error::ParseMintingTrustRootPublicKey)
+    }
+
     fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession)> {
         Ok(self.ake.client_accept(req)?)
     }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -46,6 +46,7 @@ use std::{
 #[derive(Clone)]
 pub struct ConsensusServiceMockEnclave {
     pub signing_keypair: Arc<Ed25519Pair>,
+    pub minting_trust_root_keypair: Arc<Ed25519Pair>,
     pub blockchain_config: Arc<Mutex<BlockchainConfig>>,
 }
 
@@ -53,10 +54,12 @@ impl Default for ConsensusServiceMockEnclave {
     fn default() -> Self {
         let mut csprng = Hc128Rng::seed_from_u64(0);
         let signing_keypair = Arc::new(Ed25519Pair::from_random(&mut csprng));
+        let minting_trust_root_keypair = Arc::new(Ed25519Pair::from_random(&mut csprng));
         let blockchain_config = Arc::new(Mutex::new(BlockchainConfig::default()));
 
         Self {
             signing_keypair,
+            minting_trust_root_keypair,
             blockchain_config,
         }
     }
@@ -128,6 +131,10 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
 
     fn get_signer(&self) -> Result<Ed25519Public> {
         Ok(self.signing_keypair.public_key())
+    }
+
+    fn get_minting_trust_root(&self) -> Result<Ed25519Public> {
+        Ok(self.minting_trust_root_keypair.public_key())
     }
 
     // NOTE: We hardcode here because we don't need the mock enclave currently to be

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -44,6 +44,8 @@ mock! {
 
         fn get_fee_recipient(&self) -> ConsensusEnclaveResult<FeePublicKey>;
 
+        fn get_minting_trust_root(&self) -> ConsensusEnclaveResult<Ed25519Public>;
+
         fn client_accept(&self, req: ClientAuthRequest) -> ConsensusEnclaveResult<(ClientAuthResponse, ClientSession)>;
 
         fn client_close(&self, channel_id: ClientSession) -> ConsensusEnclaveResult<()>;

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -160,6 +160,12 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn get_minting_trust_root(&self) -> Result<Ed25519Public> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetMintingTrustRoot)?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession)> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::ClientAccept(req))?;
         let outbuf = self.enclave_call(&inbuf)?;

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -54,10 +54,12 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::ClientAccept(auth_msg) => serialize(&ENCLAVE.client_accept(auth_msg)),
         EnclaveCall::ClientClose(channel_id) => serialize(&ENCLAVE.client_close(channel_id)),
         EnclaveCall::ClientDiscardMessage(msg) => serialize(&ENCLAVE.client_discard_message(msg)),
-        // Report Caching
+        // Keys
         EnclaveCall::GetIdentity => serialize(&ENCLAVE.get_identity()),
         EnclaveCall::GetSigner => serialize(&ENCLAVE.get_signer()),
         EnclaveCall::GetFeeRecipient => serialize(&ENCLAVE.get_fee_recipient()),
+        EnclaveCall::GetMintingTrustRoot => serialize(&ENCLAVE.get_minting_trust_root()),
+        // Report Caching
         EnclaveCall::NewEreport(qe_info) => serialize(&ENCLAVE.new_ereport(qe_info)),
         EnclaveCall::VerifyQuote(quote, qe_report) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report))


### PR DESCRIPTION
### Motivation

It's useful to have access to what static configuration the enclave was built with. A followup PR is going to add an RPC endpoint to get a consensus node's configuration, it including the minting trust root key that got baked into the enclave is a useful thing to include in the response. 

### In this PR
* Add a new `get_minting_trust_root` method to the consensus enclave
