### PR TITLE
unmask_value -> unmask_amount

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -395,14 +395,30 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
                 env.get_rust_field(tx_pub_key, RUST_OBJ_FIELD)?;
             let shared_secret = create_shared_secret(&tx_pub_key, &view_key);
             let (amount, _) = masked_amount.get_value(&shared_secret)?;
+            let value = env.new_object(
+                "java/math/BigInteger",
+                "(I[B)V",
+                &[
+                    jni::objects::JValue::Int(1),
+                    env.byte_array_from_slice(&amount.value.to_be_bytes())?
+                        .into(),
+                ],
+            )?;
+            let token_id = env.new_object(
+                "com/mobilecoin/lib/UnsignedLong",
+                "(J)V",
+                &[
+                    jni::objects::JValue::Long(*amount.token_id as i64)
+                ],
+            )?;
             Ok(env
                 .new_object(
                     "com/mobilecoin/lib/Amount",
-                    "(JJ)V",
+                    "(Ljava/math/BigInteger;Lcom/mobilecoin/lib/UnsignedLong;)V",
                     &[
-                        jni::objects::JValue::Long(amount.value as i64),
-                        jni::objects::JValue::Long(*amount.token_id as i64),
-                    ],
+                        jni::objects::JValue::Object(value), 
+                        jni::objects::JValue::Object(token_id),
+                        ],
                 )?
                 .into_inner())
         },

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -414,7 +414,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
                     "com/mobilecoin/lib/Amount",
                     "(Ljava/math/BigInteger;Lcom/mobilecoin/lib/UnsignedLong;)V",
                     &[
-                        jni::objects::JValue::Object(value), 
+                        jni::objects::JValue::Object(value),
                         jni::objects::JValue::Object(token_id),
                     ],
                 )?

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_finalize_1jni(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1value(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
     env: JNIEnv,
     obj: JObject,
     view_key: JObject,
@@ -397,12 +397,11 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1value(
             let (amount, _) = masked_amount.get_value(&shared_secret)?;
             Ok(env
                 .new_object(
-                    "java/math/BigInteger",
-                    "(I[B)V", // public BigInteger(int signum, byte[] magnitude)
+                    "com/mobilecoin/lib/Amount",
+                    "(JJ)V",
                     &[
-                        1.into(),
-                        env.byte_array_from_slice(&amount.value.to_be_bytes())?
-                            .into(),
+                        jni::objects::JValue::Long(amount.value as i64),
+                        jni::objects::JValue::Long(*amount.token_id as i64),
                     ],
                 )?
                 .into_inner())

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -407,9 +407,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
             let token_id = env.new_object(
                 "com/mobilecoin/lib/UnsignedLong",
                 "(J)V",
-                &[
-                    jni::objects::JValue::Long(*amount.token_id as i64)
-                ],
+                &[jni::objects::JValue::Long(*amount.token_id as i64)],
             )?;
             Ok(env
                 .new_object(
@@ -418,7 +416,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
                     &[
                         jni::objects::JValue::Object(value), 
                         jni::objects::JValue::Object(token_id),
-                        ],
+                    ],
                 )?
                 .into_inner())
         },


### PR DESCRIPTION
Renamed unmask_value to unmask_amount
unmask_amount now returns both unmasked value and unmasked token id

### Motivation

This is needed for the SDK to recover the token ID of a masked amount

### Future Work
Parameterize tx builder for token ID
