### PR TITLE
Gift Code Memos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,6 +5207,7 @@ dependencies = [
  "hmac 0.12.1",
  "maplit",
  "mc-account-keys",
+ "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-fog-report-validation",
  "mc-fog-report-validation-test-utils",

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -108,6 +108,18 @@ impl MemoHandler {
                     Err(MemoHandlerError::FailedSubaddressValidation)
                 }
             }
+            MemoType::GiftCodeCancellation(_) => {
+                // TODO: Add Gift Code Memo Validation
+                Ok(Some(memo_type))
+            }
+            MemoType::GiftCodeFunding(_) => {
+                // TODO: Add Gift Code Memo Validation
+                Ok(Some(memo_type))
+            }
+            MemoType::GiftCodeSender(_) => {
+                // TODO: Add Gift Code Validation
+                Ok(Some(memo_type))
+            }
         }
     }
 }

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -34,7 +34,10 @@ use aes::{
     cipher::{FromBlockCipher, StreamCipher},
     Aes256, Aes256Ctr, NewBlockCipher,
 };
-use core::convert::{TryFrom, TryInto};
+use core::{
+    convert::{TryFrom, TryInto},
+    str::Utf8Error,
+};
 use displaydoc::Display;
 use generic_array::{
     sequence::Split,
@@ -221,6 +224,15 @@ derive_prost_message_from_repr_bytes!(MemoPayload);
 pub enum MemoError {
     /// Wrong length for memo payload: {0}
     BadLength(usize),
+
+    /// Utf-8 did note properly decode
+    Utf8Decoding,
+}
+
+impl From<Utf8Error> for MemoError {
+    fn from(_: Utf8Error) -> Self {
+        Self::Utf8Decoding
+    }
 }
 
 #[cfg(test)]

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -225,7 +225,7 @@ pub enum MemoError {
     /// Wrong length for memo payload: {0}
     BadLength(usize),
 
-    /// Utf-8 did note properly decode
+    /// Utf-8 did not properly decode
     Utf8Decoding,
 }
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -21,6 +21,7 @@ zeroize = "1"
 
 # MobileCoin dependencies
 mc-account-keys = { path = "../../account-keys" }
+mc-crypto-hashes = { path = "../../crypto/hashes" }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
 mc-fog-report-validation = { path = "../../fog/report/validation" }
 mc-transaction-core = { path = "../../transaction/core" }

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -52,7 +52,7 @@ impl From<&[u8; Self::MEMO_DATA_LEN]> for GiftCodeCancellationMemo {
 
 impl From<GiftCodeCancellationMemo> for [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
     fn from(src: GiftCodeCancellationMemo) -> [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
-        src.memo_data.clone()
+        src.memo_data
     }
 }
 
@@ -75,6 +75,43 @@ mod tests {
     fn test_gift_code_cancellation_memo_to_and_from_u64() {
         let index: u64 = 666;
         let memo = GiftCodeCancellationMemo::from(index);
+
+        // Check recovered index is correct
+        assert_eq!(memo.cancelled_gift_code_index(), index);
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_at_min_max_bounds_succeed() {
+        let index_min: u64 = 0;
+        let index_max = u64::MAX;
+        let memo_min = GiftCodeCancellationMemo::new(index_min);
+        let memo_max = GiftCodeCancellationMemo::new(index_max);
+
+        // Check recovered indices are correct
+        assert_eq!(memo_min.cancelled_gift_code_index(), index_min);
+        assert_eq!(memo_max.cancelled_gift_code_index(), index_max);
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_from_corrupted_bytes_fails() {
+        let index: u64 = 666;
+        let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
+        memo_bytes[0..8].copy_from_slice(&index.to_le_bytes());
+        memo_bytes[5] = 124;
+        let memo = GiftCodeCancellationMemo::from(&memo_bytes);
+
+        // Check recovered index is erroneous
+        assert_ne!(memo.cancelled_gift_code_index(), index);
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_from_valid_bytes_is_ok() {
+        let index: u64 = 666;
+        let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
+        memo_bytes[0..8].copy_from_slice(&index.to_le_bytes());
+        let memo = GiftCodeCancellationMemo::from(&memo_bytes);
+
+        // Check recovered index is okay
         assert_eq!(memo.cancelled_gift_code_index(), index);
     }
 }

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Object for 0x0202 Gift Code Cancellation memo type
+//!
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/32
+
+use crate::{impl_memo_type_conversions, RegisteredMemoType};
+use std::convert::TryInto;
+
+/// Memo representing the cancellation of a gift code. If a gift code is
+/// never redeemed, the sender may cancel it by sending the TxOut back
+/// to their primary address. This memo will be written to the
+/// reserved change address with 8 bytes reserved for a u64 that
+/// represents the index of the cancelled gift code TxOut
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GiftCodeCancellationMemo {
+    /// The data representing the gift code memo
+    memo_data: [u8; Self::MEMO_DATA_LEN],
+}
+
+impl RegisteredMemoType for GiftCodeCancellationMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x02];
+}
+
+impl GiftCodeCancellationMemo {
+    /// The length of the custom memo data
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// Create a new gift code memo
+    pub fn new(memo_data: [u8; Self::MEMO_DATA_LEN]) -> Self {
+        GiftCodeCancellationMemo { memo_data }
+    }
+
+    /// Get the memo data
+    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
+        &self.memo_data
+    }
+
+    /// Get global TxOut index of the cancelled gift code
+    pub fn cancelled_gift_code_index(&self) -> u64 {
+        u64::from_le_bytes(self.memo_data[0..8].try_into().unwrap())
+    }
+}
+
+impl From<&[u8; 64]> for GiftCodeCancellationMemo {
+    fn from(src: &[u8; Self::MEMO_DATA_LEN]) -> Self {
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<GiftCodeCancellationMemo> for [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
+    fn from(src: GiftCodeCancellationMemo) -> [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
+        src.memo_data
+    }
+}
+
+impl From<u64> for GiftCodeCancellationMemo {
+    fn from(src: u64) -> Self {
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data[0..8].copy_from_slice(&src.to_le_bytes());
+        Self { memo_data }
+    }
+}
+
+impl_memo_type_conversions! { GiftCodeCancellationMemo }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_gift_code_cancellation_memo_to_and_from_u64() {
+        let index: u64 = 666;
+        let memo = GiftCodeCancellationMemo::from(index);
+        assert_eq!(memo.cancelled_gift_code_index(), index);
+    }
+}

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -27,8 +27,8 @@ impl GiftCodeCancellationMemo {
     pub const MEMO_DATA_LEN: usize = 64;
 
     /// Create a new gift code memo
-    pub fn new(memo_data: [u8; Self::MEMO_DATA_LEN]) -> Self {
-        GiftCodeCancellationMemo { memo_data }
+    pub fn new(global_index: u64) -> Self {
+        GiftCodeCancellationMemo::from(global_index)
     }
 
     /// Get the memo data
@@ -42,7 +42,7 @@ impl GiftCodeCancellationMemo {
     }
 }
 
-impl From<&[u8; 64]> for GiftCodeCancellationMemo {
+impl From<&[u8; Self::MEMO_DATA_LEN]> for GiftCodeCancellationMemo {
     fn from(src: &[u8; Self::MEMO_DATA_LEN]) -> Self {
         let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
         memo_data.copy_from_slice(src);
@@ -52,7 +52,7 @@ impl From<&[u8; 64]> for GiftCodeCancellationMemo {
 
 impl From<GiftCodeCancellationMemo> for [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
     fn from(src: GiftCodeCancellationMemo) -> [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
-        src.memo_data
+        src.memo_data.clone()
     }
 }
 

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -31,11 +31,6 @@ impl GiftCodeCancellationMemo {
         GiftCodeCancellationMemo::from(global_index)
     }
 
-    /// Get the memo data
-    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
-        &self.memo_data
-    }
-
     /// Get global TxOut index of the cancelled gift code
     pub fn cancelled_gift_code_index(&self) -> u64 {
         u64::from_le_bytes(self.memo_data[0..8].try_into().unwrap())

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -248,7 +248,7 @@ mod tests {
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
         memo_bytes
             [(GiftCodeFundingMemo::HASH_DATA_LEN - 1)..(GiftCodeFundingMemo::MEMO_DATA_LEN - 2)]
-            .copy_from_slice(&note.as_bytes());
+            .copy_from_slice(note.as_bytes());
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash isn't correctly verified
@@ -270,7 +270,7 @@ mod tests {
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
         memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..(GiftCodeFundingMemo::MEMO_DATA_LEN - 1)]
-            .copy_from_slice(&note.as_bytes());
+            .copy_from_slice(note.as_bytes());
 
         // Corrupt bytes
         memo_bytes[2] = 42;
@@ -296,7 +296,7 @@ mod tests {
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
         memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..(GiftCodeFundingMemo::MEMO_DATA_LEN - 1)]
-            .copy_from_slice(&note.as_bytes());
+            .copy_from_slice(note.as_bytes());
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash is correctly verified

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -206,11 +206,12 @@ mod tests {
     #[test]
     fn test_gift_code_funding_memo_created_with_notes_near_max_byte_lengths() {
         // Create notes near max length
-        let note_len_minus_one =
-            str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
-        let note_len_exact = str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN]).unwrap();
-        let note_len_plus_one =
-            str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1]).unwrap();
+        const LEN_EXACT: usize = GiftCodeFundingMemo::NOTE_DATA_LEN;
+        const LEN_MINUS_ONE: usize = GiftCodeFundingMemo::NOTE_DATA_LEN - 1;
+        const LEN_PLUS_ONE: usize = GiftCodeFundingMemo::NOTE_DATA_LEN + 1;
+        let note_len_minus_one = str::from_utf8(&[b'6'; LEN_MINUS_ONE]).unwrap();
+        let note_len_exact = str::from_utf8(&[b'6'; LEN_EXACT]).unwrap();
+        let note_len_plus_one = str::from_utf8(&[b'6'; LEN_PLUS_ONE]).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
 
@@ -220,14 +221,15 @@ mod tests {
         let memo_len_plus_one = GiftCodeFundingMemo::new(&key, note_len_plus_one);
 
         // Check note lengths match or error on creation if note is too large
-        let _memo_err: Result<GiftCodeFundingMemo, MemoError> =
-            Err(MemoError::BadLength(GiftCodeFundingMemo::NOTE_DATA_LEN + 1));
         assert_eq!(
             memo_len_minus_one.funding_note().unwrap(),
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.funding_note().unwrap(), note_len_exact);
-        assert!(matches!(memo_len_plus_one, _memo_err));
+        assert!(matches!(
+            memo_len_plus_one,
+            Err(MemoError::BadLength(LEN_PLUS_ONE))
+        ));
 
         // Check public keys match for successful memo lengths for memos that didn't
         // error

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Object for 0x0201 Gift Code Funding memo type
+//!
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/32
+
+use crate::{impl_memo_type_conversions, RegisteredMemoType};
+use mc_crypto_hashes::{Blake2b512, Digest};
+use mc_crypto_keys::RistrettoPublic;
+use mc_transaction_core::MemoError;
+use std::{convert::TryInto, str};
+
+/// Mobilecoin account owners can create a special TxOut called a "gift code".
+/// This TxOut is sent to a special subaddress at index u64::MAX - 2 and the
+/// TxOut private key is sent to the intended recipient. This allows people who
+/// don't yet have a Mobilecoin account to receive Mobilecoin. When the sender
+/// makes the initial TxOut to the gift code subaddress, this memo will be
+/// written to the subaddress reserved for change TxOuts indicating that a gift
+/// code was funded. It includes the first 4 bytes of the hash of the TxOut to
+/// indicate which TxOut the gift code is at and 60 bytes representing a null
+/// terminated utf-8 string
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GiftCodeFundingMemo {
+    /// The data representing the gift code memo
+    memo_data: [u8; Self::MEMO_DATA_LEN],
+}
+
+impl RegisteredMemoType for GiftCodeFundingMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x01];
+}
+
+impl GiftCodeFundingMemo {
+    /// Create a new gift funding code memo
+    pub fn new(tx_out_public_key: RistrettoPublic, note: &str) -> Result<Self, MemoError> {
+        // Check if note is of valid length and initialize memo data
+        if note.len() > Self::NOTE_DATA_LEN {
+            return Err(MemoError::BadLength(note.len()));
+        }
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+
+        // Compute TxOut hash and store it into the memo data
+        memo_data[0..Self::HASH_DATA_LEN]
+            .copy_from_slice(&tx_out_public_key_short_hash(tx_out_public_key));
+
+        // Put note into memo
+        let offset = Self::HASH_DATA_LEN;
+        memo_data[offset..(offset + note.len())].copy_from_slice(note.as_bytes());
+
+        Ok(Self { memo_data })
+    }
+
+    /// The Length of the TxOut hash
+    pub const HASH_DATA_LEN: usize = 4;
+
+    /// The length of the custom memo data
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// Length of the utf-8 note
+    pub const NOTE_DATA_LEN: usize = 60;
+
+    /// Get the memo data
+    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
+        &self.memo_data
+    }
+
+    /// Check if a given public key matches
+    /// TODO: Should this be constant time?
+    pub fn public_key_matches(&self, tx_out_public_key: RistrettoPublic) -> bool {
+        tx_out_public_key_short_hash(tx_out_public_key) == self.memo_data[0..4]
+    }
+
+    /// Get funding note from memo
+    pub fn funding_note(&self) -> &str {
+        let note_data = &self.memo_data[Self::HASH_DATA_LEN..];
+        str::from_utf8(note_data)
+            .unwrap()
+            .trim_matches(char::from(0))
+    }
+}
+
+// Compute first four bytes of TxOut hash
+fn tx_out_public_key_short_hash(
+    tx_out_public_key: RistrettoPublic,
+) -> [u8; GiftCodeFundingMemo::HASH_DATA_LEN] {
+    let mut hasher = Blake2b512::new();
+    hasher.update("mc-memo-mac");
+    hasher.update(tx_out_public_key.as_ref().compress().as_bytes());
+    hasher.finalize().as_slice()[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        .try_into()
+        .unwrap()
+}
+
+impl From<&[u8; 64]> for GiftCodeFundingMemo {
+    fn from(src: &[u8; Self::MEMO_DATA_LEN]) -> Self {
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<GiftCodeFundingMemo> for [u8; GiftCodeFundingMemo::MEMO_DATA_LEN] {
+    fn from(src: GiftCodeFundingMemo) -> [u8; GiftCodeFundingMemo::MEMO_DATA_LEN] {
+        src.memo_data
+    }
+}
+
+impl_memo_type_conversions! { GiftCodeFundingMemo }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    fn test_gift_code_funding_memo_data_outputs_match() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let note = "Cash money MeowbleCoin for Kitty";
+        let txout_public_key = RistrettoPublic::from_random(&mut rng);
+        let memo = GiftCodeFundingMemo::new(txout_public_key, note).unwrap();
+
+        // Check that the note is extracted properly
+        assert_eq!(memo.funding_note(), note);
+
+        // Check that the public key can be verified
+        assert!(memo.public_key_matches(txout_public_key));
+    }
+}

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -135,11 +135,12 @@ mod tests {
     #[test]
     fn test_gift_code_sender_memo_created_with_notes_near_max_byte_lengths() {
         // Create notes near max length
-        let note_len_minus_one =
-            str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
-        let note_len_exact = str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN]).unwrap();
-        let note_len_plus_one =
-            str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1]).unwrap();
+        const LEN_EXACT: usize = GiftCodeSenderMemo::MEMO_DATA_LEN;
+        const LEN_MINUS_ONE: usize = GiftCodeSenderMemo::MEMO_DATA_LEN - 1;
+        const LEN_PLUS_ONE: usize = GiftCodeSenderMemo::MEMO_DATA_LEN + 1;
+        let note_len_minus_one = str::from_utf8(&[b'6'; LEN_MINUS_ONE]).unwrap();
+        let note_len_exact = str::from_utf8(&[b'6'; LEN_EXACT]).unwrap();
+        let note_len_plus_one = str::from_utf8(&[b'6'; LEN_PLUS_ONE]).unwrap();
 
         // Create memos from notes
         let memo_len_minus_one = GiftCodeSenderMemo::new(note_len_minus_one).unwrap();
@@ -147,14 +148,15 @@ mod tests {
         let memo_len_plus_one = GiftCodeSenderMemo::new(note_len_plus_one);
 
         // Check note lengths match or error on creation if too large
-        let _memo_err: Result<GiftCodeSenderMemo, MemoError> =
-            Err(MemoError::BadLength(GiftCodeSenderMemo::MEMO_DATA_LEN + 1));
         assert_eq!(
             memo_len_minus_one.sender_note().unwrap(),
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.sender_note().unwrap(), note_len_exact);
-        assert!(matches!(memo_len_plus_one, _memo_err));
+        assert!(matches!(
+            memo_len_plus_one,
+            Err(MemoError::BadLength(LEN_PLUS_ONE))
+        ));
     }
 
     #[test]

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -42,7 +42,11 @@ impl GiftCodeSenderMemo {
 
     /// Get the sender note
     pub fn sender_note(&self) -> Result<&str, MemoError> {
-        Ok(str::from_utf8(&self.memo_data)?.trim_matches(char::from(0)))
+        let note = str::from_utf8(&self.memo_data)?;
+        if let Some(note) = note.split_once(char::from(0)) {
+            return Ok(note.0);
+        }
+        Ok(note)
     }
 }
 
@@ -78,13 +82,109 @@ impl_memo_type_conversions! { GiftCodeSenderMemo }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]
     fn test_gift_code_sender_memo_to_and_from_str() {
+        // Create memo with note
         let note = "Dear Kitty, you received cash money MeowbleCoin UwU";
-        let memo = GiftCodeSenderMemo::try_from(note).unwrap();
+        let memo = GiftCodeSenderMemo::new(note).unwrap();
+
+        // Check that the note is extracted properly
+        assert_eq!(memo.sender_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_with_blank_note_is_ok() {
+        // Create memo with blank note
+        let note = "";
+        let memo = GiftCodeSenderMemo::new(note).unwrap();
+
+        // Check that the note is extracted properly
+        assert_eq!(memo.sender_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_with_only_null_bytes_is_okay() {
+        // Create memo from null bytes
+        let memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
+        let memo = GiftCodeSenderMemo::from(&memo_bytes);
+        let note = "";
+
+        // Check that the note is extracted properly to a blank note
+        assert_eq!(memo.sender_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_note_terminates_at_first_null() {
+        // Create note from bytes with two null bytes
+        let mut note_bytes = [b'6'; 8];
+        note_bytes[3] = 0;
+        note_bytes[6] = 0;
+        let note = "666";
+
+        // Create memo from note bytes
+        let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
+        memo_bytes[0..8].copy_from_slice(&note_bytes);
+        let memo = GiftCodeSenderMemo::from(&memo_bytes);
+
+        // Check that the note is extracted properly and terminated at first null
+        assert_eq!(memo.sender_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_created_with_notes_near_max_byte_lengths() {
+        // Create notes near max length
+        let note_len_minus_one =
+            str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
+        let note_len_exact = str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN]).unwrap();
+        let note_len_plus_one =
+            str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1]).unwrap();
+
+        // Create memos from notes
+        let memo_len_minus_one = GiftCodeSenderMemo::new(note_len_minus_one).unwrap();
+        let memo_len_exact = GiftCodeSenderMemo::new(note_len_exact).unwrap();
+        let memo_len_plus_one = GiftCodeSenderMemo::new(note_len_plus_one);
+
+        // Check note lengths match or error on creation if too large
+        let _memo_err: Result<GiftCodeSenderMemo, MemoError> =
+            Err(MemoError::BadLength(GiftCodeSenderMemo::MEMO_DATA_LEN + 1));
+        assert_eq!(
+            memo_len_minus_one.sender_note().unwrap(),
+            note_len_minus_one
+        );
+        assert_eq!(memo_len_exact.sender_note().unwrap(), note_len_exact);
+        assert!(matches!(memo_len_plus_one, _memo_err));
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_with_corrupted_bytes_fails() {
+        // Create note bytes and corrupt them
+        let mut note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1];
+        let note = str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
+        note_bytes[42] = 42;
+
+        // Create memo from corrupted bytes
+        let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
+        memo_bytes[0..(GiftCodeSenderMemo::MEMO_DATA_LEN - 1)].copy_from_slice(&note_bytes);
+        let memo = GiftCodeSenderMemo::from(&memo_bytes);
+
+        // Check that the note is erroneous
+        assert_ne!(memo.sender_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_from_valid_bytes_is_okay() {
+        // Create note from bytes
+        let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1];
+        let note = str::from_utf8(&note_bytes).unwrap();
+
+        // Create memo from note bytes
+        let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
+        memo_bytes[0..(GiftCodeSenderMemo::MEMO_DATA_LEN - 1)].copy_from_slice(&note_bytes);
+        let memo = GiftCodeSenderMemo::from(&memo_bytes);
+
+        // Check that the note is extracted properly
         assert_eq!(memo.sender_note().unwrap(), note);
     }
 }

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -31,7 +31,7 @@ impl GiftCodeSenderMemo {
     pub const MEMO_DATA_LEN: usize = 64;
 
     /// Create a new gift code memo
-    pub fn new(note_data: &'static str) -> Result<Self, MemoError> {
+    pub fn new(note_data: &str) -> Result<Self, MemoError> {
         GiftCodeSenderMemo::try_from(note_data)
     }
 

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Object for 0x0002 Gift Code Sender memo type
+//!
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/32
+
+use crate::{impl_memo_type_conversions, RegisteredMemoType};
+use mc_transaction_core::MemoError;
+use std::{convert::TryFrom, str};
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct GiftCodeSenderMemo {
+    /// The data representing the gift code memo
+    memo_data: [u8; Self::MEMO_DATA_LEN],
+}
+
+impl RegisteredMemoType for GiftCodeSenderMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x00, 0x02];
+}
+
+impl GiftCodeSenderMemo {
+    /// The length of the custom memo data.
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// Create a new gift code memo
+    pub fn new(memo_data: [u8; Self::MEMO_DATA_LEN]) -> Self {
+        GiftCodeSenderMemo { memo_data }
+    }
+
+    /// Get the memo data
+    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
+        &self.memo_data
+    }
+
+    /// Get the sender note
+    pub fn sender_note(&self) -> &str {
+        str::from_utf8(&self.memo_data)
+            .unwrap()
+            .trim_matches(char::from(0))
+    }
+}
+
+impl From<&[u8; 64]> for GiftCodeSenderMemo {
+    fn from(src: &[u8; Self::MEMO_DATA_LEN]) -> Self {
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<GiftCodeSenderMemo> for [u8; GiftCodeSenderMemo::MEMO_DATA_LEN] {
+    fn from(src: GiftCodeSenderMemo) -> [u8; GiftCodeSenderMemo::MEMO_DATA_LEN] {
+        src.memo_data
+    }
+}
+
+impl TryFrom<&str> for GiftCodeSenderMemo {
+    type Error = MemoError;
+
+    fn try_from(src: &str) -> Result<Self, MemoError> {
+        if src.len() > Self::MEMO_DATA_LEN {
+            return Err(MemoError::BadLength(src.len()));
+        }
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+        memo_data[0..src.len()].copy_from_slice(src.as_bytes());
+        Ok(Self { memo_data })
+    }
+}
+
+impl_memo_type_conversions! { GiftCodeSenderMemo }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_gift_code_sender_memo_to_and_from_str() {
+        let note = "Dear Kitty, you received cash money MeowbleCoin UwU";
+        let memo = GiftCodeSenderMemo::try_from(note).unwrap();
+        assert_eq!(memo.sender_note(), note);
+    }
+}

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -35,18 +35,15 @@ impl GiftCodeSenderMemo {
         GiftCodeSenderMemo::try_from(note_data)
     }
 
-    /// Get the memo data
-    pub fn memo_data(&self) -> &[u8; Self::MEMO_DATA_LEN] {
-        &self.memo_data
-    }
-
     /// Get the sender note
     pub fn sender_note(&self) -> Result<&str, MemoError> {
-        let note = str::from_utf8(&self.memo_data)?;
-        if let Some(note) = note.split_once(char::from(0)) {
-            return Ok(note.0);
-        }
-        Ok(note)
+        let index = if let Some(terminator) = &self.memo_data.iter().position(|b| b == &0u8) {
+            *terminator
+        } else {
+            Self::MEMO_DATA_LEN
+        };
+
+        str::from_utf8(&self.memo_data[0..index]).map_err(Into::into)
     }
 }
 

--- a/transaction/std/src/memo/mod.rs
+++ b/transaction/std/src/memo/mod.rs
@@ -36,9 +36,12 @@
 //! | -----------     | -----------                                       |
 //! | 0x0000          | Unused                                            |
 //! | 0x0001          | Burn Redemption Memo                              |
+//! | 0x0002          | Gift Code Sender Memo                             |
 //! | 0x0100          | Authenticated Sender Memo                         |
 //! | 0x0101          | Authenticated Sender With Payment Request Id Memo |
 //! | 0x0200          | Destination Memo                                  |
+//! | 0x0201          | Gift Code Funding Memo                            |
+//! | 0x0202          | Gift Code Cancellation Memo                       |
 
 use crate::impl_memo_enum;
 use core::{convert::TryFrom, fmt::Debug};
@@ -50,6 +53,9 @@ mod authenticated_sender_with_payment_request_id;
 mod burn_redemption;
 mod credential;
 mod destination;
+mod gift_code_cancellation;
+mod gift_code_funding;
+mod gift_code_sender;
 mod macros;
 mod unused;
 
@@ -59,6 +65,9 @@ pub use authenticated_sender_with_payment_request_id::AuthenticatedSenderWithPay
 pub use burn_redemption::BurnRedemptionMemo;
 pub use credential::SenderMemoCredential;
 pub use destination::{DestinationMemo, DestinationMemoError};
+pub use gift_code_cancellation::GiftCodeCancellationMemo;
+pub use gift_code_funding::GiftCodeFundingMemo;
+pub use gift_code_sender::GiftCodeSenderMemo;
 pub use unused::UnusedMemo;
 
 /// A trait that all registered memo types should implement.
@@ -83,11 +92,14 @@ pub enum MemoDecodingError {
 }
 
 impl_memo_enum! { MemoType,
-    Unused(UnusedMemo),
-    BurnRedemption(BurnRedemptionMemo),
     AuthenticatedSender(AuthenticatedSenderMemo),
     AuthenticatedSenderWithPaymentRequestId(AuthenticatedSenderWithPaymentRequestIdMemo),
+    BurnRedemption(BurnRedemptionMemo),
     Destination(DestinationMemo),
+    GiftCodeCancellation(GiftCodeCancellationMemo),
+    GiftCodeFunding(GiftCodeFundingMemo),
+    GiftCodeSender(GiftCodeSenderMemo),
+    Unused(UnusedMemo),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

As a part of [MCIP 32](https://github.com/mobilecoinfoundation/mcips/blob/main/text/0032-fog-compatible-gift-codes.md), 3 new memo types were specified:

| Memo type bytes | Name                                              |
| -----------     | -----------                                       |
| 0x0201          | Gift code funding memo                            |
| 0x0202          | Gift code cancellation memo                       |
| 0x0002          | Gift code sender memo                       |

This pull request implements the memo types for the MCIP.  Specific questions exist about whether the gift code funding memo should involve constant time operations when validating the TxOut hash.

### In this PR
Implementation of the 3 memo types specified in MCIP 32

Addresses work specified in #1735 

### Future Work
* Implement gift code memo builder object
* Implement git code protobuf object
* Implement gift code transactions within the transaction builder
* Build codepaths for sending gift codes within libmobilecoin and mobilecoind
