### PR TITLE
Create test blocks with custom content

### DIFF
--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -5,6 +5,7 @@ use mc_account_keys::AccountKey;
 use mc_common::{HashMap, HashSet};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate};
 use mc_transaction_core::{
+    constants::TOTAL_MOB,
     mint::MintTx,
     ring_signature::KeyImage,
     tokens::Mob,
@@ -300,10 +301,138 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
     blocks_and_contents
 }
 
+/// Get blocks with custom content in order to simulate conditions seen in
+/// production
+///
+/// * `outputs_per_recipient_per_block` - transaction outputs per account per
+///   block
+/// * `num_accounts` - number of accounts in the blocks
+/// * `num_blocks` - number of simulated blocks to create
+/// * `key_images_per_block` - number of key images per block
+/// * `max_token_id` - number of distinct token ids in blocks
+pub fn get_custom_test_ledger_blocks(
+    outputs_per_recipient_per_block: usize,
+    num_accounts: usize,
+    num_blocks: usize,
+    key_images_per_block: usize,
+    max_token_id: u64,
+) -> Vec<(Block, BlockContents)> {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    // Number of total tx outputs in all blocks
+    let num_outputs: u64 =
+        (num_accounts * outputs_per_recipient_per_block * num_blocks * (max_token_id as usize + 1))
+            as u64;
+    assert!(num_outputs >= 16);
+
+    // Initialize other defaults
+    let picomob_per_output: u64 = (TOTAL_MOB / num_outputs) * 1_000_000_000_000;
+    let recipients = (0..num_accounts)
+        .map(|_| AccountKey::random(&mut rng).default_subaddress())
+        .collect::<Vec<_>>();
+    let block_version = BlockVersion::MAX;
+    let mut blocks_and_contents: Vec<(Block, BlockContents)> = Vec::new();
+    let mut previous_block: Option<Block> = None;
+
+    // Create the tx outs for all of the simulated blocks
+    for _ in 0..num_blocks as u64 {
+        let mut outputs: Vec<TxOut> = Vec::new();
+        for recipient in &recipients {
+            let tx_private_key = RistrettoPrivate::from_random(&mut rng);
+            for _ in 0..outputs_per_recipient_per_block {
+                // Create outputs for each token id in round-robin fashion
+                for token_id in 0..=max_token_id {
+                    let amount = Amount {
+                        value: picomob_per_output,
+                        token_id: token_id.into(),
+                    };
+                    let output = TxOut::new(amount, recipient, &tx_private_key, Default::default());
+                    outputs.push(output.unwrap());
+                }
+            }
+        }
+
+        // Create key images unless we're at the origin block
+        let key_images: Vec<KeyImage> = if previous_block.is_some() {
+            (0..key_images_per_block)
+                .map(|_i| KeyImage::from(rng.next_u64()))
+                .collect()
+        } else {
+            Default::default()
+        };
+
+        let block_contents = BlockContents {
+            key_images,
+            outputs: outputs.clone(),
+            ..Default::default()
+        };
+
+        // Create a block with the desired contents
+        let block = match previous_block {
+            Some(parent) => {
+                Block::new_with_parent(block_version, &parent, &Default::default(), &block_contents)
+            }
+            None => Block::new_origin_block(&outputs),
+        };
+
+        previous_block = Some(block.clone());
+        blocks_and_contents.push((block, block_contents));
+    }
+    blocks_and_contents
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use mc_transaction_core::compute_block_id;
+
+    #[test]
+    // `get_custom_test_ledger_blocks` should return blocks that match the
+    // configuration specified in the arguments and pass all normal
+    // consistency tests
+    fn test_custom_block_correctness() {
+        let blocks_and_transactions = get_custom_test_ledger_blocks(2, 3, 3, 3, 0);
+
+        let blocks: Vec<Block> = blocks_and_transactions
+            .iter()
+            .map(|(block, _transactions)| block.clone())
+            .collect();
+
+        // Ensure the correct amount of blocks have been created
+        assert_eq!(blocks_and_transactions.len(), 3);
+
+        // Ensure the origin block id isn't a hash of another block
+        let origin_block: &Block = blocks.get(0).unwrap();
+        assert_eq!(origin_block.parent_id.as_ref(), [0u8; 32]);
+        assert_eq!(origin_block.index, 0);
+
+        for (block, block_contents) in blocks_and_transactions.iter() {
+            let derived_block_id = compute_block_id(
+                block.version,
+                &block.parent_id,
+                block.index,
+                block.cumulative_txo_count,
+                &block.root_element,
+                &block.contents_hash,
+            );
+
+            // Ensure the block_id matches the id computed via the merlin transcript
+            assert_eq!(derived_block_id, block.id);
+
+            // Ensure stated block hash matches the computed hash
+            assert_eq!(block.contents_hash, block_contents.hash());
+
+            // Ensure the amount of transactions present matches expected amount
+            assert_eq!(block.cumulative_txo_count, (block.index + 1) * 6);
+
+            // Ensure the correct number of key images exist
+            if block.index == 0 {
+                assert_eq!(block_contents.key_images.len(), 0);
+            } else {
+                assert_eq!(block_contents.key_images.len(), 3);
+            }
+        }
+    }
 
     #[test]
     // `get_test_ledger_blocks` should return a valid blockchain of the specified

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -304,7 +304,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 /// Get blocks with custom content in order to simulate conditions seen in
 /// production
 ///
-/// * `outputs_per_recipient_per_token_per_block` - number of outputs for each 
+/// * `outputs_per_recipient_per_token_per_block` - number of outputs for each
 ///   unique token type per account per block
 /// * `num_accounts` - number of accounts in the blocks
 /// * `num_blocks` - number of simulated blocks to create
@@ -320,13 +320,15 @@ pub fn get_custom_test_ledger_blocks(
     let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
     // Number of total tx outputs in all blocks
-    let num_outputs: u64 =
-        (num_accounts * outputs_per_recipient_per_token_per_block * num_blocks * (max_token_id as usize + 1))
-            as u64;
+    let num_outputs: u64 = (num_accounts
+        * outputs_per_recipient_per_token_per_block
+        * num_blocks
+        * (max_token_id as usize + 1)) as u64;
     assert!(num_outputs >= 16);
 
     // Initialize other defaults
-    let picomob_per_output: u64 = ((TOTAL_MOB as f64 / num_outputs as f64) * 1000000000000.0) as u64;
+    let picomob_per_output: u64 =
+        ((TOTAL_MOB as f64 / num_outputs as f64) * 1000000000000.0) as u64;
     let recipients = (0..num_accounts)
         .map(|_| AccountKey::random(&mut rng).default_subaddress())
         .collect::<Vec<_>>();

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -304,8 +304,8 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 /// Get blocks with custom content in order to simulate conditions seen in
 /// production
 ///
-/// * `outputs_per_recipient_per_block` - transaction outputs per account per
-///   block
+/// * `outputs_per_recipient_per_token_per_block` - number of outputs for each 
+///   unique token type per account per block
 /// * `num_accounts` - number of accounts in the blocks
 /// * `num_blocks` - number of simulated blocks to create
 /// * `key_images_per_block` - number of key images per block
@@ -321,12 +321,12 @@ pub fn get_custom_test_ledger_blocks(
 
     // Number of total tx outputs in all blocks
     let num_outputs: u64 =
-        (num_accounts * outputs_per_recipient_per_block * num_blocks * (max_token_id as usize + 1))
+        (num_accounts * outputs_per_recipient_per_token_per_block * num_blocks * (max_token_id as usize + 1))
             as u64;
     assert!(num_outputs >= 16);
 
     // Initialize other defaults
-    let picomob_per_output: u64 = (TOTAL_MOB / num_outputs) * 1_000_000_000_000;
+    let picomob_per_output: u64 = ((TOTAL_MOB as f64 / num_outputs as f64) * 1000000000000.0) as u64;
     let recipients = (0..num_accounts)
         .map(|_| AccountKey::random(&mut rng).default_subaddress())
         .collect::<Vec<_>>();
@@ -335,12 +335,12 @@ pub fn get_custom_test_ledger_blocks(
     let mut previous_block: Option<Block> = None;
 
     // Create the tx outs for all of the simulated blocks
-    for _ in 0..num_blocks as u64 {
+    for _ in 0..num_blocks {
         let mut outputs: Vec<TxOut> = Vec::new();
         for recipient in &recipients {
             let tx_private_key = RistrettoPrivate::from_random(&mut rng);
-            for _ in 0..outputs_per_recipient_per_block {
-                // Create outputs for each token id in round-robin fashion
+            for _ in 0..outputs_per_recipient_per_token_per_block {
+                // Create outputs for each token id
                 for token_id in 0..=max_token_id {
                     let amount = Amount {
                         value: picomob_per_output,

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -311,7 +311,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
 /// * `key_images_per_block` - number of key images per block
 /// * `max_token_id` - number of distinct token ids in blocks
 pub fn get_custom_test_ledger_blocks(
-    outputs_per_recipient_per_block: usize,
+    outputs_per_recipient_per_token_per_block: usize,
     num_accounts: usize,
     num_blocks: usize,
     key_images_per_block: usize,


### PR DESCRIPTION
### Motivation

As part of current efforts to improve the speed of block consumers and the network as a whole, the need has arisen to benchmark block consumer & streaming components. It's desired to be able to create test blocks with content that simulates blocks seen in production so that a proper benchmark can be made.

This PR adds an extra test method which generates blocks with custom content so that realistic benchmarks can be established.

### In this PR
* Addition of a method to the mock_ledger file which allows developers to create a custom amount of blocks with a custom amount of key_images, txouts per blocks, recipients, and token ids per block.

Used to fulfill the needs of #1798 & upcoming network improvement efforts