### PR TITLE
Add cargo-sort to the pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -85,9 +85,7 @@ fi
 
 printf "${PREFIX} Checking for rustfmt ... "
 cargo fmt --version
-if [ $? == 0 ]; then
-	printf "${SUCCESS}\n"
-else
+if [ $? != 0 ]; then
 	printf "${FAILURE}\n"
 	popd >/dev/null 2>&1
 	exit 1

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -100,7 +100,6 @@ else
 	FAILED=1
 fi
 
-
 CARGOFMT="cargo fmt -- --unstable-features --skip-children"
 
 # Just check that running rustfmt doesn't do anything to the file. I do this instead of

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -70,7 +70,7 @@ fi
 
 printf "${PREFIX} Checking for cargo-sort... "
 
-cargo sort --version
+cargo sort --version 2>/dev/null
 if [ $? != 0 ]; then
 	printf "${WARNING}: cargo-sort not found, installing... "
 	cargo install cargo-sort >/dev/null
@@ -84,7 +84,7 @@ if [ $? != 0 ]; then
 fi
 
 printf "${PREFIX} Checking for rustfmt ... "
-cargo fmt --version
+cargo fmt --version 2>/dev/null
 if [ $? != 0 ]; then
 	printf "${FAILURE}\n"
 	popd >/dev/null 2>&1

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -81,7 +81,7 @@ else
 fi
 
 printf "${PREFIX} Checking that Cargo.toml dependencies are sorted..."
-cargo sort --workspace --grouped --check
+cargo sort --workspace --grouped --check >/dev/null
 if [ $? == 0 ]; then
 	printf "${SUCCESS}\n"
 else

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -68,26 +68,19 @@ else
 	printf "${SUCCESS}\n"
 fi
 
-printf "${PREFIX} Checking that cargo-sort is installed..."
+printf "${PREFIX} Checking for cargo-sort... "
 
 cargo sort --version
-if [ $? == 0 ]; then
-	printf "${SUCCESS}\n"
-else
-	printf "${WARNING}, Installing cargo-sort before continuing."
-	cargo install cargo-sort
-	popd >/dev/null 2>&1
-	exit 1
-fi
-
-printf "${PREFIX} Checking that Cargo.toml dependencies are sorted..."
-cargo sort --workspace --grouped --check >/dev/null
-if [ $? == 0 ]; then
-	printf "${SUCCESS}\n"
-else
-	printf "${FAILURE}\n"
-	popd >/dev/null 2>&1
-	exit 1
+if [ $? != 0 ]; then
+	printf "${WARNING}: cargo-sort not found, installing... "
+	cargo install cargo-sort >/dev/null
+	if [ $? == 0 ]; then
+		printf "${SUCCESS}\n"
+	else
+		printf "${FAILURE}\n"
+		popd >/dev/null 2>&1
+		exit 1
+	fi
 fi
 
 printf "${PREFIX} Checking for rustfmt ... "
@@ -99,6 +92,16 @@ else
 	popd >/dev/null 2>&1
 	exit 1
 fi
+
+printf "${PREFIX} Checking that Cargo.toml dependencies are sorted... "
+cargo sort --workspace --grouped --check >/dev/null
+if [ $? == 0 ]; then
+	printf "${SUCCESS}\n"
+else
+	printf "${FAILURE}\n"
+	FAILED=1
+fi
+
 
 CARGOFMT="cargo fmt -- --unstable-features --skip-children"
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -68,6 +68,28 @@ else
 	printf "${SUCCESS}\n"
 fi
 
+printf "${PREFIX} Checking that cargo-sort is installed..."
+
+cargo sort --version
+if [ $? == 0 ]; then
+	printf "${SUCCESS}\n"
+else
+	printf "${WARNING}, Installing cargo-sort before continuing."
+	cargo install cargo-sort
+	popd >/dev/null 2>&1
+	exit 1
+fi
+
+printf "${PREFIX} Checking that Cargo.toml dependencies are sorted..."
+cargo sort --workspace --grouped --check
+if [ $? == 0 ]; then
+	printf "${SUCCESS}\n"
+else
+	printf "${FAILURE}\n"
+	popd >/dev/null 2>&1
+	exit 1
+fi
+
 printf "${PREFIX} Checking for rustfmt ... "
 cargo fmt --version
 if [ $? == 0 ]; then


### PR DESCRIPTION
### Motivation

Our current CI uses cargo-sort to ensure our Cargo.toml dependencies are sorted. This adds a check for this to the pre-commit githook.

### In this PR
- Update precommit hook to install/use cargo sort.
- Redirect sort output to dev null.
- Do version checks first, then do tests, pipe some junk to /dev/null.
- Don't print "OK" for rustfmt check, version is sufficient.

