### PR TITLE
Initial take on implementing Burn Redemption Memo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5144,6 +5150,7 @@ dependencies = [
 name = "mc-transaction-std"
 version = "1.3.0-pre0"
 dependencies = [
+ "assert_matches",
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -5,6 +5,7 @@
 use crate::AmountError;
 use alloc::string::String;
 use displaydoc::Display;
+use mc_account_keys::PublicAddress;
 use mc_crypto_keys::KeyError;
 
 /// An error that occurs when creating a new TxOut
@@ -65,6 +66,12 @@ pub enum NewMemoError {
     OutputsAfterChange,
     /// Changing the fee after the change output is not supported
     FeeAfterChange,
+    /// Invalid recipient address
+    InvalidRecipient(PublicAddress),
+    /// Multiple outputs are not supported
+    MultipleOutputs,
+    /// Missing output
+    MissingOutput,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -34,6 +34,7 @@ curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "u64_backend"] }
 
 [dev-dependencies]
+assert_matches = "1.5"
 maplit = "1.0"
 yaml-rust = "0.4"
 

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -18,11 +18,11 @@ pub use change_destination::ChangeDestination;
 pub use error::TxBuilderError;
 pub use input_credentials::InputCredentials;
 pub use memo::{
-    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType, SenderMemoCredential,
-    UnusedMemo,
+    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo,
+    DestinationMemo, DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType,
+    SenderMemoCredential, UnusedMemo,
 };
-pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
 
 // Re-export this to help the exported macros work

--- a/transaction/std/src/memo/burn_redemption.rs
+++ b/transaction/std/src/memo/burn_redemption.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Object for 0x0001 Burn Redemption memo type
+//!
+//! TODO: Link to MCIP
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/TBD
+
+use super::RegisteredMemoType;
+use crate::impl_memo_type_conversions;
+
+/// A memo that the sender writes to associate a burn of an assert on the
+/// MobileCoin blockchain with a redemption of another asset on a different
+/// blockchain. The main intended use-case for this is burning of tokens that
+/// are correlated with redemption of some other asset on a different
+/// blockchain.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BurnRedemptionMemo {
+    /// The memo data
+    /// TODO: The contents of this have not yet been determined. It will likely
+    /// contain some or all of the following:
+    /// 1) The type of address that the redeemed external asset will be sent to
+    ///   (e.g. ERC20 wallet, ERC20 contract, etc.)
+    /// 2) The external blockchain on which the redemptio is taking place
+    ///    (e.g. Ethereum, Polygon, etc.)
+    /// 3) Address receiving the redeemed asset This is just a placeholder for
+    ///    now.
+    memo_data: [u8; 64],
+}
+
+impl RegisteredMemoType for BurnRedemptionMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x00, 0x01];
+}
+
+impl BurnRedemptionMemo {
+    /// Create a new BurnRedemptionMemo.
+    pub fn new(memo_data: [u8; 64]) -> Self {
+        BurnRedemptionMemo { memo_data }
+    }
+
+    /// Get the memo data
+    pub fn memo_data(&self) -> &[u8; 64] {
+        &self.memo_data
+    }
+}
+
+impl From<&[u8; 64]> for BurnRedemptionMemo {
+    fn from(src: &[u8; 64]) -> Self {
+        let mut memo_data = [0u8; 64];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<BurnRedemptionMemo> for [u8; 64] {
+    fn from(src: BurnRedemptionMemo) -> [u8; 64] {
+        src.memo_data
+    }
+}
+
+impl_memo_type_conversions! { BurnRedemptionMemo }

--- a/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
+++ b/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Defines the BurnRedemptionMemoBuilder.
+//! This MemoBuilder policy implements Burn Redemption tracking usin memos, as
+//! envisioned in MCIP #TODO.
+
+use super::{
+    memo::{BurnRedemptionMemo, DestinationMemo, DestinationMemoError, UnusedMemo},
+    MemoBuilder,
+};
+use crate::ChangeDestination;
+use mc_account_keys::{burn_address, PublicAddress, ShortAddressHash};
+use mc_transaction_core::{tokens::Mob, MemoContext, MemoPayload, NewMemoError, Token};
+
+/// This memo builder attaches 0x0001 Burn Redemption Memos to an output going
+/// to the designated burn address, and 0x0200 Destination Memos to change
+/// outputs. Only a single non-change output is allowed, and it must go to the
+/// designated burn address.
+///
+/// Usage:
+/// You should usually use this like:
+///
+///   let memo_data = [1; 64]; // TODO: contents of this are still not designed.
+///   let mut mb = BurnRedemptionMemoBuilder::new(memo_data);
+///   mb.enable_destination_memo();
+///
+/// Then use it to construct a transaction builder.
+///
+/// A memo builder configured this way will use 0x0001 Burn Redemption Memo
+/// on the burn output and 0x0200 Destination Memo on the change output.
+///
+/// If mb.enable_destination_memo() is not called 0x0000 Unused will appear on
+/// change output, instead of 0x0200 Destination Memo.
+///
+/// When invoking the transaction builder, the change output must be created
+/// last. If the burn output is created after the change output, an error will
+/// occur.
+///
+/// If more than one burn output is created, an error will be returned.
+#[derive(Clone, Debug)]
+pub struct BurnRedemptionMemoBuilder {
+    // The memo data we will attach to the burn output.
+    memo_data: [u8; 64],
+    // Whether destination memos are enabled.
+    destination_memo_enabled: bool,
+    // Tracks if we already wrote a burn memo, for error reporting
+    wrote_burn_memo: bool,
+    // Tracks if we already wrote a destination memo, for error reporting
+    wrote_destination_memo: bool,
+    // Tracks the amount being burn
+    burn_amount: u64,
+    // Tracks the fee
+    fee: u64,
+}
+
+impl BurnRedemptionMemoBuilder {
+    /// Construct a new BurnRedemptionMemoBuilder.
+    pub fn new(memo_data: [u8; 64]) -> Self {
+        Self {
+            memo_data,
+            destination_memo_enabled: false,
+            wrote_burn_memo: false,
+            wrote_destination_memo: false,
+            burn_amount: 0,
+            fee: Mob::MINIMUM_FEE,
+        }
+    }
+    /// Enable destination memos
+    pub fn enable_destination_memo(&mut self) {
+        self.destination_memo_enabled = true;
+    }
+
+    /// Disable destination memos
+    pub fn disable_destination_memo(&mut self) {
+        self.destination_memo_enabled = false;
+    }
+}
+
+impl MemoBuilder for BurnRedemptionMemoBuilder {
+    /// Set the fee
+    fn set_fee(&mut self, fee: u64) -> Result<(), NewMemoError> {
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
+        Ok(())
+    }
+
+    /// Build a memo for the burn output.
+    fn make_memo_for_output(
+        &mut self,
+        value: u64,
+        recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if *recipient != burn_address() {
+            return Err(NewMemoError::InvalidRecipient(recipient.clone()));
+        }
+        if self.wrote_burn_memo {
+            return Err(NewMemoError::MultipleOutputs);
+        }
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::OutputsAfterChange);
+        }
+        self.burn_amount = value;
+        self.wrote_burn_memo = true;
+        Ok(BurnRedemptionMemo::new(self.memo_data.clone()).into())
+    }
+
+    /// Build a memo for a change output (to ourselves).
+    fn make_memo_for_change_output(
+        &mut self,
+        _value: u64,
+        _change_destination: &ChangeDestination,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if !self.destination_memo_enabled {
+            return Ok(UnusedMemo {}.into());
+        }
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        if !self.wrote_burn_memo {
+            return Err(NewMemoError::MissingOutput);
+        }
+        let total_outlay = self
+            .burn_amount
+            .checked_add(self.fee)
+            .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?;
+        match DestinationMemo::new(
+            ShortAddressHash::from(&burn_address()),
+            total_outlay,
+            self.fee,
+        ) {
+            Ok(mut d_memo) => {
+                self.wrote_destination_memo = true;
+                d_memo.set_num_recipients(1);
+                Ok(d_memo.into())
+            }
+            Err(err) => match err {
+                DestinationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
+            },
+        }
+    }
+}

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -9,7 +9,10 @@ use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{MemoContext, MemoPayload, NewMemoError};
 
+mod burn_redemption_memo_builder;
 mod rth_memo_builder;
+
+pub use burn_redemption_memo_builder::BurnRedemptionMemoBuilder;
 pub use rth_memo_builder::RTHMemoBuilder;
 
 /// The MemoBuilder trait defines the API that the transaction builder uses

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -539,7 +539,10 @@ fn create_fog_hint<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
 #[cfg(test)]
 pub mod transaction_builder_tests {
     use super::*;
-    use crate::{EmptyMemoBuilder, MemoType, RTHMemoBuilder, SenderMemoCredential};
+    use crate::{
+        BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoType, RTHMemoBuilder, SenderMemoCredential,
+    };
+    use assert_matches::assert_matches;
     use maplit::btreemap;
     use mc_account_keys::{
         burn_address, burn_address_view_private, AccountKey, ShortAddressHash,
@@ -554,7 +557,7 @@ pub mod transaction_builder_tests {
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
         validation::{validate_signature, validate_tx_out},
-        TokenId,
+        NewTxError, TokenId,
     };
     use rand::{rngs::StdRng, SeedableRng};
     use std::convert::TryFrom;
@@ -2588,6 +2591,197 @@ pub mod transaction_builder_tests {
             assert!(burn_tx_out
                 .view_key_match(sender.view_private_key())
                 .is_err());
+        }
+    }
+
+    #[test]
+    // Transaction builder with Burn Redemption memo builder
+    fn test_transaction_builder_burn_redemption_memos() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let block_version = BlockVersion::MAX;
+        let token_id = TokenId::from(5);
+        let fog_resolver = MockFogResolver::default();
+        let sender = AccountKey::random(&mut rng);
+        let change_destination = ChangeDestination::from(&sender);
+
+        // Adding an output that is not to the burn address is not allowed.
+        {
+            let memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                token_id,
+                fog_resolver.clone(),
+                memo_builder,
+            );
+
+            let recipient = AccountKey::random(&mut rng);
+            let result =
+                transaction_builder.add_output(100, &recipient.default_subaddress(), &mut rng);
+            assert_matches!(result, Err(TxBuilderError::NewTx(NewTxError::Memo(NewMemoError::InvalidRecipient(addr)))) if addr == recipient.default_subaddress());
+        }
+
+        // Adding two burn outputs is not allowed.
+        {
+            let memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                token_id,
+                fog_resolver.clone(),
+                memo_builder,
+            );
+
+            transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.add_output(100, &burn_address(), &mut rng);
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MultipleOutputs
+                )))
+            );
+        }
+
+        // Adding a change output before a burn output is not allowed.
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                token_id,
+                fog_resolver.clone(),
+                memo_builder,
+            );
+
+            let result = transaction_builder.add_change_output(10, &change_destination, &mut rng);
+
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MissingOutput
+                )))
+            );
+        }
+
+        // Happy flow with change
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                token_id,
+                fog_resolver.clone(),
+                memo_builder,
+            );
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount {
+                    value: 113,
+                    token_id,
+                },
+                &AccountKey::random(&mut rng),
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let (burn_tx_out, _confirmation) = transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            transaction_builder
+                .add_change_output(10, &change_destination, &mut rng)
+                .unwrap();
+
+            let tx = transaction_builder.build(&mut rng).expect("build tx");
+
+            assert_eq!(tx.prefix.outputs.len(), 2);
+
+            let burn_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == burn_tx_out.public_key)
+                .expect("Didn't find recipient's output");
+            let change_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| {
+                    subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
+                })
+                .expect("Didn't find sender's output");
+
+            // Test that view key matching works with the burn tx out with burn address view
+            // key
+            let (amount, _) = burn_output
+                .view_key_match(&burn_address_view_private())
+                .unwrap();
+            assert_eq!(amount.value, 100);
+
+            assert!(change_output
+                .view_key_match(&burn_address_view_private())
+                .is_err());
+
+            // Test that view key matching works with the change tx out with sender's view
+            // key
+            let (amount, _) = change_output
+                .view_key_match(sender.view_private_key())
+                .unwrap();
+            assert_eq!(amount.value, 10);
+
+            assert!(burn_output
+                .view_key_match(sender.view_private_key())
+                .is_err());
+
+            // Burn output should have a burn redemption memo
+            let ss = get_tx_out_shared_secret(
+                &burn_address_view_private(),
+                &RistrettoPublic::try_from(&burn_output.public_key).unwrap(),
+            );
+            let memo = burn_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::BurnRedemption(memo) => {
+                    assert_eq!(memo.memo_data(), &[2u8; 64],);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+
+            // Change output should have a destination memo
+            let ss = get_tx_out_shared_secret(
+                sender.view_private_key(),
+                &RistrettoPublic::try_from(&change_output.public_key).unwrap(),
+            );
+            let memo = change_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Destination(memo) => {
+                    assert_eq!(
+                        memo.get_address_hash(),
+                        &ShortAddressHash::from(&burn_address()),
+                        "lookup based on address hash failed"
+                    );
+                    assert_eq!(memo.get_num_recipients(), 1);
+                    assert_eq!(memo.get_fee(), 3);
+                    assert_eq!(
+                        memo.get_total_outlay(),
+                        103,
+                        "outlay should be amount sent to recipient + fee"
+                    );
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation

We are going to want to include a memo in `TxOut`s going to the burn address to include details about the burn. More specifically ,for burns that are correlated with a redemption of an asset on a non-MobileCoin blockchain, we would like to include information about where the redeemed asset should be sent to.

This PR is the initial work at adding this memo. Its payload is currently completely untyped (it is just a 64 byte array), but as we narrow down our exact use case, we are likely going to add some structure that defines what goes in those bytes.

### In this PR
* Add a new basic `BurnRedemptionMemo` and the accompanying `BurnRedemptionMemoBuilder`
* Add a table in the `memo` module that summarizes the IDs for natively-supported memos that are bundled in the `mc-transaction-core` crate.

### Future Work
* Spec out the contents of the new memo
* Add support in `mc-mobilecoind` for generating burn transactions that utilize the new memo.
