### PR TITLE
Small adjustment to mobilecoind-json test script that makes it compatible with other test scripts

### DIFF
--- a/mobilecoind-json/tests/integration_test.py
+++ b/mobilecoind-json/tests/integration_test.py
@@ -44,7 +44,7 @@ class MobilecoindJsonClient:
             raise Exception(f"Invalid response: {response}")
         return int(response["balance"])
 
-    def create_monitor(self, account_key, first_subaddress_index=0, num_subaddresses=10):
+    def create_monitor(self, account_key, first_subaddress_index=0, num_subaddresses=1):
         return self.request(f"monitors", {
             "account_key": account_key,
             "first_subaddress": first_subaddress_index,


### PR DESCRIPTION
There's no need for 10 subaddresses in this test, and, more importantly this  makes the test compatible with the drain_accounts.py script which also uses 1 subaddress.

This is needed for running this script as part of the Jenkins CD process.