### PR TITLE
Feature/attest verifier mc seed bugfix

### DIFF
--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -140,12 +140,9 @@ fn main() {
     purge_expired_cert(&root_anchor_path);
     purge_expired_cert(&chain_path);
 
-    let new_seed = match env::var("MC_SEED") {
-        Ok(_) => true,
-        Err(_) => false,
-    };
-
-    if !(root_anchor_path.exists() && signer_key_path.exists() && chain_path.exists()) || new_seed {
+    if !(root_anchor_path.exists() && signer_key_path.exists() && chain_path.exists())
+        || env::var("MC_SEED").is_ok()
+    {
         const ROOT_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signing CA\0";
         const SIGNER_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signer\0";
 

--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -25,7 +25,7 @@ use rand_hc::Hc128Rng;
 use std::{
     convert::TryFrom,
     env,
-    fs::{read, remove_file, write},
+    fs::{read, read_to_string, remove_file, write},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -123,7 +123,7 @@ fn main() {
     let mut signer_key_path = data_path.clone();
     signer_key_path.push("signer.key");
 
-    let mut chain_path = data_path;
+    let mut chain_path = data_path.clone();
     chain_path.push("chain.pem");
 
     cargo_emit::rerun_if_env_changed!("MC_SEED");
@@ -140,7 +140,19 @@ fn main() {
     purge_expired_cert(&root_anchor_path);
     purge_expired_cert(&chain_path);
 
-    if !(root_anchor_path.exists() && signer_key_path.exists() && chain_path.exists()) {
+    let mut previous_seed_path = data_path;
+    previous_seed_path.push("previous_seed.txt");
+
+    let previous_seed = read_to_string(&previous_seed_path).unwrap_or_default();
+
+    let new_seed = match env::var("MC_SEED") {
+        Ok(seed_hex) => Some(seed_hex),
+        Err(_) => None,
+    };
+
+    if !(root_anchor_path.exists() && signer_key_path.exists() && chain_path.exists())
+        || (new_seed.is_some() && new_seed != Some(previous_seed))
+    {
         const ROOT_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signing CA\0";
         const SIGNER_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signer\0";
 
@@ -267,6 +279,9 @@ fn main() {
             .expect("Could not create PEM string of certificate");
 
         write(chain_path, &(root_cert_pem + &signer_cert_pem)).expect("Unable to write cert chain");
+        if let Some(new_seed) = new_seed {
+            write(previous_seed_path, &new_seed).expect("Unable to write previous seed");
+        }
     }
 
     let env = Environment::default();

--- a/attest/verifier/data/sim/.gitignore
+++ b/attest/verifier/data/sim/.gitignore
@@ -1,4 +1,3 @@
 *.pem
 *.crt
 *.key
-*.txt

--- a/attest/verifier/data/sim/.gitignore
+++ b/attest/verifier/data/sim/.gitignore
@@ -1,3 +1,4 @@
 *.pem
 *.crt
 *.key
+*.txt

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -160,7 +160,7 @@ class Node:
         self.ledger_distribution_process = None
         self.admin_http_gateway_process = None
         self.ledger_dir = os.path.join(WORK_DIR, f'node-ledger-{self.node_num}')
-        self.ledger_distribution_dir = os.path.join(WORK_DIR, f'node-ledger-distribution-{self.node_num}')
+        self.ledger_distribution_dir = os.path.join(TARGET_DIR, f'node-ledger-distribution-{self.node_num}')
         self.msg_signer_key_file = os.path.join(WORK_DIR, f'node-scp-{self.node_num}.pem')
         self.tokens_config_file = os.path.join(WORK_DIR, f'node-tokens-{self.node_num}.json')
         subprocess.check_output(f'openssl genpkey -algorithm ed25519 -out {self.msg_signer_key_file}', shell=True)


### PR DESCRIPTION
<!-- List changes here -->
* Attest Verifier now regenerates data/sim/* when a new MC_SEED is provided
* Local Network tool now uses TARGET_DIR for ledger-distribution folders to enable docker volume sharing
### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
We needed this to enable local networks with IAS in DEV simulation mode, which generates a random key for attestation instead of requesting it from Intel, which they won't provide during development.

This was causing issues when using different builds of the attest verifier, because each build would use a different random key while also not regenerating the correct files if they already existed and MC_SEED was present, which should cause them to be regenerated.

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
