### PR TITLE
GH-CLI Friendly PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,9 @@
-Soundtrack of this PR: [link to song that really fits the mood of this PR]()
-
 ### Motivation
 
 < The motivation for the changes in this PR. "Currently we...", "This is needed because..." >
-
-### In this PR
-* < Additions, removals, fixes, features >
-
-< Ticket status, e.g. "fixes #issue number" >
 
 ### Future Work
 * < Out of scope non-goals for this PR >
 * < These should be links to tickets. If the tickets do not exist, make them. >
 
+[Soundtrack of this PR]()

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,13 @@
+<!-- List changes here -->
+
 ### Motivation
 
-< The motivation for the changes in this PR. "Currently we...", "This is needed because..." >
+<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
 
 ### Future Work
-* < Out of scope non-goals for this PR >
-* < These should be links to tickets. If the tickets do not exist, make them. >
+<!--
+* Out of scope non-goals for this PR >
+* These should be links to tickets. If the tickets do not exist, make them.
+-->
 
 [Soundtrack of this PR]()

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ### Future Work
 <!--
-* Out of scope non-goals for this PR >
+* Out of scope non-goals for this PR
 * These should be links to tickets. If the tickets do not exist, make them.
 -->
 


### PR DESCRIPTION
- Remove the "In this PR section", Soundtrack to end
- Comment out the prompts

### Motivation

Right now, the GH CLI will prepend any commits on your branch to the start of an existing PR template. This is slightly irritating because "In this PR" is the *second* section in our template. This PR attempts to make the template easier to use from within the GH CLI by making the existing "fill stuff in here" prompts comments, and removing the "In this PR" section entirely (so the first thing in the PR is that list.)

