### PR TITLE
mint-client: make the process exitcode reflect transaction status returned from consensus when a transaction is submitted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,6 +2735,7 @@ dependencies = [
  "mc-util-parse",
  "mc-util-uri",
  "pem",
+ "protobuf",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -30,6 +30,7 @@ clap = { version = "3.1", features = ["derive", "env"] }
 grpcio = "0.10.2"
 hex = "0.4"
 pem = "1.0"
+protobuf = "2.27.1"
 rand = "0.8"
 serde = "1"
 serde_json = "1.0"

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -18,6 +18,7 @@ use mc_transaction_core::{
     mint::{MintConfigTx, MintTx},
 };
 use mc_util_grpc::ConnectionUriGrpcioChannel;
+use protobuf::ProtobufEnum;
 use serde::de::DeserializeOwned;
 use std::{fs, path::PathBuf, process::exit, sync::Arc};
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -19,7 +19,7 @@ use mc_transaction_core::{
 };
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use serde::de::DeserializeOwned;
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{fs, path::PathBuf, process::exit, sync::Arc};
 
 fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
@@ -45,6 +45,11 @@ fn main() {
                 .propose_mint_config_tx(&(&tx).into())
                 .expect("propose tx");
             println!("response: {:?}", resp);
+
+            // Relying on the success result code being 0, we terminate ourselves in a way
+            // that allows whoever started this binary to easily determine if submitting the
+            // transaction succeeded.
+            exit(resp.get_result().get_code().value());
         }
 
         Commands::GenerateMintConfigTx { out, params } => {
@@ -101,6 +106,11 @@ fn main() {
                 .propose_mint_config_tx(&(&merged_tx).into())
                 .expect("propose tx");
             println!("response: {:?}", resp);
+
+            // Relying on the success result code being 0, we terminate ourselves in a way
+            // that allows whoever started this binary to easily determine if submitting the
+            // transaction succeeded.
+            exit(resp.get_result().get_code().value());
         }
 
         Commands::GenerateAndSubmitMintTx { node, params } => {
@@ -121,6 +131,11 @@ fn main() {
                 .propose_mint_tx(&(&tx).into())
                 .expect("propose tx");
             println!("response: {:?}", resp);
+
+            // Relying on the success result code being 0, we terminate ourselves in a way
+            // that allows whoever started this binary to easily determine if submitting the
+            // transaction succeeded.
+            exit(resp.get_result().get_code().value());
         }
 
         Commands::GenerateMintTx { out, params } => {
@@ -177,6 +192,11 @@ fn main() {
                 .propose_mint_tx(&(&merged_tx).into())
                 .expect("propose tx");
             println!("response: {:?}", resp);
+
+            // Relying on the success result code being 0, we terminate ourselves in a way
+            // that allows whoever started this binary to easily determine if submitting the
+            // transaction succeeded.
+            exit(resp.get_result().get_code().value());
         }
 
         Commands::SignGovernors {


### PR DESCRIPTION
### Motivation

The `mc-consensus-mint-client` binary could potentially be called by other binaries or shell scripts. If it is used to submit a `MintTx` or `MintConfigTx` to consensus, it might get to the point where the RPC call succeeds but consensus rejects the transaction.
Prior to this PR the only way to tell that this happened is to parse the response that is printed to `stdout`, however that is inconvenient. It is a convention in the UNIX world that processes exit with exitcode 0 upon success, and a different value upon failure.
This PR makes it so that if consensus did reject a transaction, the error code is propagated as an exitcode.