### PR TITLE
Add Clippy check to lint script

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -8,6 +8,10 @@ if [[ ! -z "$1" ]]; then
     cd "$1"
 fi
 
+# We want to check with --all-targets since it checks test code, but that flag
+# leads to build errors in enclave workspaces, so check it here.
+cargo clippy --all --all-features --all-targets
+
 cargo install cargo-sort
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -834,7 +834,7 @@ mod rct_bulletproofs_tests {
                 let token_id = TokenId::from(token_ids[i % token_ids.len()]);
                 let generator = generator_cache.get(token_id);
 
-                let commitment = CompressedCommitment::new(value, blinding, &generator);
+                let commitment = CompressedCommitment::new(value, blinding, generator);
 
                 let real_index = rng.next_u64() as usize % (num_mixins + 1);
                 ring.insert(real_index, (onetime_public_key, commitment));

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2779,8 +2779,7 @@ pub mod transaction_builder_tests {
                 !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &tx_out2).unwrap()
             );
             assert!(
-                subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, &change_tx_out)
-                    .unwrap()
+                subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, change_tx_out).unwrap()
             );
 
             // Test that recipients's default subaddress owns the correct output, and not
@@ -2794,13 +2793,13 @@ pub mod transaction_builder_tests {
             assert!(!subaddress_matches_tx_out(
                 &recipient,
                 DEFAULT_SUBADDRESS_INDEX,
-                &change_tx_out
+                change_tx_out
             )
             .unwrap());
 
             // Test that view key matching works with the two tx outs
             let (amount, _) = tx_out1
-                .view_key_match(&recipient.view_private_key())
+                .view_key_match(recipient.view_private_key())
                 .unwrap();
             assert_eq!(
                 amount.value,
@@ -2809,24 +2808,24 @@ pub mod transaction_builder_tests {
             assert_eq!(amount.token_id, Mob::ID);
 
             let (amount, _) = tx_out2
-                .view_key_match(&recipient.view_private_key())
+                .view_key_match(recipient.view_private_key())
                 .unwrap();
             assert_eq!(amount, amount2);
 
             assert!(change_tx_out
-                .view_key_match(&recipient.view_private_key())
+                .view_key_match(recipient.view_private_key())
                 .is_err());
 
             // Test that view key matching works with the change tx out with sender's view
             // key
             let (amount, _) = change_tx_out
-                .view_key_match(&sender.view_private_key())
+                .view_key_match(sender.view_private_key())
                 .unwrap();
             assert_eq!(amount.value, change_amount.value);
 
-            assert!(tx_out1.view_key_match(&sender.view_private_key()).is_err());
+            assert!(tx_out1.view_key_match(sender.view_private_key()).is_err());
 
-            assert!(tx_out2.view_key_match(&sender.view_private_key()).is_err());
+            assert!(tx_out2.view_key_match(sender.view_private_key()).is_err());
         }
     }
 
@@ -2891,7 +2890,7 @@ pub mod transaction_builder_tests {
 
             assert!(test_fn(block_version, tx_out1_right_amount).is_ok());
 
-            let mut tx_out1_wrong_amount = tx_out1_right_amount.clone();
+            let mut tx_out1_wrong_amount = tx_out1_right_amount;
             tx_out1_wrong_amount.value -= 1;
             assert!(test_fn(block_version, tx_out1_wrong_amount).is_err());
 

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -221,7 +221,7 @@ mod test {
             10,
             Some(fqdn),
             Some(fog_report_id),
-            Some(&fog_authority_spki),
+            Some(fog_authority_spki),
             DEFAULT_SEED,
         )
         .expect("Error writing default keyfiles to dir1");
@@ -230,7 +230,7 @@ mod test {
             10,
             Some(fqdn),
             Some(fog_report_id),
-            Some(&fog_authority_spki),
+            Some(fog_authority_spki),
             DEFAULT_SEED,
         )
         .expect("Error writing default keyfiles to dir2");

--- a/util/keyfile/tests/bin-determinism.rs
+++ b/util/keyfile/tests/bin-determinism.rs
@@ -39,7 +39,7 @@ fn sample_keys_determinism() {
     assert!(Command::new(sample_keys_bin.clone())
         .args(&[
             "--output-dir",
-            &tempdir_path,
+            tempdir_path,
             "--num",
             "10",
             "--fog-report-url",
@@ -58,7 +58,7 @@ fn sample_keys_determinism() {
     assert!(Command::new(sample_keys_bin)
         .args(&[
             "--output-dir",
-            &tempdir2_path,
+            tempdir2_path,
             "--num",
             "10",
             "--fog-report-url",
@@ -66,7 +66,7 @@ fn sample_keys_determinism() {
             "--fog-report-id",
             "",
             "--fog-authority-root",
-            &fog_authority_root,
+            fog_authority_root,
         ])
         .status()
         .expect("sample_keys failed")
@@ -106,7 +106,7 @@ fn sample_keys_determinism2() {
     assert!(Command::new(sample_keys_bin.clone())
         .args(&[
             "--output-dir",
-            &tempdir_path,
+            tempdir_path,
             "--num",
             "10",
             "--fog-report-url",
@@ -125,7 +125,7 @@ fn sample_keys_determinism2() {
     assert!(Command::new(sample_keys_bin)
         .args(&[
             "--output-dir",
-            &tempdir2_path,
+            tempdir2_path,
             "--num",
             "20",
             "--fog-report-url",


### PR DESCRIPTION
Add `clippy --all-targets`. Supports #1693 