### PR TITLE
Rename ReservedDestination To AddressBook

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -52,8 +52,8 @@ use mc_transaction_core::{
 };
 
 use mc_transaction_std::{
-    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedDestination,
+    AddressBook, AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo,
+    DestinationMemo, InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder,
     SenderMemoCredential, TransactionBuilder,
 };
 
@@ -1747,7 +1747,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 env.get_rust_field(source_account_key, RUST_OBJ_FIELD)?;
 
             let value = jni_big_int_to_u64(env, value)?;
-            let change_destination = ReservedDestination::from(&*source_account_key);
+            let change_destination = AddressBook::from(&*source_account_key);
             let mut rng = McRng::default();
 
             // TODO (GH #1867): If you want to do mixed transactions, use something other

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -34,7 +34,7 @@ mod tests {
         constants::MILLIMOB_TO_PICOMOB, tokens::Mob, tx::Tx, Amount, BlockVersion, Token, TokenId,
     };
     use mc_transaction_std::{
-        test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
+        test_utils::get_input_credentials, AddressBook, EmptyMemoBuilder,
         SignedContingentInputBuilder, TransactionBuilder,
     };
     use protobuf::Message;
@@ -184,7 +184,7 @@ mod tests {
             transaction_builder
                 .add_change_output(
                     Amount::new(475 * MILLIMOB_TO_PICOMOB - Mob::MINIMUM_FEE, Mob::ID),
-                    &ReservedDestination::from(&alice),
+                    &AddressBook::from(&alice),
                     &mut rng,
                 )
                 .unwrap();

--- a/api/tests/prost.rs
+++ b/api/tests/prost.rs
@@ -7,8 +7,7 @@ use mc_api::external;
 use mc_fog_report_validation_test_utils::{FullyValidatedFogPubkey, MockFogResolver};
 use mc_transaction_core::{Amount, BlockVersion, SignedContingentInput};
 use mc_transaction_std::{
-    test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
-    SignedContingentInputBuilder,
+    test_utils::get_input_credentials, AddressBook, EmptyMemoBuilder, SignedContingentInputBuilder,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_test_helper::{run_with_several_seeds, CryptoRng, RngCore};
@@ -53,7 +52,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
     let sender = AccountKey::random(rng);
     let recipient = AccountKey::random(rng).default_subaddress();
     let recipient2 = AccountKey::random_with_fog(rng).default_subaddress();
-    let sender_change_dest = ReservedDestination::from(&sender);
+    let sender_change_dest = AddressBook::from(&sender);
 
     let fpr = MockFogResolver(btreemap! {
                         recipient2

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -32,7 +32,7 @@ use mc_transaction_core::{
     Amount, BlockIndex, BlockVersion, TokenId,
 };
 use mc_transaction_std::{
-    InputCredentials, MemoType, RTHMemoBuilder, ReservedDestination, SenderMemoCredential,
+    AddressBook, InputCredentials, MemoType, RTHMemoBuilder, SenderMemoCredential,
     TransactionBuilder,
 };
 use mc_util_telemetry::{block_span_builder, telemetry_static_key, tracer, Key, Span};
@@ -707,7 +707,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         .add_output(amount, target_address, rng)
         .map_err(Error::AddOutput)?;
 
-    let change_destination = ReservedDestination::from(source_account_key);
+    let change_destination = AddressBook::from(source_account_key);
 
     tx_builder
         .add_change_output(

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -23,8 +23,8 @@ use mc_transaction_core::{
 };
 
 use mc_transaction_std::{
-    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedDestination,
+    AddressBook, AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo,
+    DestinationMemo, InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder,
     SenderMemoCredential, TransactionBuilder,
 };
 
@@ -539,7 +539,7 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .into_mut()
             .as_mut()
             .expect("McTransactionBuilder instance has already been used to build a Tx");
-        let change_destination = ReservedDestination::from(&account_key_obj);
+        let change_destination = AddressBook::from(&account_key_obj);
         let mut rng = SdkRng::from_ffi(rng_callback);
         let out_tx_out_confirmation_number = out_tx_out_confirmation_number
             .into_mut()

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -24,7 +24,7 @@ use mc_transaction_core::{
     Amount, BlockIndex, BlockVersion, TokenId,
 };
 use mc_transaction_std::{
-    EmptyMemoBuilder, InputCredentials, MemoBuilder, ReservedDestination, TransactionBuilder,
+    AddressBook, EmptyMemoBuilder, InputCredentials, MemoBuilder, TransactionBuilder,
 };
 use mc_util_uri::FogUri;
 use rand::Rng;
@@ -1006,11 +1006,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 token_id,
             };
 
-            let change_dest = ReservedDestination::from_subaddress_index(
-                from_account_key,
-                Some(change_subaddress),
-                None,
-            );
+            let change_dest =
+                AddressBook::from_subaddress_index(from_account_key, Some(change_subaddress), None);
 
             tx_builder
                 .add_change_output(change_amount, &change_dest, rng)

--- a/transaction/std/src/address_book.rs
+++ b/transaction/std/src/address_book.rs
@@ -15,7 +15,7 @@ use mc_account_keys::{AccountKey, PublicAddress};
 /// This object can be created from an AccountKey, but it can also be created
 /// offline and then serialized and sent to a different machine.
 #[derive(Clone, Debug)]
-pub struct ReservedDestination {
+pub struct AddressBook {
     /// This is normally the default subaddress of an account. It is used to
     /// create the fog hint for the change output.
     pub primary_address: PublicAddress,
@@ -34,7 +34,7 @@ pub struct ReservedDestination {
     pub gift_code_subaddress: PublicAddress,
 }
 
-impl From<&AccountKey> for ReservedDestination {
+impl From<&AccountKey> for AddressBook {
     fn from(src: &AccountKey) -> Self {
         Self {
             primary_address: src.default_subaddress(),
@@ -44,7 +44,7 @@ impl From<&AccountKey> for ReservedDestination {
     }
 }
 
-impl ReservedDestination {
+impl AddressBook {
     /// Set alternate subaddresseses for reserved addresses. This is useful in
     /// some things like mobilecoind
     pub fn from_subaddress_index(

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -7,18 +7,19 @@
 
 extern crate core;
 
+mod address_book;
 mod error;
 mod input_credentials;
 mod input_materials;
 mod memo;
 mod memo_builder;
-mod reserved_destination;
 mod signed_contingent_input_builder;
 mod transaction_builder;
 
 #[cfg(any(test, feature = "test-only"))]
 pub mod test_utils;
 
+pub use address_book::AddressBook;
 pub use error::{SignedContingentInputBuilderError, TxBuilderError};
 pub use input_credentials::InputCredentials;
 pub use memo::{
@@ -27,7 +28,6 @@ pub use memo::{
     SenderMemoCredential, UnusedMemo,
 };
 pub use memo_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
-pub use reserved_destination::ReservedDestination;
 pub use signed_contingent_input_builder::SignedContingentInputBuilder;
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
 

--- a/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
+++ b/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
@@ -6,9 +6,8 @@
 
 use super::{
     memo::{BurnRedemptionMemo, DestinationMemo, DestinationMemoError, UnusedMemo},
-    MemoBuilder,
+    AddressBook, MemoBuilder,
 };
-use crate::ReservedDestination;
 use mc_account_keys::{burn_address, PublicAddress, ShortAddressHash};
 use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
@@ -107,7 +106,7 @@ impl MemoBuilder for BurnRedemptionMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         change_amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &AddressBook,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if !self.destination_memo_enabled {

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -4,7 +4,7 @@
 //! The memo builder for recoverable transaction history is defined in a
 //! submodule.
 
-use super::{memo, ReservedDestination};
+use super::{memo, AddressBook};
 use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
@@ -47,7 +47,7 @@ pub trait MemoBuilder: Debug {
     fn make_memo_for_change_output(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &AddressBook,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
 }
@@ -74,7 +74,7 @@ impl MemoBuilder for EmptyMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         _value: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &AddressBook,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         Ok(memo::UnusedMemo {}.into())

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -10,9 +10,8 @@ use super::{
         AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
         DestinationMemoError, SenderMemoCredential, UnusedMemo,
     },
-    MemoBuilder,
+    AddressBook, MemoBuilder,
 };
-use crate::ReservedDestination;
 use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_transaction_core::{
     tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token, TokenId,
@@ -200,7 +199,7 @@ impl MemoBuilder for RTHMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &AddressBook,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if !self.destination_memo_enabled {

--- a/transaction/std/src/signed_contingent_input_builder.rs
+++ b/transaction/std/src/signed_contingent_input_builder.rs
@@ -4,8 +4,7 @@
 //! This plays a similar role to the transaction builder.
 
 use crate::{
-    InputCredentials, MemoBuilder, ReservedDestination, SignedContingentInputBuilderError,
-    TxBuilderError,
+    AddressBook, InputCredentials, MemoBuilder, SignedContingentInputBuilderError, TxBuilderError,
 };
 use core::cmp::min;
 use mc_account_keys::PublicAddress;
@@ -200,7 +199,7 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
     pub fn add_required_change_output<RNG: CryptoRng + RngCore>(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &AddressBook,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         // Taking self.memo_builder here means that we can call functions on &mut self,
@@ -726,7 +725,7 @@ pub mod tests {
             // Bob adds the presigned input, which also adds the required outputs
             builder.add_presigned_input(sci).unwrap();
 
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = AddressBook::from(&bob);
 
             // Bob keeps the change from token id 2
             builder
@@ -973,7 +972,7 @@ pub mod tests {
             // Bob adds the presigned input, which also adds the required outputs
             builder.add_presigned_input(sci).unwrap();
 
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = AddressBook::from(&bob);
 
             // Bob keeps the change from token id 2
             builder
@@ -1188,7 +1187,7 @@ pub mod tests {
             .unwrap();
 
             // Bob keeps the change from token id 2
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = AddressBook::from(&bob);
             builder
                 .add_required_change_output(
                     Amount::new(200_000, token2),
@@ -1233,7 +1232,7 @@ pub mod tests {
             ));
 
             // Charlie keeps 333 as change, leaving 666 for Bob
-            let charlie_change_dest = ReservedDestination::from(&charlie);
+            let charlie_change_dest = AddressBook::from(&charlie);
             builder
                 .add_change_output(Amount::new(333, token3), &charlie_change_dest, &mut rng)
                 .unwrap();

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -5,8 +5,7 @@
 //! See https://cryptonote.org/img/cryptonote_transaction.png
 
 use crate::{
-    input_materials::InputMaterials, InputCredentials, MemoBuilder, ReservedDestination,
-    TxBuilderError,
+    input_materials::InputMaterials, AddressBook, InputCredentials, MemoBuilder, TxBuilderError,
 };
 use core::{cmp::min, fmt::Debug};
 use mc_account_keys::PublicAddress;
@@ -285,7 +284,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     pub fn add_change_output<RNG: CryptoRng + RngCore>(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &AddressBook,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         // Taking self.memo_builder here means that we can call functions on &mut self,
@@ -995,7 +994,7 @@ pub mod transaction_builder_tests {
 
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let sender = AccountKey::random_with_fog(&mut rng);
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = AddressBook::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -1171,7 +1170,7 @@ pub mod transaction_builder_tests {
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let sender = AccountKey::random_with_fog(&mut rng);
             let sender_addr = sender.default_subaddress();
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = AddressBook::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -1979,7 +1978,7 @@ pub mod transaction_builder_tests {
 
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let alice = AccountKey::random_with_fog(&mut rng);
-            let alice_change_dest = ReservedDestination::from(&alice);
+            let alice_change_dest = AddressBook::from(&alice);
             let bob = AccountKey::random_with_fog(&mut rng);
             let bob_address = bob.default_subaddress();
             let charlie = AccountKey::random_with_fog(&mut rng);
@@ -2174,7 +2173,7 @@ pub mod transaction_builder_tests {
             }
 
             let sender = AccountKey::random_with_fog(&mut rng);
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = AddressBook::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -2470,7 +2469,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = AddressBook::from(&sender);
         let recipient = burn_address();
 
         let value = 1475 * MILLIMOB_TO_PICOMOB;
@@ -2569,7 +2568,7 @@ pub mod transaction_builder_tests {
         let token_id = TokenId::from(5);
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let change_destination = ReservedDestination::from(&sender);
+        let change_destination = AddressBook::from(&sender);
 
         // Adding an output that is not to the burn address is not allowed.
         {
@@ -2906,7 +2905,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = AddressBook::from(&sender);
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 
@@ -3036,7 +3035,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = AddressBook::from(&sender);
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 


### PR DESCRIPTION
* Renamed ReservedDestination to AddressBook + Updated Dependencies

### Motivation

The number of Reserved Addresses has increased and likely will continue to do so. A previous PR created a "reserved destination" object (i.e. renamed from "ChangeAddress") for the purpose of having a way to access any given account's special reserved sub-addresses. That name however is mildly unclear as to its purpose. This suggested rename adds more clarity to the purpose of the object.