### PR TITLE
GHA CI/CD workflow_dispatch placeholders.

### DIFF
--- a/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
@@ -1,0 +1,18 @@
+name: mobilecoin-dispatch-dev-delete
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -1,0 +1,17 @@
+name: mobilecoin-dispatch-dev-deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-reset.yaml
@@ -1,0 +1,17 @@
+name: mobilecoin-dispatch-dev-reset
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-dev-test.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-test.yaml
@@ -1,0 +1,17 @@
+name: mobilecoin-dispatch-dev-test
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -1,0 +1,17 @@
+name: mobilecoin-dispatch-dev-update-consensus
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}


### PR DESCRIPTION
### Motivation

Workflow_dispatch (manual) workflows must first exist in the default branch.  This PR adds minimum functionality workflow_dispatch definitions so we can run/integrate them with the release branch.

After we get things working with release/v1.2.0 we will start follow up work to catch up with the edge (1.3.x) deployments, charts and surrounding config. 

### In this PR

* `.github/workflows/mobilecoin-dispatch-dev-*` - placeholder workflows.

### Future Work

* Merge full workflows that will soon be integrated into the release/v1.2.0 in to master.  

