### PR TITLE
Make fee map enforce divisibility by minimum fee. Also check this in enclave impl

### DIFF
--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -97,21 +97,21 @@ mod test {
     #[test]
     fn different_fee_maps_result_in_different_responder_ids() {
         let config1: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 2000)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1024), (TokenId::from(2), 2048)]).unwrap(),
             governors_map: GovernorsMap::default(),
             governors_signature: None,
             block_version: BlockVersion::ZERO,
         }
         .into();
         let config2: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(2), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1024), (TokenId::from(2), 384)]).unwrap(),
             governors_map: GovernorsMap::default(),
             governors_signature: None,
             block_version: BlockVersion::ZERO,
         }
         .into();
         let config3: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 1000), (TokenId::from(30), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 1024), (TokenId::from(30), 384)]).unwrap(),
             governors_map: GovernorsMap::default(),
             governors_signature: None,
             block_version: BlockVersion::ZERO,
@@ -147,7 +147,7 @@ mod test {
         );
 
         let config4: BlockchainConfigWithDigest = BlockchainConfig {
-            fee_map: FeeMap::try_from_iter([(Mob::ID, 200), (TokenId::from(30), 300)]).unwrap(),
+            fee_map: FeeMap::try_from_iter([(Mob::ID, 256), (TokenId::from(30), 384)]).unwrap(),
             governors_map: GovernorsMap::default(),
             governors_signature: None,
             block_version: BlockVersion::ONE,

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -150,8 +150,7 @@ pub enum Error {
     /// Token `{0}` has invalid fee (too small) `{1}`
     InvalidFeeTooSmall(TokenId, u64),
 
-    /// Token `{0}` has invalid fee (not divisible by smallest minimum fee)
-    /// `{1}`
+    /// Token `{0}` has invalid fee (not divisible) `{1}`
     InvalidFeeNotDivisible(TokenId, u64),
 
     /// Token `{0}` is missing from the fee map

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1482,8 +1482,8 @@ mod tests {
                 block_version,
                 fee_map: FeeMap::try_from_iter([
                     (Mob::ID, 1000000),
-                    (token_id1, 1000),
-                    (token_id2, 1000),
+                    (token_id1, 1024),
+                    (token_id2, 1024),
                 ])
                 .unwrap(),
                 ..Default::default()

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -45,7 +45,7 @@ use mc_common::{
     ResponderId,
 };
 use mc_consensus_enclave_api::{
-    BlockchainConfig, BlockchainConfigWithDigest, ConsensusEnclave, Error, FeePublicKey,
+    BlockchainConfig, BlockchainConfigWithDigest, ConsensusEnclave, Error, FeeMap, FeePublicKey,
     FormBlockInputs, GovernorsVerifier, LocallyEncryptedTx, Result, SealedBlockSigningKey,
     TxContext, WellFormedEncryptedTx, WellFormedTxContext, SMALLEST_MINIMUM_FEE_LOG2,
 };

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1481,7 +1481,7 @@ mod tests {
             let blockchain_config = BlockchainConfig {
                 block_version,
                 fee_map: FeeMap::try_from_iter([
-                    (Mob::ID, 1000000),
+                    (Mob::ID, 2_000_000),
                     (token_id1, 1024),
                     (token_id2, 1024),
                 ])

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -447,7 +447,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         blockchain_config: BlockchainConfig,
     ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
         // Check that fee map is actually well formed
-        FeeMap::is_valid_map(&blockchain_config.fee_map.as_ref()).map_err(Error::FeeMap)?;
+        FeeMap::is_valid_map(blockchain_config.fee_map.as_ref()).map_err(Error::FeeMap)?;
 
         // Validate governors signature.
         if !blockchain_config.governors_map.is_empty() {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -447,7 +447,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         blockchain_config: BlockchainConfig,
     ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
         // Check that fee map is actually well formed
-        FeeMap::is_valid_map(&blockchain_config.fee_map).map_err(Error::FeeMap)?;
+        FeeMap::is_valid_map(&blockchain_config.fee_map.as_ref()).map_err(Error::FeeMap)?;
 
         // Validate governors signature.
         if !blockchain_config.governors_map.is_empty() {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -446,6 +446,9 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         sealed_key: &Option<SealedBlockSigningKey>,
         blockchain_config: BlockchainConfig,
     ) -> Result<(SealedBlockSigningKey, Vec<String>)> {
+        // Check that fee map is actually well formed
+        FeeMap::is_valid_map(&blockchain_config.fee_map).map_err(Error::FeeMap)?;
+
         // Validate governors signature.
         if !blockchain_config.governors_map.is_empty() {
             let signature = blockchain_config

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -342,13 +342,13 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 1
-            minimum_fee = 123000
+            minimum_fee = 128000
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         let input_json: &str = r#"{
             "tokens": [
-                { "token_id": 1, "minimum_fee": 123000 }
+                { "token_id": 1, "minimum_fee": 128000 }
             ]
         }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
@@ -385,13 +385,13 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 0
-            minimum_fee = 123000
+            minimum_fee = 128000
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         let input_json: &str = r#"{
             "tokens": [
-                { "token_id": 0, "minimum_fee": 123000 }
+                { "token_id": 0, "minimum_fee": 128000 }
             ]
         }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
@@ -401,7 +401,7 @@ mod tests {
         assert!(tokens.validate().is_ok());
         assert_eq!(
             tokens.get_token_config(&Mob::ID).unwrap().minimum_fee,
-            Some(123000)
+            Some(128000)
         );
 
         // A random token id does not exist.
@@ -447,18 +447,18 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 0
-            minimum_fee = 123000
+            minimum_fee = 128000
 
             [[tokens]]
             token_id = 6
-            minimum_fee = 456000
+            minimum_fee = 512000
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         let input_json: &str = r#"{
             "tokens": [
-                { "token_id": 0, "minimum_fee": 123000 },
-                { "token_id": 6, "minimum_fee": 456000 }
+                { "token_id": 0, "minimum_fee": 128000 },
+                { "token_id": 6, "minimum_fee": 512000 }
             ]
         }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
@@ -472,20 +472,20 @@ mod tests {
                 .get_token_config(&Mob::ID)
                 .unwrap()
                 .minimum_fee_or_default(),
-            Some(123000)
+            Some(128000)
         );
         assert_eq!(
             tokens
                 .get_token_config(&test_token)
                 .unwrap()
                 .minimum_fee_or_default(),
-            Some(456000)
+            Some(512000)
         );
 
         // Fee map looks good.
         assert_eq!(
             tokens.fee_map().unwrap(),
-            FeeMap::try_from_iter(vec![(Mob::ID, 123000), (test_token, 456000)]).unwrap(),
+            FeeMap::try_from_iter(vec![(Mob::ID, 128000), (test_token, 512000)]).unwrap(),
         );
 
         // A random token id does not exist.
@@ -501,14 +501,14 @@ mod tests {
 
             [[tokens]]
             token_id = 6
-            minimum_fee = 456000
+            minimum_fee = 512000
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
         let input_json: &str = r#"{
             "tokens": [
                 { "token_id": 0 },
-                { "token_id": 6, "minimum_fee": 456000 }
+                { "token_id": 6, "minimum_fee": 512000 }
             ]
         }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
@@ -529,7 +529,7 @@ mod tests {
                 .get_token_config(&test_token)
                 .unwrap()
                 .minimum_fee_or_default(),
-            Some(456000)
+            Some(512000)
         );
 
         // Fee map looks good.
@@ -548,7 +548,7 @@ mod tests {
         let input_toml: &str = r#"
             [[tokens]]
             token_id = 0
-            minimum_fee = 123000
+            minimum_fee = 128000
 
             [[tokens]]
             token_id = 6
@@ -557,7 +557,7 @@ mod tests {
 
         let input_json: &str = r#"{
             "tokens": [
-                { "token_id": 0, "minimum_fee": 123000 },
+                { "token_id": 0, "minimum_fee": 128000 },
                 { "token_id": 6 }
             ]
         }"#;
@@ -581,7 +581,7 @@ mod tests {
 
             [[tokens]]
             token_id = 1
-            minimum_fee = 123000
+            minimum_fee = 128000
             allow_any_fee = true
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
@@ -589,7 +589,7 @@ mod tests {
         let input_json: &str = r#"{
             "tokens": [
                 { "token_id": 0 },
-                { "token_id": 1, "minimum_fee": 123000, "allow_any_fee": true }
+                { "token_id": 1, "minimum_fee": 128000, "allow_any_fee": true }
             ]
         }"#;
         let tokens2: TokensConfig = serde_json::from_str(input_json).expect("failed parsing json");
@@ -872,11 +872,11 @@ mod tests {
 
             [[tokens]]
             token_id = 1
-            minimum_fee = 123000
+            minimum_fee = 128000
 
             [[tokens]]
             token_id = 1
-            minimum_fee = 123000
+            minimum_fee = 128000
         "#;
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -535,7 +535,7 @@ mod tests {
         // Fee map looks good.
         assert_eq!(
             tokens.fee_map().unwrap(),
-            FeeMap::try_from_iter(vec![(Mob::ID, Mob::MINIMUM_FEE), (test_token, 456000)]).unwrap(),
+            FeeMap::try_from_iter(vec![(Mob::ID, Mob::MINIMUM_FEE), (test_token, 512000)]).unwrap(),
         );
 
         // A random token id does not exist.

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -223,7 +223,7 @@ mod tests {
     // `get_last_block_info` should returns the last block.
     fn test_get_last_block_info(logger: Logger) {
         let fee_map =
-            FeeMap::try_from_iter([(Mob::ID, 12345), (TokenId::from(60), 10203040)]).unwrap();
+            FeeMap::try_from_iter([(Mob::ID, 4000000000), (TokenId::from(60), 128000)]).unwrap();
 
         let mut ledger_db = create_ledger();
         let authenticator = Arc::new(AnonymousAuthenticator::default());
@@ -239,8 +239,8 @@ mod tests {
 
         let mut expected_response = LastBlockInfoResponse::new();
         expected_response.set_index(block_entities.last().unwrap().index);
-        expected_response.set_mob_minimum_fee(12345);
-        expected_response.set_minimum_fees(HashMap::from_iter(vec![(0, 12345), (60, 10203040)]));
+        expected_response.set_mob_minimum_fee(4000000000);
+        expected_response.set_minimum_fees(HashMap::from_iter(vec![(0, 4000000000), (60, 128000)]));
         expected_response.set_network_block_version(*BlockVersion::MAX);
         assert_eq!(
             block_entities.last().unwrap().index,

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -222,7 +222,7 @@ class Node:
                 { "token_id": 0, "minimum_fee": self.minimum_fee },
                 {
                     "token_id": 1,
-                    "minimum_fee": 1000,
+                    "minimum_fee": 1024,
                     "governors": {
                         "signers": open(os.path.join(MINTING_KEYS_DIR, 'governor1.pub')).read(),
                         "threshold": 1
@@ -230,7 +230,7 @@ class Node:
                 },
                 {
                     "token_id": 2,
-                    "minimum_fee": 1000,
+                    "minimum_fee": 1024,
                     "governors": {
                         "signers": open(os.path.join(MINTING_KEYS_DIR, 'governor2.pub')).read(),
                         "threshold": 1


### PR DESCRIPTION
We determined that, if the minimum fee of a token is not divisible by the global minimum, it can cause an information leakage, because paying the minimum fee for that token does not lead to a priority of 128 like everything else.

There are several possible ways to try to mitigate this, but right now the least disruptive (in terms of changing business logic, and MCIPs) is to enforce this rule in the fee map validation. (And for good measure we check that in the enclave init function.)

This does not cause any problems for any existing currencies like MOB, because the mob minimum fee is 4 * 10^9, and we are only requiring that it is divisible by 2^7, which it is. It is likely that most currencies will have a minimum fee value with > 6 zeroes or so, and so they will easily satisfy this requirement.