### PR TITLE
port a select subset of the changes from mixed transactions for candidate 1.2

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -48,7 +48,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockVersion, CompressedCommitment, MaskedAmount, Token,
+    Amount, BlockVersion, CompressedCommitment, MaskedAmount, Token,
 };
 
 use mc_transaction_std::{
@@ -1602,13 +1602,13 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_init_1jni(
             env.take_rust_field(memo_builder_box, RUST_OBJ_FIELD)?;
         // FIXME #1595: The token id should be a parameter and not hard coded to Mob
         // here
-        let token_id = Mob::ID;
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
         let tx_builder = TransactionBuilder::new_with_box(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver.clone(),
             memo_builder_box,
-        );
+        )?;
 
         Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, tx_builder)?)
     })

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -242,8 +242,8 @@ message TxPrefix {
     // The block index at which this transaction is no longer valid.
     uint64 tombstone_block = 4;
 
-    // Token id for this transaction
-    fixed64 token_id = 5;
+    // Token id for the fee for this transaction
+    fixed64 fee_token_id = 5;
 }
 
 message RingMLSAG {

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -34,7 +34,7 @@ mod tests {
         onetime_keys::recover_onetime_private_key,
         tokens::Mob,
         tx::{Tx, TxOut, TxOutMembershipProof},
-        BlockVersion, Token,
+        Amount, BlockVersion, Token,
     };
     use mc_transaction_core_test_utils::MockFogResolver;
     use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
@@ -70,12 +70,14 @@ mod tests {
                 )
             };
 
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                Mob::ID,
+                fee_amount,
                 MockFogResolver::default(),
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
 
             let ring: Vec<TxOut> = minted_outputs.clone();
             let public_key = RistrettoPublic::try_from(&minted_outputs[0].public_key).unwrap();

--- a/api/src/convert/tx_prefix.rs
+++ b/api/src/convert/tx_prefix.rs
@@ -18,7 +18,7 @@ impl From<&tx::TxPrefix> for external::TxPrefix {
 
         tx_prefix.set_fee(source.fee);
 
-        tx_prefix.set_token_id(source.token_id);
+        tx_prefix.set_fee_token_id(source.fee_token_id);
 
         tx_prefix.set_tombstone_block(source.tombstone_block);
 
@@ -47,7 +47,7 @@ impl TryFrom<&external::TxPrefix> for tx::TxPrefix {
             inputs,
             outputs,
             fee: source.get_fee(),
-            token_id: source.get_token_id(),
+            fee_token_id: source.get_fee_token_id(),
             tombstone_block: source.get_tombstone_block(),
         };
         Ok(tx_prefix)

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -236,7 +236,7 @@ impl SgxConsensusEnclave {
         // We need to make sure all transactions are valid. We also ensure they all
         // point at the same root membership element.
         for (tx, proofs) in transactions_with_proofs.iter() {
-            let token_id = TokenId::from(tx.prefix.token_id);
+            let token_id = TokenId::from(tx.prefix.fee_token_id);
 
             let minimum_fee = ct_min_fees
                 .get(&token_id)
@@ -685,7 +685,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
             .decrypt_bytes(locally_encrypted_tx.0)?;
         let tx: Tx = mc_util_serial::decode(&decrypted_bytes)?;
 
-        let token_id = TokenId::from(tx.prefix.token_id);
+        let token_id = TokenId::from(tx.prefix.fee_token_id);
 
         // Validate.
         let mut csprng = McRng::default();
@@ -782,7 +782,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Compute the total fees for each known token id, for tx's in this block.
         let mut total_fees: CtTokenMap<u128> = ct_min_fee_map.keys().cloned().collect();
         for tx in transactions.iter() {
-            let token_id = TokenId::from(tx.prefix.token_id);
+            let token_id = TokenId::from(tx.prefix.fee_token_id);
             total_fees.add(&token_id, tx.prefix.fee as u128);
         }
 

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -576,12 +576,14 @@ mod combine_tests {
             )
             .unwrap();
 
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                Mob::ID,
+                fee_amount,
                 MockFogResolver::default(),
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
             transaction_builder.add_input(input_credentials);
             transaction_builder.set_fee(0).unwrap();
             transaction_builder
@@ -634,12 +636,14 @@ mod combine_tests {
                     // Step 2: Create a transaction that sends the full value of `tx_out` to
                     // `recipient_account`.
 
+                    let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                     let mut transaction_builder = TransactionBuilder::new(
                         block_version,
-                        Mob::ID,
+                        fee_amount,
                         MockFogResolver::default(),
                         EmptyMemoBuilder::default(),
-                    );
+                    )
+                    .unwrap();
 
                     // Create InputCredentials to spend the TxOut.
                     let onetime_private_key = recover_onetime_private_key(
@@ -735,12 +739,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -772,12 +778,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -835,12 +843,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -928,12 +938,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -966,12 +978,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder
@@ -1030,12 +1044,14 @@ mod combine_tests {
                 )
                 .unwrap();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    Mob::ID,
+                    fee_amount,
                     MockFogResolver::default(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
                 transaction_builder.add_input(input_credentials);
                 transaction_builder.set_fee(0).unwrap();
                 transaction_builder

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -613,7 +613,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
     let input_amount = inputs
         .iter()
         .fold(0, |acc, (txo, _)| acc + txo.amount.value);
-    let fee = tx_builder.get_fee();
+    let fee = tx_builder.get_fee().value;
     if (amount.value + fee) > input_amount {
         return Err(Error::InsufficientFunds);
     }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -606,9 +606,9 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         memo_builder.set_sender_credential(SenderMemoCredential::from(source_account_key));
         memo_builder.enable_destination_memo();
 
-        TransactionBuilder::new(block_version, amount.token_id, fog_resolver, memo_builder)
+        let fee_amount = Amount::new(fee, amount.token_id);
+        TransactionBuilder::new(block_version, fee_amount, fog_resolver, memo_builder)?
     };
-    tx_builder.set_fee(fee)?;
 
     let input_amount = inputs
         .iter()

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -19,7 +19,7 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockVersion, CompressedCommitment, EncryptedMemo, MaskedAmount, Token,
+    Amount, BlockVersion, CompressedCommitment, EncryptedMemo, MaskedAmount, Token,
 };
 
 use mc_transaction_std::{
@@ -373,19 +373,17 @@ pub extern "C" fn mc_transaction_builder_create(
         // version that fog ledger told us about, or that we got from ledger-db
         //let block_version = BlockVersion::ZERO;
 
-        // TODO #1596: Support token id other than Mob
-        let token_id = Mob::ID;
+        // TODO #1596: Support token id other than Mob (but not in this release)
+        let fee_amount = Amount::new(fee, Mob::ID);
 
         let mut transaction_builder = TransactionBuilder::new_with_box(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver,
             memo_builder_box,
-        );
+        )
+        .expect("failure not expected");
 
-        transaction_builder
-            .set_fee(fee)
-            .expect("failure not expected");
         transaction_builder.set_tombstone_block(tombstone_block);
         Some(transaction_builder)
     })

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -979,7 +979,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if total_value > input_value {
             return Err(Error::InsufficientFunds);
         }
-        let change = input_value - total_value - tx_builder.get_fee();
+        let change = input_value - total_value - tx_builder.get_fee().value;
 
         // If we do, add an output for that as well.
         // TODO: Should the exchange write destination memos?

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -21,7 +21,7 @@ use mc_transaction_core::{
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
-    BlockIndex, BlockVersion, TokenId,
+    Amount, BlockIndex, BlockVersion, TokenId,
 };
 use mc_transaction_std::{
     ChangeDestination, EmptyMemoBuilder, InputCredentials, TransactionBuilder,
@@ -869,17 +869,16 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         // TODO: Use RTH memo builder, optionally?
 
+        let fee_amount = Amount::new(fee, token_id);
+
         // Create tx_builder.
         let mut tx_builder = TransactionBuilder::new(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver,
             EmptyMemoBuilder::default(),
-        );
-
-        tx_builder
-            .set_fee(fee)
-            .map_err(|err| Error::TxBuild(format!("Error setting fee: {}", err)))?;
+        )
+        .map_err(|err| Error::TxBuild(format!("Error cretaing TransactionBuilder: {}", err)))?;
 
         // Unzip each vec of tuples into a tuple of vecs.
         let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2915,12 +2915,15 @@ mod test {
 
         // Insert into database.
         let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
+
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            fee_amount,
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, tx_confirmation) = transaction_builder
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
@@ -5228,12 +5231,14 @@ mod test {
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            fee_amount,
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,
@@ -5340,12 +5345,14 @@ mod test {
         let key = mnemonic.derive_slip10_key(0);
         let account_key = AccountKey::from(key);
 
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, Mob::ID);
         let mut transaction_builder = TransactionBuilder::new(
             BLOCK_VERSION,
-            Mob::ID,
+            fee_amount,
             MockFogResolver::default(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let (tx_out, _tx_confirmation) = transaction_builder
             .add_output(
                 10,

--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -41,6 +41,13 @@ pub struct Amount {
     pub token_id: TokenId,
 }
 
+impl Amount {
+    /// Create a new amount
+    pub fn new(value: u64, token_id: TokenId) -> Self {
+        Self { value, token_id }
+    }
+}
+
 /// A commitment to an amount of MobileCoin or a related token, as it appears on
 /// the blockchain. This is a "blinded" commitment, and only the sender and
 /// receiver know the value and token id.

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -166,7 +166,7 @@ pub struct TxPrefix {
 
     /// Token id for this transaction
     #[prost(fixed64, tag = "5")]
-    pub token_id: u64,
+    pub fee_token_id: u64,
 }
 
 impl TxPrefix {
@@ -181,15 +181,14 @@ impl TxPrefix {
     pub fn new(
         inputs: Vec<TxIn>,
         outputs: Vec<TxOut>,
-        fee: u64,
-        token_id: u64,
+        fee: Amount,
         tombstone_block: u64,
     ) -> TxPrefix {
         TxPrefix {
             inputs,
             outputs,
-            fee,
-            token_id,
+            fee: fee.value,
+            fee_token_id: *fee.token_id,
             tombstone_block,
         }
     }
@@ -649,7 +648,7 @@ mod tests {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
             fee: Mob::MINIMUM_FEE,
-            token_id: *Mob::ID,
+            fee_token_id: *Mob::ID,
             tombstone_block: 23,
         };
 
@@ -712,7 +711,7 @@ mod tests {
             inputs: vec![tx_in],
             outputs: vec![tx_out],
             fee: Mob::MINIMUM_FEE,
-            token_id: *Mob::ID,
+            fee_token_id: *Mob::ID,
             tombstone_block: 23,
         };
 

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -310,7 +310,7 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
             &rings,
             &output_commitments,
             tx.prefix.fee,
-            tx.prefix.token_id,
+            tx.prefix.fee_token_id,
             rng,
         )
         .map_err(TransactionValidationError::InvalidTransactionSignature)
@@ -1169,7 +1169,7 @@ mod tests {
         for _ in 0..3 {
             let (mut tx, _ledger) = create_test_tx(BlockVersion::TWO);
 
-            tx.prefix.token_id += 1;
+            tx.prefix.fee_token_id += 1;
 
             match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
                 Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -149,12 +149,15 @@ pub fn create_transaction_with_amount_and_comparer<
 ) -> Tx {
     let (sender_amount, _) = tx_out.view_key_match(sender.view_private_key()).unwrap();
 
+    let fee_amount = Amount::new(fee, sender_amount.token_id);
+
     let mut transaction_builder = TransactionBuilder::new(
         block_version,
-        sender_amount.token_id,
+        fee_amount,
         MockFogResolver::default(),
         EmptyMemoBuilder::default(),
-    );
+    )
+    .unwrap();
 
     // The first transaction in the origin block should contain enough outputs to
     // use as mixins.

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -7,7 +7,7 @@
 use super::{memo, ChangeDestination};
 use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
-use mc_transaction_core::{MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 mod rth_memo_builder;
 pub use rth_memo_builder::RTHMemoBuilder;
@@ -30,12 +30,12 @@ pub trait MemoBuilder: Debug {
     /// and gets a chance to report an error, if the fee is too large, or if it
     /// is being changed too late
     /// in the process, and memos that are already written would be invalid.
-    fn set_fee(&mut self, value: u64) -> Result<(), NewMemoError>;
+    fn set_fee(&mut self, amount: Amount) -> Result<(), NewMemoError>;
 
     /// Build a memo for a normal output (to another party).
     fn make_memo_for_output(
         &mut self,
-        value: u64,
+        amount: Amount,
         recipient: &PublicAddress,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
@@ -43,7 +43,7 @@ pub trait MemoBuilder: Debug {
     /// Build a memo for a change output (to ourselves).
     fn make_memo_for_change_output(
         &mut self,
-        value: u64,
+        amount: Amount,
         change_destination: &ChangeDestination,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
@@ -55,13 +55,13 @@ pub trait MemoBuilder: Debug {
 pub struct EmptyMemoBuilder;
 
 impl MemoBuilder for EmptyMemoBuilder {
-    fn set_fee(&mut self, _fee: u64) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, _amount: Amount) -> Result<(), NewMemoError> {
         Ok(())
     }
 
     fn make_memo_for_output(
         &mut self,
-        _value: u64,
+        _amount: Amount,
         _recipient: &PublicAddress,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -70,7 +70,7 @@ impl MemoBuilder for EmptyMemoBuilder {
 
     fn make_memo_for_change_output(
         &mut self,
-        _value: u64,
+        _amount: Amount,
         _change_destination: &ChangeDestination,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -14,7 +14,7 @@ use super::{
 };
 use crate::ChangeDestination;
 use mc_account_keys::{PublicAddress, ShortAddressHash};
-use mc_transaction_core::{tokens::Mob, MemoContext, MemoPayload, NewMemoError, Token};
+use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
 /// This memo builder attaches 0x0100 Authenticated Sender Memos to normal
 /// outputs, and 0x0200 Destination Memos to change outputs.
@@ -67,7 +67,7 @@ pub struct RTHMemoBuilder {
     // Tracks the number of recipients so far
     num_recipients: u8,
     // Tracks the fee
-    fee: u64,
+    fee: Amount,
 }
 
 impl Default for RTHMemoBuilder {
@@ -80,7 +80,7 @@ impl Default for RTHMemoBuilder {
             last_recipient: Default::default(),
             total_outlay: 0,
             num_recipients: 0,
-            fee: Mob::MINIMUM_FEE,
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         }
     }
 }
@@ -132,7 +132,7 @@ impl RTHMemoBuilder {
 
 impl MemoBuilder for RTHMemoBuilder {
     /// Set the fee
-    fn set_fee(&mut self, fee: u64) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
         if self.wrote_destination_memo {
             return Err(NewMemoError::FeeAfterChange);
         }
@@ -143,7 +143,7 @@ impl MemoBuilder for RTHMemoBuilder {
     /// Build a memo for a normal output (to another party).
     fn make_memo_for_output(
         &mut self,
-        value: u64,
+        amount: Amount,
         recipient: &PublicAddress,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -152,7 +152,7 @@ impl MemoBuilder for RTHMemoBuilder {
         }
         self.total_outlay = self
             .total_outlay
-            .checked_add(value)
+            .checked_add(amount.value)
             .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?;
         self.num_recipients = self
             .num_recipients
@@ -185,7 +185,7 @@ impl MemoBuilder for RTHMemoBuilder {
     /// Build a memo for a change output (to ourselves).
     fn make_memo_for_change_output(
         &mut self,
-        _value: u64,
+        _value: Amount,
         _change_destination: &ChangeDestination,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -197,9 +197,13 @@ impl MemoBuilder for RTHMemoBuilder {
         }
         self.total_outlay = self
             .total_outlay
-            .checked_add(self.fee)
+            .checked_add(self.fee.value)
             .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?;
-        match DestinationMemo::new(self.last_recipient.clone(), self.total_outlay, self.fee) {
+        match DestinationMemo::new(
+            self.last_recipient.clone(),
+            self.total_outlay,
+            self.fee.value,
+        ) {
             Ok(mut d_memo) => {
                 self.wrote_destination_memo = true;
                 d_memo.set_num_recipients(self.num_recipients);

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -18,7 +18,6 @@ use mc_transaction_core::{
     tokens::Mob,
     tx::{Tx, TxIn, TxOut, TxOutConfirmationNumber, TxPrefix},
     Amount, BlockVersion, CompressedCommitment, MemoContext, MemoPayload, NewMemoError, Token,
-    TokenId,
 };
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
@@ -320,14 +319,9 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         Ok(())
     }
 
-    /// Gets the transaction fee.
-    pub fn get_fee(&self) -> u64 {
-        self.fee.value
-    }
-
-    /// Gets the transaction fee token id.
-    pub fn get_fee_token_id(&self) -> TokenId {
-        self.fee.token_id
+    /// Gets the transaction fee amount
+    pub fn get_fee(&self) -> Amount {
+        self.fee
     }
 
     /// Consume the builder and return the transaction.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -59,9 +59,7 @@ pub struct TransactionBuilder<FPR: FogPubkeyResolver> {
     /// expires, and can no longer be added to the blockchain
     tombstone_block: u64,
     /// The fee paid in connection to this transaction
-    fee: u64,
-    /// The token id for this transaction
-    token_id: TokenId,
+    fee: Amount,
     /// The source of validated fog pubkeys used for this transaction
     fog_resolver: FPR,
     /// The limit on the tombstone block value imposed pubkey_expiry values in
@@ -87,16 +85,11 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///   transaction
     pub fn new<MB: MemoBuilder + 'static + Send + Sync>(
         block_version: BlockVersion,
-        token_id: TokenId,
+        fee: Amount,
         fog_resolver: FPR,
         memo_builder: MB,
-    ) -> Self {
-        TransactionBuilder::new_with_box(
-            block_version,
-            token_id,
-            fog_resolver,
-            Box::new(memo_builder),
-        )
+    ) -> Result<Self, TxBuilderError> {
+        TransactionBuilder::new_with_box(block_version, fee, fog_resolver, Box::new(memo_builder))
     }
 
     /// Initializes a new TransactionBuilder, using a Box<dyn MemoBuilder>
@@ -109,21 +102,21 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///   transaction
     pub fn new_with_box(
         block_version: BlockVersion,
-        token_id: TokenId,
+        fee: Amount,
         fog_resolver: FPR,
-        memo_builder: Box<dyn MemoBuilder + Send + Sync>,
-    ) -> Self {
-        TransactionBuilder {
+        mut memo_builder: Box<dyn MemoBuilder + Send + Sync>,
+    ) -> Result<Self, TxBuilderError> {
+        memo_builder.set_fee(fee)?;
+        Ok(TransactionBuilder {
             block_version,
             input_credentials: Vec::new(),
             outputs_and_shared_secrets: Vec::new(),
             tombstone_block: u64::max_value(),
-            fee: Mob::MINIMUM_FEE,
-            token_id,
+            fee,
             fog_resolver,
             fog_tombstone_block_limit: u64::max_value(),
             memo_builder: Some(memo_builder),
-        }
+        })
     }
 
     /// Add an Input to the transaction.
@@ -159,13 +152,19 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             .take()
             .expect("memo builder is missing, this is a logic error");
         let block_version = self.block_version;
+        let token_id = self.fee.token_id;
         let result = self.add_output_with_fog_hint_address(
             value,
             recipient,
             recipient,
             |memo_ctxt| {
                 if block_version.e_memo_feature_is_supported() {
-                    Some(mb.make_memo_for_output(value, recipient, memo_ctxt)).transpose()
+                    Some(mb.make_memo_for_output(
+                        Amount::new(value, token_id),
+                        recipient,
+                        memo_ctxt,
+                    ))
+                    .transpose()
                 } else {
                     Ok(None)
                 }
@@ -218,14 +217,19 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             .take()
             .expect("memo builder is missing, this is a logic error");
         let block_version = self.block_version;
+        let token_id = self.fee.token_id;
         let result = self.add_output_with_fog_hint_address(
             value,
             &change_destination.change_subaddress,
             &change_destination.primary_address,
             |memo_ctxt| {
                 if block_version.e_memo_feature_is_supported() {
-                    Some(mb.make_memo_for_change_output(value, change_destination, memo_ctxt))
-                        .transpose()
+                    Some(mb.make_memo_for_change_output(
+                        Amount::new(value, token_id),
+                        change_destination,
+                        memo_ctxt,
+                    ))
+                    .transpose()
                 } else {
                     Ok(None)
                 }
@@ -266,7 +270,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         let (hint, pubkey_expiry) = create_fog_hint(fog_hint_address, &self.fog_resolver, rng)?;
         let amount = Amount {
             value,
-            token_id: self.token_id,
+            token_id: self.fee.token_id,
         };
         let (tx_out, shared_secret) =
             create_output_with_fog_hint(self.block_version, amount, recipient, hint, memo_fn, rng)?;
@@ -299,11 +303,13 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         self.tombstone_block = min(self.fog_tombstone_block_limit, self.tombstone_block);
     }
 
-    /// Sets the transaction fee.
+    /// Sets the transaction fee value.
     ///
     /// # Arguments
-    /// * `fee` - Transaction fee, in picoMOB.
+    /// * `fee` - Transaction fee, in picoMOB, or smallest representable units.
     pub fn set_fee(&mut self, fee: u64) -> Result<(), TxBuilderError> {
+        // It is not allowed to change the fee token id after construction
+        let fee = Amount::new(fee, self.fee.token_id);
         // Set the fee in memo builder first, so that it can signal an error
         // before we set self.fee, and don't have to roll back.
         self.memo_builder
@@ -316,7 +322,12 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
 
     /// Gets the transaction fee.
     pub fn get_fee(&self) -> u64 {
-        self.fee
+        self.fee.value
+    }
+
+    /// Gets the transaction fee token id.
+    pub fn get_fee_token_id(&self) -> TokenId {
+        self.fee.token_id
     }
 
     /// Consume the builder and return the transaction.
@@ -359,7 +370,9 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             ));
         }
 
-        if !self.block_version.masked_token_id_feature_is_supported() && self.token_id != Mob::ID {
+        if !self.block_version.masked_token_id_feature_is_supported()
+            && self.fee.token_id != Mob::ID
+        {
             return Err(TxBuilderError::FeatureNotSupportedAtBlockVersion(
                 *self.block_version,
                 "nonzero token id",
@@ -412,13 +425,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         let (outputs, _shared_serets): (Vec<TxOut>, Vec<_>) =
             self.outputs_and_shared_secrets.into_iter().unzip();
 
-        let tx_prefix = TxPrefix::new(
-            inputs,
-            outputs,
-            self.fee,
-            *self.token_id,
-            self.tombstone_block,
-        );
+        let tx_prefix = TxPrefix::new(inputs, outputs, self.fee, self.tombstone_block);
 
         let mut rings: Vec<Vec<(CompressedRistrettoPublic, CompressedCommitment)>> = Vec::new();
         for input in &tx_prefix.inputs {
@@ -446,9 +453,9 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
                 &input_credential.view_private_key,
             );
             let (amount, blinding) = masked_amount.get_value(&shared_secret)?;
-            if amount.token_id != self.token_id {
+            if amount.token_id != self.fee.token_id {
                 return Err(TxBuilderError::WrongTokenType(
-                    self.token_id,
+                    self.fee.token_id,
                     amount.token_id,
                 ));
             }
@@ -463,8 +470,8 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             &real_input_indices,
             &input_secrets,
             &output_values_and_blindings,
-            self.fee,
-            *self.token_id,
+            self.fee.value,
+            *self.fee.token_id,
             rng,
         )?;
 
@@ -707,12 +714,14 @@ pub mod transaction_builder_tests {
         fog_resolver: FPR,
         rng: &mut RNG,
     ) -> Result<Tx, TxBuilderError> {
+        let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
         let mut transaction_builder = TransactionBuilder::new(
             block_version,
-            token_id,
+            fee_amount,
             fog_resolver.clone(),
             EmptyMemoBuilder::default(),
-        );
+        )
+        .unwrap();
         let input_value = 1000;
         let output_value = 10;
 
@@ -776,8 +785,14 @@ pub mod transaction_builder_tests {
             let membership_proofs = input_credentials.membership_proofs.clone();
             let key_image = KeyImage::from(&input_credentials.onetime_private_key);
 
-            let mut transaction_builder =
-                TransactionBuilder::new(block_version, token_id, fpr, EmptyMemoBuilder::default());
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                fee_amount,
+                fpr,
+                EmptyMemoBuilder::default(),
+            )
+            .unwrap();
 
             transaction_builder.add_input(input_credentials);
             let (_txout, confirmation) = transaction_builder
@@ -853,12 +868,14 @@ pub mod transaction_builder_tests {
             let membership_proofs = input_credentials.membership_proofs.clone();
             let key_image = KeyImage::from(&input_credentials.onetime_private_key);
 
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                token_id,
+                fee_amount,
                 fog_resolver,
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
 
             transaction_builder.add_input(input_credentials);
             let (_txout, confirmation) = transaction_builder
@@ -943,12 +960,14 @@ pub mod transaction_builder_tests {
                     },
             });
 
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                token_id,
+                fee_amount,
                 fog_resolver.clone(),
                 EmptyMemoBuilder::default(),
-            );
+            )
+            .unwrap();
 
             let input_credentials =
                 get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
@@ -1018,12 +1037,14 @@ pub mod transaction_builder_tests {
             });
 
             {
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -1048,12 +1069,14 @@ pub mod transaction_builder_tests {
             }
 
             {
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(500);
 
@@ -1107,12 +1130,14 @@ pub mod transaction_builder_tests {
             });
 
             {
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     EmptyMemoBuilder::default(),
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -1283,12 +1308,14 @@ pub mod transaction_builder_tests {
                 memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
                 memo_builder.enable_destination_memo();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -1439,12 +1466,14 @@ pub mod transaction_builder_tests {
                 memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
                 memo_builder.enable_destination_memo();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
                 transaction_builder.set_fee(Mob::MINIMUM_FEE * 4).unwrap();
@@ -1597,12 +1626,14 @@ pub mod transaction_builder_tests {
                 memo_builder.enable_destination_memo();
                 memo_builder.set_payment_request_id(42);
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -1754,12 +1785,14 @@ pub mod transaction_builder_tests {
                 memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
                 memo_builder.set_payment_request_id(47);
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -1899,12 +1932,14 @@ pub mod transaction_builder_tests {
                 memo_builder.enable_destination_memo();
                 memo_builder.set_payment_request_id(47);
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -2069,12 +2104,14 @@ pub mod transaction_builder_tests {
                 memo_builder.set_sender_credential(SenderMemoCredential::from(&charlie));
                 memo_builder.enable_destination_memo();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -2256,12 +2293,14 @@ pub mod transaction_builder_tests {
                 memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
                 memo_builder.enable_destination_memo();
 
+                let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
                 let mut transaction_builder = TransactionBuilder::new(
                     block_version,
-                    token_id,
+                    fee_amount,
                     fog_resolver.clone(),
                     memo_builder,
-                );
+                )
+                .unwrap();
 
                 transaction_builder.set_tombstone_block(2000);
 
@@ -2359,8 +2398,14 @@ pub mod transaction_builder_tests {
             )
             .unwrap();
 
-            let mut transaction_builder =
-                TransactionBuilder::new(block_version, token_id, fpr, EmptyMemoBuilder::default());
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                fee_amount,
+                fpr,
+                EmptyMemoBuilder::default(),
+            )
+            .unwrap();
             transaction_builder.add_input(input_credentials);
 
             let wrong_value = 999;
@@ -2518,12 +2563,14 @@ pub mod transaction_builder_tests {
             memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
             memo_builder.enable_destination_memo();
 
+            let fee_amount = Amount::new(Mob::MINIMUM_FEE, token_id);
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
-                token_id,
+                fee_amount,
                 fog_resolver.clone(),
                 memo_builder,
-            );
+            )
+            .unwrap();
 
             let input_credentials = get_input_credentials(
                 block_version,


### PR DESCRIPTION
The changes ported here, from (https://github.com/mobilecoinfoundation/mobilecoin/pull/1827) are:
* Rename `token_id` to `fee_token_id` in `TxPrefix`. This avoids a breaking
  change between this and 1.3 in the hashes.
* Make `TransactionBuilder::new` take a fee amount instead of a fee token id
  This also changes te memo builder trait, so that it will be compatible with
  the burn redemption memo builder which we hope to port next.
  This also makes `TransactionBuilder::new` possibly return an error.
* Adapt all clients and sdks for `TransactionBuilder::new` changes.
* Adapt all tests for this change
* Bring the  `Amount::new` function which makes the test code nicer.

This does NOT port:
* Any other changes to transaction builder or tx protos
* The change that makes `add_output` take an amount instead of a `value: u64`. That is needed for mixed transactions but isn't needed here, and requires more changes to the clients and sdks, so we avoid it in this branch.