### PR TITLE
Proof of concept for zip-exact iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,6 +4844,7 @@ dependencies = [
  "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",
+ "mc-util-zip-exact",
  "merlin",
  "proptest",
  "prost",
@@ -5240,6 +5241,13 @@ dependencies = [
  "rand_hc 0.3.1",
  "serde",
  "url",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "itertools",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ members = [
     "util/test-helper",
     "util/test-vector",
     "util/uri",
+    "util/zip-exact",
     "watcher",
     "watcher/api",
 ]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1252,6 +1253,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "itertools",
 ]
 
 [[package]]

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1298,6 +1298,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1364,6 +1365,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "itertools",
 ]
 
 [[package]]

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1349,6 +1350,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "itertools",
 ]
 
 [[package]]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1383,6 +1384,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "itertools",
 ]
 
 [[package]]

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -32,6 +32,7 @@ mc-crypto-multisig = { path = "../../crypto/multisig", default-features = false 
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 mc-util-serial = { path = "../../util/serial" }
+mc-util-zip-exact = { path = "../../util/zip-exact" }
 
 [target.'cfg(target_feature = "avx2")'.dependencies]
 bulletproofs-og = { version = "3.0.0-pre.1", default-features = false, features = ["avx2_backend"] }

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -5,6 +5,7 @@
 use crate::{range_proofs::error::Error as RangeProofError, TokenId};
 use alloc::string::{String, ToString};
 use displaydoc::Display;
+use mc_util_zip_exact::ZipExactError;
 use serde::{Deserialize, Serialize};
 
 /// An error which can occur in connection to a ring signature
@@ -84,6 +85,9 @@ pub enum Error {
 
     /// No commitments were found for {0}, this is a logic error
     NoCommitmentsForTokenId(TokenId),
+
+    /// Zip exact error (this is a logic error around the size of lists)
+    ZipExact,
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {
@@ -95,5 +99,11 @@ impl From<mc_util_repr_bytes::LengthMismatch> for Error {
 impl From<RangeProofError> for Error {
     fn from(src: RangeProofError) -> Self {
         Error::RangeProof(src.to_string())
+    }
+}
+
+impl From<ZipExactError> for Error {
+    fn from(_src: ZipExactError) -> Self {
+        Error::ZipExact
     }
 }

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+description = "A custom iterator"
+readme = "README.md"
+
+[dependencies]
+itertools = "0.10"

--- a/util/zip-exact/README.md
+++ b/util/zip-exact/README.md
@@ -1,0 +1,9 @@
+zip-exact
+=========
+
+A utility much like [`std::iter::zip`](https://doc.rust-lang.org/stable/std/iter/fn.zip.html),
+with the difference that it returns an error if the iterators are not the same length.
+
+This is useful because sometimes, it can lead to a critical bug
+if two lists that are zipped together have the wrong size. `zip_exact` can be
+used instead of `zip` when it is important to make this error loud rather than silent.

--- a/util/zip-exact/src/lib.rs
+++ b/util/zip-exact/src/lib.rs
@@ -1,0 +1,114 @@
+#![no_std]
+
+use core::{
+    cmp::{self, Ordering::Equal},
+    fmt::{self, Debug, Display},
+    iter::{Fuse, FusedIterator},
+};
+
+// A variation on ZipLongest originally written by SimonSapin,
+// and dedicated to itertools https://github.com/rust-lang/rust/pull/19283
+//
+// This version iterates two other iterators simultaneously, but returns an
+// error if they do not have the same length, rather than failing silently.
+
+/// An iterator which iterates two other iterators simultaneously
+///
+/// This iterator is *fused*.
+///
+/// See [`.zip_exact()`](crate::mc-util-zip-exact::zip_exact) for more
+/// information.
+#[derive(Clone, Debug)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct ZipExact<T, U> {
+    a: Fuse<T>,
+    b: Fuse<U>,
+}
+
+/// Create a new `ZipExact` iterator.
+///
+/// This iterator takes two iterators and returns a pair which is the next item
+/// from both iterators. It returns None if both iterators are exhausted.
+/// It returns a ZipExactError if one iterator becomes exhausted before the
+/// other.
+pub fn zip_exact<T, U>(a: T, b: U) -> ZipExact<T, U>
+where
+    T: Iterator,
+    U: Iterator,
+{
+    ZipExact {
+        a: a.fuse(),
+        b: b.fuse(),
+    }
+}
+
+impl<T, U> Iterator for ZipExact<T, U>
+where
+    T: Iterator,
+    U: Iterator,
+{
+    type Item = Result<(T::Item, U::Item), ZipExactError>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a.next(), self.b.next()) {
+            (None, None) => None,
+            (Some(a), Some(b)) => Some(Ok((a, b))),
+            _ => Some(Err(ZipExactError {})),
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_lower, a_upper) = self.a.size_hint();
+        let (b_lower, b_upper) = self.b.size_hint();
+        let lower = cmp::min(a_lower, b_lower);
+        let upper = match (a_upper, b_upper) {
+            (Some(u1), Some(u2)) => Some(cmp::min(u1, u2)),
+            _ => a_upper.or(b_upper),
+        };
+        (lower, upper)
+    }
+}
+
+impl<T, U> DoubleEndedIterator for ZipExact<T, U>
+where
+    T: DoubleEndedIterator + ExactSizeIterator,
+    U: DoubleEndedIterator + ExactSizeIterator,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self.a.len().cmp(&self.b.len()) {
+            Equal => match (self.a.next_back(), self.b.next_back()) {
+                (None, None) => None,
+                (Some(a), Some(b)) => Some(Ok((a, b))),
+                // These can only happen if .len() is inconsistent with .next_back()
+                _ => Some(Err(ZipExactError {})),
+            },
+            _ => Some(Err(ZipExactError {})),
+        }
+    }
+}
+
+impl<T, U> ExactSizeIterator for ZipExact<T, U>
+where
+    T: ExactSizeIterator,
+    U: ExactSizeIterator,
+{
+}
+
+impl<T, U> FusedIterator for ZipExact<T, U>
+where
+    T: Iterator,
+    U: Iterator,
+{
+}
+
+#[derive(Copy, Clone, Default, Debug)]
+pub struct ZipExactError {}
+
+impl Display for ZipExactError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "ZipExactError")
+    }
+}


### PR DESCRIPTION
This is one way of trying to address #1869 

Briefly, our protobuf schemas for transactions are quite messy right now. There are many "repeated" lists of items that need to be the same size (TxIn, RingMLSAG, pseudo output token id). Serialization does not enforce this so it falls to the transaction validation logic.

In the `signature_rct_bulletproofs` file, we have numerous checks that lists that are supposed to be the same size are the same, at the beginning of the file. Later, we zip these lists together.

What would happen if one of these length checks were accidentally skipped, or lost in a refactor?
Then, someone could submit a malformed Tx that has e.g. fewer TxIn than MLSAG objects.

Usually, we process these lists by using rust iterators and `zip`. However `zip` has some potentially dangerous behavior here -- if two lists are not the same size, zip just ignores the extra elements of the longer one, and does not panic or return an error.

It's not hard to imagine that e.g. this could lead to a money printing bug if e.g. the checking of an MLSAG object is just skipped by the transaction validation logic, due to this behavior of zip.

It would be very nice if we could just fix all our Tx protos and group data logically together instead of in parallel lists. However that's a fairly large and disruptive change right now.

An alternative is to make another version of zip that panics or returns an error in this scenario and use that in this file.

We chose not to make it panic. The reasoning is, in the scenario where this is supposed to be helping (a length check was missed), a panic still takes down the enclave, and creates a DOS vector. While not as bad as a money printing bug, it's still bad. So we decided to try to return an error instead.