### PR TITLE
TransactionBuilder TxOutContext

### DIFF
--- a/android-bindings/makefile
+++ b/android-bindings/makefile
@@ -99,6 +99,7 @@ copy_artifacts:
 	cp -f ../api/proto/external.proto build/proto/
 	cp -f ../consensus/api/proto/consensus_common.proto build/proto/
 	cp -f ../consensus/api/proto/consensus_peer.proto build/proto/
+	cp -f ../consensus/api/proto/consensus_config.proto build/proto
 	cp -f ../attest/api/proto/attest.proto build/proto/
 	cp -f ../fog/report/api/proto/report.proto build/proto/
 	cp -f ../fog/api/proto/view.proto build/proto/

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_finalize_1jni(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1value(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
     env: JNIEnv,
     obj: JObject,
     view_key: JObject,
@@ -395,14 +395,27 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1value(
                 env.get_rust_field(tx_pub_key, RUST_OBJ_FIELD)?;
             let shared_secret = create_shared_secret(&tx_pub_key, &view_key);
             let (amount, _) = masked_amount.get_value(&shared_secret)?;
+            let value = env.new_object(
+                "java/math/BigInteger",
+                "(I[B)V",
+                &[
+                    jni::objects::JValue::Int(1),
+                    env.byte_array_from_slice(&amount.value.to_be_bytes())?
+                        .into(),
+                ],
+            )?;
+            let token_id = env.new_object(
+                "com/mobilecoin/lib/UnsignedLong",
+                "(J)V",
+                &[jni::objects::JValue::Long(*amount.token_id as i64)],
+            )?;
             Ok(env
                 .new_object(
-                    "java/math/BigInteger",
-                    "(I[B)V", // public BigInteger(int signum, byte[] magnitude)
+                    "com/mobilecoin/lib/Amount",
+                    "(Ljava/math/BigInteger;Lcom/mobilecoin/lib/UnsignedLong;)V",
                     &[
-                        1.into(),
-                        env.byte_array_from_slice(&amount.value.to_be_bytes())?
-                            .into(),
+                        jni::objects::JValue::Object(value),
+                        jni::objects::JValue::Object(token_id),
                     ],
                 )?
                 .into_inner())

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -54,7 +54,7 @@ use mc_transaction_core::{
 use mc_transaction_std::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, ChangeDestination,
     DestinationMemo, InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder,
-    SenderMemoCredential, TransactionBuilder,
+    SenderMemoCredential, TransactionBuilder, TxOutContext,
 };
 
 use mc_util_from_random::FromRandom;
@@ -1479,6 +1479,63 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOut_decrypt_1memo_1payload(
 }
 
 /********************************************************************
+ * TxOutContext
+ */
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1tx_1out(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let tx_out = tx_out_context.tx_out.clone();
+            let mbox = Box::new(Mutex::new(tx_out));
+            let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
+            Ok(ptr as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1confirmation_1number(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let confirmation = tx_out_context.confirmation.clone();
+            let mbox = Box::new(Mutex::new(confirmation));
+            let ptr: *mut Mutex<TxOutConfirmationNumber> = Box::into_raw(mbox);
+            Ok(ptr as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1shared_1secret(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let shared_secret = tx_out_context.shared_secret.clone();
+            let mbox = Box::new(Mutex::new(shared_secret));
+            let ptr: *mut Mutex<RistrettoPublic> = Box::into_raw(mbox);
+            Ok(ptr as jlong)
+        },
+    )
+}
+
+/********************************************************************
  * TxOutMembershipProof
  */
 
@@ -1713,8 +1770,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
                 env.get_rust_field(recipient, RUST_OBJ_FIELD)?;
 
             let mut rng = McRng::default();
-            let (tx_out, confirmation_number) =
-                tx_builder.add_output(value as u64, &recipient, &mut rng)?;
+            let tx_out_context =
+                tx_builder.add_output_with_context(value as u64, &recipient, &mut rng)?;
+            let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
                 if len as usize >= confirmation_number.to_vec().len() {
@@ -1731,8 +1789,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
                 }
             }
 
-            let mbox = Box::new(Mutex::new(tx_out));
-            let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
+            let mbox = Box::new(Mutex::new(tx_out_context));
+            let ptr: *mut Mutex<TxOutContext> = Box::into_raw(mbox);
             Ok(ptr as jlong)
         },
     )
@@ -1760,8 +1818,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 ChangeDestination::from(&*source_account_key);
             let mut rng = McRng::default();
 
-            let (tx_out, confirmation_number) =
-                tx_builder.add_change_output(value, &change_destination, &mut rng)?;
+            let tx_out_context =
+                tx_builder.add_change_output_with_context(value, &change_destination, &mut rng)?;
+            let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
                 if len as usize >= confirmation_number.to_vec().len() {
@@ -1778,8 +1837,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 }
             }
 
-            let mbox = Box::new(Mutex::new(tx_out));
-            let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
+            let mbox = Box::new(Mutex::new(tx_out_context));
+            let ptr: *mut Mutex<TxOutContext> = Box::into_raw(mbox);
             Ok(ptr as jlong)
         },
     )

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1491,7 +1491,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1tx_1out(
         &env,
         |env| {
             let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
-            let tx_out = tx_out_context.tx_out.clone();
+            let tx_out = tx_out_context.tx_out.to_owned();
             let mbox = Box::new(Mutex::new(tx_out));
             let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
             Ok(ptr as jlong)
@@ -1503,16 +1503,15 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1tx_1out(
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1confirmation_1number(
     env: JNIEnv,
     obj: JObject,
-) -> jlong {
+) -> jbyteArray {
     jni_ffi_call_or(
-        || Ok(0),
+        || Ok(JObject::null().into_inner()),
         &env,
         |env| {
             let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
-            let confirmation = tx_out_context.confirmation.clone();
-            let mbox = Box::new(Mutex::new(confirmation));
-            let ptr: *mut Mutex<TxOutConfirmationNumber> = Box::into_raw(mbox);
-            Ok(ptr as jlong)
+            let confirmation_number = &tx_out_context.confirmation;
+            let bytes = mc_util_serial::encode(confirmation_number);
+            Ok(env.byte_array_from_slice(&bytes)?)
         },
     )
 }
@@ -1527,7 +1526,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1shared_1secre
         &env,
         |env| {
             let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
-            let shared_secret = tx_out_context.shared_secret.clone();
+            let shared_secret = tx_out_context.shared_secret.to_owned();
             let mbox = Box::new(Mutex::new(shared_secret));
             let ptr: *mut Mutex<RistrettoPublic> = Box::into_raw(mbox);
             Ok(ptr as jlong)

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1490,7 +1490,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1tx_1out(
         || Ok(0),
         &env,
         |env| {
-            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let tx_out_context: MutexGuard<TxOutContext> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
             let tx_out = tx_out_context.tx_out.to_owned();
             let mbox = Box::new(Mutex::new(tx_out));
             let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
@@ -1508,7 +1509,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1confirmation_
         || Ok(JObject::null().into_inner()),
         &env,
         |env| {
-            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let tx_out_context: MutexGuard<TxOutContext> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
             let confirmation_number = &tx_out_context.confirmation;
             let bytes = mc_util_serial::encode(confirmation_number);
             Ok(env.byte_array_from_slice(&bytes)?)
@@ -1525,7 +1527,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutContext_get_1shared_1secre
         || Ok(0),
         &env,
         |env| {
-            let tx_out_context: MutexGuard<TxOutContext> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let tx_out_context: MutexGuard<TxOutContext> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
             let shared_secret = tx_out_context.shared_secret.to_owned();
             let mbox = Box::new(Mutex::new(shared_secret));
             let ptr: *mut Mutex<RistrettoPublic> = Box::into_raw(mbox);

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1773,7 +1773,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
 
             let mut rng = McRng::default();
             let tx_out_context =
-                tx_builder.add_output_with_context(value as u64, &recipient, &mut rng)?;
+                tx_builder.add_output(value as u64, &recipient, &mut rng)?;
             let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
@@ -1821,7 +1821,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
             let mut rng = McRng::default();
 
             let tx_out_context =
-                tx_builder.add_change_output_with_context(value, &change_destination, &mut rng)?;
+                tx_builder.add_change_output(value, &change_destination, &mut rng)?;
             let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1772,8 +1772,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
                 env.get_rust_field(recipient, RUST_OBJ_FIELD)?;
 
             let mut rng = McRng::default();
-            let tx_out_context =
-                tx_builder.add_output(value as u64, &recipient, &mut rng)?;
+            let tx_out_context = tx_builder.add_output(value as u64, &recipient, &mut rng)?;
             let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -306,11 +306,11 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_AttestedClient_decrypt_1payload
 }
 
 /*****************************************************************
- * Amount
+ * MaskedAmount
  */
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_init_1jni(
     env: JNIEnv,
     obj: JObject,
     commitment: jbyteArray,
@@ -331,7 +331,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_init_1jni_1with_1secret(
     env: JNIEnv,
     obj: JObject,
     tx_out_shared_secret: JObject,
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_init_1jni_1with_1secret(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_get_1bytes(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_get_1bytes(
     env: JNIEnv,
     obj: JObject,
 ) -> jbyteArray {
@@ -366,7 +366,10 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_get_1bytes(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_finalize_1jni(env: JNIEnv, obj: JObject) {
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_finalize_1jni(
+    env: JNIEnv,
+    obj: JObject,
+) {
     jni_ffi_call(&env, |env| {
         let _: MaskedAmount = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
         Ok(())
@@ -374,7 +377,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_finalize_1jni(env: JNIEn
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_Amount_unmask_1value(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1value(
     env: JNIEnv,
     obj: JObject,
     view_key: JObject,
@@ -1396,7 +1399,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOut_compute_1key_1image(
                 &tx_out_target_key,
                 &tx_pub_key,
             );
-            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (0..=DEFAULT_SUBADDRESS_INDEX)
+            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (u64::MIN
+                ..=DEFAULT_SUBADDRESS_INDEX)
                 .chain(CHANGE_SUBADDRESS_INDEX..INVALID_SUBADDRESS_INDEX)
                 .map(|index| (*account_key.subaddress(index).spend_public_key(), index))
                 .collect();
@@ -1851,7 +1855,8 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_recover_1onetime_1private_
                 &tx_target_key,
                 &tx_pub_key,
             );
-            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (0..=DEFAULT_SUBADDRESS_INDEX)
+            let spsk_to_index: BTreeMap<RistrettoPublic, u64> = (u64::MIN
+                ..=DEFAULT_SUBADDRESS_INDEX)
                 .chain(CHANGE_SUBADDRESS_INDEX..INVALID_SUBADDRESS_INDEX)
                 .map(|index| (*account_key.subaddress(index).spend_public_key(), index))
                 .collect();

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -216,9 +216,10 @@ McData* MC_NULLABLE mc_transaction_builder_add_output(
   const McPublicAddress* MC_NONNULL recipient_address,
   McRngCallback* MC_NULLABLE rng_callback,
   McMutableBuffer* MC_NONNULL out_tx_out_confirmation_number,
+  McMutableBuffer* MC_NONNULL out_tx_out_shared_secret,
   McError* MC_NULLABLE * MC_NULLABLE out_error
 )
-MC_ATTRIBUTE_NONNULL(1, 3, 6);
+MC_ATTRIBUTE_NONNULL(1, 3, 7);
 
 /// # Preconditions
 ///
@@ -237,9 +238,10 @@ McData* MC_NULLABLE mc_transaction_builder_add_change_output(
   uint64_t amount,
   McRngCallback* MC_NULLABLE rng_callback,
   McMutableBuffer* MC_NONNULL out_tx_out_confirmation_number,
+  McMutableBuffer* MC_NONNULL out_tx_out_shared_secret,
   McError* MC_NULLABLE * MC_NULLABLE out_error
 )
-MC_ATTRIBUTE_NONNULL(1, 2, 4, 6);
+MC_ATTRIBUTE_NONNULL(1, 2, 4, 7);
 
 /// # Preconditions
 ///

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -785,6 +785,7 @@ FfiOptOwnedPtr<McData> mc_transaction_builder_add_output(FfiMutPtr<McTransaction
                                                          FfiRefPtr<McPublicAddress> recipient_address,
                                                          FfiOptMutPtr<McRngCallback> rng_callback,
                                                          FfiMutPtr<McMutableBuffer> out_tx_out_confirmation_number,
+                                                         FfiMutPtr<McMutableBuffer> out_tx_out_shared_secret,
                                                          FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
@@ -806,6 +807,7 @@ FfiOptOwnedPtr<McData> mc_transaction_builder_add_change_output(FfiRefPtr<McAcco
                                                                 uint64_t amount,
                                                                 FfiOptMutPtr<McRngCallback> rng_callback,
                                                                 FfiMutPtr<McMutableBuffer> out_tx_out_confirmation_number,
+                                                                FfiMutPtr<McMutableBuffer> out_tx_out_shared_secret,
                                                                 FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -501,7 +501,13 @@ pub extern "C" fn mc_transaction_builder_add_output(
             transaction_builder.add_output_with_context(amount, &recipient_address, &mut rng)?;
 
         out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
-        out_tx_out_shared_secret.copy_from_slice(tx_out_context.shared_secret.as_ref());
+
+        let out_tx_out_shared_secret = out_tx_out_shared_secret
+            .into_mut()
+            .as_slice_mut_of_len(RistrettoPublic::size())
+            .expect("out_tx_out_shared_secret length is insufficient");
+
+        out_tx_out_shared_secret.copy_from_slice(&tx_out_context.shared_secret.to_bytes());
         Ok(mc_util_serial::encode(&tx_out_context.tx_out))
     })
 }
@@ -546,7 +552,14 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             transaction_builder.add_change_output_with_context(amount, &change_destination, &mut rng)?;
 
         out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
-        out_tx_out_shared_secret.copy_from_slice(tx_out_context.shared_secret.as_ref());
+
+
+        let out_tx_out_shared_secret = out_tx_out_shared_secret
+            .into_mut()
+            .as_slice_mut_of_len(RistrettoPublic::size())
+            .expect("out_tx_out_shared_secret length is insufficient");
+
+        out_tx_out_shared_secret.copy_from_slice(&tx_out_context.shared_secret.to_bytes());
         Ok(mc_util_serial::encode(&tx_out_context.tx_out))
     })
 }

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -498,7 +498,7 @@ pub extern "C" fn mc_transaction_builder_add_output(
             .expect("out_tx_out_confirmation_number length is insufficient");
 
         let tx_out_context =
-            transaction_builder.add_output_with_context(amount, &recipient_address, &mut rng)?;
+            transaction_builder.add_output(amount, &recipient_address, &mut rng)?;
 
         out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
 
@@ -548,7 +548,7 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        let tx_out_context = transaction_builder.add_change_output_with_context(
+        let tx_out_context = transaction_builder.add_change_output(
             amount,
             &change_destination,
             &mut rng,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -548,11 +548,13 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        let tx_out_context =
-            transaction_builder.add_change_output_with_context(amount, &change_destination, &mut rng)?;
+        let tx_out_context = transaction_builder.add_change_output_with_context(
+            amount,
+            &change_destination,
+            &mut rng,
+        )?;
 
         out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
-
 
         let out_tx_out_shared_secret = out_tx_out_shared_secret
             .into_mut()

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -481,6 +481,7 @@ pub extern "C" fn mc_transaction_builder_add_output(
     recipient_address: FfiRefPtr<McPublicAddress>,
     rng_callback: FfiOptMutPtr<McRngCallback>,
     out_tx_out_confirmation_number: FfiMutPtr<McMutableBuffer>,
+    out_tx_out_shared_secret: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<McData> {
     ffi_boundary_with_error(out_error, || {
@@ -496,11 +497,12 @@ pub extern "C" fn mc_transaction_builder_add_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        let (tx_out, confirmation) =
-            transaction_builder.add_output(amount, &recipient_address, &mut rng)?;
+        let tx_out_context =
+            transaction_builder.add_output_with_context(amount, &recipient_address, &mut rng)?;
 
-        out_tx_out_confirmation_number.copy_from_slice(confirmation.as_ref());
-        Ok(mc_util_serial::encode(&tx_out))
+        out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
+        out_tx_out_shared_secret.copy_from_slice(tx_out_context.shared_secret.as_ref());
+        Ok(mc_util_serial::encode(&tx_out_context.tx_out))
     })
 }
 
@@ -523,6 +525,7 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
     amount: u64,
     rng_callback: FfiOptMutPtr<McRngCallback>,
     out_tx_out_confirmation_number: FfiMutPtr<McMutableBuffer>,
+    out_tx_out_shared_secret: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<McData> {
     ffi_boundary_with_error(out_error, || {
@@ -539,11 +542,12 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        let (tx_out, confirmation) =
-            transaction_builder.add_change_output(amount, &change_destination, &mut rng)?;
+        let tx_out_context =
+            transaction_builder.add_change_output_with_context(amount, &change_destination, &mut rng)?;
 
-        out_tx_out_confirmation_number.copy_from_slice(confirmation.as_ref());
-        Ok(mc_util_serial::encode(&tx_out))
+        out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
+        out_tx_out_shared_secret.copy_from_slice(tx_out_context.shared_secret.as_ref());
+        Ok(mc_util_serial::encode(&tx_out_context.tx_out))
     })
 }
 

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -548,11 +548,8 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .as_slice_mut_of_len(TxOutConfirmationNumber::size())
             .expect("out_tx_out_confirmation_number length is insufficient");
 
-        let tx_out_context = transaction_builder.add_change_output(
-            amount,
-            &change_destination,
-            &mut rng,
-        )?;
+        let tx_out_context =
+            transaction_builder.add_change_output(amount, &change_destination, &mut rng)?;
 
         out_tx_out_confirmation_number.copy_from_slice(tx_out_context.confirmation.as_ref());
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -25,6 +25,7 @@ use mc_transaction_core::{
 };
 use mc_transaction_std::{
     ChangeDestination, EmptyMemoBuilder, InputCredentials, MemoBuilder, TransactionBuilder,
+    TxOutContext,
 };
 use mc_util_uri::FogUri;
 use rand::Rng;

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -971,7 +971,11 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_out_to_outlay_index = HashMap::default();
         let mut outlay_confirmation_numbers = Vec::default();
         for (i, outlay) in destinations.iter().enumerate() {
-            let TxOutContext {tx_out, confirmation, ..} = tx_builder
+            let TxOutContext {
+                tx_out,
+                confirmation,
+                ..
+            } = tx_builder
                 .add_output(outlay.value, &outlay.receiver, rng)
                 .map_err(|err| Error::TxBuild(format!("failed adding output: {}", err)))?;
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -970,7 +970,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_out_to_outlay_index = HashMap::default();
         let mut outlay_confirmation_numbers = Vec::default();
         for (i, outlay) in destinations.iter().enumerate() {
-            let (tx_out, confirmation_number) = tx_builder
+            let TxOutContext {tx_out, confirmation_number, ..} = tx_builder
                 .add_output(outlay.value, &outlay.receiver, rng)
                 .map_err(|err| Error::TxBuild(format!("failed adding output: {}", err)))?;
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -971,12 +971,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_out_to_outlay_index = HashMap::default();
         let mut outlay_confirmation_numbers = Vec::default();
         for (i, outlay) in destinations.iter().enumerate() {
-            let TxOutContext {tx_out, confirmation_number, ..} = tx_builder
+            let TxOutContext {tx_out, confirmation, ..} = tx_builder
                 .add_output(outlay.value, &outlay.receiver, rng)
                 .map_err(|err| Error::TxBuild(format!("failed adding output: {}", err)))?;
 
             tx_out_to_outlay_index.insert(tx_out, i);
-            outlay_confirmation_numbers.push(confirmation_number);
+            outlay_confirmation_numbers.push(confirmation);
 
             total_value += outlay.value;
         }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -40,7 +40,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     TokenId,
 };
-use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder};
+use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder, TxOutContext};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -40,7 +40,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     TokenId,
 };
-use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder, TxOutContext};
+use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -40,7 +40,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     TokenId,
 };
-use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder, TxOutContext};
+use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,
@@ -2103,7 +2103,7 @@ mod test {
         tx::{Tx, TxOut},
         Amount, Block, BlockContents, BlockVersion, Token,
     };
-    use mc_transaction_std::{EmptyMemoBuilder, MemoType, TransactionBuilder};
+    use mc_transaction_std::{EmptyMemoBuilder, MemoType, TransactionBuilder, TxOutContext};
     use mc_util_repr_bytes::{typenum::U32, GenericArray, ReprBytes};
     use mc_util_uri::FogUri;
     use rand::{rngs::StdRng, SeedableRng};

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3047,7 +3047,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let (tx_out, tx_confirmation) = transaction_builder
+        let TxOutContext {tx_out, confirmation, ..} = transaction_builder
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
 
@@ -3064,7 +3064,7 @@ mod test {
             ));
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(10);
-            receipt.set_confirmation_number(tx_confirmation.to_vec());
+            receipt.set_confirmation_number(confirmation.to_vec());
 
             let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -5522,7 +5522,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let TxOutContext {tx_out, _tx_confirmation, ..} = transaction_builder
+        let TxOutContext {tx_out, ..} = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
@@ -5636,7 +5636,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let TxOutContext {tx_out, _tx_confirmation, ..} = transaction_builder
+        let TxOutContext {tx_out, ..} = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3047,7 +3047,11 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let TxOutContext {tx_out, confirmation, ..} = transaction_builder
+        let TxOutContext {
+            tx_out,
+            confirmation,
+            ..
+        } = transaction_builder
             .add_output(10, &receiver.subaddress(0), &mut rng)
             .unwrap();
 
@@ -5522,7 +5526,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let TxOutContext {tx_out, ..} = transaction_builder
+        let TxOutContext { tx_out, .. } = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
@@ -5636,7 +5640,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let TxOutContext {tx_out, ..} = transaction_builder
+        let TxOutContext { tx_out, .. } = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -40,7 +40,7 @@ use mc_transaction_core::{
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     TokenId,
 };
-use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder};
+use mc_transaction_std::{BurnRedemptionMemo, BurnRedemptionMemoBuilder, TxOutContext};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,
@@ -5522,7 +5522,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let (tx_out, _tx_confirmation) = transaction_builder
+        let TxOutContext {tx_out, _tx_confirmation, ..} = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),
@@ -5636,7 +5636,7 @@ mod test {
             EmptyMemoBuilder::default(),
         )
         .unwrap();
-        let (tx_out, _tx_confirmation) = transaction_builder
+        let TxOutContext {tx_out, _tx_confirmation, ..} = transaction_builder
             .add_output(
                 10,
                 &account_key.subaddress(DEFAULT_SUBADDRESS_INDEX),

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -23,7 +23,7 @@ pub use memo::{
     SenderMemoCredential, UnusedMemo,
 };
 pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
-pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
+pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutContext, TxOutputsOrdering};
 
 // Re-export this to help the exported macros work
 pub use mc_transaction_core::MemoPayload;

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -23,7 +23,9 @@ pub use memo::{
     SenderMemoCredential, UnusedMemo,
 };
 pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
-pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutContext, TxOutputsOrdering};
+pub use transaction_builder::{
+    DefaultTxOutputsOrdering, TransactionBuilder, TxOutContext, TxOutputsOrdering
+};
 
 // Re-export this to help the exported macros work
 pub use mc_transaction_core::MemoPayload;

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -24,7 +24,7 @@ pub use memo::{
 };
 pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
 pub use transaction_builder::{
-    DefaultTxOutputsOrdering, TransactionBuilder, TxOutContext, TxOutputsOrdering
+    DefaultTxOutputsOrdering, TransactionBuilder, TxOutContext, TxOutputsOrdering,
 };
 
 // Re-export this to help the exported macros work

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -46,7 +46,8 @@ pub struct TxOutContext {
     /// TxOut that comes from a transaction builder
     /// add_output/add_change_output
     pub tx_out: TxOut,
-    /// confirmation that comes from a transaction builder add_output/add_change_output
+    /// confirmation that comes from a transaction builder
+    /// add_output/add_change_output
     pub confirmation: TxOutConfirmationNumber,
     /// Shared Secret that comes from a transaction builder
     /// add_output/add_change_output
@@ -353,7 +354,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
 
         let confirmation = TxOutConfirmationNumber::from(&shared_secret);
 
-        Ok(TxOutContext{
+        Ok(TxOutContext {
             tx_out,
             confirmation,
             shared_secret,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -811,7 +811,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let (_txout, confirmation) = transaction_builder
+            let TxOutContext {.., confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -894,7 +894,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let (_txout, confirmation) = transaction_builder
+            let TxOutContext {.., confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -1068,7 +1068,7 @@ pub mod transaction_builder_tests {
                     get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(value - Mob::MINIMUM_FEE, &recipient_address, &mut rng)
                     .unwrap();
 
@@ -1100,7 +1100,7 @@ pub mod transaction_builder_tests {
                     get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(value - Mob::MINIMUM_FEE, &recipient_address, &mut rng)
                     .unwrap();
 
@@ -1166,7 +1166,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -1344,7 +1344,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -1503,7 +1503,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE * 4,
                         &recipient_address,
@@ -1662,7 +1662,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -1821,7 +1821,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -1968,7 +1968,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -2140,7 +2140,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &bob_address,
@@ -2329,7 +2329,7 @@ pub mod transaction_builder_tests {
                 );
                 transaction_builder.add_input(input_credentials);
 
-                let (_txout, _confirmation) = transaction_builder
+                transaction_builder
                     .add_output(
                         value - change_value - Mob::MINIMUM_FEE,
                         &recipient_address,
@@ -2597,7 +2597,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let (burn_tx_out, _confirmation) = transaction_builder
+            let TxOutContext {burn_tx_out, .., ..} = transaction_builder
                 .add_output(
                     value - change_value - Mob::MINIMUM_FEE,
                     &recipient,
@@ -2759,7 +2759,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let (_burn_tx_out, _confirmation) = transaction_builder
+            transaction_builder
                 .add_output(100, &burn_address(), &mut rng)
                 .unwrap();
 
@@ -2802,7 +2802,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let (burn_output, _confirmation) = transaction_builder
+            let TxOutContext {burn_output, .., ..} = transaction_builder
                 .add_output(110, &burn_address(), &mut rng)
                 .unwrap();
 
@@ -2858,7 +2858,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let (burn_tx_out, _confirmation) = transaction_builder
+            let TxOutContext {burn_tx_out, .., ..} = transaction_builder
                 .add_output(100, &burn_address(), &mut rng)
                 .unwrap();
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -811,7 +811,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {confirmation, ..} = transaction_builder
+            let TxOutContext { confirmation, .. } = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -894,7 +894,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {confirmation, ..} = transaction_builder
+            let TxOutContext { confirmation, .. } = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -2597,7 +2597,10 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {tx_out: burn_tx_out, ..} = transaction_builder
+            let TxOutContext {
+                tx_out: burn_tx_out,
+                ..
+            } = transaction_builder
                 .add_output(
                     value - change_value - Mob::MINIMUM_FEE,
                     &recipient,
@@ -2802,7 +2805,10 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {tx_out: burn_output, ..} = transaction_builder
+            let TxOutContext {
+                tx_out: burn_output,
+                ..
+            } = transaction_builder
                 .add_output(110, &burn_address(), &mut rng)
                 .unwrap();
 
@@ -2858,7 +2864,10 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {tx_out: burn_tx_out, ..} = transaction_builder
+            let TxOutContext {
+                tx_out: burn_tx_out,
+                ..
+            } = transaction_builder
                 .add_output(100, &burn_address(), &mut rng)
                 .unwrap();
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -40,7 +40,6 @@ impl TxOutputsOrdering for DefaultTxOutputsOrdering {
 
 /// Transaction output context is produced by add_output method
 /// Used for receipt creation
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct TxOutContext {
     /// TxOut that comes from a transaction builder
@@ -158,26 +157,6 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         value: u64,
         recipient: &PublicAddress,
         rng: &mut RNG,
-    ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
-        let context = self.add_output_with_context(value, recipient, rng)?;
-        Ok((context.tx_out, context.confirmation))
-    }
-
-    /// Add a non-change output to the transaction.
-    ///
-    /// If a sender memo credential has been set, this will create an
-    /// authenticated sender memo for the TxOut. Otherwise the memo will be
-    /// unused.
-    ///
-    /// # Arguments
-    /// * `value` - The value of this output, in picoMOB.
-    /// * `recipient` - The recipient's public address
-    /// * `rng` - RNG used to generate blinding for commitment
-    pub fn add_output_with_context<RNG: CryptoRng + RngCore>(
-        &mut self,
-        value: u64,
-        recipient: &PublicAddress,
-        rng: &mut RNG,
     ) -> Result<TxOutContext, TxBuilderError> {
         // Taking self.memo_builder here means that we can call functions on &mut self,
         // and pass them something that has captured the memo builder.
@@ -239,43 +218,6 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     ///   this API does not require the account key.
     /// * `rng` - RNG used to generate blinding for commitment
     pub fn add_change_output<RNG: CryptoRng + RngCore>(
-        &mut self,
-        value: u64,
-        change_destination: &ChangeDestination,
-        rng: &mut RNG,
-    ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
-        let context = self.add_change_output_with_context(value, change_destination, rng)?;
-        Ok((context.tx_out, context.confirmation))
-    }
-
-    /// Add a standard change output to the transaction.
-    ///
-    /// The change output is meant to send any value in the inputs not already
-    /// sent via outputs or fee, back to the sender's address.
-    /// The caller should ensure that the math adds up, and that
-    /// change_value + total_outlays + fee = total_input_value
-    ///
-    /// (Here, outlay means a non-change output).
-    ///
-    /// A change output should be sent to the dedicated change subaddress of the
-    /// sender.
-    ///
-    /// If provided, a Destination memo is attached to this output, which allows
-    /// for recoverable transaction history.
-    ///
-    /// The use of dedicated change subaddress for change outputs allows to
-    /// authenticate the contents of destination memos, which are otherwise
-    /// unauthenticated.
-    ///
-    /// # Arguments
-    /// * `value` - The value of this change output.
-    /// * `change_destination` - An object including both a primary address and
-    ///   a change subaddress to use to create this change output. The primary
-    ///   address is used for the fog hint, the change subaddress owns the
-    ///   change output. These can both be obtained from an account key, but
-    ///   this API does not require the account key.
-    /// * `rng` - RNG used to generate blinding for commitment
-    pub fn add_change_output_with_context<RNG: CryptoRng + RngCore>(
         &mut self,
         value: u64,
         change_destination: &ChangeDestination,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -43,12 +43,14 @@ impl TxOutputsOrdering for DefaultTxOutputsOrdering {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TxOutContext {
-    /// TxOut that comes from a transaction builder add_output/add_change_output
+    /// TxOut that comes from a transaction builder
+    /// add_output/add_change_output
     pub tx_out: TxOut,
     /// confirmation that comes from a transaction builder add_output/add_change_output
     pub confirmation: TxOutConfirmationNumber,
-    /// Shared Secret that comes from a transaction builder add_output/add_change_output
-    pub shared_secret: RistrettoPublic
+    /// Shared Secret that comes from a transaction builder
+    /// add_output/add_change_output
+    pub shared_secret: RistrettoPublic,
 }
 
 /// Helper utility for building and signing a CryptoNote-style transaction,
@@ -351,7 +353,11 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
 
         let confirmation = TxOutConfirmationNumber::from(&shared_secret);
 
-        Ok(TxOutContext{tx_out, confirmation, shared_secret})
+        Ok(TxOutContext{
+            tx_out,
+            confirmation,
+            shared_secret,
+        })
     }
 
     /// Sets the tombstone block, clamping to smallest pubkey expiry value.

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -43,8 +43,11 @@ impl TxOutputsOrdering for DefaultTxOutputsOrdering {
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TxOutContext {
+    /// TxOut that comes from a transaction builder add_output/add_change_output
     pub tx_out: TxOut,
+    /// confirmation that comes from a transaction builder add_output/add_change_output
     pub confirmation: TxOutConfirmationNumber,
+    /// Shared Secret that comes from a transaction builder add_output/add_change_output
     pub shared_secret: RistrettoPublic
 }
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -811,7 +811,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {.., confirmation, ..} = transaction_builder
+            let TxOutContext {_txout, confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -894,7 +894,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {.., confirmation, ..} = transaction_builder
+            let TxOutContext {_txout, confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -2597,7 +2597,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_tx_out, .., ..} = transaction_builder
+            let TxOutContext {burn_tx_out, ..} = transaction_builder
                 .add_output(
                     value - change_value - Mob::MINIMUM_FEE,
                     &recipient,
@@ -2802,7 +2802,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_output, .., ..} = transaction_builder
+            let TxOutContext {burn_output, ..} = transaction_builder
                 .add_output(110, &burn_address(), &mut rng)
                 .unwrap();
 
@@ -2858,7 +2858,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_tx_out, .., ..} = transaction_builder
+            let TxOutContext {burn_tx_out, ..} = transaction_builder
                 .add_output(100, &burn_address(), &mut rng)
                 .unwrap();
 

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -894,7 +894,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {_txout, confirmation, ..} = transaction_builder
+            let TxOutContext {confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -40,11 +40,12 @@ impl TxOutputsOrdering for DefaultTxOutputsOrdering {
 
 /// Transaction output context is produced by add_output method
 /// Used for receipt creation
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct TxOutContext {
-    tx_out: TxOut,
-    confirmation: TxOutConfirmationNumber,
-    shared_secret: RistrettoPublic
+    pub tx_out: TxOut,
+    pub confirmation: TxOutConfirmationNumber,
+    pub shared_secret: RistrettoPublic
 }
 
 /// Helper utility for building and signing a CryptoNote-style transaction,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -811,7 +811,7 @@ pub mod transaction_builder_tests {
             .unwrap();
 
             transaction_builder.add_input(input_credentials);
-            let TxOutContext {_txout, confirmation, ..} = transaction_builder
+            let TxOutContext {confirmation, ..} = transaction_builder
                 .add_output(
                     value - Mob::MINIMUM_FEE,
                     &recipient.default_subaddress(),
@@ -2597,7 +2597,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_tx_out, ..} = transaction_builder
+            let TxOutContext {tx_out: burn_tx_out, ..} = transaction_builder
                 .add_output(
                     value - change_value - Mob::MINIMUM_FEE,
                     &recipient,
@@ -2802,7 +2802,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_output, ..} = transaction_builder
+            let TxOutContext {tx_out: burn_output, ..} = transaction_builder
                 .add_output(110, &burn_address(), &mut rng)
                 .unwrap();
 
@@ -2858,7 +2858,7 @@ pub mod transaction_builder_tests {
             );
             transaction_builder.add_input(input_credentials);
 
-            let TxOutContext {burn_tx_out, ..} = transaction_builder
+            let TxOutContext {tx_out: burn_tx_out, ..} = transaction_builder
                 .add_output(100, &burn_address(), &mut rng)
                 .unwrap();
 


### PR DESCRIPTION
* Adding TxOutContext struct to return TxOut, TxOutConfirmationNumber, and a shared secret from transaction builder add_output
* Adding iOS native updates to expose TxOutContext to SDK
* Adding Android native updates to expose TxOutContext to SDK

### Motivation

This is needed for the SDKs to support Moby transaction history