### PR TITLE
Update local_network script for new docker target dir

### DIFF
--- a/MAINNET.md
+++ b/MAINNET.md
@@ -33,7 +33,7 @@ An example MainNet build and launch command for mobilecoind is:
 1. Run mobilecoind, connecting to one or multiple Consensus Validator Nodes:
 
     ```
-    ./target/release/mobilecoind \
+    ${CARGO_TARGET_DIR:-./target}/release/mobilecoind \
         --ledger-db /path/to/ledger-db \
         --mobilecoind-db /path/to/mobilecoind-db \
         --poll-interval 10 \
@@ -47,7 +47,7 @@ An example MainNet build and launch command for mobilecoind is:
 1. Run mobilecoind-json
 
     ```
-    ./target/release/mobilecoind-json
+    ${CARGO_TARGET_DIR:-./target}/release/mobilecoind-json
     ```
 
 1. Issue curl commands to mobilecoind-json, listening on 9090, or send protobuf requests to mobilecoind, listening on localhost:4444.

--- a/consensus/service/README.md
+++ b/consensus/service/README.md
@@ -173,7 +173,7 @@ SGX_MODE=HW IAS_MODE=DEV \
 Alternatively, if the binary has already been built, you can run:
 
 ```
-./target/release/consensus-service --client-responder-id \
+${CARGO_TARGET_DIR}/release/consensus-service --client-responder-id \
     (omitted)
 ```
 

--- a/consensus/service/README.md
+++ b/consensus/service/README.md
@@ -173,7 +173,7 @@ SGX_MODE=HW IAS_MODE=DEV \
 Alternatively, if the binary has already been built, you can run:
 
 ```
-${CARGO_TARGET_DIR}/release/consensus-service --client-responder-id \
+${CARGO_TARGET_DIR:-./target}/release/consensus-service --client-responder-id \
     (omitted)
 ```
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
 
           // Copy relevant binaries to staging area
           sh '''
-            for file in $(find $WORKSPACE/target/release -maxdepth 1 -type f "(" -name '*.so' -o -executable ")" -not -name '*_test' ); do
+            for file in $(find ${CARGO_TARGET_DIR:-$WORKSPACE/target}/release -maxdepth 1 -type f "(" -name '*.so' -o -executable ")" -not -name '*_test' ); do
               cp -v ${file} $WORKSPACE/ops/bin/
             done
             ls -la $WORKSPACE/ops/bin

--- a/start-testnet-client.sh
+++ b/start-testnet-client.sh
@@ -19,7 +19,7 @@ echo "Pulling down TestNet consensus validator signature material"
 SIGSTRUCT_URI=$(curl -s https://enclave-distribution.test.mobilecoin.com/production.json | grep sigstruct | awk '{print $2}' | tr -d \")
 curl -O https://enclave-distribution.test.mobilecoin.com/${SIGSTRUCT_URI}
 
-TARGETDIR=./target/release
+TARGETDIR=${CARGO_TARGET_DIR:-./target}/release
 
 echo "Building mobilecoind and mc-mobilecoind-json. This will take a few moments."
 SGX_MODE=HW IAS_MODE=PROD CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css \

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -58,8 +58,11 @@ In order to use it, the following steps are necessary.
     # Create a set of target keys. They would be identical to the first N keys inside `keys/`. This is needed if you don't
     # want to send to transactions to all 1000 keys created at step 1.
     # Notice the addition of the --output-dir argument
-    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10
-    --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(${CARGO_TARGET_DIR:-target}/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+    cargo run -p mc-util-keyfile --bin sample-keys --release -- \
+        --num 10 \
+        --output-dir fog_keys \
+        --fog-report-url 'insecure-fog://localhost:6200' \
+        --fog-authority-root $(${CARGO_TARGET_DIR:-target}/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
 
     # Run the distribution script. This takes awhile and you should see transactions going through by looking at the logs.
     SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -58,7 +58,8 @@ In order to use it, the following steps are necessary.
     # Create a set of target keys. They would be identical to the first N keys inside `keys/`. This is needed if you don't
     # want to send to transactions to all 1000 keys created at step 1.
     # Notice the addition of the --output-dir argument
-    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(../target/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
+    cargo run -p mc-util-keyfile --bin sample-keys --release -- --num 10
+    --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $(${CARGO_TARGET_DIR:-target}/release/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head)
 
     # Run the distribution script. This takes awhile and you should see transactions going through by looking at the logs.
     SGX_MODE=SW IAS_MODE=DEV MC_LOG=debug \

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -36,7 +36,7 @@ class FogNetwork(Network):
         cmd = ' && '.join([
             f'dropdb --if-exists {FOG_SQL_DATABASE_NAME}',
             f'createdb {FOG_SQL_DATABASE_NAME}',
-            f'DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} {PROJECT_DIR}/{TARGET_DIR}/fog-sql-recovery-db-migrations',
+            f'DATABASE_URL=postgres://localhost/{FOG_SQL_DATABASE_NAME} {TARGET_DIR}/fog-sql-recovery-db-migrations',
         ])
         print(f'Creating postgres database: {cmd}')
         subprocess.check_output(cmd, shell=True)
@@ -60,11 +60,11 @@ class FogNetwork(Network):
             pass
 
         # Get chain and key
-        root = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head",
+        root = subprocess.check_output(f"{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_head",
                                    encoding='utf8', shell=True).strip()
-        chain = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_chain_25519_leaf",
+        chain = subprocess.check_output(f"{TARGET_DIR}/mc-crypto-x509-test-vectors --type=chain --test-name=ok_rsa_chain_25519_leaf",
                                    encoding='utf8', shell=True).strip()
-        key = subprocess.check_output(f"{PROJECT_DIR}/{TARGET_DIR}/mc-crypto-x509-test-vectors --type=key --test-name=ok_rsa_chain_25519_leaf",
+        key = subprocess.check_output(f"{TARGET_DIR}/mc-crypto-x509-test-vectors --type=key --test-name=ok_rsa_chain_25519_leaf",
                                  encoding='utf8', shell=True).strip()
         print(f"chain path = {chain}, key path = {key}")
 
@@ -127,7 +127,7 @@ class FogNetwork(Network):
         # Tell the ingest server to activate, giving it a little time for RPC to wakeup
         time.sleep(15)
         cmd = ' '.join([
-            f'exec {PROJECT_DIR}/{TARGET_DIR}/fog_ingest_client',
+            f'exec {TARGET_DIR}/fog_ingest_client',
             f'--uri insecure-fog-ingest://localhost:{BASE_INGEST_CLIENT_PORT}',
             f'activate',
         ])

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -33,7 +33,9 @@ IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
 FOG_SQL_DATABASE_NAME = 'fog_local'
 
 def target_dir(release):
-    return os.path.join(PROJECT_DIR, 'target', 'release' if release else 'debug')
+    default_target_dir = os.path.join(PROJECT_DIR, 'target')
+    base_target_dir = os.path.abspath(os.getenv('CARGO_TARGET_DIR', default_target_dir))
+    return os.path.join(base_target_dir, 'release' if release else 'debug')
 
 # Log a command and then call subprocess.run
 def log_and_run_shell(cmd, **kwargs):

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -35,9 +35,9 @@ else:
     CARGO_FLAGS = ''
     BUILD_TYPE = 'debug'
 
-BASE_TARGET_DIR = os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target'))
+BASE_TARGET_DIR = os.getenv('CARGO_TARGET_DIR', 'target')
 TARGET_DIR = os.path.join(os.path.relpath(BASE_TARGET_DIR, PROJECT_DIR), BUILD_TYPE)
-WORK_DIR =  os.path.join(TARGET_DIR, 'mc-local-network')
+WORK_DIR =  os.path.join(PROJECT_DIR, TARGET_DIR, 'mc-local-network')
 MINTING_KEYS_DIR = os.path.join(WORK_DIR, 'minting-keys')
 CLI_PORT = 31337
 

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -29,15 +29,18 @@ IAS_API_KEY = os.getenv('IAS_API_KEY', default='0'*64) # 32 bytes
 IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 MOB_RELEASE = os.getenv('MOB_RELEASE', '1')
-CARGO_FLAGS = '--release'
-TARGET_DIR = os.path.join(os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target')), 'release')
+if MOB_RELEASE == '1':
+    CARGO_FLAGS = '--release'
+    BUILD_TYPE = 'release'
+else:
+    CARGO_FLAGS = ''
+    BUILD_TYPE = 'debug'
+
+BASE_TARGET_DIR = os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target'))
+TARGET_DIR = os.path.join(BASE_TARGET_DIR, BUILD_TYPE)
 WORK_DIR =  os.path.join(TARGET_DIR, 'mc-local-network')
 MINTING_KEYS_DIR = os.path.join(WORK_DIR, 'minting-keys')
 CLI_PORT = 31337
-
-if MOB_RELEASE == '0':
-    CARGO_FLAGS = ''
-    TARGET_DIR = os.path.join(os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target')), 'debug')
 
 # Sane default log configuration
 if 'MC_LOG' not in os.environ:

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -30,14 +30,14 @@ IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 MOB_RELEASE = os.getenv('MOB_RELEASE', '1')
 CARGO_FLAGS = '--release'
-TARGET_DIR = 'target/release'
-WORK_DIR =  os.path.join(PROJECT_DIR, TARGET_DIR, 'mc-local-network')
+TARGET_DIR = os.path.join(os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target')), 'release')
+WORK_DIR =  os.path.join(TARGET_DIR, 'mc-local-network')
 MINTING_KEYS_DIR = os.path.join(WORK_DIR, 'minting-keys')
 CLI_PORT = 31337
 
 if MOB_RELEASE == '0':
     CARGO_FLAGS = ''
-    TARGET_DIR = 'target/debug'
+    TARGET_DIR = os.path.join(os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target')), 'debug')
 
 # Sane default log configuration
 if 'MC_LOG' not in os.environ:

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -35,9 +35,10 @@ else:
     CARGO_FLAGS = ''
     BUILD_TYPE = 'debug'
 
-BASE_TARGET_DIR = os.getenv('CARGO_TARGET_DIR', 'target')
-TARGET_DIR = os.path.join(os.path.relpath(BASE_TARGET_DIR, PROJECT_DIR), BUILD_TYPE)
-WORK_DIR =  os.path.join(PROJECT_DIR, TARGET_DIR, 'mc-local-network')
+DEFAULT_TARGET_DIR = os.path.join(PROJECT_DIR, 'target')
+BASE_TARGET_DIR = os.path.abspath(os.getenv('CARGO_TARGET_DIR', DEFAULT_TARGET_DIR))
+TARGET_DIR = os.path.join(BASE_TARGET_DIR, BUILD_TYPE)
+WORK_DIR = os.path.join(TARGET_DIR, 'mc-local-network')
 MINTING_KEYS_DIR = os.path.join(WORK_DIR, 'minting-keys')
 CLI_PORT = 31337
 

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import socketserver
 import subprocess
-import sys
 import threading
 import time
 from pprint import pformat
@@ -37,7 +36,7 @@ else:
     BUILD_TYPE = 'debug'
 
 BASE_TARGET_DIR = os.getenv('CARGO_TARGET_DIR', os.path.join(PROJECT_DIR, 'target'))
-TARGET_DIR = os.path.join(BASE_TARGET_DIR, BUILD_TYPE)
+TARGET_DIR = os.path.join(os.path.relpath(BASE_TARGET_DIR, PROJECT_DIR), BUILD_TYPE)
 WORK_DIR =  os.path.join(TARGET_DIR, 'mc-local-network')
 MINTING_KEYS_DIR = os.path.join(WORK_DIR, 'minting-keys')
 CLI_PORT = 31337

--- a/tools/local-network/mobilecoind.sh
+++ b/tools/local-network/mobilecoind.sh
@@ -7,10 +7,8 @@ trap 'pkill -P $$' SIGINT SIGTERM
 
 if [ "$MOB_RELEASE" = "0" ]; then
     CARGO_FLAGS=""
-    TARGET_DIR="target/debug"
 else
     CARGO_FLAGS="--release"
-    TARGET_DIR="target/release"
 fi
 
 if [[ -z "$MC_LOG" ]]; then


### PR DESCRIPTION
Previously the local_network script looked in `target/release` for the
binaries.  Now the local_network script will attempt to use the
`CARGO_TARGET_DIR` if it's set.

Also updates associated markdown files so copy and paste of commands
works in docker containers.

<!-- List changes here -->

### Motivation
The local_network script no longer works without local modification when run from inside of the docker image via `./mob prompt`

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
