### PR TITLE
Switch to using our fork of opentelemetry.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6009,8 +6009,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+source = "git+https://github.com/mobilecoinofficial/opentelemetry-rust.git?rev=1817229c56340bbb4a6dca63c8dfb5154606e5bf#1817229c56340bbb4a6dca63c8dfb5154606e5bf"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -6028,8 +6027,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-http"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
+source = "git+https://github.com/mobilecoinofficial/opentelemetry-rust.git?rev=1817229c56340bbb4a6dca63c8dfb5154606e5bf#1817229c56340bbb4a6dca63c8dfb5154606e5bf"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -6040,8 +6038,7 @@ dependencies = [
 [[package]]
 name = "opentelemetry-jaeger"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
+source = "git+https://github.com/mobilecoinofficial/opentelemetry-rust.git?rev=1817229c56340bbb4a6dca63c8dfb5154606e5bf#1817229c56340bbb4a6dca63c8dfb5154606e5bf"
 dependencies = [
  "async-trait",
  "http 0.2.1",
@@ -6057,17 +6054,16 @@ dependencies = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
+source = "git+https://github.com/mobilecoinofficial/opentelemetry-rust.git?rev=1817229c56340bbb4a6dca63c8dfb5154606e5bf#1817229c56340bbb4a6dca63c8dfb5154606e5bf"
 dependencies = [
  "opentelemetry",
 ]
 
 [[package]]
 name = "ordered-float"
-version = "1.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
 dependencies = [
  "num-traits",
 ]
@@ -7893,9 +7889,8 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
+version = "0.17.0"
+source = "git+https://github.com/mobilecoinofficial/thrift.git?rev=9caf65384c5ec50b4988e2fb07b984f275785123#9caf65384c5ec50b4988e2fb07b984f275785123"
 dependencies = [
  "byteorder",
  "integer-encoding",

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -14,5 +14,7 @@ path = "src/lib.rs"
 cfg-if = "1.0"
 displaydoc = "0.2"
 hostname = "0.3.1"
-opentelemetry = "0.17"
-opentelemetry-jaeger = { version = "0.16", features = ["collector_client", "isahc"], optional = true }
+
+# requires a fork due to a dependency upgrade on the `thrift` crate that has not yet been released
+opentelemetry = { git = "https://github.com/mobilecoinofficial/opentelemetry-rust.git", rev = "1817229c56340bbb4a6dca63c8dfb5154606e5bf" }
+opentelemetry-jaeger = { git = "https://github.com/mobilecoinofficial/opentelemetry-rust.git", rev = "1817229c56340bbb4a6dca63c8dfb5154606e5bf", features = ["collector_client", "isahc"], optional = true }


### PR DESCRIPTION
This was needed since we had to upgrade opentelemetry-jaeger's
dependency on thrift, which in turn depended on a broken verison of
ordered-float.

The changes to opentelemetry-jaeger and thrift can be viewed here:
https://github.com/mobilecoinofficial/opentelemetry-rust/commit/1817229c56340bbb4a6dca63c8dfb5154606e5bf
https://github.com/mobilecoinofficial/thrift/commit/9caf65384c5ec50b4988e2fb07b984f275785123