### PR TITLE
Create ResponderId out of host and port in PollingNetworkState

### DIFF
--- a/connection/src/manager.rs
+++ b/connection/src/manager.rs
@@ -40,12 +40,13 @@ impl<C: Connection> ConnectionManager<C> {
                     .into_iter()
                     .map(|conn| {
                         let name = conn.to_string();
-                        let responder_id = conn.uri().host_and_port_responder_id().unwrap_or_else(|_| {
-                            panic!(
-                                "Could not create responder_id from {:?}",
-                                conn.uri().to_string()
-                            )
-                        });
+                        let responder_id =
+                            conn.uri().host_and_port_responder_id().unwrap_or_else(|_| {
+                                panic!(
+                                    "Could not create responder_id from {:?}",
+                                    conn.uri().to_string()
+                                )
+                            });
                         let sync_conn =
                             SyncConnection::new(conn, logger.new(o!("mc.peers.peer_name" => name)));
                         (responder_id, sync_conn)

--- a/connection/src/manager.rs
+++ b/connection/src/manager.rs
@@ -40,7 +40,7 @@ impl<C: Connection> ConnectionManager<C> {
                     .into_iter()
                     .map(|conn| {
                         let name = conn.to_string();
-                        let responder_id = conn.uri().responder_id().unwrap_or_else(|_| {
+                        let responder_id = conn.uri().host_and_port_responder_id().unwrap_or_else(|_| {
                             panic!(
                                 "Could not create responder_id from {:?}",
                                 conn.uri().to_string()

--- a/connection/src/manager.rs
+++ b/connection/src/manager.rs
@@ -41,12 +41,15 @@ impl<C: Connection> ConnectionManager<C> {
                     .map(|conn| {
                         let name = conn.to_string();
                         let responder_id =
-                            conn.uri().host_and_port_responder_id().unwrap_or_else(|_| {
-                                panic!(
-                                    "Could not create responder_id from {:?}",
-                                    conn.uri().to_string()
-                                )
-                            });
+                            conn.uri()
+                                .host_and_port_responder_id()
+                                .unwrap_or_else(|err| {
+                                    panic!(
+                                        "Could not create responder_id from {:?}: {}",
+                                        conn.uri().to_string(),
+                                        err
+                                    )
+                                });
                         let sync_conn =
                             SyncConnection::new(conn, logger.new(o!("mc.peers.peer_name" => name)));
                         (responder_id, sync_conn)

--- a/connection/test-utils/src/lib.rs
+++ b/connection/test-utils/src/lib.rs
@@ -9,8 +9,11 @@ mod blockchain;
 mod user_tx;
 
 pub fn test_client_uri(node_id: u32) -> ConsensusClientUri {
-    ConsensusClientUri::from_str(&format!("mc://node{}.test.com/", node_id))
-        .expect("Could not construct client uri from string")
+    ConsensusClientUri::from_str(&format!(
+        "mc://node{}.test.com?responder-id=loadbalancer.foo.com:4882",
+        node_id
+    ))
+    .expect("Could not construct client uri from string")
 }
 
 pub use crate::{blockchain::MockBlockchainConnection, user_tx::MockUserTxConnection};

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -67,7 +67,7 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
         type ResultsMap = HashMap<ResponderId, Option<BlockIndex>>;
         let results_and_condvar = Arc::new((Mutex::new(ResultsMap::default()), Condvar::new()));
 
-        for conn in conns {
+        for conn in self.manager.conns() {
             // Create a new ResponderId out of the uri's host and port. This allows us to
             // distinguish between individual nodes that share the same "canonical"
             // ResponderId.
@@ -77,8 +77,8 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
             // to use NodeID, this is a huge undertaking due to tech debt.
             let responder_id = conn
                 .uri()
-                .responder_id()
-                .expect("Could not get responder_id from URI");
+                .host_and_port_responder_id()
+                .expect("Could not get host and port responder_id from URI");
 
             let thread_logger = self.logger.clone();
             let thread_results_and_condvar = results_and_condvar.clone();

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -67,7 +67,14 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
         type ResultsMap = HashMap<ResponderId, Option<BlockIndex>>;
         let results_and_condvar = Arc::new((Mutex::new(ResultsMap::default()), Condvar::new()));
 
-        for conn in self.manager.conns() {
+        for conn in conns {
+            // Create a new ResponderId out of the uri's host and port. This allows us to
+            // distinguish between individual nodes that share the same "canonical"
+            // ResponderId.
+            //
+            // Note: this is a hack that allows us to  use a ResponderId in the way that
+            // we'd use a NodeID. While it'd be better to change SCPNetworkState
+            // to use NodeID, this is a huge undertaking due to tech debt.
             let responder_id = conn
                 .uri()
                 .responder_id()

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -260,13 +260,11 @@ pub fn setup_server<FPR: FogPubkeyResolver + Default + Send + Sync + 'static>(
     let peer1 = MockBlockchainConnection::new(test_client_uri(1), ledger_db.clone(), 0);
     let peer2 = MockBlockchainConnection::new(test_client_uri(2), ledger_db.clone(), 0);
 
-    let quorum_set = QuorumSet::new_with_node_ids(
-        2,
-        vec![
-            peer1.uri().responder_id().unwrap(),
-            peer2.uri().responder_id().unwrap(),
-        ],
-    );
+    let node_ids = vec![
+        peer1.uri().host_and_port_responder_id().unwrap(),
+        peer2.uri().host_and_port_responder_id().unwrap(),
+    ];
+    let quorum_set = QuorumSet::new_with_node_ids(2, node_ids);
 
     let conn_manager = ConnectionManager::new(vec![peer1, peer2], logger.clone());
 

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -95,6 +95,11 @@ pub trait ConnectionUri:
         Ok(ResponderId::from_str(&responder_id_string)?)
     }
 
+    /// Create a responder id from the ConnectionUri's host and port.
+    fn host_and_port_responder_id(&self) -> StdResult<ResponderId, UriConversionError> {
+        Ok(ResponderId::from_str(&self.addr())?)
+    }
+
     /// Retrieve the `NodeID` for this connection.
     fn node_id(&self) -> StdResult<NodeID, UriConversionError> {
         Ok(NodeID {


### PR DESCRIPTION
### Motivation
See #848. 

### In this PR
* Creates and uses `host_and_port_responder_id` method.
* Updates mobilecoind test configuration to test this new feature 

Fixes #848