### PR TITLE
Gift Code Memo Builder

### DIFF
--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -417,6 +417,11 @@ impl AccountKey {
         self.subaddress_spend_private(CHANGE_SUBADDRESS_INDEX)
     }
 
+    /// The private spend key for the gift code subaddress
+    pub fn gift_code_subaddress_spend_private(&self) -> RistrettoPrivate {
+        self.subaddress_spend_private(GIFT_CODE_SUBADDRESS_INDEX)
+    }
+
     /// The private spend key for the i^th subaddress.
     pub fn subaddress_spend_private(&self, index: u64) -> RistrettoPrivate {
         let a: &Scalar = self.view_private_key.as_ref();

--- a/account-keys/src/lib.rs
+++ b/account-keys/src/lib.rs
@@ -18,7 +18,7 @@ mod identity;
 pub use crate::{
     account_keys::{
         AccountKey, PublicAddress, CHANGE_SUBADDRESS_INDEX, DEFAULT_SUBADDRESS_INDEX,
-        INVALID_SUBADDRESS_INDEX,
+        GIFT_CODE_SUBADDRESS_INDEX, INVALID_SUBADDRESS_INDEX,
     },
     address_hash::ShortAddressHash,
     burn_address::{burn_address, burn_address_view_private, BURN_ADDRESS_VIEW_PRIVATE},

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -223,7 +223,7 @@ derive_serde_from_repr_bytes!(MemoPayload);
 derive_prost_message_from_repr_bytes!(MemoPayload);
 
 /// An error which can occur when handling memos
-#[derive(Debug, Display, PartialEq, Eq)]
+#[derive(Debug, Display, Eq, PartialEq)]
 pub enum MemoError {
     /// Wrong length for memo payload: {0}
     BadLength(usize),

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -223,7 +223,7 @@ derive_serde_from_repr_bytes!(MemoPayload);
 derive_prost_message_from_repr_bytes!(MemoPayload);
 
 /// An error which can occur when handling memos
-#[derive(Display, Debug)]
+#[derive(Debug, Display, PartialEq, Eq)]
 pub enum MemoError {
     /// Wrong length for memo payload: {0}
     BadLength(usize),

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -2,8 +2,8 @@
 
 //! Errors that can occur when creating a new TxOut
 
-use crate::AmountError;
-use alloc::string::String;
+use crate::{AmountError, MemoError};
+use alloc::{format, string::String};
 use displaydoc::Display;
 use mc_crypto_keys::KeyError;
 
@@ -71,8 +71,31 @@ pub enum NewMemoError {
     MultipleOutputs,
     /// Missing output
     MissingOutput,
+    /// Missing required input to build the memo: {0}
+    MissingInput(String),
     /// Mixed Token Ids are not supported in these memos
     MixedTokenIds,
+    /// Destination memo is not supported
+    DestinationMemoNotAllowed,
+    /// Improperly configured input: {0}
+    BadInputs(String),
+    /// Creation
+    Creation(MemoError),
+    /// Utf-8 did not properly decode
+    Utf8Decoding,
     /// Other: {0}
     Other(String),
+}
+
+impl From<MemoError> for NewMemoError {
+    fn from (src: MemoError) -> Self {
+        match src {
+            MemoError::Utf8Decoding => Self::Utf8Decoding,
+            MemoError::BadLength(byte_len) => {
+                Self::BadInputs(
+                    format!("Input of length: {} exceeded max byte length", byte_len)
+                )
+            }
+        }
+    }
 }

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -56,7 +56,7 @@ impl From<AmountError> for ViewKeyMatchError {
 /// We have included error codes for some known useful error conditions.
 /// For a custom MemoBuilder, you can try to reuse those, or use the Other
 /// error code.
-#[derive(Debug, Display, PartialEq, Eq)]
+#[derive(Debug, Display, Eq, PartialEq)]
 pub enum NewMemoError {
     /// Limits for '{0}' value exceeded
     LimitsExceeded(&'static str),

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -4,6 +4,7 @@
 
 use crate::{AmountError, MemoError};
 use alloc::{format, string::String};
+use core::str::Utf8Error;
 use displaydoc::Display;
 use mc_crypto_keys::KeyError;
 
@@ -96,5 +97,11 @@ impl From<MemoError> for NewMemoError {
                 byte_len
             )),
         }
+    }
+}
+
+impl From<Utf8Error> for NewMemoError {
+    fn from(_: Utf8Error) -> Self {
+        Self::Utf8Decoding
     }
 }

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -88,14 +88,13 @@ pub enum NewMemoError {
 }
 
 impl From<MemoError> for NewMemoError {
-    fn from (src: MemoError) -> Self {
+    fn from(src: MemoError) -> Self {
         match src {
             MemoError::Utf8Decoding => Self::Utf8Decoding,
-            MemoError::BadLength(byte_len) => {
-                Self::BadInputs(
-                    format!("Input of length: {} exceeded max byte length", byte_len)
-                )
-            }
+            MemoError::BadLength(byte_len) => Self::BadInputs(format!(
+                "Input of length: {} exceeded max byte length",
+                byte_len
+            )),
         }
     }
 }

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -23,10 +23,13 @@ pub use error::{SignedContingentInputBuilderError, TxBuilderError};
 pub use input_credentials::InputCredentials;
 pub use memo::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo,
-    DestinationMemo, DestinationMemoError, MemoDecodingError, MemoType, RegisteredMemoType,
+    DestinationMemo, DestinationMemoError, GiftCodeCancellationMemo, GiftCodeFundingMemo,
+    GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType,
     SenderMemoCredential, UnusedMemo,
 };
-pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder,
+                       GiftCodeCancellationMemoBuilder, GiftCodeFundingMemoBuilder,
+                       GiftCodeSenderMemoBuilder, MemoBuilder, RTHMemoBuilder};
 pub use reserved_destination::ReservedDestination;
 pub use signed_contingent_input_builder::SignedContingentInputBuilder;
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -24,12 +24,13 @@ pub use input_credentials::InputCredentials;
 pub use memo::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo,
     DestinationMemo, DestinationMemoError, GiftCodeCancellationMemo, GiftCodeFundingMemo,
-    GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType,
-    SenderMemoCredential, UnusedMemo,
+    GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType, SenderMemoCredential,
+    UnusedMemo,
 };
-pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder,
-                       GiftCodeCancellationMemoBuilder, GiftCodeFundingMemoBuilder,
-                       GiftCodeSenderMemoBuilder, MemoBuilder, RTHMemoBuilder};
+pub use memo_builder::{
+    BurnRedemptionMemoBuilder, EmptyMemoBuilder, GiftCodeCancellationMemoBuilder,
+    GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder, MemoBuilder, RTHMemoBuilder,
+};
 pub use reserved_destination::ReservedDestination;
 pub use signed_contingent_input_builder::SignedContingentInputBuilder;
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -3,7 +3,10 @@
 //! Defines the Memo Builder for the gift code cancellation memo (0x0202)
 //! specified in MCIP #32
 
-use super::{memo::{UnusedMemo, GiftCodeCancellationMemo}, ReservedDestination, MemoBuilder};
+use super::{
+    memo::{GiftCodeCancellationMemo, UnusedMemo},
+    MemoBuilder, ReservedDestination,
+};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -95,5 +98,14 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
                 "Missing global index of TxOut to be cancelled".into(),
             ));
         }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gift_code() {
+        // Tests forthcoming
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -117,7 +117,7 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::build_zero_value_change_memo;
+    use crate::test_utils::{build_change_memo_with_amount, build_zero_value_change_memo};
     use std::convert::TryInto;
 
     #[test]
@@ -166,6 +166,21 @@ mod tests {
             memo_payload,
             Err(NewMemoError::MultipleChangeOutputs)
         ));
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_fails_for_nonzero_amount() {
+        // Create memo builder
+        let mut builder = GiftCodeCancellationMemoBuilder::default();
+
+        // Set the cancellation index
+        let index = 666;
+        builder.set_gift_code_tx_out_index(index);
+
+        // Build the memo payload
+        let amount = Amount::new(666, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
+        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -15,8 +15,8 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// | -->0x0202<--    | Gift Code Cancellation Memo |
 /// This memo builder builds a gift code cancellation memo (0x0202). Gift code
 /// cancellation is defined as the sender sending the gift code TxOut at the
-/// gift code subaddress back to their change address prior to it being spent
-/// by the receiver. When that happens a gift code cancellation memo is
+/// gift code subaddress to their change address prior to it being spent by
+/// the receiver. When that happens a gift code cancellation memo is
 /// written to the change TxOut that stores the index of the TxOut originally
 /// sent to the gift code subaddress when the gift code was funded.
 #[derive(Clone, Debug)]
@@ -54,8 +54,7 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
         Err(NewMemoError::DestinationMemoNotAllowed)
     }
 
-    /// Write the cancellation memo to the change output the gift code is
-    /// refunded to
+    /// Write the cancellation memo to the change output
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Defines the Memo Builder for the gift code cancellation memo (0x0202)
+//! specified in MCIP #32
+
+use super::{memo::{UnusedMemo, GiftCodeCancellationMemo}, ReservedDestination, MemoBuilder};
+use mc_account_keys::PublicAddress;
+use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+
+/// There are three possible gift code memo types specified in MCIP #32
+/// | Memo type bytes | Name                                              |
+/// | -----------     | -----------                                       |
+/// |    0x0002       | Gift Code Sender Memo                             |
+/// |    0x0201       | Gift Code Funding Memo                            |
+/// | -->0x0202<--    | Gift Code Cancellation Memo                       |
+/// This memo builder builds a gift code cancellation memo (0x0202). Gift code
+/// cancellation is defined as the sender sending the gift code TxOut at the
+/// gift code subaddress back to their default address prior to it being spent
+/// by the receiver. When that happens a zero valued TxOut is sent to the gift
+/// code sender's change subaddress with a gift code cancellation memo that
+/// stores the index of the TxOut originally sent to the gift code subaddress
+/// when the gift code was funded.
+#[derive(Clone, Debug)]
+pub struct GiftCodeCancellationMemoBuilder {
+    // Index of the gift code TxOut that was originally funded
+    gift_code_tx_out_global_index: Option<u64>,
+    // Whether or not to enable change memos
+    gift_code_change_memo_enabled: bool,
+    // Whether we've already written the change memo
+    wrote_change_memo: bool,
+}
+
+impl GiftCodeCancellationMemoBuilder {
+    /// Create a new cancellation gift code memo builder
+    pub fn new() -> Self {
+        Self {
+            gift_code_tx_out_global_index: None,
+            gift_code_change_memo_enabled: true,
+            wrote_change_memo: false,
+        }
+    }
+    /// Set the index of the gift code TxOut that was cancelled
+    pub fn set_gift_code_tx_out_index(&mut self, tx_out_global_index: u64) {
+        self.gift_code_tx_out_global_index = Some(tx_out_global_index)
+    }
+    /// Clear the index
+    pub fn clear_gift_code_tx_out_index(&mut self) {
+        self.gift_code_tx_out_global_index = None;
+    }
+    /// Enable change memos
+    pub fn enable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = true;
+    }
+    /// Disable change memos
+    pub fn disable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = false;
+    }
+}
+
+impl MemoBuilder for GiftCodeCancellationMemoBuilder {
+    /// Set the fee
+    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+        Ok(())
+    }
+
+    /// Gift code destination memos are not allowed - all gift code
+    /// memos accompany TxOuts sent to the change address
+    fn make_memo_for_output(
+        &mut self,
+        _amount: Amount,
+        _recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        Err(NewMemoError::DestinationMemoNotAllowed)
+    }
+
+    /// Build a memo for a gift code change output
+    fn make_memo_for_change_output(
+        &mut self,
+        _amount: Amount,
+        _change_destination: &ReservedDestination,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if !self.gift_code_change_memo_enabled {
+            return Ok(UnusedMemo {}.into());
+        }
+        if self.wrote_change_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        self.wrote_change_memo = true;
+        if let Some(tx_out_global_index) = self.gift_code_tx_out_global_index.take() {
+            return Ok(GiftCodeCancellationMemo::from(tx_out_global_index).into());
+        } else {
+            return Err(NewMemoError::MissingInput(
+                "Missing global index of TxOut to be cancelled".into(),
+            ));
+        }
+    }
+}

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -3,10 +3,7 @@
 //! Defines the Memo Builder for the gift code cancellation memo (0x0202)
 //! specified in MCIP #32
 
-use super::{
-    memo::{GiftCodeCancellationMemo, UnusedMemo},
-    MemoBuilder, ReservedDestination,
-};
+use super::{memo::GiftCodeCancellationMemo, MemoBuilder, ReservedDestination};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -18,48 +15,26 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// | -->0x0202<--    | Gift Code Cancellation Memo |
 /// This memo builder builds a gift code cancellation memo (0x0202). Gift code
 /// cancellation is defined as the sender sending the gift code TxOut at the
-/// gift code subaddress back to their default address prior to it being spent
-/// by the receiver. When that happens a change TxOut is sent to the gift
-/// code sender's change subaddress with a gift code cancellation memo that
-/// stores the index of the TxOut originally sent to the gift code subaddress
-/// when the gift code was funded.
+/// gift code subaddress back to their change address prior to it being spent
+/// by the receiver. When that happens a gift code cancellation memo is
+/// written to the change TxOut that stores the index of the TxOut originally
+/// sent to the gift code subaddress when the gift code was funded.
 #[derive(Clone, Debug)]
 pub struct GiftCodeCancellationMemoBuilder {
     // Index of the gift code TxOut that was originally funded
-    gift_code_tx_out_global_index: Option<u64>,
-    // Whether or not to enable change memos
-    gift_code_change_memo_enabled: bool,
+    gift_code_tx_out_global_index: u64,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
 }
 
-// Create an empty GiftCodeCancellationMemoBuilder
-impl Default for GiftCodeCancellationMemoBuilder {
-    fn default() -> Self {
+impl GiftCodeCancellationMemoBuilder {
+    /// Initialize memo builder with the index of the originally
+    /// funded gift code TxOut
+    pub fn new(gift_code_tx_out_global_index: u64) -> Self {
         Self {
-            gift_code_tx_out_global_index: None,
-            gift_code_change_memo_enabled: true,
+            gift_code_tx_out_global_index,
             wrote_change_memo: false,
         }
-    }
-}
-
-impl GiftCodeCancellationMemoBuilder {
-    /// Set the index of the gift code TxOut that was cancelled
-    pub fn set_gift_code_tx_out_index(&mut self, tx_out_global_index: u64) {
-        self.gift_code_tx_out_global_index = Some(tx_out_global_index)
-    }
-    /// Clear the index
-    pub fn clear_gift_code_tx_out_index(&mut self) {
-        self.gift_code_tx_out_global_index = None;
-    }
-    /// Enable change memos
-    pub fn enable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = true;
-    }
-    /// Disable change memos
-    pub fn disable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = false;
     }
 }
 
@@ -69,42 +44,29 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
         Ok(())
     }
 
-    /// Gift code cancellation memos write blank memos to destination TxOut(s)
+    /// Destination memos for gift code cancellation memos are not allowed
     fn make_memo_for_output(
         &mut self,
         _amount: Amount,
         _recipient: &PublicAddress,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
-        Ok(UnusedMemo {}.into())
+        Err(NewMemoError::DestinationMemoNotAllowed)
     }
 
-    /// Build a memo for a gift code change output
+    /// Write the cancellation memo to the change output the gift code is
+    /// refunded to
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
         _change_destination: &ReservedDestination,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
-        if !self.gift_code_change_memo_enabled {
-            return Ok(UnusedMemo {}.into());
-        }
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
         }
-        if self.gift_code_tx_out_global_index.is_none() {
-            return Err(NewMemoError::MissingInput(
-                "Must specify gift code TxOut global index".into(),
-            ));
-        }
         self.wrote_change_memo = true;
-        if let Some(tx_out_global_index) = self.gift_code_tx_out_global_index.take() {
-            Ok(GiftCodeCancellationMemo::from(tx_out_global_index).into())
-        } else {
-            Err(NewMemoError::MissingInput(
-                "Missing global index of TxOut to be cancelled".into(),
-            ))
-        }
+        Ok(GiftCodeCancellationMemo::from(self.gift_code_tx_out_global_index).into())
     }
 }
 
@@ -116,12 +78,9 @@ mod tests {
 
     #[test]
     fn test_gift_code_cancellation_memo_built_successfully_with_index() {
-        // Create memo builder
-        let mut builder = GiftCodeCancellationMemoBuilder::default();
-
-        // Set the cancellation index
+        // Set the cancellation index and create memo builder
         let index = 666;
-        builder.set_gift_code_tx_out_index(index);
+        let mut builder = GiftCodeCancellationMemoBuilder::new(index);
 
         // Build the memo payload and get the data
         let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
@@ -133,83 +92,19 @@ mod tests {
     }
 
     #[test]
-    fn test_gift_code_cancellation_memo_fails_without_index() {
-        // Instantiate memo builder
-        let mut builder = GiftCodeCancellationMemoBuilder::default();
-
-        // Build the memo payload
-        let memo_payload = build_zero_value_change_memo(&mut builder);
-
-        // Assert we've created the correct error
-        assert!(matches!(memo_payload, Err(NewMemoError::MissingInput(_))));
-    }
-
-    #[test]
     fn test_gift_code_cancellation_memo_fails_for_more_than_one_change_memo() {
-        // Create memo builder
-        let mut builder = GiftCodeCancellationMemoBuilder::default();
-
-        // Set the cancellation index
+        // Set the cancellation index and create memo builder
         let index = 666;
-        builder.set_gift_code_tx_out_index(index);
+        let mut builder = GiftCodeCancellationMemoBuilder::new(index);
 
-        // Build the memo payload
+        // Attempt to build two change outputs
         build_zero_value_change_memo(&mut builder).unwrap();
         let memo_payload = build_zero_value_change_memo(&mut builder);
+
+        // Assert failure for the second output
         assert!(matches!(
             memo_payload,
             Err(NewMemoError::MultipleChangeOutputs)
         ));
-    }
-
-    #[test]
-    fn test_gift_code_cancellation_memo_fields_are_set_and_cleared_properly() {
-        // Create memo builder
-        let mut builder = GiftCodeCancellationMemoBuilder::default();
-
-        // Set the cancellation index, and then replace it
-        let index = 666;
-        builder.set_gift_code_tx_out_index(index);
-        let replacement_index = 420;
-        builder.set_gift_code_tx_out_index(replacement_index);
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify memo data
-        let derived_index = u64::from_le_bytes(memo_data[0..8].try_into().unwrap());
-        assert_eq!(replacement_index, derived_index);
-
-        // Create another memo builder
-        let mut builder_2 = GiftCodeCancellationMemoBuilder::default();
-
-        // Set the cancellation index and then clear it
-        let index_2 = 666;
-        builder_2.set_gift_code_tx_out_index(index_2);
-        builder_2.clear_gift_code_tx_out_index();
-
-        // Build the memo payload and get the data
-        let memo_payload_2 = build_zero_value_change_memo(&mut builder_2);
-        assert!(matches!(memo_payload_2, Err(NewMemoError::MissingInput(_))));
-    }
-
-    #[test]
-    fn test_gift_code_cancellation_memo_writes_unused_if_change_disabled() {
-        // Create memo builder
-        let mut builder = GiftCodeCancellationMemoBuilder::default();
-
-        // Set the cancellation index
-        let index = 666;
-        builder.set_gift_code_tx_out_index(index);
-
-        // Disable change outputs
-        builder.disable_gift_code_change_memo();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-
-        // Verify memo data is blank
-        assert_eq!(memo_payload.get_memo_data(), &[0u8; 64]);
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -11,11 +11,11 @@ use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 /// There are three possible gift code memo types specified in MCIP #32
-/// | Memo type bytes | Name                                              |
-/// | -----------     | -----------                                       |
-/// |    0x0002       | Gift Code Sender Memo                             |
-/// |    0x0201       | Gift Code Funding Memo                            |
-/// | -->0x0202<--    | Gift Code Cancellation Memo                       |
+/// | Memo type bytes | Name                        |
+/// | -----------     | -----------                 |
+/// |    0x0002       | Gift Code Sender Memo       |
+/// |    0x0201       | Gift Code Funding Memo      |
+/// | -->0x0202<--    | Gift Code Cancellation Memo |
 /// This memo builder builds a gift code cancellation memo (0x0202). Gift code
 /// cancellation is defined as the sender sending the gift code TxOut at the
 /// gift code subaddress back to their default address prior to it being spent

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -33,15 +33,18 @@ pub struct GiftCodeCancellationMemoBuilder {
     wrote_change_memo: bool,
 }
 
-impl GiftCodeCancellationMemoBuilder {
-    /// Create a new cancellation gift code memo builder
-    pub fn new() -> Self {
+// Create an empty GiftCodeCancellationMemoBuilder
+impl Default for GiftCodeCancellationMemoBuilder {
+    fn default() -> Self {
         Self {
             gift_code_tx_out_global_index: None,
             gift_code_change_memo_enabled: true,
             wrote_change_memo: false,
         }
     }
+}
+
+impl GiftCodeCancellationMemoBuilder {
     /// Set the index of the gift code TxOut that was cancelled
     pub fn set_gift_code_tx_out_index(&mut self, tx_out_global_index: u64) {
         self.gift_code_tx_out_global_index = Some(tx_out_global_index)
@@ -92,17 +95,16 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
         }
         self.wrote_change_memo = true;
         if let Some(tx_out_global_index) = self.gift_code_tx_out_global_index.take() {
-            return Ok(GiftCodeCancellationMemo::from(tx_out_global_index).into());
+            Ok(GiftCodeCancellationMemo::from(tx_out_global_index).into())
         } else {
-            return Err(NewMemoError::MissingInput(
+            Err(NewMemoError::MissingInput(
                 "Missing global index of TxOut to be cancelled".into(),
-            ));
+            ))
         }
     }
 }
 
 mod tests {
-    use super::*;
 
     #[test]
     fn test_gift_code() {

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -38,10 +38,9 @@ pub struct GiftCodeFundingMemoBuilder {
 }
 
 impl GiftCodeFundingMemoBuilder {
-    /// Initialize memo builder with a utf-8 note (up to 60 bytes)
-    /// indicating what the gift code was for. This method will enforce
-    /// the 60 byte limit with a NewMemoErr if the &str passed is longer
-    /// than 60 bytes.
+    /// Initialize memo builder with a utf-8 note (up to 60 bytes), This
+    /// method will enforce the 60 byte limit with a NewMemoErr if the
+    /// note passed is longer than 60 bytes.
     pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
             return Err(NewMemoError::BadInputs(
@@ -169,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_gift_code_funding_memo_built_successfully_with_edge_case_notes() {
-        // Create memo builder with blank note
+        // Create blank notes and notes near max length
         let blank_note = "";
         let note_minus_one =
             std::str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
@@ -232,7 +231,7 @@ mod tests {
         let alice_address_book = ReservedDestination::from(&alice);
         let change_amount = Amount::new(666, 666.into());
 
-        // Erroneously set change TxOut public address to the funding TxOut
+        // Erroneously set funding TxOut pubkey to the change TxOut pubkey
         let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
         builder
             .make_memo_for_output(

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -12,11 +12,11 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 /// There are three possible gift code memo types specified in MCIP #32
-/// | Memo type bytes | Name                                              |
-/// | -----------     | -----------                                       |
-/// |    0x0002       | Gift Code Sender Memo                             |
-/// | -->0x0201<--    | Gift Code Funding Memo                            |
-/// |    0x0202       | Gift Code Cancellation Memo                       |
+/// | Memo type bytes | Name                        |
+/// | -----------     | -----------                 |
+/// |    0x0002       | Gift Code Sender Memo       |
+/// | -->0x0201<--    | Gift Code Funding Memo      |
+/// |    0x0202       | Gift Code Cancellation Memo |
 /// This memo builder builds a gift code funding memo (0x0201). When a gift
 /// code is funded, the amount of the gift code is sent to a TxOut at the
 /// Sender's reserved gift code subaddress and a second zero valued TxOut

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -42,9 +42,9 @@ pub struct GiftCodeFundingMemoBuilder {
     wrote_change_memo: bool,
 }
 
-impl GiftCodeFundingMemoBuilder {
-    /// Create a new gift code funding memo builder
-    pub fn new() -> Self {
+// Create an empty GiftCodeFundingMemoBuilder
+impl Default for GiftCodeFundingMemoBuilder {
+    fn default() -> Self {
         Self {
             note: "".into(),
             gift_code_tx_out_public_key: None,
@@ -52,6 +52,9 @@ impl GiftCodeFundingMemoBuilder {
             wrote_change_memo: false,
         }
     }
+}
+
+impl GiftCodeFundingMemoBuilder {
     /// Set a utf-8 note (up to 60 bytes) onto the funding memo indicating
     /// what the gift code was for. This method will enforce the 60 byte
     /// limit with a NewMemoErr if the &str passed is longer than
@@ -131,17 +134,16 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
         }
         if let Some(tx_out_public_key) = self.gift_code_tx_out_public_key.take() {
             self.wrote_change_memo = true;
-            return Ok(GiftCodeFundingMemo::new(&tx_out_public_key, self.note.as_str())?.into());
+            Ok(GiftCodeFundingMemo::new(&tx_out_public_key, self.note.as_str())?.into())
         } else {
-            return Err(NewMemoError::MissingInput(
+            Err(NewMemoError::MissingInput(
                 "Missing gift code TxOut public key".into(),
-            ));
+            ))
         }
     }
 }
 
 mod tests {
-    use super::*;
 
     #[test]
     fn test_gift_code() {

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -25,88 +25,35 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// the first 4 bytes of the hash of the gift code TxOut sent to the
 /// sender's reserved gift code subaddress and 60 bytes for an optional
 /// utf-8 memo.
-///
-/// IMPORTANT NOTE: The public_key of the change TxOut that the Gift Code
-/// Funding Memo is written to is NOT the public_key that should be passed into
-/// set_gift_code_tx_out_public_key(tx_out_public_key). Instead the public_key
-/// of the TxOut sent to the gift code subaddress is what should be passed into
-/// set_gift_code_tx_out_public_key(tx_out_public_key)
 #[derive(Clone, Debug)]
 pub struct GiftCodeFundingMemoBuilder {
     // Utf-8 note within the memo that can be up to 60 bytes long
     note: String,
     // TxOut Public Key of the gift code TxOut sent to the gift code subaddress
     gift_code_tx_out_public_key: Option<RistrettoPublic>,
-    // Whether or not to enable change memo
-    gift_code_change_memo_enabled: bool,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
-    // Whether we've written an unused memo to the destination
+    // Whether we've already written the gift code TxOut
     wrote_destination_memo: bool,
-    // Whether our last note setting attempt was invalid and the note hasn't
-    // been reset with a valid note or cleared
-    attempted_invalid_note: bool,
-}
-
-// Create an empty GiftCodeFundingMemoBuilder
-impl Default for GiftCodeFundingMemoBuilder {
-    fn default() -> Self {
-        Self {
-            note: "".into(),
-            gift_code_tx_out_public_key: None,
-            gift_code_change_memo_enabled: true,
-            wrote_change_memo: false,
-            wrote_destination_memo: false,
-            attempted_invalid_note: false,
-        }
-    }
 }
 
 impl GiftCodeFundingMemoBuilder {
-    /// Set a utf-8 note (up to 60 bytes) onto the funding memo indicating
-    /// what the gift code was for. This method will enforce the 60 byte
-    /// limit with a NewMemoErr if the &str passed is longer than
-    /// 60 bytes.
-    pub fn set_funding_note(&mut self, note: &str) -> Result<(), NewMemoError> {
+    /// Initialize memo builder with a utf-8 note (up to 60 bytes)
+    /// indicating what the gift code was for. This method will enforce
+    /// the 60 byte limit with a NewMemoErr if the &str passed is longer
+    /// than 60 bytes.
+    pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
-            self.attempted_invalid_note = true;
             return Err(NewMemoError::BadInputs(
                 "Note memo cannot be greater than 60 bytes".into(),
             ));
         }
-        self.attempted_invalid_note = false;
-        self.note = note.into();
-        Ok(())
-    }
-    /// Clear the gift code funding note
-    pub fn clear_funding_note(&mut self) {
-        self.attempted_invalid_note = false;
-        self.note = "".into();
-    }
-    /// Set the TxOut public_key of the gift code TxOut sent to the
-    /// reserved gift code subaddress.
-    ///
-    /// IMPORTANT NOTE: Do NOT pass the public_key of the change TxOut
-    /// that the gift code memo is attached to as an argument. Doing
-    /// so will result in an error when attempting to build the memo.
-    pub fn set_gift_code_tx_out_public_key(
-        &mut self,
-        tx_out_public_key: &RistrettoPublic,
-    ) -> Result<(), NewMemoError> {
-        self.gift_code_tx_out_public_key = Some(*tx_out_public_key);
-        Ok(())
-    }
-    /// Clear the gift code tx_out_public_key
-    pub fn clear_gift_code_tx_out_public_key(&mut self) {
-        self.gift_code_tx_out_public_key = None;
-    }
-    /// Enable change memos
-    pub fn enable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = true;
-    }
-    /// Disable change memos
-    pub fn disable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = false;
+        Ok(Self {
+            note: note.into(),
+            gift_code_tx_out_public_key: None,
+            wrote_change_memo: false,
+            wrote_destination_memo: false,
+        })
     }
 }
 
@@ -116,40 +63,40 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
         Ok(())
     }
 
-    /// Gift code destination memos applied to the gift code TxOut
-    /// are empty.
+    /// This method is called when writing the gift TxOut to the reserved
+    /// gift code subaddress and can only be called once. Once called it
+    /// will store the public key of the gift code TxOut in the memo
+    /// builder.
     fn make_memo_for_output(
         &mut self,
         _amount: Amount,
         _recipient: &PublicAddress,
-        _memo_context: MemoContext,
+        memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         // Only one gift code should be funded
         if self.wrote_destination_memo {
+            return Err(NewMemoError::MultipleOutputs);
+        }
+        if self.wrote_change_memo {
             return Err(NewMemoError::OutputsAfterChange);
         }
+        self.gift_code_tx_out_public_key = Some(*memo_context.tx_public_key);
         self.wrote_destination_memo = true;
         Ok(UnusedMemo {}.into())
     }
 
-    /// Build a memo for a gift code change output
+    /// Write the funding memo onto the change output of the gift code TxOut
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
         _change_destination: &ReservedDestination,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
-        if !self.gift_code_change_memo_enabled {
-            return Ok(UnusedMemo {}.into());
+        if !self.wrote_destination_memo {
+            return Err(NewMemoError::MissingOutput);
         }
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
-        }
-        // Prevent callers from writing memo if last note set attempt was a failure
-        if self.attempted_invalid_note {
-            return Err(NewMemoError::BadInputs(
-                "Tried to set a note longer than 64 bytes".into(),
-            ));
         }
         if self.gift_code_tx_out_public_key.as_ref() == Some(memo_context.tx_public_key) {
             return Err(NewMemoError::BadInputs("The public_key in the memo should be the TxOut at the gift code subaddress and not that of the memo TxOut".into()));
@@ -168,259 +115,203 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{build_zero_value_change_memo, MemoDecoder};
     use mc_account_keys::AccountKey;
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
-    #[test]
-    fn test_gift_code_funding_memo_built_successfully_with_note() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key and note
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-        let note = "It's MEMO TIME!!";
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        builder.set_funding_note(note).unwrap();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify memo data
-        let derived_note = MemoDecoder::decode_funding_note(memo_data);
-        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
-        assert_eq!(note, derived_note);
-        assert_eq!(
-            expected_hash,
-            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
-        );
-    }
-
-    #[test]
-    fn test_gift_code_funding_memo_built_successfully_without_note() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key only
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify memo data
-        let derived_note = MemoDecoder::decode_funding_note(memo_data);
-        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
-        let blank_note = "";
-        assert_eq!(blank_note, derived_note);
-        assert_eq!(
-            expected_hash,
-            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
-        );
-    }
-
-    #[test]
-    fn test_gift_code_funding_memo_fails_to_build_if_key_matches_empty_change_memo_public_key() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code note and the public_key as the empty gift code public_key
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
-        let note = "It's MEMO TIME!!";
-        builder
-            .set_gift_code_tx_out_public_key(&change_tx_public_key)
-            .unwrap();
-        builder.set_funding_note(note).unwrap();
-
-        // Build a memo
+    fn build_gift_code_memos(
+        builder: &mut impl MemoBuilder,
+        funding_tx_pubkey: &RistrettoPublic,
+    ) -> Result<MemoPayload, NewMemoError> {
+        // Create simulated context
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
         let alice = AccountKey::random_with_fog(&mut rng);
         let alice_address_book = ReservedDestination::from(&alice);
-        let change_amount = Amount::new(666, 666.into());
-        let memo_context = MemoContext {
-            tx_public_key: &change_tx_public_key,
+        let change_tx_pubkey = RistrettoPublic::from_random(&mut rng);
+        let change_amount = Amount::new(1, 0.into());
+        let funding_amount = Amount::new(10, 0.into());
+        let funding_context = MemoContext {
+            tx_public_key: &funding_tx_pubkey,
         };
-        let memo_payload =
-            builder.make_memo_for_change_output(change_amount, &alice_address_book, memo_context);
+        let change_context = MemoContext {
+            tx_public_key: &change_tx_pubkey,
+        };
+
+        // Build blank output memo for TxOut at gift code address & funding memo to
+        // change output
+        builder
+            .make_memo_for_output(
+                funding_amount,
+                &alice_address_book.gift_code_subaddress,
+                funding_context,
+            )
+            .unwrap();
+        builder.make_memo_for_change_output(change_amount, &alice_address_book, change_context)
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_built_successfully_with_note() {
+        // Create Memo Builder with note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+
+        // Verify memo data
+        let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
+        let derived_note = memo.funding_note().unwrap();
+        assert_eq!(note, derived_note);
+        assert!(memo.public_key_matches(&gift_code_public_key));
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_built_successfully_with_edge_case_notes() {
+        // Create memo builder with blank note
+        let blank_note = "";
+        let note_minus_one =
+            std::str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
+        let note_exact = std::str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN]).unwrap();
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+
+        // Test blank note is okay
+        {
+            let mut builder = GiftCodeFundingMemoBuilder::new(blank_note).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+
+            // Verify memo data
+            let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
+            let derived_note = memo.funding_note().unwrap();
+            assert_eq!(blank_note, derived_note);
+            assert!(memo.public_key_matches(&gift_code_public_key));
+        }
+
+        // Test note with max length minus one is okay
+        {
+            let mut builder = GiftCodeFundingMemoBuilder::new(note_minus_one).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+
+            // Verify memo data
+            let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
+            let derived_note = memo.funding_note().unwrap();
+            assert_eq!(note_minus_one, derived_note);
+            assert!(memo.public_key_matches(&gift_code_public_key));
+        }
+
+        // Test max length note is okay
+        {
+            let mut builder = GiftCodeFundingMemoBuilder::new(note_exact).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+
+            // Verify memo data
+            let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
+            let derived_note = memo.funding_note().unwrap();
+            assert_eq!(note_exact, derived_note);
+            assert!(memo.public_key_matches(&gift_code_public_key));
+        }
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fails_to_build_if_key_matches_change_memo_public_key() {
+        // Create memo builder with note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let note = "It's MEMO TIME!!";
+        let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+
+        // Build a memo
+        let alice = AccountKey::random_with_fog(&mut rng);
+        let alice_address_book = ReservedDestination::from(&alice);
+        let change_amount = Amount::new(666, 666.into());
+
+        // Erroneously set change TxOut public address to the funding TxOut
+        let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
+        builder
+            .make_memo_for_output(
+                change_amount,
+                &alice_address_book.gift_code_subaddress,
+                MemoContext {
+                    tx_public_key: &change_tx_public_key,
+                },
+            )
+            .unwrap();
+        let memo_payload = builder.make_memo_for_change_output(
+            change_amount,
+            &alice_address_book,
+            MemoContext {
+                tx_public_key: &change_tx_public_key,
+            },
+        );
 
         // Assert memo creation fails
         assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
     }
 
     #[test]
-    fn test_gift_code_funding_memo_fails_for_more_than_one_change_memo() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key and note
+    fn test_gift_code_funding_memos_fail_for_multiple_change_memos() {
+        // Create memo builder with note
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
         let note = "It's MEMO TIME!!";
+        let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+
+        // Build a memo
+        let alice = AccountKey::random_with_fog(&mut rng);
+        let alice_address_book = ReservedDestination::from(&alice);
+        let change_amount = Amount::new(666, 666.into());
+
+        // Write 2 change outputs
+        let funding_tx_out_public_key = RistrettoPublic::from_random(&mut rng);
+        let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
+        let change_tx_public_key_2 = RistrettoPublic::from_random(&mut rng);
         builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .make_memo_for_output(
+                change_amount,
+                &alice_address_book.gift_code_subaddress,
+                MemoContext {
+                    tx_public_key: &funding_tx_out_public_key,
+                },
+            )
             .unwrap();
-        builder.set_funding_note(note).unwrap();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify memo data
-        let derived_note = MemoDecoder::decode_funding_note(memo_data);
-        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
-        assert_eq!(note, derived_note);
-        assert_eq!(
-            expected_hash,
-            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        builder
+            .make_memo_for_change_output(
+                change_amount,
+                &alice_address_book,
+                MemoContext {
+                    tx_public_key: &change_tx_public_key,
+                },
+            )
+            .unwrap();
+        let memo_payload = builder.make_memo_for_change_output(
+            change_amount,
+            &alice_address_book,
+            MemoContext {
+                tx_public_key: &change_tx_public_key_2,
+            },
         );
 
-        // Try building another memo and assert failure
-        let memo_payload = build_zero_value_change_memo(&mut builder);
+        // Assert memo creation fails for second change output
         assert!(matches!(
             memo_payload,
             Err(NewMemoError::MultipleChangeOutputs)
-        ))
+        ));
     }
 
     #[test]
-    fn test_gift_code_funding_memo_fields_are_cleared_properly_and_fails_if_no_public_key() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key and note
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-        let note = "It's MEMO TIME!!";
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        builder.set_funding_note(note).unwrap();
-
-        // Clear the funding note
-        builder.clear_funding_note();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify note was cleared
-        let blank_note = "";
-        let derived_note = MemoDecoder::decode_funding_note(memo_data);
-        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
-        assert_eq!(blank_note, derived_note);
-        assert_eq!(
-            expected_hash,
-            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
-        );
-
-        // Create another memo builder
-        let mut builder_2 = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key and note
-        builder_2
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        builder_2.set_funding_note(note).unwrap();
-        builder_2.clear_gift_code_tx_out_public_key();
-
-        // Build the memo payload and ensure we can't build it without the tx public key
-        let memo_payload_2 = build_zero_value_change_memo(&mut builder_2);
-        assert!(matches!(memo_payload_2, Err(NewMemoError::MissingInput(_))));
-    }
-
-    #[test]
-    fn test_gift_code_funding_memo_writes_unused_if_change_disabled() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key and note
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-        let note = "It's MEMO TIME!!";
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        builder.set_funding_note(note).unwrap();
-
-        // Disable change memos
-        builder.disable_gift_code_change_memo();
-
-        // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Assert data is equal to zero byte array
-        assert_eq!(memo_data, &[0u8; GiftCodeFundingMemo::MEMO_DATA_LEN]);
-    }
-
-    #[test]
-    fn test_gift_code_funding_memo_fails_if_last_note_setting_attempt_failed() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-
-        // Attempt to set an invalid note longer than allowed bytes
+    fn test_gift_code_sender_note_builder_creation_fails_with_invalid_note() {
+        // Create Memo Builder with Bad Inputs
         let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1];
-        let bad_note = std::str::from_utf8(&note_bytes).unwrap();
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        let result = builder.set_funding_note(bad_note);
+        let note = std::str::from_utf8(&note_bytes).unwrap();
+        let builder = GiftCodeFundingMemoBuilder::new(note);
 
-        // Ensure set method errors correctly
-        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
-
-        // Attempt to set the memo anyways and assert our attempt is a failure
-        let memo_payload = build_zero_value_change_memo(&mut builder);
-        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
-    }
-
-    #[test]
-    fn test_gift_code_funding_memo_succeeds_after_invalid_note_is_reset_with_valid_note() {
-        // Create memo builder
-        let mut builder = GiftCodeFundingMemoBuilder::default();
-
-        // Set the gift code TxOut public key
-        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
-        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-
-        // Attempt to set an invalid note longer than allowed bytes
-        let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1];
-        let bad_note = std::str::from_utf8(&note_bytes).unwrap();
-        builder
-            .set_gift_code_tx_out_public_key(&gift_code_public_key)
-            .unwrap();
-        let result = builder.set_funding_note(bad_note);
-
-        // Ensure set method errors correctly
-        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
-
-        // Set a correct memo and ensure we can build a valid memo
-        let correct_note = "I'm also bad mwa-ha (but in a healthy, fun way)";
-        builder.set_funding_note(correct_note).unwrap();
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_data = memo_payload.get_memo_data();
-
-        // Verify memo data
-        let derived_note = MemoDecoder::decode_funding_note(memo_data);
-        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
-        assert_eq!(correct_note, derived_note);
-        assert_eq!(
-            expected_hash,
-            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
-        );
+        //Assert memo creation fails
+        assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Defines the Memo Builder for the gift code funding memo (0x0201)
+//! specified in MCIP #32
+
+use crate::{memo::{UnusedMemo, GiftCodeFundingMemo}, MemoBuilder, ReservedDestination};
+use mc_account_keys::PublicAddress;
+use mc_crypto_keys::RistrettoPublic;
+use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+
+/// There are three possible gift code memo types specified in MCIP #32
+/// | Memo type bytes | Name                                              |
+/// | -----------     | -----------                                       |
+/// |    0x0002       | Gift Code Sender Memo                             |
+/// | -->0x0201<--    | Gift Code Funding Memo                            |
+/// |    0x0202       | Gift Code Cancellation Memo                       |
+/// This memo builder builds a gift code funding memo (0x0201). When a gift
+/// code is funded, the amount of the gift code is sent to a TxOut at the 
+/// Sender's reserved gift code subaddress and a second zero valued TxOut 
+/// is sent to the sender's reserved change subaddress with the gift code 
+/// funding memo attached. The funding memo will include the first 4 bytes 
+/// of the hash of the gift code TxOut sent to the sender's reserved gift 
+/// code subaddress and 60 bytes for an optional utf-8 memo.
+///
+/// IMPORTANT NOTE: The public_key of the zero valued TxOut that the Gift Code
+/// Funding Memo is written to is NOT the public_key that should be passed into
+/// set_gift_code_tx_out_public_key(tx_out_public_key). Instead the public_key
+/// of the TxOut sent to the gift code subaddress is what should be passed into
+/// set_gift_code_tx_out_public_key(tx_out_public_key)
+#[derive(Clone, Debug)]
+pub struct GiftCodeFundingMemoBuilder {
+    // Utf-8 note within the memo that can be up to 60 bytes long
+    note: String,
+    // TxOut Public Key of the gift code TxOut sent to the gift code subaddress
+    gift_code_tx_out_public_key: Option<RistrettoPublic>,
+    // Whether or not to enable change memo
+    gift_code_change_memo_enabled: bool,
+    // Whether we've already written the change memo
+    wrote_change_memo: bool,
+}
+
+impl GiftCodeFundingMemoBuilder {
+    /// Create a new gift code funding memo builder
+    pub fn new() -> Self {
+        Self {
+            note: "".into(),
+            gift_code_tx_out_public_key: None,
+            gift_code_change_memo_enabled: true,
+            wrote_change_memo: false,
+        }
+    }
+    /// Set a utf-8 note (up to 60 bytes) onto the funding memo indicating
+    /// what the gift code was for. This method will enforce the 60 byte
+    /// limit with a NewMemoErr if the &str passed is longer than
+    /// 60 bytes.
+    pub fn set_funding_note(&mut self, note: &str) -> Result<(), NewMemoError> {
+        if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
+            return Err(NewMemoError::BadInputs("Note memo cannot be greater than 60 bytes".into()))
+        }
+        self.note = note.into();
+        Ok(())
+    }
+    /// Clear the gift code funding note
+    pub fn clear_funding_note(&mut self) {
+        self.note = "".into();
+    }
+    /// Set the TxOut public_key of the gift code TxOut sent to the
+    /// reserved gift code subaddress.
+    ///
+    /// IMPORTANT NOTE: Do NOT pass the public_key of the zero valued change
+    /// TxOut that the gift code memo is attached to as an argument. Doing
+    /// so will result in an error when attempting to build the memo.
+    pub fn set_gift_code_tx_out_public_key(
+        &mut self,
+        tx_out_public_key: RistrettoPublic,
+    ) -> Result<(), NewMemoError> {
+        self.gift_code_tx_out_public_key = Some(tx_out_public_key);
+        Ok(())
+    }
+    /// Clear the gift code tx_out_public_key
+    pub fn clear_gift_code_tx_out_public_key(&mut self) {
+        self.gift_code_tx_out_public_key = None;
+    }
+    /// Enable change memos
+    pub fn enable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = true;
+    }
+    /// Disable change memos
+    pub fn disable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = false;
+    }
+}
+
+impl MemoBuilder for GiftCodeFundingMemoBuilder {
+    /// Set the fee
+    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+        Ok(())
+    }
+
+    /// Gift code destination memos are not allowed - all gift code
+    /// memos accompany TxOuts sent to the change address
+    fn make_memo_for_output(
+        &mut self,
+        _amount: Amount,
+        _recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        Err(NewMemoError::DestinationMemoNotAllowed)
+    }
+
+    /// Build a memo for a gift code change output
+    fn make_memo_for_change_output(
+        &mut self,
+        _amount: Amount,
+        _change_destination: &ReservedDestination,
+        memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if !self.gift_code_change_memo_enabled {
+            return Ok(UnusedMemo {}.into());
+        }
+        if self.wrote_change_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        if self.gift_code_tx_out_public_key.as_ref() == Some(memo_context.tx_public_key) {
+            return Err(NewMemoError::BadInputs("The public_key in the memo should be the TxOut at the gift code subaddress and not that of the memo TxOut".into()));
+        }
+        if let Some(tx_out_public_key) = self.gift_code_tx_out_public_key.take() {
+            self.wrote_change_memo = true;
+            return Ok(GiftCodeFundingMemo::new(&tx_out_public_key, self.note.as_str())?.into());
+        } else {
+            return Err(NewMemoError::MissingInput(
+                "Missing gift code TxOut public key".into(),
+            ));
+        }
+    }
+}

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -3,7 +3,10 @@
 //! Defines the Memo Builder for the gift code funding memo (0x0201)
 //! specified in MCIP #32
 
-use crate::{memo::{UnusedMemo, GiftCodeFundingMemo}, MemoBuilder, ReservedDestination};
+use crate::{
+    memo::{GiftCodeFundingMemo, UnusedMemo},
+    MemoBuilder, ReservedDestination,
+};
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::RistrettoPublic;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
@@ -15,11 +18,11 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// | -->0x0201<--    | Gift Code Funding Memo                            |
 /// |    0x0202       | Gift Code Cancellation Memo                       |
 /// This memo builder builds a gift code funding memo (0x0201). When a gift
-/// code is funded, the amount of the gift code is sent to a TxOut at the 
-/// Sender's reserved gift code subaddress and a second zero valued TxOut 
-/// is sent to the sender's reserved change subaddress with the gift code 
-/// funding memo attached. The funding memo will include the first 4 bytes 
-/// of the hash of the gift code TxOut sent to the sender's reserved gift 
+/// code is funded, the amount of the gift code is sent to a TxOut at the
+/// Sender's reserved gift code subaddress and a second zero valued TxOut
+/// is sent to the sender's reserved change subaddress with the gift code
+/// funding memo attached. The funding memo will include the first 4 bytes
+/// of the hash of the gift code TxOut sent to the sender's reserved gift
 /// code subaddress and 60 bytes for an optional utf-8 memo.
 ///
 /// IMPORTANT NOTE: The public_key of the zero valued TxOut that the Gift Code
@@ -55,7 +58,9 @@ impl GiftCodeFundingMemoBuilder {
     /// 60 bytes.
     pub fn set_funding_note(&mut self, note: &str) -> Result<(), NewMemoError> {
         if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
-            return Err(NewMemoError::BadInputs("Note memo cannot be greater than 60 bytes".into()))
+            return Err(NewMemoError::BadInputs(
+                "Note memo cannot be greater than 60 bytes".into(),
+            ));
         }
         self.note = note.into();
         Ok(())
@@ -132,5 +137,14 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
                 "Missing gift code TxOut public key".into(),
             ));
         }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gift_code() {
+        // Tests forthcoming
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -40,6 +40,9 @@ pub struct GiftCodeFundingMemoBuilder {
     gift_code_change_memo_enabled: bool,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
+    // Whether our last note setting attempt was invalid and the note hasn't
+    // been reset with a valid note or cleared
+    attempted_invalid_note: bool,
 }
 
 // Create an empty GiftCodeFundingMemoBuilder
@@ -50,6 +53,7 @@ impl Default for GiftCodeFundingMemoBuilder {
             gift_code_tx_out_public_key: None,
             gift_code_change_memo_enabled: true,
             wrote_change_memo: false,
+            attempted_invalid_note: false,
         }
     }
 }
@@ -61,15 +65,18 @@ impl GiftCodeFundingMemoBuilder {
     /// 60 bytes.
     pub fn set_funding_note(&mut self, note: &str) -> Result<(), NewMemoError> {
         if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
+            self.attempted_invalid_note = true;
             return Err(NewMemoError::BadInputs(
                 "Note memo cannot be greater than 60 bytes".into(),
             ));
         }
+        self.attempted_invalid_note = false;
         self.note = note.into();
         Ok(())
     }
     /// Clear the gift code funding note
     pub fn clear_funding_note(&mut self) {
+        self.attempted_invalid_note = false;
         self.note = "".into();
     }
     /// Set the TxOut public_key of the gift code TxOut sent to the
@@ -80,9 +87,9 @@ impl GiftCodeFundingMemoBuilder {
     /// so will result in an error when attempting to build the memo.
     pub fn set_gift_code_tx_out_public_key(
         &mut self,
-        tx_out_public_key: RistrettoPublic,
+        tx_out_public_key: &RistrettoPublic,
     ) -> Result<(), NewMemoError> {
-        self.gift_code_tx_out_public_key = Some(tx_out_public_key);
+        self.gift_code_tx_out_public_key = Some(*tx_out_public_key);
         Ok(())
     }
     /// Clear the gift code tx_out_public_key
@@ -134,6 +141,12 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
                 "Funding memo TxOut should be zero valued".into(),
             ));
         }
+        // Prevent callers from writing memo if last note set attempt was a failure
+        if self.attempted_invalid_note {
+            return Err(NewMemoError::BadInputs(
+                "Tried to set a note longer than 64 bytes".into(),
+            ));
+        }
         if self.gift_code_tx_out_public_key.as_ref() == Some(memo_context.tx_public_key) {
             return Err(NewMemoError::BadInputs("The public_key in the memo should be the TxOut at the gift code subaddress and not that of the memo TxOut".into()));
         }
@@ -150,34 +163,282 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::test_utils::{
+        build_change_memo_with_amount, build_zero_value_change_memo, MemoDecoder,
+    };
+    use mc_account_keys::AccountKey;
+    use mc_util_from_random::FromRandom;
+    use rand::{rngs::StdRng, SeedableRng};
 
     #[test]
     fn test_gift_code_funding_memo_built_successfully_with_note() {
-        // Tests forthcoming
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Verify memo data
+        let derived_note = MemoDecoder::decode_funding_note(memo_data);
+        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
+        assert_eq!(note, derived_note);
+        assert_eq!(
+            expected_hash,
+            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        );
     }
 
     #[test]
     fn test_gift_code_funding_memo_built_successfully_without_note() {
-        // Tests forthcoming
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key only
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Verify memo data
+        let derived_note = MemoDecoder::decode_funding_note(memo_data);
+        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
+        let blank_note = "";
+        assert_eq!(blank_note, derived_note);
+        assert_eq!(
+            expected_hash,
+            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        );
     }
 
     #[test]
-    fn test_gift_code_funding_memo_fails_to_build_with_key_from_context() {
-        // Tests forthcoming
+    fn test_gift_code_funding_memo_fails_to_build_if_key_matches_empty_change_memo_public_key() {
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code note and the public_key as the empty gift code public_key
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&change_tx_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Build a memo
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let alice = AccountKey::random_with_fog(&mut rng);
+        let alice_address_book = ReservedDestination::from(&alice);
+        let change_amount = Amount::new(666, 666.into());
+        let memo_context = MemoContext {
+            tx_public_key: &change_tx_public_key,
+        };
+        let memo_payload =
+            builder.make_memo_for_change_output(change_amount, &alice_address_book, memo_context);
+
+        // Assert memo creation fails
+        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fails_for_nonzero_amount() {
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Build the memo payload and get the data
+        let amount = Amount::new(666, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
+        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
     }
 
     #[test]
     fn test_gift_code_funding_memo_fails_for_more_than_one_change_memo() {
-        // Tests forthcoming
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Verify memo data
+        let derived_note = MemoDecoder::decode_funding_note(memo_data);
+        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
+        assert_eq!(note, derived_note);
+        assert_eq!(
+            expected_hash,
+            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        );
+
+        // Try building another memo and assert failure
+        let memo_payload = build_zero_value_change_memo(&mut builder);
+        assert!(matches!(
+            memo_payload,
+            Err(NewMemoError::MultipleChangeOutputs)
+        ))
     }
 
     #[test]
-    fn test_gift_code_funding_memo_fields_are_cleared_properly() {
-        // Tests forthcoming
+    fn test_gift_code_funding_memo_fields_are_cleared_properly_and_fails_if_no_public_key() {
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Clear the funding note
+        builder.clear_funding_note();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Verify note was cleared
+        let blank_note = "";
+        let derived_note = MemoDecoder::decode_funding_note(memo_data);
+        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
+        assert_eq!(blank_note, derived_note);
+        assert_eq!(
+            expected_hash,
+            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        );
+
+        // Create another memo builder
+        let mut builder_2 = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        builder_2
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder_2.set_funding_note(note).unwrap();
+        builder_2.clear_gift_code_tx_out_public_key();
+
+        // Build the memo payload and ensure we can't build it without the tx public key
+        let memo_payload_2 = build_zero_value_change_memo(&mut builder_2);
+        assert!(matches!(memo_payload_2, Err(NewMemoError::MissingInput(_))));
     }
 
     #[test]
     fn test_gift_code_funding_memo_writes_unused_if_change_disabled() {
-        // Tests forthcoming
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key and note
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        builder.set_funding_note(note).unwrap();
+
+        // Disable change memos
+        builder.disable_gift_code_change_memo();
+
+        // Build the memo payload and get the data
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Assert data is equal to zero byte array
+        assert_eq!(memo_data, &[0u8; GiftCodeFundingMemo::MEMO_DATA_LEN]);
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fails_if_last_note_setting_attempt_failed() {
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+
+        // Attempt to set an invalid note longer than allowed bytes
+        let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1];
+        let bad_note = std::str::from_utf8(&note_bytes).unwrap();
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        let result = builder.set_funding_note(bad_note);
+
+        // Ensure set method errors correctly
+        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
+
+        // Attempt to set the memo anyways and assert our attempt is a failure
+        let memo_payload = build_zero_value_change_memo(&mut builder);
+        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_succeeds_after_invalid_note_is_reset_with_valid_note() {
+        // Create memo builder
+        let mut builder = GiftCodeFundingMemoBuilder::default();
+
+        // Set the gift code TxOut public key
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+
+        // Attempt to set an invalid note longer than allowed bytes
+        let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1];
+        let bad_note = std::str::from_utf8(&note_bytes).unwrap();
+        builder
+            .set_gift_code_tx_out_public_key(&gift_code_public_key)
+            .unwrap();
+        let result = builder.set_funding_note(bad_note);
+
+        // Ensure set method errors correctly
+        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
+
+        // Set a correct memo and ensure we can build a valid memo
+        let correct_note = "I'm also bad mwa-ha (but in a healthy, fun way)";
+        builder.set_funding_note(correct_note).unwrap();
+        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_data = memo_payload.get_memo_data();
+
+        // Verify memo data
+        let derived_note = MemoDecoder::decode_funding_note(memo_data);
+        let expected_hash = MemoDecoder::tx_out_public_key_short_hash(&gift_code_public_key);
+        assert_eq!(correct_note, derived_note);
+        assert_eq!(
+            expected_hash,
+            memo_data[0..GiftCodeFundingMemo::HASH_DATA_LEN]
+        );
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -131,7 +131,7 @@ mod tests {
         let change_amount = Amount::new(1, 0.into());
         let funding_amount = Amount::new(10, 0.into());
         let funding_context = MemoContext {
-            tx_public_key: &funding_tx_pubkey,
+            tx_public_key: funding_tx_pubkey,
         };
         let change_context = MemoContext {
             tx_public_key: &change_tx_pubkey,

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -119,7 +119,7 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
     /// Build a memo for a gift code change output
     fn make_memo_for_change_output(
         &mut self,
-        _amount: Amount,
+        amount: Amount,
         _change_destination: &ReservedDestination,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -128,6 +128,11 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
         }
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        if amount.value > 0 {
+            return Err(NewMemoError::BadInputs(
+                "Funding memo TxOut should be zero valued".into(),
+            ));
         }
         if self.gift_code_tx_out_public_key.as_ref() == Some(memo_context.tx_public_key) {
             return Err(NewMemoError::BadInputs("The public_key in the memo should be the TxOut at the gift code subaddress and not that of the memo TxOut".into()));
@@ -143,10 +148,36 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
     }
 }
 
+#[cfg(test)]
 mod tests {
 
     #[test]
-    fn test_gift_code() {
+    fn test_gift_code_funding_memo_built_successfully_with_note() {
+        // Tests forthcoming
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_built_successfully_without_note() {
+        // Tests forthcoming
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fails_to_build_with_key_from_context() {
+        // Tests forthcoming
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fails_for_more_than_one_change_memo() {
+        // Tests forthcoming
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fields_are_cleared_properly() {
+        // Tests forthcoming
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_writes_unused_if_change_disabled() {
         // Tests forthcoming
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -33,15 +33,18 @@ pub struct GiftCodeSenderMemoBuilder {
     wrote_change_memo: bool,
 }
 
-impl GiftCodeSenderMemoBuilder {
-    /// Create a new gift code sender memo builder
-    pub fn new() -> Self {
+// Create an empty GiftCodeSenderMemoBuilder
+impl Default for GiftCodeSenderMemoBuilder {
+    fn default() -> Self {
         Self {
             note: "".into(),
             gift_code_change_memo_enabled: true,
             wrote_change_memo: false,
         }
     }
+}
+
+impl GiftCodeSenderMemoBuilder {
     /// Set a utf-8 note (up to 64 bytes) onto the sender memo indicating
     /// any desired info about the gift code. This method will enforce the
     /// 64 byte limit with a NewMemoErr if the &str passed is longer than
@@ -105,7 +108,6 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
 }
 
 mod tests {
-    use super::*;
 
     #[test]
     fn test_gift_code() {

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -3,7 +3,10 @@
 //! Defines the Memo Builder for the gift code sender memo (0x0002)
 //! specified in MCIP #32
 
-use crate::{memo::{GiftCodeSenderMemo, UnusedMemo}, MemoBuilder, ReservedDestination};
+use crate::{
+    memo::{GiftCodeSenderMemo, UnusedMemo},
+    MemoBuilder, ReservedDestination,
+};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -45,7 +48,9 @@ impl GiftCodeSenderMemoBuilder {
     /// 64 bytes.
     pub fn set_gift_code_sender_note(&mut self, note: &str) -> Result<(), NewMemoError> {
         if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
-            return Err(NewMemoError::BadInputs("Sender note cannot be longer than 64 bytes".into()));
+            return Err(NewMemoError::BadInputs(
+                "Sender note cannot be longer than 64 bytes".into(),
+            ));
         }
         self.note = note.into();
         Ok(())
@@ -96,5 +101,14 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
         };
         self.wrote_change_memo = true;
         Ok(GiftCodeSenderMemo::new(self.note.as_str())?.into())
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gift_code() {
+        // Tests forthcoming
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -31,6 +31,8 @@ pub struct GiftCodeSenderMemoBuilder {
     gift_code_change_memo_enabled: bool,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
+    // Whetever we've set a valid note
+    wrote_valid_note: bool,
 }
 
 // Create an empty GiftCodeSenderMemoBuilder
@@ -40,6 +42,7 @@ impl Default for GiftCodeSenderMemoBuilder {
             note: "".into(),
             gift_code_change_memo_enabled: true,
             wrote_change_memo: false,
+            wrote_valid_note: true,
         }
     }
 }
@@ -51,6 +54,7 @@ impl GiftCodeSenderMemoBuilder {
     /// 64 bytes.
     pub fn set_gift_code_sender_note(&mut self, note: &str) -> Result<(), NewMemoError> {
         if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
+            self.wrote_valid_note = false;
             return Err(NewMemoError::BadInputs(
                 "Sender note cannot be longer than 64 bytes".into(),
             ));
@@ -102,15 +106,156 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
         };
+        if !self.wrote_valid_note {
+            return Err(NewMemoError::BadInputs(
+                "Tried to set a note longer than 64 bytes".into(),
+            ));
+        }
         self.wrote_change_memo = true;
         Ok(GiftCodeSenderMemo::new(self.note.as_str())?.into())
     }
 }
 
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::test_utils::build_change_memo_with_amount;
+
+    /// Get the sender note
+    fn get_sender_note(memo_data: &[u8; GiftCodeSenderMemo::MEMO_DATA_LEN]) -> &str {
+        let index = if let Some(terminator) = memo_data.iter().position(|b| b == &0u8) {
+            terminator
+        } else {
+            GiftCodeSenderMemo::MEMO_DATA_LEN
+        };
+
+        std::str::from_utf8(&memo_data[0..index]).unwrap()
+    }
 
     #[test]
-    fn test_gift_code() {
-        // Tests forthcoming
+    fn test_gift_code_sender_memo_built_successfully_with_note() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Set the note
+        let note = "It's MEMO TIME!!";
+        builder.set_gift_code_sender_note(note).unwrap();
+
+        // Build the memo payload and get the data
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+        // Verify memo data
+        let derived_note = get_sender_note(memo_payload.get_memo_data());
+        assert_eq!(note, derived_note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_built_successfully_without_note() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Build the memo payload and get the data
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+        // Verify memo data
+        let blank_note = "";
+        let derived_note = get_sender_note(memo_payload.get_memo_data());
+        assert_eq!(blank_note, derived_note);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_fails_for_more_than_one_change_memo() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Set the note
+        let note = "It's MEMO TIME!!";
+        builder.set_gift_code_sender_note(note).unwrap();
+
+        // Build the memo payload and get the data
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+        // Verify memo data works once
+        let derived_note = get_sender_note(memo_payload.get_memo_data());
+        assert_eq!(note, derived_note);
+
+        // Verify memo_data doesn't work more than once
+        let amount_2 = Amount::new(42, 0.into());
+        let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount_2);
+
+        let matches = matches!(memo_payload_2, Err(NewMemoError::MultipleChangeOutputs));
+        assert!(matches);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_fields_are_cleared_properly() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Set the note
+        let note = "It's MEMO TIME!!";
+        builder.set_gift_code_sender_note(note).unwrap();
+        builder.clear_sender_note();
+
+        // Build the memo payload
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+        // Verify memo data
+        let blank_note = "";
+        let derived_note = get_sender_note(memo_payload.get_memo_data());
+        assert_eq!(blank_note, derived_note);
+
+        // Create another memo builder
+        let mut builder_2 = GiftCodeSenderMemoBuilder::default();
+
+        // Set the cancellation index and then set another note on top of it
+        let note_2 = "Is anything actually real?";
+        builder_2.set_gift_code_sender_note(note).unwrap();
+        builder_2.set_gift_code_sender_note(note_2).unwrap();
+
+        // Build the memo payload and get the data
+        let amount_2 = Amount::new(666, 0.into());
+        let memo_payload_2 = build_change_memo_with_amount(&mut builder_2, amount_2).unwrap();
+        let derived_note_2 = get_sender_note(memo_payload_2.get_memo_data());
+        assert_eq!(note_2, derived_note_2);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_writes_unused_if_change_disabled() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Set the note
+        let note = "It's MEMO TIME!!";
+        builder.set_gift_code_sender_note(note).unwrap();
+
+        // Disable change memos
+        builder.disable_gift_code_change_memo();
+
+        // Build the memo payload
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+        assert_eq!(memo_payload.get_memo_data(), &[0u8; 64]);
+    }
+
+    #[test]
+    fn test_gift_code_sender_builder_doesnt_allow_invalid_note_length() {
+        // Create memo builder
+        let mut builder = GiftCodeSenderMemoBuilder::default();
+
+        // Set an invalid note
+        let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1];
+        let note = std::str::from_utf8(&note_bytes).unwrap();
+        let result = builder.set_gift_code_sender_note(note);
+        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
+
+        // Try to build after failing to set note
+        let amount = Amount::new(42, 0.into());
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
+        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Defines the Memo Builder for the gift code sender memo (0x0002)
+//! specified in MCIP #32
+
+use crate::{memo::{GiftCodeSenderMemo, UnusedMemo}, MemoBuilder, ReservedDestination};
+use mc_account_keys::PublicAddress;
+use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+
+/// There are three possible gift code memo types specified in MCIP #32
+/// | Memo type bytes | Name                                              |
+/// | -----------     | -----------                                       |
+/// | -->0x0002<--    | Gift Code Sender Memo                             |
+/// |    0x0201       | Gift Code Funding Memo                            |
+/// |    0x0202       | Gift Code Cancellation Memo                       |
+/// This memo builder builds a gift code sender memo (0x0002). A gift code
+/// considered redeemed when the Receiver uses the TxOut spend private key
+/// of the gift code TxOut they received from the Sender to send the TxOut
+/// from the sender's gift code subaddress to their own change subaddress.
+/// The destination memo is written into that TxOut at the change address
+/// and includes an optional Utf-8 note up to 64 bytes long the Receiver
+/// can use to record any information they desire about the gift code.
+#[derive(Clone, Debug)]
+pub struct GiftCodeSenderMemoBuilder {
+    // Utf-8 formatted note within the memo that can be up to 64 bytes long
+    note: String,
+    // Whether or not to enable change memos
+    gift_code_change_memo_enabled: bool,
+    // Whether we've already written the change memo
+    wrote_change_memo: bool,
+}
+
+impl GiftCodeSenderMemoBuilder {
+    /// Create a new gift code sender memo builder
+    pub fn new() -> Self {
+        Self {
+            note: "".into(),
+            gift_code_change_memo_enabled: true,
+            wrote_change_memo: false,
+        }
+    }
+    /// Set a utf-8 note (up to 64 bytes) onto the sender memo indicating
+    /// any desired info about the gift code. This method will enforce the
+    /// 64 byte limit with a NewMemoErr if the &str passed is longer than
+    /// 64 bytes.
+    pub fn set_gift_code_sender_note(&mut self, note: &str) -> Result<(), NewMemoError> {
+        if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
+            return Err(NewMemoError::BadInputs("Sender note cannot be longer than 64 bytes".into()));
+        }
+        self.note = note.into();
+        Ok(())
+    }
+    /// Clear the gift code sender note
+    pub fn clear_sender_note(&mut self) {
+        self.note = "".into();
+    }
+    /// Enable change memos
+    pub fn enable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = true;
+    }
+    /// Disable change memos
+    pub fn disable_gift_code_change_memo(&mut self) {
+        self.gift_code_change_memo_enabled = false;
+    }
+}
+
+impl MemoBuilder for GiftCodeSenderMemoBuilder {
+    /// Set the fee
+    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+        Ok(())
+    }
+
+    /// Gift code destination memos are not allowed - all gift code
+    /// memos accompany TxOuts sent to the change address
+    fn make_memo_for_output(
+        &mut self,
+        _amount: Amount,
+        _recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        Err(NewMemoError::DestinationMemoNotAllowed)
+    }
+
+    /// Build a memo for a gift code change output
+    fn make_memo_for_change_output(
+        &mut self,
+        _amount: Amount,
+        _change_destination: &ReservedDestination,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+        if !self.gift_code_change_memo_enabled {
+            return Ok(UnusedMemo {}.into());
+        };
+        if self.wrote_change_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        };
+        self.wrote_change_memo = true;
+        Ok(GiftCodeSenderMemo::new(self.note.as_str())?.into())
+    }
+}

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -11,11 +11,11 @@ use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 /// There are three possible gift code memo types specified in MCIP #32
-/// | Memo type bytes | Name                                              |
-/// | -----------     | -----------                                       |
-/// | -->0x0002<--    | Gift Code Sender Memo                             |
-/// |    0x0201       | Gift Code Funding Memo                            |
-/// |    0x0202       | Gift Code Cancellation Memo                       |
+/// | Memo type bytes | Name                        |
+/// | -----------     | -----------                 |
+/// | -->0x0002<--    | Gift Code Sender Memo       |
+/// |    0x0201       | Gift Code Funding Memo      |
+/// |    0x0202       | Gift Code Cancellation Memo |
 /// This memo builder builds a gift code sender memo (0x0002). A gift code
 /// considered redeemed when the Receiver uses the TxOut spend private key
 /// of the gift code TxOut they received from the Sender to send the TxOut

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -19,7 +19,7 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// from the sender's gift code subaddress to their own change subaddress.
 /// The sender memo is written into the TxOut the receiver sends to the
 /// change address and includes an optional Utf-8 note up to 64 bytes long
-/// the Receiver can  use to record any information they desire about the
+/// the Receiver can use to record any information they desire about the
 /// gift code.
 #[derive(Clone, Debug)]
 pub struct GiftCodeSenderMemoBuilder {
@@ -35,9 +35,10 @@ impl GiftCodeSenderMemoBuilder {
     /// note passed is longer than 64 bytes.
     pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
-            return Err(NewMemoError::BadInputs(
-                "Sender note cannot be longer than 64 bytes".into(),
-            ));
+            return Err(NewMemoError::BadInputs(format!(
+                "Note memo cannot be greater than {} bytes",
+                GiftCodeSenderMemo::MEMO_DATA_LEN
+            )));
         }
         Ok(Self {
             note: note.into(),

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -13,13 +13,14 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// | -->0x0002<--    | Gift Code Sender Memo       |
 /// |    0x0201       | Gift Code Funding Memo      |
 /// |    0x0202       | Gift Code Cancellation Memo |
-/// This memo builder builds a gift code sender memo (0x0002). A gift code
+/// This memo builder builds the gift code sender memo (0x0002). A gift code
 /// considered redeemed when the Receiver uses the TxOut spend private key
 /// of the gift code TxOut they received from the Sender to send the TxOut
 /// from the sender's gift code subaddress to their own change subaddress.
-/// The destination memo is written into that TxOut at the change address
-/// and includes an optional Utf-8 note up to 64 bytes long the Receiver
-/// can use to record any information they desire about the gift code.
+/// The sender memo is written into the TxOut the receiver sends to the
+/// change address and includes an optional Utf-8 note up to 64 bytes long
+/// the Receiver can  use to record any information they desire about the
+/// gift code.
 #[derive(Clone, Debug)]
 pub struct GiftCodeSenderMemoBuilder {
     // Utf-8 formatted note within the memo that can be up to 64 bytes long
@@ -29,10 +30,9 @@ pub struct GiftCodeSenderMemoBuilder {
 }
 
 impl GiftCodeSenderMemoBuilder {
-    /// Initialize memo builder with a utf-8 note (up to 64 bytes)
-    /// indicating what the gift code was for. This method will enforce
-    /// the 64 byte limit with a NewMemoErr if the &str passed is longer
-    /// than 64 bytes.
+    /// Initialize memo builder with a utf-8 note (up to 64 bytes), This
+    /// method will enforce the 64 byte limit with a NewMemoErr if the
+    /// note passed is longer than 64 bytes.
     pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
             return Err(NewMemoError::BadInputs(
@@ -80,7 +80,6 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::test_utils::build_change_memo_with_amount;
 

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -3,10 +3,7 @@
 //! Defines the Memo Builder for the gift code sender memo (0x0002)
 //! specified in MCIP #32
 
-use crate::{
-    memo::{GiftCodeSenderMemo, UnusedMemo},
-    MemoBuilder, ReservedDestination,
-};
+use crate::{memo::GiftCodeSenderMemo, MemoBuilder, ReservedDestination};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -27,55 +24,25 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 pub struct GiftCodeSenderMemoBuilder {
     // Utf-8 formatted note within the memo that can be up to 64 bytes long
     note: String,
-    // Whether or not to enable change memos
-    gift_code_change_memo_enabled: bool,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
-    // Whether our last note setting attempt was invalid and the note hasn't
-    // been reset with a valid note or cleared
-    attempted_invalid_note: bool,
-}
-
-// Create an empty GiftCodeSenderMemoBuilder
-impl Default for GiftCodeSenderMemoBuilder {
-    fn default() -> Self {
-        Self {
-            note: "".into(),
-            gift_code_change_memo_enabled: true,
-            wrote_change_memo: false,
-            attempted_invalid_note: false,
-        }
-    }
 }
 
 impl GiftCodeSenderMemoBuilder {
-    /// Set a utf-8 note (up to 64 bytes) onto the sender memo indicating
-    /// any desired info about the gift code. This method will enforce the
-    /// 64 byte limit with a NewMemoErr if the &str passed is longer than
-    /// 64 bytes.
-    pub fn set_gift_code_sender_note(&mut self, note: &str) -> Result<(), NewMemoError> {
+    /// Initialize memo builder with a utf-8 note (up to 64 bytes)
+    /// indicating what the gift code was for. This method will enforce
+    /// the 64 byte limit with a NewMemoErr if the &str passed is longer
+    /// than 64 bytes.
+    pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
-            self.attempted_invalid_note = true;
             return Err(NewMemoError::BadInputs(
                 "Sender note cannot be longer than 64 bytes".into(),
             ));
         }
-        self.note = note.into();
-        self.attempted_invalid_note = false;
-        Ok(())
-    }
-    /// Clear the gift code sender note
-    pub fn clear_sender_note(&mut self) {
-        self.attempted_invalid_note = false;
-        self.note = "".into();
-    }
-    /// Enable change memos
-    pub fn enable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = true;
-    }
-    /// Disable change memos
-    pub fn disable_gift_code_change_memo(&mut self) {
-        self.gift_code_change_memo_enabled = false;
+        Ok(Self {
+            note: note.into(),
+            wrote_change_memo: false,
+        })
     }
 }
 
@@ -85,8 +52,7 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
         Ok(())
     }
 
-    /// Gift code destination memos are not allowed - all gift code
-    /// memos accompany TxOuts sent to the change address
+    /// Destination memos are not allowed for gift code sender memos
     fn make_memo_for_output(
         &mut self,
         _amount: Amount,
@@ -96,25 +62,17 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
         Err(NewMemoError::DestinationMemoNotAllowed)
     }
 
-    /// Build a memo for a gift code change output
+    /// Write the sender memo to the TxOut the receiver sends to their change
+    /// address when the gift code is redeemed
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
         _change_destination: &ReservedDestination,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
-        if !self.gift_code_change_memo_enabled {
-            return Ok(UnusedMemo {}.into());
-        };
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
         };
-        // Prevent callers from writing memo if last note set attempt was a failure
-        if self.attempted_invalid_note {
-            return Err(NewMemoError::BadInputs(
-                "Tried to set a note longer than 64 bytes".into(),
-            ));
-        }
         self.wrote_change_memo = true;
         Ok(GiftCodeSenderMemo::new(self.note.as_str())?.into())
     }
@@ -122,155 +80,100 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
-    use crate::test_utils::{build_change_memo_with_amount, MemoDecoder};
+    use crate::test_utils::build_change_memo_with_amount;
 
     #[test]
     fn test_gift_code_sender_memo_built_successfully_with_note() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Set the note
+        // Create memo builder with note
         let note = "It's MEMO TIME!!";
-        builder.set_gift_code_sender_note(note).unwrap();
+        let mut builder = GiftCodeSenderMemoBuilder::new(note).unwrap();
 
         // Build the memo payload and get the data
         let amount = Amount::new(42, 0.into());
         let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
         // Verify memo data
-        let derived_note = MemoDecoder::decode_sender_note(memo_payload.get_memo_data());
-        assert_eq!(note, derived_note);
+        let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+        assert_eq!(note, derived_note.sender_note().unwrap());
     }
 
     #[test]
-    fn test_gift_code_sender_memo_built_successfully_without_note() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Build the memo payload and get the data
+    fn test_gift_code_sender_memo_built_successfully_with_blank_note_and_notes_close_to_max_length()
+    {
+        // Create edge case notes
         let amount = Amount::new(42, 0.into());
-        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
-
-        // Verify memo data
         let blank_note = "";
-        let derived_note = MemoDecoder::decode_sender_note(memo_payload.get_memo_data());
-        assert_eq!(blank_note, derived_note);
+        let note_minus_one =
+            std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
+        let note_exact = std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN]).unwrap();
+
+        // Verify blank note is okay
+        {
+            let mut builder = GiftCodeSenderMemoBuilder::new(blank_note).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+            // Verify memo data
+            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(blank_note, derived_note.sender_note().unwrap());
+        }
+
+        // Verify note with max length minus one is okay
+        {
+            let mut builder = GiftCodeSenderMemoBuilder::new(note_minus_one).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+            // Verify memo data
+            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(note_minus_one, derived_note.sender_note().unwrap());
+        }
+
+        // Verify note with max length okay
+        {
+            let mut builder = GiftCodeSenderMemoBuilder::new(note_exact).unwrap();
+
+            // Build the memo payload and get the data
+            let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+
+            // Verify memo data
+            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(note_exact, derived_note.sender_note().unwrap());
+        }
     }
 
     #[test]
     fn test_gift_code_sender_memo_fails_for_more_than_one_change_memo() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Set the note
+        // Create memo builder with note
         let note = "It's MEMO TIME!!";
-        builder.set_gift_code_sender_note(note).unwrap();
+        let mut builder = GiftCodeSenderMemoBuilder::new(note).unwrap();
 
         // Build the memo payload and get the data
         let amount = Amount::new(42, 0.into());
         let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
-        // Verify memo data works once
-        let derived_note = MemoDecoder::decode_sender_note(memo_payload.get_memo_data());
-        assert_eq!(note, derived_note);
+        // Verify memo data can be verified after writing the first change memo
+        let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+        assert_eq!(note, derived_note.sender_note().unwrap());
 
-        // Verify memo_data doesn't work more than once
-        let amount_2 = Amount::new(42, 0.into());
-        let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount_2);
-
-        let matches = matches!(memo_payload_2, Err(NewMemoError::MultipleChangeOutputs));
-        assert!(matches);
+        // Verify attempting to write two change memos fail
+        let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount);
+        assert!(matches!(
+            memo_payload_2,
+            Err(NewMemoError::MultipleChangeOutputs)
+        ));
     }
 
     #[test]
-    fn test_gift_code_sender_memo_fields_are_cleared_properly() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Set the note
-        let note = "It's MEMO TIME!!";
-        builder.set_gift_code_sender_note(note).unwrap();
-        builder.clear_sender_note();
-
-        // Build the memo payload
-        let amount = Amount::new(42, 0.into());
-        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
-
-        // Verify memo data
-        let blank_note = "";
-        let derived_note = MemoDecoder::decode_sender_note(memo_payload.get_memo_data());
-        assert_eq!(blank_note, derived_note);
-
-        // Create another memo builder
-        let mut builder_2 = GiftCodeSenderMemoBuilder::default();
-
-        // Set the cancellation index and then set another note on top of it
-        let note_2 = "Is anything actually real?";
-        builder_2.set_gift_code_sender_note(note).unwrap();
-        builder_2.set_gift_code_sender_note(note_2).unwrap();
-
-        // Build the memo payload and get the data
-        let amount_2 = Amount::new(666, 0.into());
-        let memo_payload_2 = build_change_memo_with_amount(&mut builder_2, amount_2).unwrap();
-        let derived_note_2 = MemoDecoder::decode_sender_note(memo_payload_2.get_memo_data());
-        assert_eq!(note_2, derived_note_2);
-    }
-
-    #[test]
-    fn test_gift_code_sender_memo_writes_unused_if_change_disabled() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Set the note
-        let note = "It's MEMO TIME!!";
-        builder.set_gift_code_sender_note(note).unwrap();
-
-        // Disable change memos
-        builder.disable_gift_code_change_memo();
-
-        // Build the memo payload
-        let amount = Amount::new(42, 0.into());
-        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
-        assert_eq!(memo_payload.get_memo_data(), &[0u8; 64]);
-    }
-
-    #[test]
-    fn test_gift_code_sender_note_builder_fails_after_attempting_invalid_note() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Attempt to set an invalid note
+    fn test_gift_code_sender_note_builder_creation_fails_with_invalid_note() {
+        // Create Memo Builder with an input longer than allowed
         let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1];
         let note = std::str::from_utf8(&note_bytes).unwrap();
-        let result = builder.set_gift_code_sender_note(note);
-        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
-
-        // Fail to build memo after failing to set valid note
-        let amount = Amount::new(42, 0.into());
-        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
-        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
-    }
-
-    #[test]
-    fn test_gift_code_sender_note_builder_succeeds_after_resetting_invalid_note_with_valid_note() {
-        // Create memo builder
-        let mut builder = GiftCodeSenderMemoBuilder::default();
-
-        // Attempt to set an invalid note
-        let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1];
-        let note = std::str::from_utf8(&note_bytes).unwrap();
-        let result = builder.set_gift_code_sender_note(note);
-        assert!(matches!(result, Err(NewMemoError::BadInputs(_))));
-
-        // Reset with valid note
-        let valid_note = "Im within the byte length, but validity is a subjective concept";
-        builder.set_gift_code_sender_note(valid_note).unwrap();
-        let amount = Amount::new(42, 0.into());
-        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
-
-        // Assert we can build the memo and get the correct output
-        let derived_note = MemoDecoder::decode_sender_note(memo_payload.get_memo_data());
-        assert_eq!(valid_note, derived_note);
+        let builder = GiftCodeSenderMemoBuilder::new(note);
+        assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
     }
 }

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -10,9 +10,16 @@ use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
 mod burn_redemption_memo_builder;
+mod gift_code_cancellation_memo_builder;
+mod gift_code_funding_memo_builder;
+mod gift_code_sender_memo_builder;
 mod rth_memo_builder;
 
+
 pub use burn_redemption_memo_builder::BurnRedemptionMemoBuilder;
+pub use gift_code_cancellation_memo_builder::GiftCodeCancellationMemoBuilder;
+pub use gift_code_funding_memo_builder::GiftCodeFundingMemoBuilder;
+pub use gift_code_sender_memo_builder::GiftCodeSenderMemoBuilder;
 pub use rth_memo_builder::RTHMemoBuilder;
 
 /// The MemoBuilder trait defines the API that the transaction builder uses

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -15,7 +15,6 @@ mod gift_code_funding_memo_builder;
 mod gift_code_sender_memo_builder;
 mod rth_memo_builder;
 
-
 pub use burn_redemption_memo_builder::BurnRedemptionMemoBuilder;
 pub use gift_code_cancellation_memo_builder::GiftCodeCancellationMemoBuilder;
 pub use gift_code_funding_memo_builder::GiftCodeFundingMemoBuilder;

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -207,14 +207,14 @@ pub fn get_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver + Clone>
     transaction_builder.build(rng)
 }
 
-/// Build simulated test memo with zero amount
+/// Build simulated change memo with zero amount
 pub fn build_zero_value_change_memo(
     builder: &mut impl MemoBuilder,
 ) -> Result<MemoPayload, NewMemoError> {
     build_change_memo_with_amount(builder, Amount::new(0, 0.into()))
 }
 
-/// Build simulated test memo with amount
+/// Build simulated change memo with amount
 pub fn build_change_memo_with_amount(
     builder: &mut impl MemoBuilder,
     change_amount: Amount,
@@ -236,7 +236,7 @@ pub fn build_change_memo_with_amount(
 pub struct MemoDecoder;
 
 impl MemoDecoder {
-    /// Get the sender note
+    /// Decode a sender note from bytes
     pub fn decode_sender_note(memo_data: &[u8; GiftCodeSenderMemo::MEMO_DATA_LEN]) -> &str {
         let index = if let Some(terminator) = memo_data.iter().position(|b| b == &0u8) {
             terminator
@@ -247,7 +247,7 @@ impl MemoDecoder {
         std::str::from_utf8(&memo_data[0..index]).unwrap()
     }
 
-    /// Get funding note from memo
+    /// Decode a funding note from bytes
     pub fn decode_funding_note(memo_data: &[u8; GiftCodeFundingMemo::MEMO_DATA_LEN]) -> &str {
         let index = if let Some(terminator) = memo_data
             .iter()
@@ -262,7 +262,8 @@ impl MemoDecoder {
         std::str::from_utf8(&memo_data[GiftCodeFundingMemo::HASH_DATA_LEN..index]).unwrap()
     }
 
-    /// Get the first four bytes of a gift code TxOut public key
+    /// Get the first four bytes of the Blake2b hash of a gift code TxOut public
+    /// key
     pub fn tx_out_public_key_short_hash(
         tx_out_public_key: &RistrettoPublic,
     ) -> [u8; GiftCodeFundingMemo::HASH_DATA_LEN] {

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -54,7 +54,7 @@ pub fn create_output<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
     )
 }
 
-// Make fake outputs for the ring
+// Make fake outputs for a ring
 fn add_fake_outputs_to_ring<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
     mut ring: Vec<TxOut>,
     block_version: BlockVersion,
@@ -63,7 +63,7 @@ fn add_fake_outputs_to_ring<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
     fog_resolver: &FPR,
     rng: &mut RNG,
 ) -> Vec<TxOut> {
-    // Create ring_size - 1 mixins with assorted token ids
+    // Create fake mixins with assorted token ids
     for idx in 0..ring_size - 1 {
         let address = AccountKey::random(rng).default_subaddress();
         let token_id = if block_version.masked_token_id_feature_is_supported() {
@@ -109,7 +109,7 @@ pub fn get_ring<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
         rng,
     );
 
-    // Insert the real element.
+    // Insert the "real" element.
     let real_index = (rng.next_u64() % ring_size as u64) as usize;
     let (tx_out, _) = create_output(
         block_version,
@@ -154,6 +154,8 @@ pub fn get_ring_for_txout<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
         fog_resolver,
         rng,
     );
+
+    // Insert the TxOut
     let real_index = (rng.next_u64() % ring_size as u64) as usize;
     ring.insert(real_index, tx_out.clone());
     assert_eq!(ring.len(), ring_size);

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -2,7 +2,10 @@
 
 //! Utilities that help with testing the transaction builder and related objects
 
-use crate::{EmptyMemoBuilder, InputCredentials, MemoPayload, TransactionBuilder, TxBuilderError};
+use crate::{
+    EmptyMemoBuilder, InputCredentials, MemoBuilder, MemoPayload, ReservedDestination,
+    TransactionBuilder, TxBuilderError,
+};
 use core::convert::TryFrom;
 use mc_account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX};
 use mc_crypto_keys::RistrettoPublic;
@@ -11,9 +14,10 @@ use mc_transaction_core::{
     onetime_keys::*,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
-    Amount, BlockVersion, Token, TokenId,
+    Amount, BlockVersion, MemoContext, NewMemoError, Token, TokenId,
 };
-use rand::{CryptoRng, RngCore};
+use mc_util_from_random::FromRandom;
+use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 
 /// Creates a TxOut that sends `value` to `recipient`.
 ///
@@ -200,4 +204,29 @@ pub fn get_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver + Clone>
     transaction_builder.set_fee(fee).unwrap();
 
     transaction_builder.build(rng)
+}
+
+/// Build simulated test memo with zero amount
+pub fn build_zero_value_change_memo(
+    builder: &mut impl MemoBuilder,
+) -> Result<MemoPayload, NewMemoError> {
+    build_change_memo_with_amount(builder, Amount::new(0, 0.into()))
+}
+
+/// Build simulated test memo with amount
+pub fn build_change_memo_with_amount(
+    builder: &mut impl MemoBuilder,
+    change_amount: Amount,
+) -> Result<MemoPayload, NewMemoError> {
+    // Create simulated context
+    let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+    let alice = AccountKey::random_with_fog(&mut rng);
+    let alice_address_book = ReservedDestination::from(&alice);
+    let change_tx_pubkey = RistrettoPublic::from_random(&mut rng);
+    let memo_context = MemoContext {
+        tx_public_key: &change_tx_pubkey,
+    };
+
+    //Build memo
+    builder.make_memo_for_change_output(change_amount, &alice_address_book, memo_context)
 }

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -152,7 +152,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///
     /// Note: Before adding a signed_contingent_input, you probably want to:
     /// * validate it (call .validate())
-    /// * check if key image appreared already (call .key_image())
+    /// * check if key image appeared already (call .key_image())
     /// * provide merkle proofs of membership for each ring member (see
     ///   .tx_out_global_indices)
     ///

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -3252,13 +3252,13 @@ pub mod transaction_builder_tests {
             // construct TxOutGiftCode object from it
             let global_index = 42;
             let gift_code_tx_out_private_key = recover_onetime_private_key(
-                &gift_code_tx_out_public_key,
-                &sender.spend_private_key(),
+                gift_code_tx_out_public_key,
+                sender.spend_private_key(),
                 &sender.gift_code_subaddress_spend_private(),
             );
             let tx_out_gift_code = TxOutGiftCode {
                 global_index,
-                onetime_private_key: gift_code_tx_out_private_key.clone(),
+                onetime_private_key: gift_code_tx_out_private_key,
                 shared_secret: gift_code_ss,
             };
 
@@ -3273,7 +3273,7 @@ pub mod transaction_builder_tests {
             let sending_output_amount = Amount::new(sending_input_amount.value - fee, token_id);
 
             let (ring, real_index) = get_ring_for_txout(
-                &funding_output,
+                funding_output,
                 block_version,
                 sending_input_amount,
                 3,
@@ -3306,7 +3306,7 @@ pub mod transaction_builder_tests {
                 input_secret: InputSecret {
                     onetime_private_key: gift_code_tx_out_private_key,
                     amount: sending_input_amount,
-                    blinding: blinding,
+                    blinding,
                 },
             };
 


### PR DESCRIPTION
### Motivation

Build transaction builders for gift codes. Tracks #1735.

### In this PR
* A transaction builder for each gift code memo type

### Future Work
* Create a protobuf message schema for TxOutGiftCode and relevant conversions in mc-api
* Add a gift code tx path in transaction builder
* Make code paths for libsignal ffis & mobilecoind to use to build gift code transactions

