### PR TITLE
Port to candidate 1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,6 +5157,7 @@ dependencies = [
 name = "mc-transaction-std"
 version = "1.3.0-pre0"
 dependencies = [
+ "assert_matches",
  "cfg-if 1.0.0",
  "curve25519-dalek",
  "displaydoc",

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -21,7 +21,7 @@ use jni::{
 };
 use mc_account_keys::{
     AccountKey, PublicAddress, RootEntropy, RootIdentity, ShortAddressHash,
-    CHANGE_SUBADDRESS_INDEX, DEFAULT_SUBADDRESS_INDEX,
+    CHANGE_SUBADDRESS_INDEX, DEFAULT_SUBADDRESS_INDEX, INVALID_SUBADDRESS_INDEX,
 };
 use mc_account_keys_slip10::Slip10KeyGenerator;
 use mc_api::printable::PrintableWrapper;
@@ -1396,8 +1396,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOut_compute_1key_1image(
                 &tx_out_target_key,
                 &tx_pub_key,
             );
-            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (DEFAULT_SUBADDRESS_INDEX
-                ..=CHANGE_SUBADDRESS_INDEX)
+            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (0..=DEFAULT_SUBADDRESS_INDEX)
+                .chain(CHANGE_SUBADDRESS_INDEX..INVALID_SUBADDRESS_INDEX)
                 .map(|index| (*account_key.subaddress(index).spend_public_key(), index))
                 .collect();
             let subaddress_index = spsk_to_index
@@ -1851,8 +1851,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_recover_1onetime_1private_
                 &tx_target_key,
                 &tx_pub_key,
             );
-            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (DEFAULT_SUBADDRESS_INDEX
-                ..=CHANGE_SUBADDRESS_INDEX)
+            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (0..=DEFAULT_SUBADDRESS_INDEX)
+                .chain(CHANGE_SUBADDRESS_INDEX..INVALID_SUBADDRESS_INDEX)
                 .map(|index| (*account_key.subaddress(index).spend_public_key(), index))
                 .collect();
             let subaddress_index = spsk_to_index

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -63,6 +63,14 @@ impl MemoHandler {
         log::trace!(self.logger, "Obtained a memo: {:?}", memo_type);
         match memo_type.clone() {
             MemoType::Unused(_) => Ok(None),
+            MemoType::BurnRedemption(_) => {
+                // TODO: For now we are not validating anything with burn redemption memos.
+                // Right now the memo data is unstructured, so there's nothing
+                // to verify there. In theory we should only find this type of
+                // memo on a the burn account, which cannot be used with the sample paykit since
+                // the spend key is unknown.
+                Ok(Some(memo_type))
+            }
             MemoType::AuthenticatedSender(memo) => {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
                     if bool::from(memo.validate(

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -420,7 +420,7 @@ impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
             tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
             tx_out_hash: hex::encode(&src.get_tx_out_hash()),
             tombstone: src.get_tombstone(),
-            confirmation_number: hex::encode(&src.get_tx_out_hash()),
+            confirmation_number: hex::encode(&src.get_confirmation_number()),
         }
     }
 }

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -44,6 +44,7 @@ service MobilecoindAPI {
     rpc GenerateOptimizationTx (GenerateOptimizationTxRequest) returns (GenerateOptimizationTxResponse) {}
     rpc GenerateTransferCodeTx (GenerateTransferCodeTxRequest) returns (GenerateTransferCodeTxResponse) {}
     rpc GenerateTxFromTxOutList (GenerateTxFromTxOutListRequest) returns (GenerateTxFromTxOutListResponse) {}
+    rpc GenerateBurnRedemptionTx (GenerateBurnRedemptionTxRequest) returns (GenerateBurnRedemptionTxResponse) {}
     rpc SubmitTx (SubmitTxRequest) returns (SubmitTxResponse) {}
 
     // Databases
@@ -560,6 +561,49 @@ message GenerateTxFromTxOutListRequest {
 }
 
 message GenerateTxFromTxOutListResponse {
+    TxProposal tx_proposal = 1;
+}
+
+// Generate a burn redemption transaction proposal object.
+// Notes:
+// - Sum of inputs needs to be greater than or equal to the burn amount and fee.
+// - The set of inputs to use would be chosen automatically by mobilecoind.
+// - The fee field could be set to zero, in which case mobilecoind would try and choose a fee.
+message GenerateBurnRedemptionTxRequest {
+    // Monitor id sending the funds.
+    bytes sender_monitor_id = 1;
+
+    // Subaddress to return change to.
+    uint64 change_subaddress = 2;
+
+    // List of UnspentTxOuts to be spent by the transaction.
+    // All UnspentTxOuts must belong to the same sender_monitor_id.
+    // mobilecoind would choose a subset of these inputs to construct the transaction.
+    // Total input amount must be >= burn amount + fee.
+    repeated UnspentTxOut input_list = 3;
+
+    // Amount to be burnt. This excludes change and fee.
+    uint64 burn_amount = 4;
+
+    // Fee (setting to 0 causes mobilecoind to choose a value).
+    // The value used can be checked (but not changed) in tx_proposal.tx.prefix.fee
+    uint64 fee = 5;
+
+    // Tombstone block (setting to 0 causes mobilecoind to choose a value).
+    // The value used can be checked (but not changed) in tx_proposal.tx.prefix.tombstone_block
+    uint64 tombstone = 6;
+
+    // Token id to use for the transaction.
+    uint64 token_id = 7;
+
+    // Optional 64 bytes of data to include in the burn redemption memo that is attached to the burn TxOut.
+    // If not provided zeros will be used.
+    bytes redemption_memo = 8;
+
+    // Enable RTH destination memo.
+    bool enable_destination_memo = 9;
+}
+message GenerateBurnRedemptionTxResponse {
     TxProposal tx_proposal = 1;
 }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -16,7 +16,9 @@ use crate::{
 };
 use bip39::{Language, Mnemonic, MnemonicType};
 use grpcio::{EnvBuilder, RpcContext, RpcStatus, RpcStatusCode, ServerBuilder, UnarySink};
-use mc_account_keys::{AccountKey, PublicAddress, RootIdentity, DEFAULT_SUBADDRESS_INDEX};
+use mc_account_keys::{
+    burn_address, AccountKey, PublicAddress, RootIdentity, DEFAULT_SUBADDRESS_INDEX,
+};
 use mc_account_keys_slip10::Slip10KeyGenerator;
 use mc_common::{
     logger::{log, Logger},
@@ -38,6 +40,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     TokenId,
 };
+use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,
@@ -46,7 +49,7 @@ use mc_util_grpc::{
 use mc_watcher::watcher_db::WatcherDB;
 use protobuf::{ProtobufEnum, RepeatedField};
 use std::{
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     sync::{Arc, Mutex, RwLock},
 };
 
@@ -880,6 +883,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 &outlays,
                 request.fee,
                 request.tombstone,
+                None,
             )
             .map_err(|err| {
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
@@ -972,6 +976,119 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?;
 
         let mut response = mc_mobilecoind_api::GenerateTxFromTxOutListResponse::new();
+        response.set_tx_proposal((&tx_proposal).into());
+        Ok(response)
+    }
+
+    fn generate_burn_redemption_tx_impl(
+        &mut self,
+        request: mc_mobilecoind_api::GenerateBurnRedemptionTxRequest,
+    ) -> Result<mc_mobilecoind_api::GenerateBurnRedemptionTxResponse, RpcStatus> {
+        // Get sender monitor id from request.
+        let sender_monitor_id = MonitorId::try_from(&request.sender_monitor_id)
+            .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
+
+        // Get monitor data for this monitor.
+        let sender_monitor_data = self
+            .mobilecoind_db
+            .get_monitor_data(&sender_monitor_id)
+            .map_err(|err| {
+                rpc_internal_error("mobilecoind_db.get_monitor_data", err, &self.logger)
+            })?;
+
+        // Check that change_subaddress is covered by this monitor.
+        if !sender_monitor_data
+            .subaddress_indexes()
+            .contains(&request.change_subaddress)
+        {
+            return Err(RpcStatus::with_message(
+                RpcStatusCode::INVALID_ARGUMENT,
+                "change_subaddress".into(),
+            ));
+        }
+
+        // Get the list of potential inputs passed to.
+        let input_list: Vec<UnspentTxOut> = request
+            .get_input_list()
+            .iter()
+            .enumerate()
+            .map(|(i, proto_utxo)| {
+                // Proto -> Rust struct conversion.
+                let utxo = UnspentTxOut::try_from(proto_utxo).map_err(|err| {
+                    rpc_internal_error(format!("unspent_tx_out[{}].try_from", i), err, &self.logger)
+                })?;
+
+                // Verify token id matches.
+                if utxo.token_id != request.token_id {
+                    return Err(RpcStatus::with_message(
+                        RpcStatusCode::INVALID_ARGUMENT,
+                        format!("input_list[{}].token_id", i),
+                    ));
+                }
+
+                // Verify this output belongs to the monitor.
+                let subaddress_id = self
+                    .mobilecoind_db
+                    .get_subaddress_id_by_utxo_id(&UtxoId::from(&utxo))
+                    .map_err(|err| {
+                        rpc_internal_error(
+                            "mobilecoind_db.get_subaddress_id_by_utxo_id",
+                            err,
+                            &self.logger,
+                        )
+                    })?;
+
+                if subaddress_id.monitor_id != sender_monitor_id {
+                    return Err(RpcStatus::with_message(
+                        RpcStatusCode::INVALID_ARGUMENT,
+                        format!("input_list[{}].monitor_id", i),
+                    ));
+                }
+
+                // Success.
+                Ok(utxo)
+            })
+            .collect::<Result<Vec<UnspentTxOut>, RpcStatus>>()?;
+
+        // Generate the list of outlays.
+        let outlays = vec![Outlay {
+            value: request.get_burn_amount(),
+            receiver: burn_address(),
+        }];
+
+        // Create memo builder.
+        let mut memo_data = request.get_redemption_memo().to_vec();
+        if memo_data.is_empty() {
+            memo_data.resize(BurnRedemptionMemo::MEMO_DATA_LEN, 0);
+        }
+        let memo_data_array = memo_data.try_into().map_err(|_err| {
+            RpcStatus::with_message(RpcStatusCode::INVALID_ARGUMENT, "redemption_memo".into())
+        })?;
+
+        let mut memo_builder = BurnRedemptionMemoBuilder::new(memo_data_array);
+        if request.enable_destination_memo {
+            memo_builder.enable_destination_memo();
+        }
+
+        // Attempt to construct a transaction.
+        let tx_proposal = self
+            .transactions_manager
+            .build_transaction(
+                &sender_monitor_id,
+                TokenId::from(request.token_id),
+                request.change_subaddress,
+                &input_list,
+                &outlays,
+                request.fee,
+                request.tombstone,
+                Some(Box::new(memo_builder)),
+            )
+            .map_err(|err| {
+                rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
+            })?;
+
+        // Success.
+        let mut response = mc_mobilecoind_api::GenerateBurnRedemptionTxResponse::new();
         response.set_tx_proposal((&tx_proposal).into());
         Ok(response)
     }
@@ -1735,6 +1852,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 &outlays,
                 request.fee,
                 request.tombstone,
+                None,
             )
             .map_err(|err| {
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
@@ -1928,6 +2046,7 @@ build_api! {
     generate_optimization_tx GenerateOptimizationTxRequest GenerateOptimizationTxResponse generate_optimization_tx_impl,
     generate_transfer_code_tx GenerateTransferCodeTxRequest GenerateTransferCodeTxResponse generate_transfer_code_tx_impl,
     generate_tx_from_tx_out_list GenerateTxFromTxOutListRequest GenerateTxFromTxOutListResponse generate_tx_from_tx_out_list_impl,
+    generate_burn_redemption_tx GenerateBurnRedemptionTxRequest GenerateBurnRedemptionTxResponse generate_burn_redemption_tx_impl,
     submit_tx SubmitTxRequest SubmitTxResponse submit_tx_impl,
 
     // Databases
@@ -1966,7 +2085,10 @@ mod test {
         utxo_store::UnspentTxOut,
     };
     use grpcio::Error as GrpcError;
-    use mc_account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX};
+    use mc_account_keys::{
+        burn_address_view_private, AccountKey, PublicAddress, ShortAddressHash,
+        DEFAULT_SUBADDRESS_INDEX,
+    };
     use mc_common::{logger::test_with_logger, HashSet};
     use mc_crypto_keys::RistrettoPrivate;
     use mc_crypto_rand::RngCore;
@@ -1981,11 +2103,12 @@ mod test {
         tx::{Tx, TxOut},
         Amount, Block, BlockContents, BlockVersion, Token,
     };
-    use mc_transaction_std::{EmptyMemoBuilder, TransactionBuilder};
+    use mc_transaction_std::{EmptyMemoBuilder, MemoType, TransactionBuilder};
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
     use mc_util_uri::FogUri;
     use rand::{rngs::StdRng, SeedableRng};
     use std::{
+        assert_matches::assert_matches,
         convert::{TryFrom, TryInto},
         iter::FromIterator,
         str::FromStr,
@@ -3800,6 +3923,166 @@ mod test {
                     .collect(),
             ));
             assert!(client.generate_tx(&request).is_err());
+        }
+    }
+
+    #[test_with_logger]
+    fn test_generate_burn_redemption_tx(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
+        let token_id2 = TokenId::from(2);
+
+        let sender = AccountKey::random(&mut rng);
+        let data = MonitorData::new(
+            sender.clone(),
+            0,  // first_subaddress
+            20, // num_subaddresses
+            0,  // first_block
+            "", // name
+        )
+        .unwrap();
+
+        // 1 known recipient, 3 random recipients and no monitors.
+        let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
+            get_testing_environment(
+                BLOCK_VERSION,
+                3,
+                &[sender.default_subaddress()],
+                &[],
+                logger.clone(),
+                &mut rng,
+            );
+
+        // Add a block with a non-MOB token ID.
+        add_block_to_ledger_db(
+            BlockVersion::MAX,
+            &mut ledger_db,
+            &vec![
+                AccountKey::random(&mut rng).default_subaddress(),
+                AccountKey::random(&mut rng).default_subaddress(),
+                AccountKey::random(&mut rng).default_subaddress(),
+                sender.default_subaddress(),
+            ],
+            Amount {
+                value: 1_000_000_000_000,
+                token_id: token_id2,
+            },
+            &[KeyImage::from(101)],
+            &mut rng,
+        );
+
+        // Insert into database.
+        let monitor_id = mobilecoind_db.add_monitor(&data).unwrap();
+
+        // Allow the new monitor to process the ledger.
+        wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
+
+        // Get list of unspent tx outs that we want to burn
+        let utxos = mobilecoind_db
+            .get_utxos_for_subaddress(&monitor_id, 0)
+            .unwrap()
+            .iter()
+            .filter(|utxo| utxo.token_id == token_id2)
+            .map(Into::into)
+            .collect::<RepeatedField<_>>();
+        assert!(!utxos.is_empty());
+
+        // Prepare request
+        let mut request = mc_mobilecoind_api::GenerateBurnRedemptionTxRequest::new();
+        request.set_sender_monitor_id(monitor_id.to_vec());
+        request.set_change_subaddress(0);
+        request.set_input_list(utxos);
+        request.set_burn_amount(100_000);
+        request.set_fee(200_000);
+        request.set_token_id(*token_id2);
+        request.set_redemption_memo(vec![5u8; BurnRedemptionMemo::MEMO_DATA_LEN]);
+        request.set_enable_destination_memo(true);
+
+        // Test the happy flow.
+        {
+            let response = client.generate_burn_redemption_tx(&request).unwrap();
+
+            // Sanity test the response.
+            let tx_proposal = response.get_tx_proposal();
+            let tx = Tx::try_from(tx_proposal.get_tx()).unwrap();
+
+            // Two outputs - change and burn
+            assert_eq!(tx.prefix.outputs.len(), 2);
+
+            // Validate the change output.
+            let (change_tx_out, change_amount) = tx
+                .prefix
+                .outputs
+                .iter()
+                .find_map(|tx_out| {
+                    tx_out
+                        .view_key_match(sender.view_private_key())
+                        .map(|(amount, _commitment)| (tx_out.clone(), amount))
+                        .ok()
+                })
+                .expect("Didn't find sender's change output");
+
+            assert_eq!(change_amount.value, 1_000_000_000_000 - 100_000 - 200_000);
+
+            let ss = get_tx_out_shared_secret(
+                sender.view_private_key(),
+                &RistrettoPublic::try_from(&change_tx_out.public_key).unwrap(),
+            );
+            let memo = change_tx_out.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Destination(memo) => {
+                    assert_eq!(
+                        memo.get_address_hash(),
+                        &ShortAddressHash::from(&burn_address()),
+                        "lookup based on address hash failed"
+                    );
+                    assert_eq!(memo.get_num_recipients(), 1);
+                    assert_eq!(memo.get_fee(), 200_000);
+                    assert_eq!(
+                        memo.get_total_outlay(),
+                        300_000,
+                        "outlay should be amount sent to recipient + fee"
+                    );
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+
+            // Validate the burn output.
+            let (burn_tx_out, burn_amount) = tx
+                .prefix
+                .outputs
+                .iter()
+                .find_map(|tx_out| {
+                    tx_out
+                        .view_key_match(&burn_address_view_private())
+                        .map(|(amount, _commitment)| (tx_out.clone(), amount))
+                        .ok()
+                })
+                .expect("Didn't find burn output");
+
+            assert_eq!(burn_amount.value, 100_000);
+
+            let ss = get_tx_out_shared_secret(
+                &burn_address_view_private(),
+                &RistrettoPublic::try_from(&burn_tx_out.public_key).unwrap(),
+            );
+            let memo = burn_tx_out.e_memo.unwrap().decrypt(&ss);
+            assert_matches!(MemoType::try_from(&memo).expect("Couldn't decrypt memo"), MemoType::BurnRedemption(memo) if memo.memo_data() == &[5u8; 64]);
+        }
+
+        // Invalid memo data length results in an error.
+        {
+            let mut request = request.clone();
+            request.set_redemption_memo(vec![5u8; BurnRedemptionMemo::MEMO_DATA_LEN + 1]);
+            assert!(client.generate_burn_redemption_tx(&request).is_err());
+        }
+
+        // Trying to burn more than we have results in an error.
+        {
+            let mut request = request.clone();
+            request.set_burn_amount(1_000_000_000_000 - request.get_fee() + 1);
+            assert!(client.generate_burn_redemption_tx(&request).is_err());
         }
     }
 

--- a/mobilecoind/strategies/accounts.py
+++ b/mobilecoind/strategies/accounts.py
@@ -41,8 +41,8 @@ def connect(host, port):
 
 def register_account(key_data, stub) -> AccountData:
     # Generate an account key from this root entropy
-    resp = stub.GetAccountKeyFromRootEntropy(
-        mobilecoind_api_pb2.GetAccountKeyFromMnemonic(
+    resp = stub.GetAccountKeyFromMnemonic(
+        mobilecoind_api_pb2.GetAccountKeyFromMnemonicRequest(
             mnemonic=key_data['mnemonic']))
     account_key = resp.account_key
 

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -65,6 +65,14 @@ pub enum NewMemoError {
     OutputsAfterChange,
     /// Changing the fee after the change output is not supported
     FeeAfterChange,
+    /// Invalid recipient address
+    InvalidRecipient,
+    /// Multiple outputs are not supported
+    MultipleOutputs,
+    /// Missing output
+    MissingOutput,
+    /// Mixed Token Ids are not supported in these memos
+    MixedTokenIds,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -34,6 +34,7 @@ curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features = ["nightly", "u64_backend"] }
 
 [dev-dependencies]
+assert_matches = "1.5"
 maplit = "1.0"
 yaml-rust = "0.4"
 

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -18,11 +18,11 @@ pub use change_destination::ChangeDestination;
 pub use error::TxBuilderError;
 pub use input_credentials::InputCredentials;
 pub use memo::{
-    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType, SenderMemoCredential,
-    UnusedMemo,
+    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo,
+    DestinationMemo, DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType,
+    SenderMemoCredential, UnusedMemo,
 };
-pub use memo_builder::{EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
 
 // Re-export this to help the exported macros work

--- a/transaction/std/src/memo/burn_redemption.rs
+++ b/transaction/std/src/memo/burn_redemption.rs
@@ -1,0 +1,57 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Object for 0x0001 Burn Redemption memo type
+//!
+//! TODO: Link to MCIP
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/TBD
+
+use super::RegisteredMemoType;
+use crate::impl_memo_type_conversions;
+
+/// A memo that the sender writes to associate a burn of an assert on the
+/// MobileCoin blockchain with a redemption of another asset on a different
+/// blockchain. The main intended use-case for this is burning of tokens that
+/// are correlated with redemption of some other asset on a different
+/// blockchain.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BurnRedemptionMemo {
+    /// The memo data.
+    /// The contents of the memo depend on the token being burnt, and as such do
+    /// not have a strict schema.
+    memo_data: [u8; Self::MEMO_DATA_LEN],
+}
+
+impl RegisteredMemoType for BurnRedemptionMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x00, 0x01];
+}
+
+impl BurnRedemptionMemo {
+    /// The length of the custom memo data.
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// Create a new BurnRedemptionMemo.
+    pub fn new(memo_data: [u8; Self::MEMO_DATA_LEN]) -> Self {
+        BurnRedemptionMemo { memo_data }
+    }
+
+    /// Get the memo data
+    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
+        &self.memo_data
+    }
+}
+
+impl From<&[u8; Self::MEMO_DATA_LEN]> for BurnRedemptionMemo {
+    fn from(src: &[u8; Self::MEMO_DATA_LEN]) -> Self {
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<BurnRedemptionMemo> for [u8; BurnRedemptionMemo::MEMO_DATA_LEN] {
+    fn from(src: BurnRedemptionMemo) -> [u8; BurnRedemptionMemo::MEMO_DATA_LEN] {
+        src.memo_data
+    }
+}
+
+impl_memo_type_conversions! { BurnRedemptionMemo }

--- a/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
+++ b/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2022 The MobileCoin Foundation
+
+//! Defines the BurnRedemptionMemoBuilder.
+//! This MemoBuilder policy implements Burn Redemption tracking using memos, as
+//! envisioned in MCIP #TODO.
+
+use super::{
+    memo::{BurnRedemptionMemo, DestinationMemo, DestinationMemoError, UnusedMemo},
+    MemoBuilder,
+};
+use crate::ChangeDestination;
+use mc_account_keys::{burn_address, PublicAddress, ShortAddressHash};
+use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
+
+/// This memo builder attaches 0x0001 Burn Redemption Memos to an output going
+/// to the designated burn address, and 0x0200 Destination Memos to change
+/// outputs. Only a single non-change output is allowed, and it must go to the
+/// designated burn address.
+///
+/// Usage:
+/// You should usually use this like:
+///
+///   let memo_data = [1; BurnRedemptionMemo::MEMO_DATA_LEN];
+///   let mut mb = BurnRedemptionMemoBuilder::new(memo_data);
+///   mb.enable_destination_memo();
+///
+/// Then use it to construct a transaction builder.
+///
+/// A memo builder configured this way will use 0x0001 Burn Redemption Memo
+/// on the burn output and 0x0200 Destination Memo on the change output.
+///
+/// If mb.enable_destination_memo() is not called 0x0000 Unused will appear on
+/// change output, instead of 0x0200 Destination Memo.
+///
+/// When invoking the transaction builder, the change output must be created
+/// last. If the burn output is created after the change output, an error will
+/// occur.
+///
+/// If more than one burn output is created, an error will be returned.
+#[derive(Clone, Debug)]
+pub struct BurnRedemptionMemoBuilder {
+    // The memo data we will attach to the burn output.
+    memo_data: [u8; BurnRedemptionMemo::MEMO_DATA_LEN],
+    // Whether destination memos are enabled.
+    destination_memo_enabled: bool,
+    // Tracks if we already wrote a destination memo, for error reporting
+    wrote_destination_memo: bool,
+    // Tracks the amount being burned
+    burn_amount: Option<Amount>,
+    // Tracks the fee
+    fee: Amount,
+}
+
+impl BurnRedemptionMemoBuilder {
+    /// Construct a new BurnRedemptionMemoBuilder.
+    pub fn new(memo_data: [u8; BurnRedemptionMemo::MEMO_DATA_LEN]) -> Self {
+        Self {
+            memo_data,
+            destination_memo_enabled: false,
+            wrote_destination_memo: false,
+            burn_amount: None,
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
+        }
+    }
+    /// Enable destination memos
+    pub fn enable_destination_memo(&mut self) {
+        self.destination_memo_enabled = true;
+    }
+
+    /// Disable destination memos
+    pub fn disable_destination_memo(&mut self) {
+        self.destination_memo_enabled = false;
+    }
+}
+
+impl MemoBuilder for BurnRedemptionMemoBuilder {
+    /// Set the fee
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
+        Ok(())
+    }
+
+    /// Build a memo for the burn output.
+    fn make_memo_for_output(
+        &mut self,
+        amount: Amount,
+        recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if *recipient != burn_address() {
+            return Err(NewMemoError::InvalidRecipient);
+        }
+        if self.burn_amount.is_some() {
+            return Err(NewMemoError::MultipleOutputs);
+        }
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::OutputsAfterChange);
+        }
+        self.burn_amount = Some(amount);
+        Ok(BurnRedemptionMemo::new(self.memo_data).into())
+    }
+
+    /// Build a memo for a change output (to ourselves).
+    fn make_memo_for_change_output(
+        &mut self,
+        change_amount: Amount,
+        _change_destination: &ChangeDestination,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if !self.destination_memo_enabled {
+            return Ok(UnusedMemo {}.into());
+        }
+        if self.wrote_destination_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        let burn_amount = self.burn_amount.ok_or(NewMemoError::MissingOutput)?;
+        if burn_amount.token_id != self.fee.token_id
+            || burn_amount.token_id != change_amount.token_id
+        {
+            return Err(NewMemoError::MixedTokenIds);
+        }
+
+        let total_outlay = burn_amount
+            .value
+            .checked_add(self.fee.value)
+            .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?;
+        match DestinationMemo::new(
+            ShortAddressHash::from(&burn_address()),
+            total_outlay,
+            self.fee.value,
+        ) {
+            Ok(mut d_memo) => {
+                self.wrote_destination_memo = true;
+                d_memo.set_num_recipients(1);
+                Ok(d_memo.into())
+            }
+            Err(err) => match err {
+                DestinationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
+            },
+        }
+    }
+}

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -9,7 +9,10 @@ use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
+mod burn_redemption_memo_builder;
 mod rth_memo_builder;
+
+pub use burn_redemption_memo_builder::BurnRedemptionMemoBuilder;
 pub use rth_memo_builder::RTHMemoBuilder;
 
 /// The MemoBuilder trait defines the API that the transaction builder uses

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2756,31 +2756,8 @@ pub mod transaction_builder_tests {
         }
 
         // Change in a different token is not allowed.
-        {
-            let mut memo_builder = BurnRedemptionMemoBuilder::new([3u8; 64]);
-            memo_builder.enable_destination_memo();
-
-            let mut transaction_builder = TransactionBuilder::new(
-                block_version,
-                Amount::new(10, Mob::ID),
-                fog_resolver.clone(),
-                memo_builder,
-            )
-            .unwrap();
-
-            let (_burn_tx_out, _confirmation) = transaction_builder
-                .add_output(100, &burn_address(), &mut rng)
-                .unwrap();
-
-            let result = transaction_builder.add_change_output(10, &change_destination, &mut rng);
-
-            assert_matches!(
-                result,
-                Err(TxBuilderError::NewTx(NewTxError::Memo(
-                    NewMemoError::MixedTokenIds
-                )))
-            );
-        }
+        // Note: We cannot test for the mixed tokens because mixed transactions
+        // are not supported at all in the TransactionBuilder API in 1.2 branch.
 
         // Happy flow without change
         {

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -540,7 +540,10 @@ fn create_fog_hint<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
 #[cfg(test)]
 pub mod transaction_builder_tests {
     use super::*;
-    use crate::{EmptyMemoBuilder, MemoType, RTHMemoBuilder, SenderMemoCredential};
+    use crate::{
+        BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoType, RTHMemoBuilder, SenderMemoCredential,
+    };
+    use assert_matches::assert_matches;
     use maplit::btreemap;
     use mc_account_keys::{
         burn_address, burn_address_view_private, AccountKey, ShortAddressHash,
@@ -555,7 +558,7 @@ pub mod transaction_builder_tests {
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
         validation::{validate_signature, validate_tx_out},
-        TokenId,
+        NewTxError, TokenId,
     };
     use rand::{rngs::StdRng, SeedableRng};
     use std::convert::TryFrom;
@@ -2629,6 +2632,325 @@ pub mod transaction_builder_tests {
             assert!(burn_tx_out
                 .view_key_match(sender.view_private_key())
                 .is_err());
+        }
+    }
+
+    #[test]
+    // Transaction builder with Burn Redemption memo builder
+    fn test_transaction_builder_burn_redemption_memos() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let block_version = BlockVersion::MAX;
+        let token_id = TokenId::from(5);
+        let fog_resolver = MockFogResolver::default();
+        let sender = AccountKey::random(&mut rng);
+        let change_destination = ChangeDestination::from(&sender);
+
+        // Adding an output that is not to the burn address is not allowed.
+        {
+            let memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            let recipient = AccountKey::random(&mut rng);
+            let result =
+                transaction_builder.add_output(100, &recipient.default_subaddress(), &mut rng);
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::InvalidRecipient
+                )))
+            );
+        }
+
+        // Adding two burn outputs is not allowed.
+        {
+            let memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.add_output(100, &burn_address(), &mut rng);
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MultipleOutputs
+                )))
+            );
+        }
+
+        // Adding a change output before a burn output is not allowed.
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            let result = transaction_builder.add_change_output(10, &change_destination, &mut rng);
+
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MissingOutput
+                )))
+            );
+        }
+
+        // Setting fee after change output has been written is not allowed.
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([3u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(113, token_id),
+                &AccountKey::random(&mut rng),
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let (_burn_tx_out, _confirmation) = transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            transaction_builder
+                .add_change_output(10, &change_destination, &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.set_fee(1235);
+            assert_matches!(
+                result,
+                Err(TxBuilderError::Memo(NewMemoError::FeeAfterChange))
+            );
+        }
+
+        // Change in a different token is not allowed.
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([3u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, Mob::ID),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            let (_burn_tx_out, _confirmation) = transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.add_change_output(10, &change_destination, &mut rng);
+
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MixedTokenIds
+                )))
+            );
+        }
+
+        // Happy flow without change
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([2u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(113, token_id),
+                &AccountKey::random(&mut rng),
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let (burn_output, _confirmation) = transaction_builder
+                .add_output(110, &burn_address(), &mut rng)
+                .unwrap();
+
+            let tx = transaction_builder.build(&mut rng).expect("build tx");
+
+            assert_eq!(tx.prefix.outputs.len(), 1);
+            assert_eq!(burn_output, tx.prefix.outputs[0]);
+
+            // Test that view key matching works with the burn tx out with burn address view
+            // key
+            let (amount, _) = burn_output
+                .view_key_match(&burn_address_view_private())
+                .unwrap();
+            assert_eq!(amount, Amount::new(110, token_id));
+
+            // Burn output should have a burn redemption memo
+            let ss = get_tx_out_shared_secret(
+                &burn_address_view_private(),
+                &RistrettoPublic::try_from(&burn_output.public_key).unwrap(),
+            );
+            let memo = burn_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::BurnRedemption(memo) => {
+                    assert_eq!(memo.memo_data(), &[2u8; 64],);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+        }
+
+        // Happy flow with change
+        {
+            let mut memo_builder = BurnRedemptionMemoBuilder::new([3u8; 64]);
+            memo_builder.enable_destination_memo();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(113, token_id),
+                &AccountKey::random(&mut rng),
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let (burn_tx_out, _confirmation) = transaction_builder
+                .add_output(100, &burn_address(), &mut rng)
+                .unwrap();
+
+            transaction_builder
+                .add_change_output(100, &change_destination, &mut rng)
+                .unwrap();
+
+            let tx = transaction_builder.build(&mut rng).expect("build tx");
+
+            assert_eq!(tx.prefix.outputs.len(), 2);
+
+            let burn_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == burn_tx_out.public_key)
+                .expect("Didn't find recipient's output");
+            let change_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| {
+                    subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
+                })
+                .expect("Didn't find sender's output");
+
+            // Test that view key matching works with the burn tx out with burn address view
+            // key
+            let (amount, _) = burn_output
+                .view_key_match(&burn_address_view_private())
+                .unwrap();
+            assert_eq!(amount, Amount::new(100, token_id));
+
+            assert!(change_output
+                .view_key_match(&burn_address_view_private())
+                .is_err());
+
+            // Test that view key matching works with the change tx out with sender's view
+            // key
+            let (amount, _) = change_output
+                .view_key_match(sender.view_private_key())
+                .unwrap();
+            assert_eq!(amount, Amount::new(10, token_id));
+
+            assert!(burn_output
+                .view_key_match(sender.view_private_key())
+                .is_err());
+
+            // Burn output should have a burn redemption memo
+            let ss = get_tx_out_shared_secret(
+                &burn_address_view_private(),
+                &RistrettoPublic::try_from(&burn_output.public_key).unwrap(),
+            );
+            let memo = burn_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::BurnRedemption(memo) => {
+                    assert_eq!(memo.memo_data(), &[3u8; 64],);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+
+            // Change output should have a destination memo
+            let ss = get_tx_out_shared_secret(
+                sender.view_private_key(),
+                &RistrettoPublic::try_from(&change_output.public_key).unwrap(),
+            );
+            let memo = change_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Destination(memo) => {
+                    assert_eq!(
+                        memo.get_address_hash(),
+                        &ShortAddressHash::from(&burn_address()),
+                        "lookup based on address hash failed"
+                    );
+                    assert_eq!(memo.get_num_recipients(), 1);
+                    assert_eq!(memo.get_fee(), 3);
+                    assert_eq!(
+                        memo.get_total_outlay(),
+                        103,
+                        "outlay should be amount sent to recipient + fee"
+                    );
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
         }
     }
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -2844,7 +2844,7 @@ pub mod transaction_builder_tests {
                 .unwrap();
 
             transaction_builder
-                .add_change_output(100, &change_destination, &mut rng)
+                .add_change_output(10, &change_destination, &mut rng)
                 .unwrap();
 
             let tx = transaction_builder.build(&mut rng).expect("build tx");

--- a/util/keyfile/src/bin/keygen_main.rs
+++ b/util/keyfile/src/bin/keygen_main.rs
@@ -27,7 +27,7 @@ fn main() {
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap());
     let fog_report_url = config.general.fog_report_url.as_deref();
-    let fog_report_id = config.general.fog_report_id.as_deref();
+    let fog_report_id = config.general.fog_report_id;
     let fog_authority_spki = config
         .general
         .fog_authority_spki
@@ -50,7 +50,7 @@ fn main() {
         &mnemonic,
         0,
         fog_report_url,
-        fog_report_id,
+        &fog_report_id,
         fog_authority_spki,
     )
     .expect("Could not write keyfile");

--- a/util/keyfile/src/bin/sample_keys_main.rs
+++ b/util/keyfile/src/bin/sample_keys_main.rs
@@ -34,17 +34,13 @@ fn main() {
         panic!("Fog report url was passed, so fog is enabled, but no fog authority spki was provided. This is needed for the fog authority signature scheme. Use --fog-authority-root to pass a .pem file or --fog-authority-spki to pass base64 encoded bytes specifying this.")
     }
 
-    if config.general.fog_report_url.is_some() && config.general.fog_report_id.is_none() {
-        panic!("Fog report url was passed, so fog is enabled, but no fog report id was provided. This is needed for the fog authority signature scheme. Use --fog_report_id to pass an id string specifying this.")
-    }
-
     println!("Writing {} keys to {:?}", config.num, path);
 
     mc_util_keyfile::keygen::write_default_keyfiles(
         path,
         config.num,
         config.general.fog_report_url.as_deref(),
-        config.general.fog_report_id.as_deref(),
+        &config.general.fog_report_id,
         spki.as_deref(),
         config.general.seed,
     )

--- a/util/keyfile/src/config.rs
+++ b/util/keyfile/src/config.rs
@@ -14,8 +14,8 @@ pub struct Config {
     pub fog_report_url: Option<String>,
 
     /// Fog Report ID
-    #[clap(long, env = "MC_FOG_REPORT_ID")]
-    pub fog_report_id: Option<String>,
+    #[clap(long, env = "MC_FOG_REPORT_ID", default_value = "")]
+    pub fog_report_id: String,
 
     /// Fog Authority subjectPublicKeyInfo, loaded from a PEM root certificate
     #[clap(long, parse(try_from_str = load_spki_from_pemfile), env = "MC_FOG_AUTHORITY_ROOT")]

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -28,14 +28,14 @@ pub fn write_keyfiles<P: AsRef<Path>>(
     mnemonic: &Mnemonic,
     account_index: u32,
     fog_report_url: Option<&str>,
-    fog_report_id: Option<&str>,
+    fog_report_id: &str,
     fog_authority_spki: Option<&[u8]>,
 ) -> Result<(), Error> {
     let slip10key = mnemonic.clone().derive_slip10_key(account_index);
-    let acct_key = match (fog_report_url, fog_report_id, fog_authority_spki) {
-        (None, None, None) => AccountKey::try_from(slip10key)
+    let acct_key = match (fog_report_url, fog_authority_spki) {
+        (None, None) => AccountKey::try_from(slip10key)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err.to_string()))?,
-        (Some(fog_report_url), Some(fog_report_id), Some(fog_authority_spki)) => {
+        (Some(fog_report_url), Some(fog_authority_spki)) => {
             slip10key.try_into_account_key(fog_report_url, fog_report_id, fog_authority_spki)?
         }
         _ => return Err(Error::MissingFogDetails),
@@ -69,7 +69,7 @@ pub fn write_default_keyfiles<P: AsRef<Path>>(
     path: P,
     num_accounts: usize,
     fog_report_url: Option<&str>,
-    fog_report_id: Option<&str>,
+    fog_report_id: &str,
     fog_authority_spki: Option<&[u8]>,
     seed: [u8; 32],
 ) -> Result<(), Error> {
@@ -220,8 +220,8 @@ mod test {
             &dir1,
             10,
             Some(fqdn),
-            Some(fog_report_id),
-            Some(&fog_authority_spki),
+            fog_report_id,
+            Some(fog_authority_spki),
             DEFAULT_SEED,
         )
         .expect("Error writing default keyfiles to dir1");
@@ -229,8 +229,8 @@ mod test {
             &dir2,
             10,
             Some(fqdn),
-            Some(fog_report_id),
-            Some(&fog_authority_spki),
+            fog_report_id,
+            Some(fog_authority_spki),
             DEFAULT_SEED,
         )
         .expect("Error writing default keyfiles to dir2");
@@ -245,9 +245,9 @@ mod test {
         let dir1 = tempfile::tempdir().expect("Could not create temporary dir1");
         let dir2 = tempfile::tempdir().expect("Could not create temporary dir2");
 
-        write_default_keyfiles(&dir1, 10, None, None, None, DEFAULT_SEED)
+        write_default_keyfiles(&dir1, 10, None, "", None, DEFAULT_SEED)
             .expect("Could not write keyfiles to dir1");
-        write_default_keyfiles(&dir2, 10, None, None, None, DEFAULT_SEED)
+        write_default_keyfiles(&dir2, 10, None, "", None, DEFAULT_SEED)
             .expect("Could not write keyfiles to dir2");
 
         assert_default_pubfiles_eq(&dir1, &dir2);
@@ -270,7 +270,7 @@ mod test {
 
         let dir1 = tempfile::tempdir().expect("Could not create temporary dir1");
 
-        write_default_keyfiles(&dir1, 10, None, None, None, DEFAULT_SEED)
+        write_default_keyfiles(&dir1, 10, None, "", None, DEFAULT_SEED)
             .expect("Could not write example keyfiles");
 
         let mut actual = read_default_keyfiles(&dir1)

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -28,14 +28,14 @@ pub fn write_keyfile<P: AsRef<Path>>(
     mnemonic: &Mnemonic,
     account_index: u32,
     fog_report_url: Option<&str>,
-    fog_report_id: Option<&str>,
+    fog_report_id: &str,
     fog_authority_spki: Option<&[u8]>,
 ) -> Result<(), Error> {
     let json = UncheckedMnemonicAccount {
         mnemonic: Some(mnemonic.clone().into_phrase()),
         account_index: Some(account_index),
         fog_report_url: fog_report_url.map(ToOwned::to_owned),
-        fog_report_id: fog_report_id.map(ToOwned::to_owned),
+        fog_report_id: Some(fog_report_id.to_owned()),
         fog_authority_spki: fog_authority_spki.map(ToOwned::to_owned),
     };
     Ok(serde_json::to_writer(File::create(path)?, &json)?)
@@ -141,7 +141,7 @@ mod testing {
         let dir = tempfile::tempdir().expect("Could not create temp dir");
         let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
         let path = dir.path().join("no_fog");
-        write_keyfile(&path, &mnemonic, 0, None, None, None).expect("Could not write keyfile");
+        write_keyfile(&path, &mnemonic, 0, None, "", None).expect("Could not write keyfile");
         let expected = AccountKey::from(mnemonic.derive_slip10_key(0));
         let actual = read_keyfile(&path).expect("Could not read keyfile");
         assert_eq!(expected, actual);
@@ -170,7 +170,7 @@ mod testing {
             &mnemonic,
             0,
             Some(fog_report_url),
-            Some(fog_report_id),
+            fog_report_id,
             Some(fog_authority_spki),
         )
         .expect("Could not write keyfile");


### PR DESCRIPTION
This PR cherry-picks a series of PRs in master branch which landed after Mixed transactions, to the candidate 1.2 branch.

It is staged after the PR that moves pieces of Mixed transactions to candidate 1.2 branch.

The PRs that are picked are:

a26b06fea71f783fbb0399b0cca6026d2453b258 "[Initial take on implementing Burn Redemption Memo](https://github.com/mobilecoinfoundation/mobilecoin/commit/a26b06fea71f783fbb0399b0cca6026d2453b258)" (eran)
e4038aabce65e3752780e6dc3fe9a0b487d03bd1"[Update Change Subaddress Index (](https://github.com/mobilecoinfoundation/mobilecoin/commit/e4038aabce65e3752780e6dc3fe9a0b487d03bd1)[#1880](https://github.com/mobilecoinfoundation/mobilecoin/pull/1880)[)](https://github.com/mobilecoinfoundation/mobilecoin/commit/e4038aabce65e3752780e6dc3fe9a0b487d03bd1)" (bernie)
d991eee7b2c4da9fec06f7f13e6189651c0ffe49 "[API for generating burn txs in mobilecoind (](https://github.com/mobilecoinfoundation/mobilecoin/commit/d991eee7b2c4da9fec06f7f13e6189651c0ffe49)[#1872](https://github.com/mobilecoinfoundation/mobilecoin/pull/1872)[)](https://github.com/mobilecoinfoundation/mobilecoin/commit/d991eee7b2c4da9fec06f7f13e6189651c0ffe49)" (eran)
83dcf525e8f4333d84439fd4ce8b48dec308692a "[fix typo (](https://github.com/mobilecoinfoundation/mobilecoin/commit/83dcf525e8f4333d84439fd4ce8b48dec308692a)[#1883](https://github.com/mobilecoinfoundation/mobilecoin/pull/1883)[)](https://github.com/mobilecoinfoundation/mobilecoin/commit/83dcf525e8f4333d84439fd4ce8b48dec308692a)" (eran)
3fac7a8861aa9e1d8058ddf73860dea1c6db35e0 "Fix/slip10errors" #1893 (william)

If this passes tests and CD then I propose that we merge both PRs and then rename `candidate-1.2` to `release-1.2` or something like this.