### PR TITLE
New attempt at zip_exact utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4847,6 +4847,7 @@ dependencies = [
  "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",
+ "mc-util-zip-exact",
  "merlin",
  "proptest",
  "prost",
@@ -5243,6 +5244,13 @@ dependencies = [
  "rand_hc 0.3.1",
  "serde",
  "url",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1253,6 +1254,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1298,6 +1298,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1364,6 +1365,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1283,6 +1283,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1349,6 +1350,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-zip-exact",
  "merlin",
  "prost",
  "rand_core",
@@ -1383,6 +1384,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_cbor",
+]
+
+[[package]]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -32,6 +32,7 @@ mc-crypto-multisig = { path = "../../crypto/multisig", default-features = false 
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 mc-util-serial = { path = "../../util/serial" }
+mc-util-zip-exact = { path = "../../util/zip-exact" }
 
 [target.'cfg(target_feature = "avx2")'.dependencies]
 bulletproofs-og = { version = "3.0.0-pre.1", default-features = false, features = ["avx2_backend"] }

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -5,6 +5,7 @@
 use crate::{range_proofs::error::Error as RangeProofError, TokenId};
 use alloc::string::{String, ToString};
 use displaydoc::Display;
+use mc_util_zip_exact::ZipExactError;
 use serde::{Deserialize, Serialize};
 
 /// An error which can occur in connection to a ring signature
@@ -90,6 +91,9 @@ pub enum Error {
 
     /// Signed input rules not allowed at this revision
     SignedInputRulesNotAllowed,
+
+    /// Zip Exact: {0}
+    ZipExact(ZipExactError),
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {
@@ -101,5 +105,11 @@ impl From<mc_util_repr_bytes::LengthMismatch> for Error {
 impl From<RangeProofError> for Error {
     fn from(src: RangeProofError) -> Self {
         Error::RangeProof(src.to_string())
+    }
+}
+
+impl From<ZipExactError> for Error {
+    fn from(src: ZipExactError) -> Self {
+        Error::ZipExact(src)
     }
 }

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -7,4 +7,4 @@ description = "An iterator helper"
 readme = "README.md"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", default-features = false }

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mc-util-zip-exact"
 version = "1.3.0-pre0"
 authors = ["MobileCoin"]
-edition = "2018"
+edition = "2021"
 description = "An iterator helper"
 readme = "README.md"
 

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mc-util-zip-exact"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2018"
+description = "An iterator helper"
+readme = "README.md"
+
+[dependencies]
+serde = "1.0"

--- a/util/zip-exact/README.md
+++ b/util/zip-exact/README.md
@@ -1,0 +1,9 @@
+zip-exact
+=========
+
+A utility much like [`std::iter::zip`](https://doc.rust-lang.org/stable/std/iter/fn.zip.html),
+with the difference that it returns an error if the iterators are not the same length.
+
+This is useful because sometimes, it can lead to a critical bug
+if two lists that are zipped together have the wrong size. `zip_exact` can be
+used instead of `zip` when it is important to make this error loud rather than silent.

--- a/util/zip-exact/src/lib.rs
+++ b/util/zip-exact/src/lib.rs
@@ -1,0 +1,34 @@
+#![no_std]
+
+use core::{
+    fmt::{self, Debug, Display},
+    iter::Zip,
+};
+use serde::{Deserialize, Serialize};
+
+// An alternate version of `Iterator::zip` which returns an error if the two
+// zipped iterators do not have the same length, rather than failing silently.
+//
+// This is only implemented for ExactSizeIterator, because it significantly
+// simplifies the implementation and we don't need it for other things.
+
+pub fn zip_exact<T, U>(a: T, b: U) -> Result<Zip<T, U>, ZipExactError>
+where
+    T: ExactSizeIterator,
+    U: ExactSizeIterator,
+{
+    if a.len() == b.len() {
+        Ok(a.zip(b))
+    } else {
+        Err(ZipExactError(a.len(), b.len()))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct ZipExactError(usize, usize);
+
+impl Display for ZipExactError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "iterator len {0} != {1}", self.0, self.1)
+    }
+}

--- a/util/zip-exact/src/lib.rs
+++ b/util/zip-exact/src/lib.rs
@@ -1,4 +1,9 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! An iterator helper
+
 #![no_std]
+#![deny(missing_docs)]
 
 use core::{
     fmt::{self, Debug, Display},
@@ -6,12 +11,12 @@ use core::{
 };
 use serde::{Deserialize, Serialize};
 
-// An alternate version of `Iterator::zip` which returns an error if the two
-// zipped iterators do not have the same length, rather than failing silently.
-//
-// This is only implemented for ExactSizeIterator, because it significantly
-// simplifies the implementation and we don't need it for other things.
-
+/// An alternate version of `Iterator::zip` which returns an error if the two
+/// zipped iterators do not have the same length, rather than failing silently.
+///
+/// This is only implemented `for ExactSizeIterator`, because it significantly
+/// simplifies the implementation and usage, and we don't need it for other
+/// things.
 pub fn zip_exact<T, U>(a: T, b: U) -> Result<Zip<T, U>, ZipExactError>
 where
     T: ExactSizeIterator,
@@ -24,6 +29,7 @@ where
     }
 }
 
+/// An error that occurs when zip_exact fails
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct ZipExactError(usize, usize);
 


### PR DESCRIPTION
This is intended to ease maintenance of the `rct_bulletproofs` module,
since accidentally removing or wrongly implementing a length check
no longer silently leads to transaction elements being skipped.

Fixes #1869

I think this version was less annoying in terms of syntax explosion