### PR TITLE
MintTx/MintConfigTx tombstone validation bugfixes

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -408,11 +408,7 @@ impl SgxConsensusEnclave {
             // result in TombstoneBlockExceeded after enough blocks have been appended
             // following it. The workaround here is to pretend that the current
             // block index it is being validated against is within the tombstone range.
-            let config_block_index = mint_config_tx
-                .prefix
-                .tombstone_block
-                .checked_sub(1)
-                .unwrap_or(0);
+            let config_block_index = mint_config_tx.prefix.tombstone_block.saturating_sub(1);
             self.validate_mint_config_txs(vec![mint_config_tx], config_block_index, config)?;
 
             // The MintTx should be valid.

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -325,10 +325,18 @@ impl SgxConsensusEnclave {
     }
 
     /// Validate a list of MintConfigTxs.
+    ///
+    /// # Arguments
+    /// * `mint_config_txs` - The [MintConfigTx] objects to validate.
+    /// * `current_block_index` - The index of the current block that is being
+    ///   built. See documentation of
+    ///   [mc_transaction_core::mint::validate_mint_config_tx] for more details
+    ///   on why this is optional.
+    /// * `config` - The current blockchain configuration.
     fn validate_mint_config_txs(
         &self,
         mint_config_txs: Vec<MintConfigTx>,
-        current_block_index: u64,
+        current_block_index: Option<u64>,
         config: &BlockchainConfig,
     ) -> Result<Vec<ValidatedMintConfigTx>> {
         let mut seen_nonces = BTreeSet::default();
@@ -401,15 +409,11 @@ impl SgxConsensusEnclave {
             }
 
             // The associated MintConfigTx should be valid.
-            // Important note about the tombstone block: Since we are validating a
-            // MintConfigTx that has been previously added to the
-            // ledger, we shouldn't take the tombstone block into account. If we use
-            // current_block_index then a past MintConfigTx will eventually
-            // result in TombstoneBlockExceeded after enough blocks have been appended
-            // following it. The workaround here is to pretend that the current
-            // block index it is being validated against is within the tombstone range.
-            let config_block_index = mint_config_tx.prefix.tombstone_block.saturating_sub(1);
-            self.validate_mint_config_txs(vec![mint_config_tx], config_block_index, config)?;
+            // No block index is passed since the MintConfigTx is already assumed to be in
+            // the ledger, so doing the tombstone check is pointless (and could
+            // fail if enough blocks have passed since the MintConfigTx got
+            // accepted).
+            self.validate_mint_config_txs(vec![mint_config_tx], None, config)?;
 
             // The MintTx should be valid.
             validate_mint_tx(
@@ -916,8 +920,11 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         key_images.sort();
 
         // Get the list of MintConfigTxs included in the block.
-        let validated_mint_config_txs =
-            self.validate_mint_config_txs(inputs.mint_config_txs, parent_block.index + 1, config)?;
+        let validated_mint_config_txs = self.validate_mint_config_txs(
+            inputs.mint_config_txs,
+            Some(parent_block.index + 1),
+            config,
+        )?;
 
         // We purposefully do not ..Default::default() here so that new block fields
         // show up as a compilation error until addressed.
@@ -2265,9 +2272,10 @@ mod tests {
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
 
-            // We want the next block that getts appended to the ledger to exceed the tombstone limit of the mint config tx,
-            // since we want to make sure that minting that relies on an old MintConfigTx (one that is
-            // past its tombstone block) still validate and mint successfully.
+            // We want the next block that getts appended to the ledger to exceed the
+            // tombstone limit of the mint config tx, since we want to make sure
+            // that minting that relies on an old MintConfigTx (one that is past
+            // its tombstone block) still validate and mint successfully.
             let n_blocks = mint_config_tx1.prefix.tombstone_block;
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2265,10 +2265,10 @@ mod tests {
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
 
-            // We want more blocks than the tombstone of the mint config txs since we want
-            // to make sure that minting that relies on an old MintConfigTx (one that is
+            // We want the next block that getts appended to the ledger to exceed the tombstone limit of the mint config tx,
+            // since we want to make sure that minting that relies on an old MintConfigTx (one that is
             // past its tombstone block) still validate and mint successfully.
-            let n_blocks = mint_config_tx1.prefix.tombstone_block + 2;
+            let n_blocks = mint_config_tx1.prefix.tombstone_block;
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
             // Form block

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -401,7 +401,19 @@ impl SgxConsensusEnclave {
             }
 
             // The associated MintConfigTx should be valid.
-            self.validate_mint_config_txs(vec![mint_config_tx], current_block_index, config)?;
+            // Important note about the tombstone block: Since we are validating a
+            // MintConfigTx that has been previously added to the
+            // ledger, we shouldn't take the tombstone block into account. If we use
+            // current_block_index then a past MintConfigTx will eventually
+            // result in TombstoneBlockExceeded after enough blocks have been appended
+            // following it. The workaround here is to pretend that the current
+            // block index it is being validated against is within the tombstone range.
+            let config_block_index = mint_config_tx
+                .prefix
+                .tombstone_block
+                .checked_sub(1)
+                .unwrap_or(0);
+            self.validate_mint_config_txs(vec![mint_config_tx], config_block_index, config)?;
 
             // The MintTx should be valid.
             validate_mint_tx(
@@ -2256,7 +2268,11 @@ mod tests {
             // Initialize a ledger.
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
-            let n_blocks = 3;
+
+            // We want more blocks than the tombstone of the mint config txs since we want
+            // to make sure that minting that relies on an old MintConfigTx (one that is
+            // past its tombstone block) still validate and mint successfully.
+            let n_blocks = mint_config_tx1.prefix.tombstone_block + 2;
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
             // Form block
@@ -2547,7 +2563,7 @@ mod tests {
             // Initialize a ledger.
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
-            let n_blocks = 3;
+            let n_blocks = mint_config_tx1.prefix.tombstone_block - 1; // Don't want to exceed the tombstone block
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
             // Form block
@@ -2706,7 +2722,7 @@ mod tests {
             // Initialize a ledger.
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
-            let n_blocks = 3;
+            let n_blocks = mint_config_tx1.prefix.tombstone_block - 1; // Don't want to exceed the tombstone block
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
             // Form block
@@ -2767,7 +2783,7 @@ mod tests {
             // Initialize a ledger.
             let sender = AccountKey::random(&mut rng);
             let mut ledger = create_ledger();
-            let n_blocks = 3;
+            let n_blocks = mint_config_tx1.prefix.tombstone_block - 1; // Don't want to exceed the tombstone block
             initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
             // Form block

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -1170,7 +1170,7 @@ mod mint_tx_tests {
         // index is less than tombstone_block. n_blocks controls how many blocks
         // we create, specifically it will result in blocks with indexes [0, n_blocks).
         // setting n_blocks to tombstone_block - 1 means the transaction will be valid
-        // for exactly 1 block, but once thats written it will exceed it. However, we
+        // for exactly 1 block, but once that's written it will exceed it. However, we
         // subtract 2 since we also need to add a block for the mint config tx.
         let n_blocks = mint_tx.prefix.tombstone_block - 2;
         let block_version = BlockVersion::MAX;

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -89,7 +89,7 @@ impl<L: Ledger> MintTxManager for MintTxManagerImpl<L> {
         // Perform the actual validation.
         validate_mint_config_tx(
             mint_config_tx,
-            current_block_index,
+            Some(current_block_index),
             self.block_version,
             &governors,
         )?;

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -342,7 +342,7 @@ mod mint_config_tx_tests {
         // index is less than tombstone_block. n_blocks controls how many blocks
         // we create, specifically it will result in blocks with indexes [0, n_blocks).
         // setting n_blocks to tombstone_block - 1 means the transaction will be valid
-        // for exactly 1 block, but once thats written it will exceed it.
+        // for exactly 1 block, but once that's written it will exceed it.
         let n_blocks = mint_config_tx.prefix.tombstone_block - 1;
         let block_version = BlockVersion::MAX;
         let sender = AccountKey::random(&mut rng);

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -83,8 +83,8 @@ impl<L: Ledger> MintTxManager for MintTxManagerImpl<L> {
                 MintValidationError::NoGovernors(token_id),
             ))?;
 
-        // Get the current block index.
-        let current_block_index = self.ledger_db.num_blocks()? - 1;
+        // Get the index of the block currently being built.
+        let current_block_index = self.ledger_db.num_blocks()?;
 
         // Perform the actual validation.
         validate_mint_config_tx(
@@ -147,8 +147,8 @@ impl<L: Ledger> MintTxManager for MintTxManagerImpl<L> {
                 err => err.into(),
             })?;
 
-        // Get the current block index.
-        let current_block_index = self.ledger_db.num_blocks()? - 1;
+        // Get the index of the block currently being built.
+        let current_block_index = self.ledger_db.num_blocks()?;
 
         // Perform the actual validation.
         validate_mint_tx(
@@ -236,9 +236,9 @@ mod mint_config_tx_tests {
     use super::*;
     use mc_common::logger::test_with_logger;
     use mc_crypto_multisig::SignerSet;
-    use mc_transaction_core::{Block, BlockContents};
+    use mc_transaction_core::{ring_signature::KeyImage, Block, BlockContents};
     use mc_transaction_core_test_utils::{
-        create_ledger, create_mint_config_tx_and_signers, initialize_ledger,
+        create_ledger, create_mint_config_tx_and_signers, create_test_tx_out, initialize_ledger,
         mint_config_tx_to_validated as to_validated, AccountKey,
     };
     use rand::{rngs::StdRng, SeedableRng};
@@ -320,6 +320,72 @@ mod mint_config_tx_tests {
         assert_eq!(
             mint_tx_manager.validate_mint_config_tx(&mint_config_tx3),
             Ok(())
+        );
+    }
+
+    /// validate_mint_config_tx rejects a mint config tx with an exceeded
+    /// tombstone block.
+    #[test_with_logger]
+    fn validate_mint_config_tx_rejects_past_tombstone(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
+        let token_id_1 = TokenId::from(1);
+
+        let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
+        let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
+            token_id_1,
+            SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+        )])
+        .unwrap();
+
+        let mut ledger = create_ledger();
+        // tombstone_block specifies that the tx will get accepted at any block whose
+        // index is less than tombstone_block. n_blocks controls how many blocks
+        // we create, specifically it will result in blocks with indexes [0, n_blocks).
+        // setting n_blocks to tombstone_block - 1 means the transaction will be valid
+        // for exactly 1 block, but once thats written it will exceed it.
+        let n_blocks = mint_config_tx.prefix.tombstone_block - 1;
+        let block_version = BlockVersion::MAX;
+        let sender = AccountKey::random(&mut rng);
+        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+        let mint_tx_manager = MintTxManagerImpl::new(
+            ledger.clone(),
+            BlockVersion::MAX,
+            token_id_to_governors,
+            logger,
+        );
+
+        // At first we should succeed since we have not yet exceeded the tombstone
+        // block.
+        assert_eq!(
+            mint_tx_manager.validate_mint_config_tx(&mint_config_tx),
+            Ok(())
+        );
+
+        // Append a block to the ledger.
+        let parent_block = ledger.get_block(n_blocks - 1).unwrap();
+
+        let block_contents = BlockContents {
+            outputs: vec![create_test_tx_out(&mut rng)],
+            key_images: vec![KeyImage::from(123)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Try again, we should fail.
+        assert_eq!(
+            mint_tx_manager.validate_mint_config_tx(&mint_config_tx),
+            Err(MintTxManagerError::MintValidation(
+                MintValidationError::TombstoneBlockExceeded
+            ))
         );
     }
 
@@ -562,7 +628,7 @@ mod mint_tx_tests {
     use mc_common::logger::test_with_logger;
     use mc_crypto_keys::Ed25519Pair;
     use mc_crypto_multisig::SignerSet;
-    use mc_transaction_core::{Block, BlockContents};
+    use mc_transaction_core::{ring_signature::KeyImage, Block, BlockContents};
     use mc_transaction_core_test_utils::{
         create_ledger, create_mint_config_tx_and_signers, create_mint_tx, create_test_tx_out,
         initialize_ledger, mint_config_tx_to_validated as to_validated, AccountKey,
@@ -1081,6 +1147,174 @@ mod mint_tx_tests {
             mint_tx_manager.validate_mint_tx(&mint_tx),
             Err(MintTxManagerError::MintValidation(
                 MintValidationError::NoMatchingMintConfig
+            ))
+        );
+    }
+
+    /// validate_mint_tx rejects a tx with an exceeded tombstone block.
+    #[test_with_logger]
+    fn validate_mint_tx_rejects_past_tombstone(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
+        let token_id_1 = TokenId::from(1);
+
+        let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            1,
+            &mut rng,
+        );
+
+        let mut ledger = create_ledger();
+        // tombstone_block specifies that the tx will get accepted at any block whose
+        // index is less than tombstone_block. n_blocks controls how many blocks
+        // we create, specifically it will result in blocks with indexes [0, n_blocks).
+        // setting n_blocks to tombstone_block - 1 means the transaction will be valid
+        // for exactly 1 block, but once thats written it will exceed it. However, we
+        // subtract 2 since we also need to add a block for the mint config tx.
+        let n_blocks = mint_tx.prefix.tombstone_block - 2;
+        let block_version = BlockVersion::MAX;
+        let sender = AccountKey::random(&mut rng);
+        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+        // Append the mint config to the ledger
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let block_contents = BlockContents {
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Create MintTxManagerImpl
+        let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
+            token_id_1,
+            SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+        )])
+        .unwrap();
+        let mint_tx_manager = MintTxManagerImpl::new(
+            ledger.clone(),
+            BlockVersion::MAX,
+            token_id_to_governors,
+            logger,
+        );
+
+        // At first we should succeed since we have not yet exceeded the tombstone
+        // block.
+        assert_eq!(mint_tx_manager.validate_mint_tx(&mint_tx), Ok(()));
+
+        // Append a block to the ledger.
+        let parent_block = block;
+
+        let block_contents = BlockContents {
+            outputs: vec![create_test_tx_out(&mut rng)],
+            key_images: vec![KeyImage::from(123)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Try again, we should fail.
+        assert_eq!(
+            mint_tx_manager.validate_mint_tx(&mint_tx),
+            Err(MintTxManagerError::MintValidation(
+                MintValidationError::TombstoneBlockExceeded
+            ))
+        );
+    }
+
+    /// validate_mint_tx rejects duplicate nonce.
+    #[test_with_logger]
+    fn validate_mint_tx_rejects_duplicate_nonce(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([77u8; 32]);
+        let token_id_1 = TokenId::from(1);
+
+        let mut ledger = create_ledger();
+        let n_blocks = 3;
+        let block_version = BlockVersion::MAX;
+        let sender = AccountKey::random(&mut rng);
+        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+        // Create a mint configuration and append it to the ledger.
+        let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
+
+        let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
+
+        let block_contents = BlockContents {
+            validated_mint_config_txs: vec![to_validated(&mint_config_tx)],
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Create MintTxManagerImpl
+        let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
+            token_id_1,
+            SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+        )])
+        .unwrap();
+        let mint_tx_manager = MintTxManagerImpl::new(
+            ledger.clone(),
+            BlockVersion::MAX,
+            token_id_to_governors,
+            logger,
+        );
+
+        // Create a valid MintTx signed by the governor.
+        let mint_tx = create_mint_tx(
+            token_id_1,
+            &[Ed25519Pair::from(signers[0].private_key())],
+            1,
+            &mut rng,
+        );
+
+        // At first we should succeed since the nonce is not yet in the ledger.
+        assert_eq!(mint_tx_manager.validate_mint_tx(&mint_tx), Ok(()));
+
+        // Append to the ledger.
+        let block_contents = BlockContents {
+            outputs: vec![create_test_tx_out(&mut rng)],
+            mint_txs: vec![mint_tx.clone()],
+            ..Default::default()
+        };
+
+        let parent_block = block;
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &parent_block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        ledger.append_block(&block, &block_contents, None).unwrap();
+
+        // Try again, we should fail.
+        assert_eq!(
+            mint_tx_manager.validate_mint_tx(&mint_tx),
+            Err(MintTxManagerError::MintValidation(
+                MintValidationError::NonceAlreadyUsed
             ))
         );
     }

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -251,7 +251,7 @@ mod mint_config_tx_tests {
         let token_id_1 = TokenId::from(1);
 
         let mut ledger = create_ledger();
-        let n_blocks = 3;
+        let n_blocks = 1;
         let block_version = BlockVersion::MAX;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
@@ -281,7 +281,7 @@ mod mint_config_tx_tests {
         let token_id_3 = TokenId::from(3);
 
         let mut ledger = create_ledger();
-        let n_blocks = 3;
+        let n_blocks = 1;
         let block_version = BlockVersion::MAX;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
@@ -397,7 +397,7 @@ mod mint_config_tx_tests {
         let token_id_1 = TokenId::from(1);
 
         let mut ledger = create_ledger();
-        let n_blocks = 3;
+        let n_blocks = 1;
         let block_version = BlockVersion::MAX;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
@@ -488,7 +488,7 @@ mod mint_config_tx_tests {
         let token_id_1 = TokenId::from(1);
 
         let mut ledger = create_ledger();
-        let n_blocks = 3;
+        let n_blocks = 1;
         let block_version = BlockVersion::MAX;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -23,13 +23,16 @@ use mc_crypto_multisig::SignerSet;
 /// # Arguments
 /// * `tx` - A pending transaction.
 /// * `current_block_index` - The index of the current block that is being
-///   built.
+///   built. This is used to enforce the tombstone block limit, and is optional.
+///   It is optional because we want to be able to validate MintConfigTxs that
+///   are already in the ledger (e.g. when we are validating new MintTxs and
+///   matching them against existing MintConfigTxs).
 /// * `block_version` - The version of the block that is being built.
 /// * `governors` - The set of signers that are allowed to sign MintConfigTx
 ///   transactions.
 pub fn validate_mint_config_tx(
     tx: &MintConfigTx,
-    current_block_index: u64,
+    current_block_index: Option<u64>,
     block_version: BlockVersion,
     governors: &SignerSet<Ed25519Public>,
 ) -> Result<(), Error> {
@@ -42,7 +45,9 @@ pub fn validate_mint_config_tx(
 
     validate_nonce(&tx.prefix.nonce)?;
 
-    validate_tombstone(current_block_index, tx.prefix.tombstone_block)?;
+    if let Some(current_block_index) = current_block_index {
+        validate_tombstone(current_block_index, tx.prefix.tombstone_block)?;
+    }
 
     validate_signature(tx, governors)?;
 

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -64,7 +64,7 @@ pub fn create_mint_config_tx_and_signers(
         token_id: *token_id,
         configs: configs.clone(),
         nonce,
-        tombstone_block: 10,
+        tombstone_block: 2,
         total_mint_limit: configs[0].mint_limit + configs[1].mint_limit + configs[2].mint_limit,
     };
 


### PR DESCRIPTION
### Motivation

While working on the mint auditor CD stuff I ran into two bugs:
1) When a `MintTx` is validated, part of the validation ensures it matches a valid `MintConfigTx`. Prior to the change in this PR, `MintConfigTx` tombstone block would get compared to the block index currently being formed, however that is incorrect since the `MintConfigTx` was accepted at some point in the past and it is very much a possibility that when it gets re-validated as part of the `MintTx` validation its tombstone block would've been exceeded. The solution I came up with is to essentially bypass the tombstone block validation in this particular scenario. The `MintConfigTx` is already in the blockchain so the tombstone block is of no significance. We really only care about the signature being right, but might as well validate everything else we are capable of validating.
2) There was an off-by-one error in validating the tombstone block of incoming `MintTx` and `MintConfigTx`. We were accidentally comparing it to the last appended block index, where in fact we should've been comparing it to the index that the new block is going to have.

Additionally, I noticed there wasn't a unit test for duplicate `MintTx` nonces being rejected, so I added one.
