### PR TITLE
move validation tests to be an integration test, remove adapt_hack

### DIFF
--- a/transaction/core/src/validation/mod.rs
+++ b/transaction/core/src/validation/mod.rs
@@ -7,5 +7,13 @@ mod validate;
 
 pub use self::{
     error::{TransactionValidationError, TransactionValidationResult},
-    validate::{validate, validate_signature, validate_tombstone, validate_tx_out},
+    validate::{
+        validate, validate_inputs_are_sorted, validate_key_images_are_unique,
+        validate_masked_token_id_exists, validate_membership_proofs, validate_memo_exists,
+        validate_no_masked_token_id_exists, validate_no_memo_exists, validate_number_of_inputs,
+        validate_number_of_outputs, validate_outputs_are_sorted,
+        validate_outputs_public_keys_are_unique, validate_ring_elements_are_sorted,
+        validate_ring_elements_are_unique, validate_ring_sizes, validate_signature,
+        validate_tombstone, validate_transaction_fee, validate_tx_out,
+    },
 };

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -486,3 +486,14 @@ fn check_unique<T: Eq + core::hash::Hash>(
 
     Ok(())
 }
+
+// NOTE: There are unit tests of every validation function, which appear in
+// transaction/core/tests/validation.rs.
+//
+// The reason that these appear there is,
+// many of the tests use `mc-transaction-core-test-utils` which itself depends
+// on `mc-ledger-db` and `mc-transaction-core`, and this creates a circular
+// dependency which leads to build problems, if the unit tests appear in-line
+// here.
+//
+// Please add tests for any new validation functions there. Thank you!

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -119,7 +119,7 @@ pub fn validate_tx_out(
 
 /// The transaction must have at least one input, and no more than the maximum
 /// allowed number of inputs.
-fn validate_number_of_inputs(
+pub fn validate_number_of_inputs(
     tx_prefix: &TxPrefix,
     maximum_allowed_inputs: u64,
 ) -> TransactionValidationResult<()> {
@@ -139,7 +139,7 @@ fn validate_number_of_inputs(
 }
 
 /// The transaction must have at least one output.
-fn validate_number_of_outputs(
+pub fn validate_number_of_outputs(
     tx_prefix: &TxPrefix,
     maximum_allowed_outputs: u64,
 ) -> TransactionValidationResult<()> {
@@ -160,7 +160,10 @@ fn validate_number_of_outputs(
 }
 
 /// Each input must contain a ring containing `ring_size` elements.
-fn validate_ring_sizes(tx_prefix: &TxPrefix, ring_size: usize) -> TransactionValidationResult<()> {
+pub fn validate_ring_sizes(
+    tx_prefix: &TxPrefix,
+    ring_size: usize,
+) -> TransactionValidationResult<()> {
     for input in &tx_prefix.inputs {
         if input.ring.len() != ring_size {
             let e = if input.ring.len() > ring_size {
@@ -175,7 +178,7 @@ fn validate_ring_sizes(tx_prefix: &TxPrefix, ring_size: usize) -> TransactionVal
 }
 
 /// Elements in all rings within the transaction must be unique.
-fn validate_ring_elements_are_unique(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
+pub fn validate_ring_elements_are_unique(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
     let ring_elements: Vec<&TxOut> = tx_prefix
         .inputs
         .iter()
@@ -189,7 +192,7 @@ fn validate_ring_elements_are_unique(tx_prefix: &TxPrefix) -> TransactionValidat
 }
 
 /// Elements in a ring must be sorted.
-fn validate_ring_elements_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
+pub fn validate_ring_elements_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
     for tx_in in &tx_prefix.inputs {
         check_sorted(
             &tx_in.ring,
@@ -203,7 +206,7 @@ fn validate_ring_elements_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidat
 
 /// Inputs must be sorted by the public key of the first ring element of each
 /// input.
-fn validate_inputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
+pub fn validate_inputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
     check_sorted(
         &tx_prefix.inputs,
         |a, b| {
@@ -213,7 +216,8 @@ fn validate_inputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResu
     )
 }
 
-fn validate_outputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
+/// Outputs must be sorted by the public key
+pub fn validate_outputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationResult<()> {
     check_sorted(
         &tx_prefix.outputs,
         |a, b| a.public_key < b.public_key,
@@ -222,7 +226,7 @@ fn validate_outputs_are_sorted(tx_prefix: &TxPrefix) -> TransactionValidationRes
 }
 
 /// All key images within the transaction must be unique.
-fn validate_key_images_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
+pub fn validate_key_images_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
     check_unique(
         &tx.key_images(),
         TransactionValidationError::DuplicateKeyImages,
@@ -230,7 +234,7 @@ fn validate_key_images_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
 }
 
 /// All output public keys within the transaction must be unique.
-fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
+pub fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResult<()> {
     check_unique(
         &tx.output_public_keys(),
         TransactionValidationError::DuplicateOutputPublicKey,
@@ -238,7 +242,7 @@ fn validate_outputs_public_keys_are_unique(tx: &Tx) -> TransactionValidationResu
 }
 
 /// All outputs have no memo (new-style TxOuts (Post MCIP #3) are rejected)
-fn validate_no_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+pub fn validate_no_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
     if tx_out.e_memo.is_some() {
         return Err(TransactionValidationError::MemosNotAllowed);
     }
@@ -246,7 +250,7 @@ fn validate_no_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
 }
 
 /// All outputs have a memo (old-style TxOuts (Pre MCIP #3) are rejected)
-fn validate_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+pub fn validate_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
     if tx_out.e_memo.is_none() {
         return Err(TransactionValidationError::MissingMemo);
     }
@@ -255,7 +259,7 @@ fn validate_memo_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
 
 /// All outputs have no masked token id (new-style TxOuts (Post MCIP #25) are
 /// rejected)
-fn validate_no_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+pub fn validate_no_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
     if !tx_out.masked_amount.masked_token_id.is_empty() {
         return Err(TransactionValidationError::MaskedTokenIdNotAllowed);
     }
@@ -264,7 +268,7 @@ fn validate_no_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationRe
 
 /// All outputs have a masked token id (old-style TxOuts (Pre MCIP #25) are
 /// rejected)
-fn validate_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
+pub fn validate_masked_token_id_exists(tx_out: &TxOut) -> TransactionValidationResult<()> {
     if tx_out.masked_amount.masked_token_id.len() != TokenId::NUM_BYTES {
         return Err(TransactionValidationError::MissingMaskedTokenId);
     }
@@ -316,7 +320,7 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
 }
 
 /// The fee amount must be greater than or equal to the given minimum fee.
-fn validate_transaction_fee(tx: &Tx, minimum_fee: u64) -> TransactionValidationResult<()> {
+pub fn validate_transaction_fee(tx: &Tx, minimum_fee: u64) -> TransactionValidationResult<()> {
     if tx.prefix.fee < minimum_fee {
         Err(TransactionValidationError::TxFeeError)
     } else {
@@ -331,7 +335,7 @@ fn validate_transaction_fee(tx: &Tx, minimum_fee: u64) -> TransactionValidationR
 /// * `root_proofs` - Proofs of membership, provided by the untrusted system,
 ///   that are used to check the root hashes of the transaction's membership
 ///   proofs.
-fn validate_membership_proofs(
+pub fn validate_membership_proofs(
     tx_prefix: &TxPrefix,
     root_proofs: &[TxOutMembershipProof],
 ) -> TransactionValidationResult<()> {
@@ -481,898 +485,4 @@ fn check_unique<T: Eq + core::hash::Hash>(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    extern crate alloc;
-
-    use alloc::vec::Vec;
-
-    use crate::{
-        constants::RING_SIZE,
-        tokens::Mob,
-        tx::{Tx, TxOutMembershipHash, TxOutMembershipProof},
-        validation::error::TransactionValidationError,
-        Token,
-    };
-
-    use crate::membership_proofs::Range;
-    use mc_crypto_keys::{CompressedRistrettoPublic, ReprBytes};
-    use mc_ledger_db::{Ledger, LedgerDB};
-    use mc_transaction_core_test_utils::{
-        create_ledger, create_transaction, create_transaction_with_amount_and_comparer,
-        initialize_ledger, AccountKey, InverseTxOutputsOrdering, INITIALIZE_LEDGER_AMOUNT,
-    };
-    use mc_transaction_std::{DefaultTxOutputsOrdering, TxOutputsOrdering};
-    use rand::{rngs::StdRng, SeedableRng};
-    use serde::{de::DeserializeOwned, ser::Serialize};
-
-    // HACK: To test validation we need valid Tx objects. The code to create them is
-    // complicated, and a variant of it resides inside the
-    // `transaction_test_utils` crate. However,when we depend on it in our
-    // [dev-dependencies], it will compile and link against another copy of this
-    // crate, since cargo is weird like that. Relying in the fact that both data
-    // structures are actually the same, this hack lets us convert from the
-    // `transaction` crate being compiled by `transaction_test_utils` to the one
-    // compiled as part of building test tests.
-    // If we want to avoid this hack, we could move transaction validation into its
-    // own crate.
-    fn adapt_hack<Src: Serialize, Dst: DeserializeOwned>(src: &Src) -> Dst {
-        let bytes = mc_util_serial::serialize(src).unwrap();
-        mc_util_serial::deserialize(&bytes).unwrap()
-    }
-
-    fn create_test_tx(block_version: BlockVersion) -> (Tx, LedgerDB) {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let sender = AccountKey::random(&mut rng);
-        let mut ledger = create_ledger();
-        let n_blocks = 1;
-        initialize_ledger(
-            adapt_hack(&block_version),
-            &mut ledger,
-            n_blocks,
-            &sender,
-            &mut rng,
-        );
-
-        // Spend an output from the last block.
-        let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
-        let tx_out = block_contents.outputs[0].clone();
-
-        let recipient = AccountKey::random(&mut rng);
-        let tx = create_transaction(
-            adapt_hack(&block_version),
-            &mut ledger,
-            &tx_out,
-            &sender,
-            &recipient.default_subaddress(),
-            n_blocks + 1,
-            &mut rng,
-        );
-
-        (adapt_hack(&tx), ledger)
-    }
-
-    fn create_test_tx_with_amount(
-        block_version: BlockVersion,
-        amount: u64,
-        fee: u64,
-    ) -> (Tx, LedgerDB) {
-        create_test_tx_with_amount_and_comparer::<DefaultTxOutputsOrdering>(
-            block_version,
-            amount,
-            fee,
-        )
-    }
-
-    fn create_test_tx_with_amount_and_comparer<O: TxOutputsOrdering>(
-        block_version: BlockVersion,
-        amount: u64,
-        fee: u64,
-    ) -> (Tx, LedgerDB) {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let sender = AccountKey::random(&mut rng);
-        let mut ledger = create_ledger();
-        let n_blocks = 1;
-        initialize_ledger(
-            adapt_hack(&block_version),
-            &mut ledger,
-            n_blocks,
-            &sender,
-            &mut rng,
-        );
-
-        // Spend an output from the last block.
-        let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
-        let tx_out = block_contents.outputs[0].clone();
-
-        let recipient = AccountKey::random(&mut rng);
-        let tx = create_transaction_with_amount_and_comparer::<_, _, O>(
-            adapt_hack(&block_version),
-            &mut ledger,
-            &tx_out,
-            &sender,
-            &recipient.default_subaddress(),
-            amount,
-            fee,
-            n_blocks + 1,
-            &mut rng,
-        );
-
-        (adapt_hack(&tx), ledger)
-    }
-
-    #[test]
-    // Should return MissingMemo when memos are missing in an output
-    fn test_validate_memo_exists() {
-        let (tx, _) = create_test_tx(BlockVersion::ZERO);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.e_memo.is_none());
-        assert_eq!(
-            validate_memo_exists(tx_out),
-            Err(TransactionValidationError::MissingMemo)
-        );
-
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.e_memo.is_some());
-        assert_eq!(validate_memo_exists(tx_out), Ok(()));
-    }
-
-    #[test]
-    // Should return MemosNotAllowed when memos are present in an output
-    fn test_validate_no_memo_exists() {
-        let (tx, _) = create_test_tx(BlockVersion::ZERO);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.e_memo.is_none());
-        assert_eq!(validate_no_memo_exists(tx_out), Ok(()));
-
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.e_memo.is_some());
-        assert_eq!(
-            validate_no_memo_exists(tx_out),
-            Err(TransactionValidationError::MemosNotAllowed)
-        );
-    }
-
-    #[test]
-    // Should return MissingMaskedTokenId when masked_token_id are missing in an
-    // output
-    fn test_validate_masked_token_id_exists() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(
-            validate_masked_token_id_exists(tx_out),
-            Err(TransactionValidationError::MissingMaskedTokenId)
-        );
-
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(!tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(validate_memo_exists(tx_out), Ok(()));
-    }
-
-    #[test]
-    // Should return MemosNotAllowed when memos are present in an output
-    fn test_validate_no_masked_token_id_exists() {
-        let (tx, _) = create_test_tx(BlockVersion::ONE);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(validate_no_masked_token_id_exists(tx_out), Ok(()));
-
-        let (tx, _) = create_test_tx(BlockVersion::TWO);
-        let tx_out = tx.prefix.outputs.first().unwrap();
-
-        assert!(!tx_out.masked_amount.masked_token_id.is_empty());
-        assert_eq!(
-            validate_no_masked_token_id_exists(tx_out),
-            Err(TransactionValidationError::MaskedTokenIdNotAllowed)
-        );
-    }
-
-    #[test]
-    // Should return Ok(()) when the Tx's membership proofs are correct and agree
-    // with ledger.
-    fn test_validate_membership_proofs() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, ledger) = create_test_tx(block_version);
-
-            let highest_indices = tx.get_membership_proof_highest_indices();
-            let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                &ledger
-                    .get_tx_out_proof_of_memberships(&highest_indices)
-                    .expect("failed getting proofs"),
-            );
-
-            // Validate the transaction prefix without providing the correct ledger context.
-            {
-                let mut broken_proofs = root_proofs.clone();
-                broken_proofs[0].elements[0].hash = TxOutMembershipHash::from([1u8; 32]);
-                assert_eq!(
-                    validate_membership_proofs(&tx.prefix, &broken_proofs),
-                    Err(TransactionValidationError::InvalidTxOutMembershipProof)
-                );
-            }
-
-            // Validate the transaction prefix with the correct root proofs.
-            {
-                let highest_indices = tx.get_membership_proof_highest_indices();
-                let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                    &ledger
-                        .get_tx_out_proof_of_memberships(&highest_indices)
-                        .expect("failed getting proofs"),
-                );
-                assert_eq!(validate_membership_proofs(&tx.prefix, &root_proofs), Ok(()));
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidRangeProof if a membership proof containing an invalid
-    // Range.
-    fn test_validate_membership_proofs_invalid_range_in_tx() {
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, ledger) = create_test_tx(block_version);
-
-            let highest_indices = tx.get_membership_proof_highest_indices();
-            let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                &ledger
-                    .get_tx_out_proof_of_memberships(&highest_indices)
-                    .expect("failed getting proofs"),
-            );
-
-            // Modify tx to include an invalid Range.
-            let mut proof = tx.prefix.inputs[0].proofs[0].clone();
-            let mut first_element = proof.elements[0].clone();
-            first_element.range = Range { from: 7, to: 3 };
-            proof.elements[0] = first_element;
-            tx.prefix.inputs[0].proofs[0] = proof;
-
-            assert_eq!(
-                validate_membership_proofs(&tx.prefix, &root_proofs),
-                Err(TransactionValidationError::MembershipProofValidationError)
-            );
-        }
-    }
-
-    #[test]
-    // Should return InvalidRangeProof if a root proof containing an invalid Range.
-    fn test_validate_membership_proofs_invalid_range_in_root_proof() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, ledger) = create_test_tx(block_version);
-
-            let highest_indices = tx.get_membership_proof_highest_indices();
-            let mut root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                &ledger
-                    .get_tx_out_proof_of_memberships(&highest_indices)
-                    .expect("failed getting proofs"),
-            );
-
-            // Modify a root proof to include an invalid Range.
-            let mut proof = root_proofs[0].clone();
-            let mut first_element = proof.elements[0].clone();
-            first_element.range = Range { from: 7, to: 3 };
-            proof.elements[0] = first_element;
-            root_proofs[0] = proof;
-
-            assert_eq!(
-                validate_membership_proofs(&tx.prefix, &root_proofs),
-                Err(TransactionValidationError::MembershipProofValidationError)
-            );
-        }
-    }
-
-    #[test]
-    fn test_validate_number_of_inputs() {
-        for block_version in BlockVersion::iterator() {
-            let (orig_tx, _ledger) = create_test_tx(block_version);
-            let max_inputs = 25;
-
-            for num_inputs in 0..100 {
-                let mut tx_prefix = orig_tx.prefix.clone();
-                tx_prefix.inputs.clear();
-                for _i in 0..num_inputs {
-                    tx_prefix.inputs.push(orig_tx.prefix.inputs[0].clone());
-                }
-
-                let expected_result = if num_inputs == 0 {
-                    Err(TransactionValidationError::NoInputs)
-                } else if num_inputs > max_inputs {
-                    Err(TransactionValidationError::TooManyInputs)
-                } else {
-                    Ok(())
-                };
-
-                assert_eq!(
-                    validate_number_of_inputs(&tx_prefix, max_inputs),
-                    expected_result,
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_validate_number_of_outputs() {
-        for block_version in BlockVersion::iterator() {
-            let (orig_tx, _ledger) = create_test_tx(block_version);
-            let max_outputs = 25;
-
-            for num_outputs in 0..100 {
-                let mut tx_prefix = orig_tx.prefix.clone();
-                tx_prefix.outputs.clear();
-                for _i in 0..num_outputs {
-                    tx_prefix.outputs.push(orig_tx.prefix.outputs[0].clone());
-                }
-
-                let expected_result = if num_outputs == 0 {
-                    Err(TransactionValidationError::NoOutputs)
-                } else if num_outputs > max_outputs {
-                    Err(TransactionValidationError::TooManyOutputs)
-                } else {
-                    Ok(())
-                };
-
-                assert_eq!(
-                    validate_number_of_outputs(&tx_prefix, max_outputs),
-                    expected_result,
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_validate_ring_sizes() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(tx.prefix.inputs.len(), 1);
-            assert_eq!(tx.prefix.inputs[0].ring.len(), RING_SIZE);
-
-            // A transaction with a single input containing RING_SIZE elements.
-            assert_eq!(validate_ring_sizes(&tx.prefix, RING_SIZE), Ok(()));
-
-            // A single input containing zero elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                tx_prefix.inputs[0].ring.clear();
-
-                assert_eq!(
-                    validate_ring_sizes(&tx_prefix, RING_SIZE),
-                    Err(TransactionValidationError::InsufficientRingSize),
-                );
-            }
-
-            // A single input containing too few elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                tx_prefix.inputs[0].ring.pop();
-
-                assert_eq!(
-                    validate_ring_sizes(&tx_prefix, RING_SIZE),
-                    Err(TransactionValidationError::InsufficientRingSize),
-                );
-            }
-
-            // A single input containing too many elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                let element = tx_prefix.inputs[0].ring[0].clone();
-                tx_prefix.inputs[0].ring.push(element);
-
-                assert_eq!(
-                    validate_ring_sizes(&tx_prefix, RING_SIZE),
-                    Err(TransactionValidationError::ExcessiveRingSize),
-                );
-            }
-
-            // Two inputs each containing RING_SIZE elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                let input = tx_prefix.inputs[0].clone();
-                tx_prefix.inputs.push(input);
-
-                assert_eq!(validate_ring_sizes(&tx_prefix, RING_SIZE), Ok(()));
-            }
-
-            // The second input contains too few elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                let mut input = tx_prefix.inputs[0].clone();
-                input.ring.pop();
-                tx_prefix.inputs.push(input);
-
-                assert_eq!(
-                    validate_ring_sizes(&tx_prefix, RING_SIZE),
-                    Err(TransactionValidationError::InsufficientRingSize),
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_validate_ring_elements_are_unique() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(tx.prefix.inputs.len(), 1);
-
-            // A transaction with a single input and unique ring elements.
-            assert_eq!(validate_ring_elements_are_unique(&tx.prefix), Ok(()));
-
-            // A transaction with a single input and duplicate ring elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                tx_prefix.inputs[0]
-                    .ring
-                    .push(tx.prefix.inputs[0].ring[0].clone());
-
-                assert_eq!(
-                    validate_ring_elements_are_unique(&tx_prefix),
-                    Err(TransactionValidationError::DuplicateRingElements)
-                );
-            }
-
-            // A transaction with a multiple inputs and unique ring elements.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
-
-                for mut tx_out in tx_prefix.inputs[1].ring.iter_mut() {
-                    let mut bytes = tx_out.target_key.to_bytes();
-                    bytes[0] = !bytes[0];
-                    tx_out.target_key = CompressedRistrettoPublic::from_bytes(&bytes).unwrap();
-                }
-
-                assert_eq!(validate_ring_elements_are_unique(&tx_prefix), Ok(()));
-            }
-
-            // A transaction with a multiple inputs and duplicate ring elements in different
-            // rings.
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
-
-                assert_eq!(
-                    validate_ring_elements_are_unique(&tx_prefix),
-                    Err(TransactionValidationError::DuplicateRingElements)
-                );
-            }
-        }
-    }
-
-    #[test]
-    /// validate_ring_elements_are_sorted should reject an unsorted ring.
-    fn test_validate_ring_elements_are_sorted() {
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(validate_ring_elements_are_sorted(&tx.prefix), Ok(()));
-
-            // Change the ordering of a ring.
-            tx.prefix.inputs[0].ring.swap(0, 3);
-            assert_eq!(
-                validate_ring_elements_are_sorted(&tx.prefix),
-                Err(TransactionValidationError::UnsortedRingElements)
-            );
-        }
-    }
-
-    #[test]
-    /// validate_inputs_are_sorted should reject unsorted inputs.
-    fn test_validate_inputs_are_sorted() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-
-            // Add a second input to the transaction.
-            let mut tx_prefix = tx.prefix.clone();
-            tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
-
-            // By removing the first ring element of the second input we ensure the inputs
-            // are different, but remain sorted (since the ring elements are
-            // sorted).
-            tx_prefix.inputs[1].ring.remove(0);
-
-            assert_eq!(validate_inputs_are_sorted(&tx_prefix), Ok(()));
-
-            // Change the ordering of inputs.
-            tx_prefix.inputs.swap(0, 1);
-            assert_eq!(
-                validate_inputs_are_sorted(&tx_prefix),
-                Err(TransactionValidationError::UnsortedInputs)
-            );
-        }
-    }
-
-    #[test]
-    /// Should reject a transaction with unsorted outputs.
-    fn test_validate_outputs_are_sorted() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-
-            let mut output_a = tx.prefix.outputs.get(0).unwrap().clone();
-            output_a.public_key = CompressedRistrettoPublic::from(&[1u8; 32]);
-
-            let mut output_b = output_a.clone();
-            output_b.public_key = CompressedRistrettoPublic::from(&[2u8; 32]);
-
-            assert!(output_a.public_key < output_b.public_key);
-
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                // A single output is trivially sorted.
-                tx_prefix.outputs = vec![output_a.clone()];
-                assert_eq!(validate_outputs_are_sorted(&tx_prefix), Ok(()));
-            }
-
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                // Outputs sorted by public_key, ascending.
-                tx_prefix.outputs = vec![output_a.clone(), output_b.clone()];
-                assert_eq!(validate_outputs_are_sorted(&tx_prefix), Ok(()));
-            }
-
-            {
-                let mut tx_prefix = tx.prefix.clone();
-                // Outputs are not correctly sorted.
-                tx_prefix.outputs = vec![output_b.clone(), output_a.clone()];
-                assert_eq!(
-                    validate_outputs_are_sorted(&tx_prefix),
-                    Err(TransactionValidationError::UnsortedOutputs)
-                );
-            }
-        }
-    }
-
-    #[test]
-    /// validate_key_images_are_unique rejects duplicate key image.
-    fn test_validate_key_images_are_unique_rejects_duplicate() {
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-            // Tx only contains a single ring signature, which contains the key image.
-            // Duplicate the ring signature so that tx.key_images() returns a
-            // duplicate key image.
-            let ring_signature = tx.signature.ring_signatures[0].clone();
-            tx.signature.ring_signatures.push(ring_signature);
-
-            assert_eq!(
-                validate_key_images_are_unique(&tx),
-                Err(TransactionValidationError::DuplicateKeyImages)
-            );
-        }
-    }
-
-    #[test]
-    /// validate_key_images_are_unique returns Ok if all key images are unique.
-    fn test_validate_key_images_are_unique_ok() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(validate_key_images_are_unique(&tx), Ok(()),);
-        }
-    }
-
-    #[test]
-    /// validate_outputs_public_keys_are_unique rejects duplicate public key.
-    fn test_validate_output_public_keys_are_unique_rejects_duplicate() {
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-            // Tx only contains a single output. Duplicate the
-            // output so that tx.output_public_keys() returns a duplicate public key.
-            let tx_out = tx.prefix.outputs[0].clone();
-            tx.prefix.outputs.push(tx_out);
-
-            assert_eq!(
-                validate_outputs_public_keys_are_unique(&tx),
-                Err(TransactionValidationError::DuplicateOutputPublicKey)
-            );
-        }
-    }
-
-    #[test]
-    /// validate_outputs_public_keys_are_unique returns Ok if all public keys
-    /// are unique.
-    fn test_validate_output_public_keys_are_unique_ok() {
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(validate_outputs_public_keys_are_unique(&tx), Ok(()),);
-        }
-    }
-
-    #[test]
-    // `validate_signature` return OK for a valid transaction.
-    fn test_validate_signature_ok() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for block_version in BlockVersion::iterator() {
-            let (tx, _ledger) = create_test_tx(block_version);
-            assert_eq!(
-                validate_signature(block_version, &tx, &mut rng),
-                Ok(()),
-                "failed at block version: {}",
-                block_version
-            );
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if an input is modified.
-    fn test_transaction_signature_err_modified_input() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-
-            // Remove an input.
-            tx.prefix.inputs[0].ring.pop();
-
-            match validate_signature(block_version, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if an output is modified.
-    fn test_transaction_signature_err_modified_output() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-
-            // Add an output.
-            let output = tx.prefix.outputs.get(0).unwrap().clone();
-            tx.prefix.outputs.push(output);
-
-            match validate_signature(block_version, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if the fee is modified.
-    fn test_transaction_signature_err_modified_fee() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for block_version in BlockVersion::iterator() {
-            let (mut tx, _ledger) = create_test_tx(block_version);
-
-            tx.prefix.fee += 1;
-
-            match validate_signature(block_version, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if the token_id is modified
-    fn test_transaction_signature_err_modified_token_id() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for _ in 0..3 {
-            let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
-
-            tx.prefix.fee_token_id += 1;
-
-            match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if block v 1 is validated as 2
-    fn test_transaction_signature_err_version_one_as_two() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for _ in 0..3 {
-            let (tx, _ledger) = create_test_tx(BlockVersion::ONE);
-
-            match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    // Should return InvalidTransactionSignature if block v 2 is validated as 1
-    fn test_transaction_signature_err_version_two_as_one() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-
-        for _ in 0..3 {
-            let (tx, _ledger) = create_test_tx(BlockVersion::TWO);
-
-            match validate_signature(BlockVersion::ONE, &tx, &mut rng) {
-                Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
-                Err(e) => {
-                    panic!("Unexpected error {}", e);
-                }
-                Ok(()) => panic!("Unexpected success"),
-            }
-        }
-    }
-
-    #[test]
-    fn test_validate_transaction_fee() {
-        for block_version in BlockVersion::iterator() {
-            {
-                // Zero fees gets rejected
-                let (tx, _ledger) =
-                    create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT, 0);
-                assert_eq!(
-                    validate_transaction_fee(&tx, 1000),
-                    Err(TransactionValidationError::TxFeeError)
-                );
-            }
-
-            {
-                // Off by one fee gets rejected
-                let fee = Mob::MINIMUM_FEE - 1;
-                let (tx, _ledger) =
-                    create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT - fee, fee);
-                assert_eq!(
-                    validate_transaction_fee(&tx, Mob::MINIMUM_FEE),
-                    Err(TransactionValidationError::TxFeeError)
-                );
-            }
-
-            {
-                // Exact fee amount is okay
-                let (tx, _ledger) = create_test_tx_with_amount(
-                    block_version,
-                    INITIALIZE_LEDGER_AMOUNT - Mob::MINIMUM_FEE,
-                    Mob::MINIMUM_FEE,
-                );
-                assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
-            }
-
-            {
-                // Overpaying fees is okay
-                let fee = Mob::MINIMUM_FEE + 1;
-                let (tx, _ledger) =
-                    create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT - fee, fee);
-                assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
-            }
-        }
-    }
-
-    #[test]
-    /// Should return TombstoneBlockExceeded if the transaction has expired.
-    fn test_validate_tombstone_tombstone_block_exceeded() {
-        {
-            // The tombstone block is in the near future, so Ok.
-            let current_block_index = 888;
-            let tombstone_block_index = 889;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Ok(())
-            );
-        }
-
-        {
-            // The tombstone block is the current block.
-            let current_block_index = 7;
-            let tombstone_block_index = 7;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Err(TransactionValidationError::TombstoneBlockExceeded)
-            );
-        }
-
-        {
-            // The tombstone block is in the past.
-            let current_block_index = 888;
-            let tombstone_block_index = 7;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Err(TransactionValidationError::TombstoneBlockExceeded)
-            );
-        }
-    }
-
-    #[test]
-    /// Should return TombstoneBlockTooFar if the tombstone is too far in the
-    /// future.
-    fn test_validate_tombstone_tombstone_block_too_far() {
-        {
-            // The tombstone block is in the near future, so Ok.
-            let current_block_index = 7;
-            let tombstone_block_index = current_block_index + 1;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Ok(())
-            );
-        }
-
-        {
-            // Largest tombstone that is still Ok.
-            let current_block_index = 7;
-            let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Ok(())
-            );
-        }
-
-        {
-            // Tombstone is too far in the future.
-            let current_block_index = 7;
-            let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS + 1;
-            assert_eq!(
-                validate_tombstone(current_block_index, tombstone_block_index),
-                Err(TransactionValidationError::TombstoneBlockTooFar)
-            );
-        }
-    }
-
-    // FIXME: This test needs to involve a Tx with more than one output to make
-    // sense
-    #[test]
-    #[ignore]
-    fn test_global_validate_for_blocks_with_sorted_outputs() {
-        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let fee = Mob::MINIMUM_FEE + 1;
-        for block_version in BlockVersion::iterator() {
-            // for block version < 3 it doesn't matter
-            // for >= 3 it shall return an error about unsorted outputs
-            let (tx, ledger) = create_test_tx_with_amount_and_comparer::<InverseTxOutputsOrdering>(
-                block_version,
-                INITIALIZE_LEDGER_AMOUNT - fee,
-                fee,
-            );
-
-            let highest_indices = tx.get_membership_proof_highest_indices();
-            let root_proofs: Vec<TxOutMembershipProof> = adapt_hack(
-                &ledger
-                    .get_tx_out_proof_of_memberships(&highest_indices)
-                    .expect("failed getting proofs"),
-            );
-
-            let result = validate(
-                &tx,
-                tx.prefix.tombstone_block - 1,
-                block_version,
-                &root_proofs,
-                0,
-                &mut rng,
-            );
-
-            assert_eq!(
-                result,
-                match block_version.validate_transaction_outputs_are_sorted() {
-                    true => Err(TransactionValidationError::UnsortedOutputs),
-                    false => Ok(()),
-                }
-            )
-        }
-    }
 }

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -1,9 +1,13 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! This module is meant to unit test all of the functionality in the validation
+//! module in mc-transaction-core.
+
 extern crate alloc;
 
 use alloc::vec::Vec;
-
 use mc_crypto_keys::{CompressedRistrettoPublic, ReprBytes};
-
+use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{
     constants::{MAX_TOMBSTONE_BLOCKS, RING_SIZE},
     membership_proofs::Range,
@@ -12,8 +16,6 @@ use mc_transaction_core::{
     validation::*,
     BlockVersion, Token,
 };
-
-use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core_test_utils::{
     create_ledger, create_transaction, create_transaction_with_amount_and_comparer,
     initialize_ledger, AccountKey, InverseTxOutputsOrdering, INITIALIZE_LEDGER_AMOUNT,
@@ -247,6 +249,7 @@ fn test_validate_membership_proofs_invalid_range_in_root_proof() {
 }
 
 #[test]
+// Test that validate_number_of_inputs is working as expected
 fn test_validate_number_of_inputs() {
     for block_version in BlockVersion::iterator() {
         let (orig_tx, _ledger) = create_test_tx(block_version);
@@ -276,6 +279,7 @@ fn test_validate_number_of_inputs() {
 }
 
 #[test]
+// Test that validate_number_of_outputs is working as expected
 fn test_validate_number_of_outputs() {
     for block_version in BlockVersion::iterator() {
         let (orig_tx, _ledger) = create_test_tx(block_version);
@@ -305,6 +309,7 @@ fn test_validate_number_of_outputs() {
 }
 
 #[test]
+// Test that validate_ring_sizes is working as expected
 fn test_validate_ring_sizes() {
     for block_version in BlockVersion::iterator() {
         let (tx, _ledger) = create_test_tx(block_version);
@@ -373,6 +378,7 @@ fn test_validate_ring_sizes() {
 }
 
 #[test]
+// Test that validate_ring_elements_are_unique is working as expected
 fn test_validate_ring_elements_are_unique() {
     for block_version in BlockVersion::iterator() {
         let (tx, _ledger) = create_test_tx(block_version);

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -1,0 +1,847 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use mc_crypto_keys::{CompressedRistrettoPublic, ReprBytes};
+
+use mc_transaction_core::{
+    constants::{MAX_TOMBSTONE_BLOCKS, RING_SIZE},
+    membership_proofs::Range,
+    tokens::Mob,
+    tx::{Tx, TxOutMembershipHash, TxOutMembershipProof},
+    validation::*,
+    BlockVersion, Token,
+};
+
+use mc_ledger_db::{Ledger, LedgerDB};
+use mc_transaction_core_test_utils::{
+    create_ledger, create_transaction, create_transaction_with_amount_and_comparer,
+    initialize_ledger, AccountKey, InverseTxOutputsOrdering, INITIALIZE_LEDGER_AMOUNT,
+};
+use mc_transaction_std::{DefaultTxOutputsOrdering, TxOutputsOrdering};
+use rand::{rngs::StdRng, SeedableRng};
+
+fn create_test_tx(block_version: BlockVersion) -> (Tx, LedgerDB) {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+    let sender = AccountKey::random(&mut rng);
+    let mut ledger = create_ledger();
+    let n_blocks = 1;
+    initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+    // Spend an output from the last block.
+    let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
+    let tx_out = block_contents.outputs[0].clone();
+
+    let recipient = AccountKey::random(&mut rng);
+    let tx = create_transaction(
+        block_version,
+        &mut ledger,
+        &tx_out,
+        &sender,
+        &recipient.default_subaddress(),
+        n_blocks + 1,
+        &mut rng,
+    );
+
+    (tx, ledger)
+}
+
+fn create_test_tx_with_amount(
+    block_version: BlockVersion,
+    amount: u64,
+    fee: u64,
+) -> (Tx, LedgerDB) {
+    create_test_tx_with_amount_and_comparer::<DefaultTxOutputsOrdering>(block_version, amount, fee)
+}
+
+fn create_test_tx_with_amount_and_comparer<O: TxOutputsOrdering>(
+    block_version: BlockVersion,
+    amount: u64,
+    fee: u64,
+) -> (Tx, LedgerDB) {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+    let sender = AccountKey::random(&mut rng);
+    let mut ledger = create_ledger();
+    let n_blocks = 1;
+    initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+    // Spend an output from the last block.
+    let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
+    let tx_out = block_contents.outputs[0].clone();
+
+    let recipient = AccountKey::random(&mut rng);
+    let tx = create_transaction_with_amount_and_comparer::<_, _, O>(
+        block_version,
+        &mut ledger,
+        &tx_out,
+        &sender,
+        &recipient.default_subaddress(),
+        amount,
+        fee,
+        n_blocks + 1,
+        &mut rng,
+    );
+
+    (tx, ledger)
+}
+
+#[test]
+// Should return MissingMemo when memos are missing in an output
+fn test_validate_memo_exists() {
+    let (tx, _) = create_test_tx(BlockVersion::ZERO);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.e_memo.is_none());
+    assert_eq!(
+        validate_memo_exists(tx_out),
+        Err(TransactionValidationError::MissingMemo)
+    );
+
+    let (tx, _) = create_test_tx(BlockVersion::ONE);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.e_memo.is_some());
+    assert_eq!(validate_memo_exists(tx_out), Ok(()));
+}
+
+#[test]
+// Should return MemosNotAllowed when memos are present in an output
+fn test_validate_no_memo_exists() {
+    let (tx, _) = create_test_tx(BlockVersion::ZERO);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.e_memo.is_none());
+    assert_eq!(validate_no_memo_exists(tx_out), Ok(()));
+
+    let (tx, _) = create_test_tx(BlockVersion::ONE);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.e_memo.is_some());
+    assert_eq!(
+        validate_no_memo_exists(tx_out),
+        Err(TransactionValidationError::MemosNotAllowed)
+    );
+}
+
+#[test]
+// Should return MissingMaskedTokenId when masked_token_id are missing in an
+// output
+fn test_validate_masked_token_id_exists() {
+    let (tx, _) = create_test_tx(BlockVersion::ONE);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.masked_amount.masked_token_id.is_empty());
+    assert_eq!(
+        validate_masked_token_id_exists(tx_out),
+        Err(TransactionValidationError::MissingMaskedTokenId)
+    );
+
+    let (tx, _) = create_test_tx(BlockVersion::TWO);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+    assert_eq!(validate_memo_exists(tx_out), Ok(()));
+}
+
+#[test]
+// Should return MemosNotAllowed when memos are present in an output
+fn test_validate_no_masked_token_id_exists() {
+    let (tx, _) = create_test_tx(BlockVersion::ONE);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(tx_out.masked_amount.masked_token_id.is_empty());
+    assert_eq!(validate_no_masked_token_id_exists(tx_out), Ok(()));
+
+    let (tx, _) = create_test_tx(BlockVersion::TWO);
+    let tx_out = tx.prefix.outputs.first().unwrap();
+
+    assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+    assert_eq!(
+        validate_no_masked_token_id_exists(tx_out),
+        Err(TransactionValidationError::MaskedTokenIdNotAllowed)
+    );
+}
+
+#[test]
+// Should return Ok(()) when the Tx's membership proofs are correct and agree
+// with ledger.
+fn test_validate_membership_proofs() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, ledger) = create_test_tx(block_version);
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let root_proofs: Vec<TxOutMembershipProof> = ledger
+            .get_tx_out_proof_of_memberships(&highest_indices)
+            .expect("failed getting proofs");
+
+        // Validate the transaction prefix without providing the correct ledger context.
+        {
+            let mut broken_proofs = root_proofs.clone();
+            broken_proofs[0].elements[0].hash = TxOutMembershipHash::from([1u8; 32]);
+            assert_eq!(
+                validate_membership_proofs(&tx.prefix, &broken_proofs),
+                Err(TransactionValidationError::InvalidTxOutMembershipProof)
+            );
+        }
+
+        // Validate the transaction prefix with the correct root proofs.
+        {
+            let highest_indices = tx.get_membership_proof_highest_indices();
+            let root_proofs: Vec<TxOutMembershipProof> = ledger
+                .get_tx_out_proof_of_memberships(&highest_indices)
+                .expect("failed getting proofs");
+            assert_eq!(validate_membership_proofs(&tx.prefix, &root_proofs), Ok(()));
+        }
+    }
+}
+
+#[test]
+// Should return InvalidRangeProof if a membership proof containing an invalid
+// Range.
+fn test_validate_membership_proofs_invalid_range_in_tx() {
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, ledger) = create_test_tx(block_version);
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let root_proofs: Vec<TxOutMembershipProof> = ledger
+            .get_tx_out_proof_of_memberships(&highest_indices)
+            .expect("failed getting proofs");
+
+        // Modify tx to include an invalid Range.
+        let mut proof = tx.prefix.inputs[0].proofs[0].clone();
+        let mut first_element = proof.elements[0].clone();
+        first_element.range = Range { from: 7, to: 3 };
+        proof.elements[0] = first_element;
+        tx.prefix.inputs[0].proofs[0] = proof;
+
+        assert_eq!(
+            validate_membership_proofs(&tx.prefix, &root_proofs),
+            Err(TransactionValidationError::MembershipProofValidationError)
+        );
+    }
+}
+
+#[test]
+// Should return InvalidRangeProof if a root proof containing an invalid Range.
+fn test_validate_membership_proofs_invalid_range_in_root_proof() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, ledger) = create_test_tx(block_version);
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let mut root_proofs: Vec<TxOutMembershipProof> = ledger
+            .get_tx_out_proof_of_memberships(&highest_indices)
+            .expect("failed getting proofs");
+
+        // Modify a root proof to include an invalid Range.
+        let mut proof = root_proofs[0].clone();
+        let mut first_element = proof.elements[0].clone();
+        first_element.range = Range { from: 7, to: 3 };
+        proof.elements[0] = first_element;
+        root_proofs[0] = proof;
+
+        assert_eq!(
+            validate_membership_proofs(&tx.prefix, &root_proofs),
+            Err(TransactionValidationError::MembershipProofValidationError)
+        );
+    }
+}
+
+#[test]
+fn test_validate_number_of_inputs() {
+    for block_version in BlockVersion::iterator() {
+        let (orig_tx, _ledger) = create_test_tx(block_version);
+        let max_inputs = 25;
+
+        for num_inputs in 0..100 {
+            let mut tx_prefix = orig_tx.prefix.clone();
+            tx_prefix.inputs.clear();
+            for _i in 0..num_inputs {
+                tx_prefix.inputs.push(orig_tx.prefix.inputs[0].clone());
+            }
+
+            let expected_result = if num_inputs == 0 {
+                Err(TransactionValidationError::NoInputs)
+            } else if num_inputs > max_inputs {
+                Err(TransactionValidationError::TooManyInputs)
+            } else {
+                Ok(())
+            };
+
+            assert_eq!(
+                validate_number_of_inputs(&tx_prefix, max_inputs),
+                expected_result,
+            );
+        }
+    }
+}
+
+#[test]
+fn test_validate_number_of_outputs() {
+    for block_version in BlockVersion::iterator() {
+        let (orig_tx, _ledger) = create_test_tx(block_version);
+        let max_outputs = 25;
+
+        for num_outputs in 0..100 {
+            let mut tx_prefix = orig_tx.prefix.clone();
+            tx_prefix.outputs.clear();
+            for _i in 0..num_outputs {
+                tx_prefix.outputs.push(orig_tx.prefix.outputs[0].clone());
+            }
+
+            let expected_result = if num_outputs == 0 {
+                Err(TransactionValidationError::NoOutputs)
+            } else if num_outputs > max_outputs {
+                Err(TransactionValidationError::TooManyOutputs)
+            } else {
+                Ok(())
+            };
+
+            assert_eq!(
+                validate_number_of_outputs(&tx_prefix, max_outputs),
+                expected_result,
+            );
+        }
+    }
+}
+
+#[test]
+fn test_validate_ring_sizes() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(tx.prefix.inputs.len(), 1);
+        assert_eq!(tx.prefix.inputs[0].ring.len(), RING_SIZE);
+
+        // A transaction with a single input containing RING_SIZE elements.
+        assert_eq!(validate_ring_sizes(&tx.prefix, RING_SIZE), Ok(()));
+
+        // A single input containing zero elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            tx_prefix.inputs[0].ring.clear();
+
+            assert_eq!(
+                validate_ring_sizes(&tx_prefix, RING_SIZE),
+                Err(TransactionValidationError::InsufficientRingSize),
+            );
+        }
+
+        // A single input containing too few elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            tx_prefix.inputs[0].ring.pop();
+
+            assert_eq!(
+                validate_ring_sizes(&tx_prefix, RING_SIZE),
+                Err(TransactionValidationError::InsufficientRingSize),
+            );
+        }
+
+        // A single input containing too many elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            let element = tx_prefix.inputs[0].ring[0].clone();
+            tx_prefix.inputs[0].ring.push(element);
+
+            assert_eq!(
+                validate_ring_sizes(&tx_prefix, RING_SIZE),
+                Err(TransactionValidationError::ExcessiveRingSize),
+            );
+        }
+
+        // Two inputs each containing RING_SIZE elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            let input = tx_prefix.inputs[0].clone();
+            tx_prefix.inputs.push(input);
+
+            assert_eq!(validate_ring_sizes(&tx_prefix, RING_SIZE), Ok(()));
+        }
+
+        // The second input contains too few elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            let mut input = tx_prefix.inputs[0].clone();
+            input.ring.pop();
+            tx_prefix.inputs.push(input);
+
+            assert_eq!(
+                validate_ring_sizes(&tx_prefix, RING_SIZE),
+                Err(TransactionValidationError::InsufficientRingSize),
+            );
+        }
+    }
+}
+
+#[test]
+fn test_validate_ring_elements_are_unique() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(tx.prefix.inputs.len(), 1);
+
+        // A transaction with a single input and unique ring elements.
+        assert_eq!(validate_ring_elements_are_unique(&tx.prefix), Ok(()));
+
+        // A transaction with a single input and duplicate ring elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            tx_prefix.inputs[0]
+                .ring
+                .push(tx.prefix.inputs[0].ring[0].clone());
+
+            assert_eq!(
+                validate_ring_elements_are_unique(&tx_prefix),
+                Err(TransactionValidationError::DuplicateRingElements)
+            );
+        }
+
+        // A transaction with a multiple inputs and unique ring elements.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
+
+            for mut tx_out in tx_prefix.inputs[1].ring.iter_mut() {
+                let mut bytes = tx_out.target_key.to_bytes();
+                bytes[0] = !bytes[0];
+                tx_out.target_key = CompressedRistrettoPublic::from_bytes(&bytes).unwrap();
+            }
+
+            assert_eq!(validate_ring_elements_are_unique(&tx_prefix), Ok(()));
+        }
+
+        // A transaction with a multiple inputs and duplicate ring elements in different
+        // rings.
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
+
+            assert_eq!(
+                validate_ring_elements_are_unique(&tx_prefix),
+                Err(TransactionValidationError::DuplicateRingElements)
+            );
+        }
+    }
+}
+
+#[test]
+/// validate_ring_elements_are_sorted should reject an unsorted ring.
+fn test_validate_ring_elements_are_sorted() {
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(validate_ring_elements_are_sorted(&tx.prefix), Ok(()));
+
+        // Change the ordering of a ring.
+        tx.prefix.inputs[0].ring.swap(0, 3);
+        assert_eq!(
+            validate_ring_elements_are_sorted(&tx.prefix),
+            Err(TransactionValidationError::UnsortedRingElements)
+        );
+    }
+}
+
+#[test]
+/// validate_inputs_are_sorted should reject unsorted inputs.
+fn test_validate_inputs_are_sorted() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+
+        // Add a second input to the transaction.
+        let mut tx_prefix = tx.prefix.clone();
+        tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
+
+        // By removing the first ring element of the second input we ensure the inputs
+        // are different, but remain sorted (since the ring elements are
+        // sorted).
+        tx_prefix.inputs[1].ring.remove(0);
+
+        assert_eq!(validate_inputs_are_sorted(&tx_prefix), Ok(()));
+
+        // Change the ordering of inputs.
+        tx_prefix.inputs.swap(0, 1);
+        assert_eq!(
+            validate_inputs_are_sorted(&tx_prefix),
+            Err(TransactionValidationError::UnsortedInputs)
+        );
+    }
+}
+
+#[test]
+/// Should reject a transaction with unsorted outputs.
+fn test_validate_outputs_are_sorted() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+
+        let mut output_a = tx.prefix.outputs.get(0).unwrap().clone();
+        output_a.public_key = CompressedRistrettoPublic::from(&[1u8; 32]);
+
+        let mut output_b = output_a.clone();
+        output_b.public_key = CompressedRistrettoPublic::from(&[2u8; 32]);
+
+        assert!(output_a.public_key < output_b.public_key);
+
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            // A single output is trivially sorted.
+            tx_prefix.outputs = vec![output_a.clone()];
+            assert_eq!(validate_outputs_are_sorted(&tx_prefix), Ok(()));
+        }
+
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            // Outputs sorted by public_key, ascending.
+            tx_prefix.outputs = vec![output_a.clone(), output_b.clone()];
+            assert_eq!(validate_outputs_are_sorted(&tx_prefix), Ok(()));
+        }
+
+        {
+            let mut tx_prefix = tx.prefix.clone();
+            // Outputs are not correctly sorted.
+            tx_prefix.outputs = vec![output_b.clone(), output_a.clone()];
+            assert_eq!(
+                validate_outputs_are_sorted(&tx_prefix),
+                Err(TransactionValidationError::UnsortedOutputs)
+            );
+        }
+    }
+}
+
+#[test]
+/// validate_key_images_are_unique rejects duplicate key image.
+fn test_validate_key_images_are_unique_rejects_duplicate() {
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+        // Tx only contains a single ring signature, which contains the key image.
+        // Duplicate the ring signature so that tx.key_images() returns a
+        // duplicate key image.
+        let ring_signature = tx.signature.ring_signatures[0].clone();
+        tx.signature.ring_signatures.push(ring_signature);
+
+        assert_eq!(
+            validate_key_images_are_unique(&tx),
+            Err(TransactionValidationError::DuplicateKeyImages)
+        );
+    }
+}
+
+#[test]
+/// validate_key_images_are_unique returns Ok if all key images are unique.
+fn test_validate_key_images_are_unique_ok() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(validate_key_images_are_unique(&tx), Ok(()),);
+    }
+}
+
+#[test]
+/// validate_outputs_public_keys_are_unique rejects duplicate public key.
+fn test_validate_output_public_keys_are_unique_rejects_duplicate() {
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+        // Tx only contains a single output. Duplicate the
+        // output so that tx.output_public_keys() returns a duplicate public key.
+        let tx_out = tx.prefix.outputs[0].clone();
+        tx.prefix.outputs.push(tx_out);
+
+        assert_eq!(
+            validate_outputs_public_keys_are_unique(&tx),
+            Err(TransactionValidationError::DuplicateOutputPublicKey)
+        );
+    }
+}
+
+#[test]
+/// validate_outputs_public_keys_are_unique returns Ok if all public keys
+/// are unique.
+fn test_validate_output_public_keys_are_unique_ok() {
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(validate_outputs_public_keys_are_unique(&tx), Ok(()),);
+    }
+}
+
+#[test]
+// `validate_signature` return OK for a valid transaction.
+fn test_validate_signature_ok() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for block_version in BlockVersion::iterator() {
+        let (tx, _ledger) = create_test_tx(block_version);
+        assert_eq!(
+            validate_signature(block_version, &tx, &mut rng),
+            Ok(()),
+            "failed at block version: {}",
+            block_version
+        );
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if an input is modified.
+fn test_transaction_signature_err_modified_input() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+
+        // Remove an input.
+        tx.prefix.inputs[0].ring.pop();
+
+        match validate_signature(block_version, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if an output is modified.
+fn test_transaction_signature_err_modified_output() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+
+        // Add an output.
+        let output = tx.prefix.outputs.get(0).unwrap().clone();
+        tx.prefix.outputs.push(output);
+
+        match validate_signature(block_version, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if the fee is modified.
+fn test_transaction_signature_err_modified_fee() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for block_version in BlockVersion::iterator() {
+        let (mut tx, _ledger) = create_test_tx(block_version);
+
+        tx.prefix.fee += 1;
+
+        match validate_signature(block_version, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if the token_id is modified
+fn test_transaction_signature_err_modified_token_id() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for _ in 0..3 {
+        let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
+
+        tx.prefix.fee_token_id += 1;
+
+        match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if block v 1 is validated as 2
+fn test_transaction_signature_err_version_one_as_two() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for _ in 0..3 {
+        let (tx, _ledger) = create_test_tx(BlockVersion::ONE);
+
+        match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+// Should return InvalidTransactionSignature if block v 2 is validated as 1
+fn test_transaction_signature_err_version_two_as_one() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+    for _ in 0..3 {
+        let (tx, _ledger) = create_test_tx(BlockVersion::TWO);
+
+        match validate_signature(BlockVersion::ONE, &tx, &mut rng) {
+            Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
+            Err(e) => {
+                panic!("Unexpected error {}", e);
+            }
+            Ok(()) => panic!("Unexpected success"),
+        }
+    }
+}
+
+#[test]
+fn test_validate_transaction_fee() {
+    for block_version in BlockVersion::iterator() {
+        {
+            // Zero fees gets rejected
+            let (tx, _ledger) =
+                create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT, 0);
+            assert_eq!(
+                validate_transaction_fee(&tx, 1000),
+                Err(TransactionValidationError::TxFeeError)
+            );
+        }
+
+        {
+            // Off by one fee gets rejected
+            let fee = Mob::MINIMUM_FEE - 1;
+            let (tx, _ledger) =
+                create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT - fee, fee);
+            assert_eq!(
+                validate_transaction_fee(&tx, Mob::MINIMUM_FEE),
+                Err(TransactionValidationError::TxFeeError)
+            );
+        }
+
+        {
+            // Exact fee amount is okay
+            let (tx, _ledger) = create_test_tx_with_amount(
+                block_version,
+                INITIALIZE_LEDGER_AMOUNT - Mob::MINIMUM_FEE,
+                Mob::MINIMUM_FEE,
+            );
+            assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
+        }
+
+        {
+            // Overpaying fees is okay
+            let fee = Mob::MINIMUM_FEE + 1;
+            let (tx, _ledger) =
+                create_test_tx_with_amount(block_version, INITIALIZE_LEDGER_AMOUNT - fee, fee);
+            assert_eq!(validate_transaction_fee(&tx, Mob::MINIMUM_FEE), Ok(()));
+        }
+    }
+}
+
+#[test]
+/// Should return TombstoneBlockExceeded if the transaction has expired.
+fn test_validate_tombstone_tombstone_block_exceeded() {
+    {
+        // The tombstone block is in the near future, so Ok.
+        let current_block_index = 888;
+        let tombstone_block_index = 889;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Ok(())
+        );
+    }
+
+    {
+        // The tombstone block is the current block.
+        let current_block_index = 7;
+        let tombstone_block_index = 7;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Err(TransactionValidationError::TombstoneBlockExceeded)
+        );
+    }
+
+    {
+        // The tombstone block is in the past.
+        let current_block_index = 888;
+        let tombstone_block_index = 7;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Err(TransactionValidationError::TombstoneBlockExceeded)
+        );
+    }
+}
+
+#[test]
+/// Should return TombstoneBlockTooFar if the tombstone is too far in the
+/// future.
+fn test_validate_tombstone_tombstone_block_too_far() {
+    {
+        // The tombstone block is in the near future, so Ok.
+        let current_block_index = 7;
+        let tombstone_block_index = current_block_index + 1;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Ok(())
+        );
+    }
+
+    {
+        // Largest tombstone that is still Ok.
+        let current_block_index = 7;
+        let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Ok(())
+        );
+    }
+
+    {
+        // Tombstone is too far in the future.
+        let current_block_index = 7;
+        let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS + 1;
+        assert_eq!(
+            validate_tombstone(current_block_index, tombstone_block_index),
+            Err(TransactionValidationError::TombstoneBlockTooFar)
+        );
+    }
+}
+
+// FIXME: This test needs to involve a Tx with more than one output to make
+// sense
+#[test]
+#[ignore]
+fn test_global_validate_for_blocks_with_sorted_outputs() {
+    let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+    let fee = Mob::MINIMUM_FEE + 1;
+    for block_version in BlockVersion::iterator() {
+        // for block version < 3 it doesn't matter
+        // for >= 3 it shall return an error about unsorted outputs
+        let (tx, ledger) = create_test_tx_with_amount_and_comparer::<InverseTxOutputsOrdering>(
+            block_version,
+            INITIALIZE_LEDGER_AMOUNT - fee,
+            fee,
+        );
+
+        let highest_indices = tx.get_membership_proof_highest_indices();
+        let root_proofs: Vec<TxOutMembershipProof> = ledger
+            .get_tx_out_proof_of_memberships(&highest_indices)
+            .expect("failed getting proofs");
+
+        let result = validate(
+            &tx,
+            tx.prefix.tombstone_block - 1,
+            block_version,
+            &root_proofs,
+            0,
+            &mut rng,
+        );
+
+        assert_eq!(
+            result,
+            match block_version.validate_transaction_outputs_are_sorted() {
+                true => Err(TransactionValidationError::UnsortedOutputs),
+                false => Ok(()),
+            }
+        )
+    }
+}


### PR DESCRIPTION
This works because, when cargo compiles in-line unit tests, they are
compiled into the module of the code under test, but when cargo
compiles integration tests (in tests directory), that is considered
a separate module (effectively a separate crate, just without its
own cargo toml).

This fixes the adapt hack issue because now we no longer need to
compile the `mc-transaction-core` crate in test mode, which also
references the `mc-transaction-core` crate which `mc-ledger-db`
depends on. The types in the test code always refer to the types
in the same version of `mc-transaction-core` that `mc-ledger-db`
is using

(This experiment came out of discussion in #1870 review)

---

This is not the only way we could fix it (remove adapt hack), we could also move validation to its own crate (this was suggested)
This is just the smallest change that allows to remove adapt hack. We could still also move validation to its own crate.