### PR TITLE
Add proto schema for GiftCode and rust equivalent object 

### DIFF
--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -49,7 +49,7 @@ message TransferPayload {
 /// un-blind the amount, and spend the TxOut. This can be used to give
 /// MobileCoin to a both FOG users & non-FOG users who may not yet have
 // a MobileCoin account enabled
-message GiftCode {
+message TxOutGiftCode {
 
   // The global index of the TxOut that has been gifted. This allows
   // the receiver to find & uniquely identify the TxOut
@@ -70,5 +70,5 @@ message PrintableWrapper { oneof wrapper {
     external.PublicAddress public_address = 1;
     PaymentRequest payment_request = 2;
     TransferPayload transfer_payload = 3;
-    GiftCode gift_code = 4;
+    TxOutGiftCode tx_out_gift_code = 4;
 }}

--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -45,20 +45,17 @@ message TransferPayload {
     bytes bip39_entropy = 4;
 }
 
-/// Message encoding information about a TxOut required to locate a TxOut,
+/// Message encoding information required to locate a TxOut,
 /// un-blind the amount, and spend the TxOut. This can be used to give
-/// MobileCoin to a both FOG users & non-FOG users who may not yet have
+/// MobileCoin to both FOG & non-FOG users who may not yet have
 // a MobileCoin account enabled
 message TxOutGiftCode {
-
   // The global index of the TxOut that has been gifted. This allows
   // the receiver to find & uniquely identify the TxOut
   uint64 global_index = 1;
-
   // The one-time private key which can be used to spend the TxOut
   external.RistrettoPrivate onetime_private_key = 2;
-
-  // The shared secret used to unblind the amount of the TxOut
+  // The shared secret used to un-blind the amount of the TxOut
   external.CompressedRistretto shared_secret = 3;
 
 }

--- a/api/proto/printable.proto
+++ b/api/proto/printable.proto
@@ -45,6 +45,24 @@ message TransferPayload {
     bytes bip39_entropy = 4;
 }
 
+/// Message encoding information about a TxOut required to locate a TxOut,
+/// un-blind the amount, and spend the TxOut. This can be used to give
+/// MobileCoin to a both FOG users & non-FOG users who may not yet have
+// a MobileCoin account enabled
+message GiftCode {
+
+  // The global index of the TxOut that has been gifted. This allows
+  // the receiver to find & uniquely identify the TxOut
+  uint64 global_index = 1;
+
+  // The one-time private key which can be used to spend the TxOut
+  external.RistrettoPrivate onetime_private_key = 2;
+
+  // The shared secret used to unblind the amount of the TxOut
+  external.CompressedRistretto shared_secret = 3;
+
+}
+
 /// This wraps all of the above messages using "oneof", allowing us to
 /// have a single encoding scheme and extend as necessary simply by adding
 /// new messages without breaking backwards compatibility
@@ -52,4 +70,5 @@ message PrintableWrapper { oneof wrapper {
     external.PublicAddress public_address = 1;
     PaymentRequest payment_request = 2;
     TransferPayload transfer_payload = 3;
+    GiftCode gift_code = 4;
 }}

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -44,6 +44,9 @@ mod verification_report;
 mod verification_signature;
 mod watcher;
 
+// printable
+mod tx_out_gift_code;
+
 pub use self::error::ConversionError;
 
 use std::path::PathBuf;

--- a/api/src/convert/tx_out_gift_code.rs
+++ b/api/src/convert/tx_out_gift_code.rs
@@ -26,7 +26,7 @@ impl TryFrom<&printable::TxOutGiftCode> for mc_transaction_core::TxOutGiftCode {
     fn try_from(src: &printable::TxOutGiftCode) -> Result<Self, Self::Error> {
         let global_index = src.get_global_index();
         let onetime_private_key = RistrettoPrivate::try_from(src.get_onetime_private_key())?;
-        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())?
+        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())?;
         let shared_secret = RistrettoPublic::try_from(&compressed_shared_secret)?;
 
         Ok(Self {

--- a/api/src/convert/tx_out_gift_code.rs
+++ b/api/src/convert/tx_out_gift_code.rs
@@ -26,7 +26,8 @@ impl TryFrom<&printable::TxOutGiftCode> for mc_transaction_core::TxOutGiftCode {
     fn try_from(src: &printable::TxOutGiftCode) -> Result<Self, Self::Error> {
         let global_index = src.get_global_index();
         let onetime_private_key = RistrettoPrivate::try_from(src.get_onetime_private_key())?;
-        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())?;
+        let compressed_shared_secret =
+            CompressedRistrettoPublic::try_from(src.get_shared_secret())?;
         let shared_secret = RistrettoPublic::try_from(&compressed_shared_secret)?;
 
         Ok(Self {

--- a/api/src/convert/tx_out_gift_code.rs
+++ b/api/src/convert/tx_out_gift_code.rs
@@ -26,8 +26,7 @@ impl TryFrom<&printable::TxOutGiftCode> for mc_transaction_core::TxOutGiftCode {
     fn try_from(src: &printable::TxOutGiftCode) -> Result<Self, Self::Error> {
         let global_index = src.get_global_index();
         let onetime_private_key = RistrettoPrivate::try_from(src.get_onetime_private_key())?;
-        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())
-            .map_err(|_| ConversionError::KeyCastError)?;
+        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())?
         let shared_secret = RistrettoPublic::try_from(&compressed_shared_secret)?;
 
         Ok(Self {

--- a/api/src/convert/tx_out_gift_code.rs
+++ b/api/src/convert/tx_out_gift_code.rs
@@ -1,31 +1,33 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 //! Convert to/from printable::TxOutGiftCode
 
 use crate::{external, printable, ConversionError};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
 use std::convert::TryFrom;
 
-/// Convert mc_transaction_core::GiftCode --> printable::GiftCode.
-impl From<&mc_transaction_core::GiftCode> for printable::GiftCode {
-    fn from(src: &mc_transaction_core::GiftCode) -> Self {
-        let mut gift_code = printable::GiftCode::new();
-        gift_code.set_global_index(src.global_index);
-        gift_code
+/// Convert mc_transaction_core::TxOutGiftCode --> printable::TxOutGiftCode.
+impl From<&mc_transaction_core::TxOutGiftCode> for printable::TxOutGiftCode {
+    fn from(src: &mc_transaction_core::TxOutGiftCode) -> Self {
+        let mut tx_out_gift_code = printable::TxOutGiftCode::new();
+        tx_out_gift_code.set_global_index(src.global_index);
+        tx_out_gift_code
             .set_onetime_private_key(external::RistrettoPrivate::from(&src.onetime_private_key));
-        gift_code.set_shared_secret(external::CompressedRistretto::from(&src.shared_secret));
+        tx_out_gift_code.set_shared_secret(external::CompressedRistretto::from(&src.shared_secret));
 
-        gift_code
+        tx_out_gift_code
     }
 }
 
-/// Convert from printable::GiftCode --> mc_transaction_core::GiftCode
-impl TryFrom<&printable::GiftCode> for mc_transaction_core::GiftCode {
+/// Convert from printable::TxOutGiftCode --> mc_transaction_core::TxOutGiftCode
+impl TryFrom<&printable::TxOutGiftCode> for mc_transaction_core::TxOutGiftCode {
     type Error = ConversionError;
 
-    fn try_from(src: &printable::GiftCode) -> Result<Self, Self::Error> {
+    fn try_from(src: &printable::TxOutGiftCode) -> Result<Self, Self::Error> {
         let global_index = src.get_global_index();
         let onetime_private_key = RistrettoPrivate::try_from(src.get_onetime_private_key())?;
         let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())
-            .map_err(|_| ConversionError::ArrayCastError)?;
+            .map_err(|_| ConversionError::KeyCastError)?;
         let shared_secret = RistrettoPublic::try_from(&compressed_shared_secret)?;
 
         Ok(Self {
@@ -39,22 +41,51 @@ impl TryFrom<&printable::GiftCode> for mc_transaction_core::GiftCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mc_transaction_core::TxOutGiftCode;
     use mc_util_from_random::FromRandom;
+    use mc_util_serial::{decode, encode};
+    use protobuf::Message;
     use rand::rngs::StdRng;
     use rand_core::SeedableRng;
 
     #[test]
-    // test conversion between mc_transaction_core::GiftCode <-->
-    // printable::GiftCode.
+    // test conversion between mc_transaction_core::TxOutGiftCode <-->
+    // printable::TxOutGiftCode.
     fn test_gift_code_serialization() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
-        let gift_code_input = mc_transaction_core::GiftCode::new(
+        let source = mc_transaction_core::TxOutGiftCode::new(
             9001,
             RistrettoPrivate::from_random(&mut rng),
             RistrettoPublic::from_random(&mut rng),
         );
-        let external = printable::GiftCode::from(&gift_code_input);
-        let recovered = mc_transaction_core::GiftCode::try_from(&external).unwrap();
-        assert_eq!(gift_code_input, recovered);
+
+        // Roundtrip from protobuf should return the same object
+        {
+            let external = printable::TxOutGiftCode::from(&source);
+            let recovered = mc_transaction_core::TxOutGiftCode::try_from(&external).unwrap();
+            assert_eq!(source, recovered);
+        }
+
+        // Prost decode(encode(source)) should produce the same object
+        {
+            let bytes = encode(&source);
+            let recovered = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
+
+        // Encoding with prost, decoding with protobuf should produce the same object
+        {
+            let bytes = encode(&source);
+            let recovered = printable::TxOutGiftCode::parse_from_bytes(&bytes).unwrap();
+            assert_eq!(recovered, printable::TxOutGiftCode::from(&source));
+        }
+
+        // Encoding with protobuf, decoding with prost should produce the same object
+        {
+            let external = printable::TxOutGiftCode::from(&source);
+            let bytes = external.write_to_bytes().unwrap();
+            let recovered: TxOutGiftCode = decode(&bytes).unwrap();
+            assert_eq!(source, recovered);
+        }
     }
 }

--- a/api/src/convert/tx_out_gift_code.rs
+++ b/api/src/convert/tx_out_gift_code.rs
@@ -1,0 +1,60 @@
+//! Convert to/from printable::TxOutGiftCode
+
+use crate::{external, printable, ConversionError};
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
+use std::convert::TryFrom;
+
+/// Convert mc_transaction_core::GiftCode --> printable::GiftCode.
+impl From<&mc_transaction_core::GiftCode> for printable::GiftCode {
+    fn from(src: &mc_transaction_core::GiftCode) -> Self {
+        let mut gift_code = printable::GiftCode::new();
+        gift_code.set_global_index(src.global_index);
+        gift_code
+            .set_onetime_private_key(external::RistrettoPrivate::from(&src.onetime_private_key));
+        gift_code.set_shared_secret(external::CompressedRistretto::from(&src.shared_secret));
+
+        gift_code
+    }
+}
+
+/// Convert from printable::GiftCode --> mc_transaction_core::GiftCode
+impl TryFrom<&printable::GiftCode> for mc_transaction_core::GiftCode {
+    type Error = ConversionError;
+
+    fn try_from(src: &printable::GiftCode) -> Result<Self, Self::Error> {
+        let global_index = src.get_global_index();
+        let onetime_private_key = RistrettoPrivate::try_from(src.get_onetime_private_key())?;
+        let compressed_shared_secret = CompressedRistrettoPublic::try_from(src.get_shared_secret())
+            .map_err(|_| ConversionError::ArrayCastError)?;
+        let shared_secret = RistrettoPublic::try_from(&compressed_shared_secret)?;
+
+        Ok(Self {
+            global_index,
+            onetime_private_key,
+            shared_secret,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_util_from_random::FromRandom;
+    use rand::rngs::StdRng;
+    use rand_core::SeedableRng;
+
+    #[test]
+    // test conversion between mc_transaction_core::GiftCode <-->
+    // printable::GiftCode.
+    fn test_gift_code_serialization() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let gift_code_input = mc_transaction_core::GiftCode::new(
+            9001,
+            RistrettoPrivate::from_random(&mut rng),
+            RistrettoPublic::from_random(&mut rng),
+        );
+        let external = printable::GiftCode::from(&gift_code_input);
+        let recovered = mc_transaction_core::GiftCode::try_from(&external).unwrap();
+        assert_eq!(gift_code_input, recovered);
+    }
+}

--- a/transaction/core/src/gift_code.rs
+++ b/transaction/core/src/gift_code.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Code for computing & receiving gift codes
+
+use crate::{Amount, AmountError, MaskedAmount};
+use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
+
+/// Object representing a TxOut that can be sent to a receiver enabling them
+/// to find/uniquely identify a TxOut, un-blind the amount, and spend the TxOut
+#[derive(Clone, Debug)]
+pub struct GiftCode {
+    /// The global index of the TxOut which has been gifted
+    pub global_index: u64,
+
+    /// The one-time private key which can be used to spend this TxOut
+    pub onetime_private_key: RistrettoPrivate,
+
+    /// The shared secret which can be used to un-blind the amount of this TxOut
+    pub shared_secret: RistrettoPublic,
+}
+
+impl GiftCode {
+    /// Create a new gift code object
+    pub fn new(
+        global_index: u64,
+        onetime_private_key: RistrettoPrivate,
+        shared_secret: RistrettoPublic,
+    ) -> Self {
+        Self {
+            global_index,
+            onetime_private_key,
+            shared_secret,
+        }
+    }
+
+    /// Un-blind amount given a MaskedAmount object
+    pub fn unblind_amount(&self, masked_amount: MaskedAmount) -> Result<Amount, AmountError> {
+        let (amount, _) = masked_amount.get_value(&self.shared_secret)?;
+        Ok(amount)
+    }
+
+    /// Un-blind amount given a masked value and token id
+    pub fn unblind_amount_with_masked_token_id(
+        &self,
+        masked_value: u64,
+        masked_token_id: &[u8],
+    ) -> Result<Amount, AmountError> {
+        let (_, amount) =
+            MaskedAmount::reconstruct(masked_value, masked_token_id, &self.shared_secret)?;
+        Ok(amount)
+    }
+}
+
+impl PartialEq for GiftCode {
+    fn eq(&self, other: &Self) -> bool {
+        self.global_index == other.global_index && self.shared_secret == other.shared_secret
+    }
+}

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -21,6 +21,7 @@ use mc_crypto_keys::{KeyError, RistrettoPrivate, RistrettoPublic};
 mod amount;
 mod blockchain;
 mod domain_separators;
+mod gift_code;
 mod memo;
 mod token;
 mod tx_error;
@@ -41,6 +42,7 @@ pub mod proptest_fixtures;
 
 pub use amount::{Amount, AmountError, Commitment, CompressedCommitment, MaskedAmount};
 pub use blockchain::*;
+pub use gift_code::GiftCode;
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
 pub use token::{tokens, Token, TokenId};
 pub use tx::MemoContext;

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -21,7 +21,7 @@ use mc_crypto_keys::{KeyError, RistrettoPrivate, RistrettoPublic};
 mod amount;
 mod blockchain;
 mod domain_separators;
-mod gift_code;
+mod tx_out_gift_code;
 mod memo;
 mod token;
 mod tx_error;
@@ -42,11 +42,11 @@ pub mod proptest_fixtures;
 
 pub use amount::{Amount, AmountError, Commitment, CompressedCommitment, MaskedAmount};
 pub use blockchain::*;
-pub use gift_code::GiftCode;
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
 pub use token::{tokens, Token, TokenId};
 pub use tx::MemoContext;
 pub use tx_error::{NewMemoError, NewTxError, ViewKeyMatchError};
+pub use tx_out_gift_code::TxOutGiftCode;
 
 use core::convert::TryFrom;
 use mc_account_keys::AccountKey;

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -21,10 +21,10 @@ use mc_crypto_keys::{KeyError, RistrettoPrivate, RistrettoPublic};
 mod amount;
 mod blockchain;
 mod domain_separators;
-mod tx_out_gift_code;
 mod memo;
 mod token;
 mod tx_error;
+mod tx_out_gift_code;
 
 pub mod constants;
 pub mod encrypted_fog_hint;

--- a/transaction/core/src/tx_out_gift_code.rs
+++ b/transaction/core/src/tx_out_gift_code.rs
@@ -41,7 +41,8 @@ impl TxOutGiftCode {
 
     /// Un-blind amount given a MaskedAmount object
     pub fn unblind_amount(&self, masked_amount: MaskedAmount) -> Result<Amount, AmountError> {
-        masked_amount.get_value(&self.shared_secret)
+        masked_amount
+            .get_value(&self.shared_secret)
             .map(|(amount, _)| amount)
     }
 
@@ -60,9 +61,16 @@ impl TxOutGiftCode {
 impl ConstantTimeEq for TxOutGiftCode {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.global_index.ct_eq(&other.global_index).ct_eq(
-            &self.onetime_private_key.ct_eq(&other.onetime_private_key).ct_eq(
-                &self.shared_secret.as_ref().ct_eq(other.shared_secret.as_ref()))
-            )
+            &self
+                .onetime_private_key
+                .ct_eq(&other.onetime_private_key)
+                .ct_eq(
+                    &self
+                        .shared_secret
+                        .as_ref()
+                        .ct_eq(other.shared_secret.as_ref()),
+                ),
+        )
     }
 }
 

--- a/transaction/core/src/tx_out_gift_code.rs
+++ b/transaction/core/src/tx_out_gift_code.rs
@@ -4,22 +4,28 @@
 
 use crate::{Amount, AmountError, MaskedAmount};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use subtle::{Choice, ConstantTimeEq};
 
 /// Object representing a TxOut that can be sent to a receiver enabling them
 /// to find/uniquely identify a TxOut, un-blind the amount, and spend the TxOut
-#[derive(Clone, Debug)]
-pub struct GiftCode {
+#[derive(Clone, Deserialize, Serialize, Message)]
+pub struct TxOutGiftCode {
     /// The global index of the TxOut which has been gifted
+    #[prost(uint64, required, tag = "1")]
     pub global_index: u64,
 
     /// The one-time private key which can be used to spend this TxOut
+    #[prost(message, required, tag = "2")]
     pub onetime_private_key: RistrettoPrivate,
 
     /// The shared secret which can be used to un-blind the amount of this TxOut
+    #[prost(message, required, tag = "3")]
     pub shared_secret: RistrettoPublic,
 }
 
-impl GiftCode {
+impl TxOutGiftCode {
     /// Create a new gift code object
     pub fn new(
         global_index: u64,
@@ -51,8 +57,20 @@ impl GiftCode {
     }
 }
 
-impl PartialEq for GiftCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.global_index == other.global_index && self.shared_secret == other.shared_secret
+// Implement constant time equality for all fields given they're all sensitive
+impl ConstantTimeEq for TxOutGiftCode {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        self.global_index.ct_eq(&other.global_index).ct_eq(
+            &self.onetime_private_key.ct_eq(&other.onetime_private_key).ct_eq(
+                &self.shared_secret.as_ref().ct_eq(other.shared_secret.as_ref()))
+            )
     }
 }
+
+impl PartialEq for TxOutGiftCode {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(other).into()
+    }
+}
+
+impl Eq for TxOutGiftCode {}

--- a/transaction/core/src/tx_out_gift_code.rs
+++ b/transaction/core/src/tx_out_gift_code.rs
@@ -41,8 +41,8 @@ impl TxOutGiftCode {
 
     /// Un-blind amount given a MaskedAmount object
     pub fn unblind_amount(&self, masked_amount: MaskedAmount) -> Result<Amount, AmountError> {
-        let (amount, _) = masked_amount.get_value(&self.shared_secret)?;
-        Ok(amount)
+        masked_amount.get_value(&self.shared_secret)
+            .map(|(amount, _)| amount)
     }
 
     /// Un-blind amount given a masked value and token id
@@ -51,9 +51,8 @@ impl TxOutGiftCode {
         masked_value: u64,
         masked_token_id: &[u8],
     ) -> Result<Amount, AmountError> {
-        let (_, amount) =
-            MaskedAmount::reconstruct(masked_value, masked_token_id, &self.shared_secret)?;
-        Ok(amount)
+        MaskedAmount::reconstruct(masked_value, masked_token_id, &self.shared_secret)
+            .map(|(_, amount)| amount)
     }
 }
 


### PR DESCRIPTION
Add a new protobuf for the gift code message payload which conforms to the new design for gift codes specified in [#MCIP 32](https://github.com/garbageslam/mcips/blob/fog-compatible-gift-codes/text/0032-fog-compatible-gift-codes.md) and rust equivalent object.

### Motivation

A message format needs to be used to communicate that MobileCoin account holder has sent a gift code TxOut with enough information for the receiver to find the TxOut, unmask its amount, and spend the TxOut.

### Future Work
[Add libmobilecoin and android ffis for building gift codes](https://github.com/mobilecoinfoundation/mobilecoin/issues/1945)
[Add mobilecoind codepaths for creating & sending gift codes](https://github.com/mobilecoinfoundation/mobilecoin/issues/1946)
[Update InputCredentials](https://github.com/mobilecoinfoundation/mobilecoin/issues/1852)