### PR TITLE
introduce a ring signer trait and use it

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -46,6 +46,7 @@ use mc_transaction_core::{
         create_shared_secret, recover_onetime_private_key, recover_public_subaddress_spend_key,
     },
     ring_signature::KeyImage,
+    signer::NoKeysRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, BlockVersion, CompressedCommitment, MaskedAmount, Token,
@@ -1827,7 +1828,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_build_1tx(
                 env.take_rust_field(obj, RUST_OBJ_FIELD)?;
 
             let mut rng = McRng::default();
-            let tx = tx_builder.build(&mut rng)?;
+            let tx = tx_builder.build(&NoKeysRingSigner {}, &mut rng)?;
 
             let mbox = Box::new(Mutex::new(tx));
             let ptr: *mut Mutex<Tx> = Box::into_raw(mbox);

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -31,7 +31,8 @@ mod tests {
     use mc_account_keys::AccountKey;
     use mc_fog_report_validation_test_utils::MockFogResolver;
     use mc_transaction_core::{
-        constants::MILLIMOB_TO_PICOMOB, tokens::Mob, tx::Tx, Amount, BlockVersion, Token, TokenId,
+        constants::MILLIMOB_TO_PICOMOB, signer::NoKeysRingSigner, tokens::Mob, tx::Tx, Amount,
+        BlockVersion, Token, TokenId,
     };
     use mc_transaction_std::{
         test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
@@ -76,7 +77,9 @@ mod tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // decode(encode(tx)) should be the identity function.
             {
@@ -152,7 +155,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let mut sci = sci_builder.build(&mut rng).unwrap();
+            let mut sci = sci_builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // Alice adds proofs to the SCI
             sci.tx_in.proofs = proofs;
@@ -192,7 +195,9 @@ mod tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // decode(encode(tx)) should be the identity function.
             {

--- a/api/tests/prost.rs
+++ b/api/tests/prost.rs
@@ -5,7 +5,7 @@ use maplit::btreemap;
 use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
 use mc_api::external;
 use mc_fog_report_validation_test_utils::{FullyValidatedFogPubkey, MockFogResolver};
-use mc_transaction_core::{Amount, BlockVersion, SignedContingentInput};
+use mc_transaction_core::{signer::NoKeysRingSigner, Amount, BlockVersion, SignedContingentInput};
 use mc_transaction_std::{
     test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
     SignedContingentInputBuilder,
@@ -84,7 +84,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
     builder
         .add_required_output(Amount::new(400, 0.into()), &recipient, rng)
         .unwrap();
-    result.push(builder.build(rng).unwrap());
+    result.push(builder.build(&NoKeysRingSigner {}, rng).unwrap());
 
     let input_credentials = get_input_credentials(
         block_version,
@@ -106,7 +106,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
     builder
         .add_required_output(Amount::new(600, 2.into()), &recipient2, rng)
         .unwrap();
-    result.push(builder.build(rng).unwrap());
+    result.push(builder.build(&NoKeysRingSigner {}, rng).unwrap());
 
     let input_credentials = get_input_credentials(
         block_version,
@@ -131,7 +131,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
     builder
         .add_required_change_output(Amount::new(100, 1.into()), &sender_change_dest, rng)
         .unwrap();
-    result.push(builder.build(rng).unwrap());
+    result.push(builder.build(&NoKeysRingSigner {}, rng).unwrap());
 
     result
 }

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 use mc_api::ConversionError;
 use mc_transaction_core::{
-    mint::MintValidationError, ring_signature, validation::TransactionValidationError as Error,
-    BlockVersion, InputRuleError, TokenId,
+    mint::MintValidationError, ring_signature, ring_signature::MLSAGError,
+    validation::TransactionValidationError as Error, BlockVersion, InputRuleError, TokenId,
 };
 use std::convert::{From, TryFrom, TryInto};
 
@@ -84,7 +84,7 @@ impl TryInto<Error> for ProposeTxResult {
             Self::InsufficientInputSignatures => Ok(Error::InsufficientInputSignatures),
             Self::InvalidInputSignature => Ok(Error::InvalidInputSignature),
             Self::InvalidTransactionSignature => Ok(Error::InvalidTransactionSignature(
-                ring_signature::Error::InvalidSignature,
+                ring_signature::Error::MLSAG(MLSAGError::InvalidSignature),
             )),
             Self::InvalidRangeProof => Ok(Error::InvalidRangeProof),
             Self::InsufficientRingSize => Ok(Error::InsufficientRingSize),

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -494,6 +494,7 @@ mod combine_tests {
     use mc_ledger_db::test_utils::get_mock_ledger;
     use mc_transaction_core::{
         onetime_keys::recover_onetime_private_key,
+        signer::NoKeysRingSigner,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipProof},
         Amount, BlockVersion, Token,
@@ -591,7 +592,9 @@ mod combine_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
             let client_tx = WellFormedTxContext::from_tx(&tx, 0);
 
             // "Combining" a singleton set should return a vec containing the single
@@ -677,7 +680,9 @@ mod combine_tests {
                         )
                         .unwrap();
 
-                    let tx = transaction_builder.build(&mut rng).unwrap();
+                    let tx = transaction_builder
+                        .build(&NoKeysRingSigner {}, &mut rng)
+                        .unwrap();
                     WellFormedTxContext::from_tx(&tx, 0)
                 };
                 transaction_set.push(client_tx);
@@ -757,7 +762,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 
@@ -799,7 +806,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 
@@ -864,7 +873,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 
@@ -956,7 +967,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 
@@ -999,7 +1012,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let mut tx = transaction_builder.build(&mut rng).unwrap();
+                let mut tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 tx.prefix.outputs[0].public_key = first_client_tx.output_public_keys()[0];
                 WellFormedTxContext::from_tx(&tx, 0)
             };
@@ -1065,7 +1080,9 @@ mod combine_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
                 WellFormedTxContext::from_tx(&tx, 0)
             };
 

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -40,6 +40,7 @@ use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    signer::NoKeysRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     validation::TransactionValidationError,
@@ -825,7 +826,9 @@ fn build_tx(
     tx_builder.set_tombstone_block(tombstone_block);
 
     // Build and return tx.
-    tx_builder.build(&mut rng).expect("failed building tx")
+    tx_builder
+        .build(&NoKeysRingSigner {}, &mut rng)
+        .expect("failed building tx")
 }
 
 /// Get merkle proofs of membership from the ledger for several utxos

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -1034,7 +1034,6 @@ mod test_build_transaction_helper {
     use mc_transaction_core::{
         constants::MILLIMOB_TO_PICOMOB,
         onetime_keys::recover_public_subaddress_spend_key,
-        signer::NoKeysRingSigner,
         tokens::Mob,
         tx::{TxOut, TxOutMembershipProof},
         Amount, Token,
@@ -1156,7 +1155,7 @@ mod test_build_transaction_helper {
                 &recipient_account_key.default_subaddress(),
                 super::BlockIndex::max_value(),
                 fake_acct_resolver,
-                &NoKeysRingSigner {},
+                &LocalRingSigner::from(&sender_account_key),
                 &mut rng,
                 &logger,
                 Mob::MINIMUM_FEE,

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -28,6 +28,7 @@ use mc_fog_view_connection::FogViewGrpcClient;
 use mc_transaction_core::{
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    signer::NoKeysRingSigner,
     tx::{Tx, TxOut, TxOutMembershipProof},
     Amount, BlockIndex, BlockVersion, SignedContingentInput, TokenId,
 };
@@ -446,7 +447,7 @@ impl Client {
 
         sci_builder.set_tombstone_block(tombstone_block);
 
-        Ok(sci_builder.build(rng)?)
+        Ok(sci_builder.build(&NoKeysRingSigner {}, rng)?)
     }
 
     /// Builds a transaction that fulfills a swap request, sending all excess
@@ -635,7 +636,7 @@ impl Client {
             )?;
         }
 
-        Ok(tx_builder.build(rng)?)
+        Ok(tx_builder.build(&NoKeysRingSigner {}, rng)?)
     }
 
     /// Helper: Get merkle proofs corresponding to a given set of our inputs
@@ -928,7 +929,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
     // Finalize
     tx_builder.set_tombstone_block(tombstone_block);
 
-    Ok(tx_builder.build(rng)?)
+    Ok(tx_builder.build(&NoKeysRingSigner {}, rng)?)
 }
 
 fn add_inputs_to_tx_builder<FPR: FogPubkeyResolver>(

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -17,6 +17,7 @@ use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::{recover_onetime_private_key, recover_public_subaddress_spend_key},
     ring_signature::KeyImage,
+    signer::NoKeysRingSigner,
     tokens::Mob,
     tx::{TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, BlockVersion, CompressedCommitment, EncryptedMemo, MaskedAmount, Token,
@@ -612,7 +613,7 @@ pub extern "C" fn mc_transaction_builder_build(
         let mut rng = SdkRng::from_ffi(rng_callback);
 
         let tx = transaction_builder
-            .build(&mut rng)
+            .build(&NoKeysRingSigner {}, &mut rng)
             .map_err(|err| LibMcError::InvalidInput(format!("{:?}", err)))?;
         Ok(mc_util_serial::encode(&tx))
     })

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -20,6 +20,7 @@ use mc_transaction_core::{
     constants::{MAX_INPUTS, MILLIMOB_TO_PICOMOB, RING_SIZE},
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    signer::NoKeysRingSigner,
     tx::{Tx, TxOut, TxOutConfirmationNumber, TxOutMembershipProof},
     Amount, BlockIndex, BlockVersion, TokenId,
 };
@@ -1022,7 +1023,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         // Build tx.
         let tx = tx_builder
-            .build(rng)
+            .build(&NoKeysRingSigner {}, rng)
             .map_err(|err| Error::TxBuild(format!("build tx failed: {}", err)))?;
 
         // Map each TxOut in the constructed transaction to its respective outlay.

--- a/transaction/core/src/amount/commitment.rs
+++ b/transaction/core/src/amount/commitment.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ring_signature::{Error, PedersenGens, Scalar},
+    ring_signature::{MLSAGError, PedersenGens, Scalar},
     CompressedCommitment,
 };
 use core::{convert::TryFrom, fmt};
@@ -37,10 +37,13 @@ impl Commitment {
 }
 
 impl TryFrom<&CompressedCommitment> for Commitment {
-    type Error = crate::ring_signature::Error;
+    type Error = crate::ring_signature::MLSAGError;
 
     fn try_from(src: &CompressedCommitment) -> Result<Self, Self::Error> {
-        let point = src.point.decompress().ok_or(Error::InvalidCurvePoint)?;
+        let point = src
+            .point
+            .decompress()
+            .ok_or(MLSAGError::InvalidCurvePoint)?;
         Ok(Self { point })
     }
 }
@@ -56,15 +59,15 @@ impl fmt::Debug for Commitment {
 }
 
 impl ReprBytes for Commitment {
-    type Error = Error;
+    type Error = MLSAGError;
     type Size = U32;
     fn to_bytes(&self) -> GenericArray<u8, U32> {
         self.point.compress().to_bytes().into()
     }
-    fn from_bytes(src: &GenericArray<u8, U32>) -> Result<Self, Error> {
+    fn from_bytes(src: &GenericArray<u8, U32>) -> Result<Self, Self::Error> {
         let point = CompressedRistretto::from_slice(src.as_slice())
             .decompress()
-            .ok_or(Error::InvalidCurvePoint)?;
+            .ok_or(MLSAGError::InvalidCurvePoint)?;
         Ok(Self { point })
     }
 }

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mint;
 pub mod onetime_keys;
 pub mod range_proofs;
 pub mod ring_signature;
+pub mod signer;
 pub mod tx;
 pub mod validation;
 

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -29,23 +29,8 @@ pub enum Error {
     /// Invalid input_secrets size: `{0}`
     InvalidInputSecretsSize(usize),
 
-    /// Invalid curve point
-    InvalidCurvePoint,
-
-    /// Invalid curve scalar
-    InvalidCurveScalar,
-
-    /// The signature was not able to be validated
-    InvalidSignature,
-
-    /// Failed to compress/decompress a KeyImage
-    InvalidKeyImage,
-
     /// Duplicate key image
     DuplicateKeyImage,
-
-    /// There was an opaque error returned by another crate or library
-    InternalError,
 
     /**
      * Signing failed because the value of inputs did not equal the value of

--- a/transaction/core/src/ring_signature/error.rs
+++ b/transaction/core/src/ring_signature/error.rs
@@ -2,7 +2,10 @@
 
 //! Errors which can occur in connection to ring signatures
 
-use crate::{range_proofs::error::Error as RangeProofError, TokenId};
+use crate::{
+    range_proofs::error::Error as RangeProofError, ring_signature::MLSAGError,
+    signer::Error as SignerError, TokenId,
+};
 use alloc::string::{String, ToString};
 use displaydoc::Display;
 use mc_util_zip_exact::ZipExactError;
@@ -94,6 +97,12 @@ pub enum Error {
 
     /// Zip Exact: {0}
     ZipExact(ZipExactError),
+
+    /// MLSAG: {0}
+    MLSAG(MLSAGError),
+
+    /// Signer: {0}
+    Signer(SignerError),
 }
 
 impl From<mc_util_repr_bytes::LengthMismatch> for Error {
@@ -111,5 +120,16 @@ impl From<RangeProofError> for Error {
 impl From<ZipExactError> for Error {
     fn from(src: ZipExactError) -> Self {
         Error::ZipExact(src)
+    }
+}
+
+impl From<MLSAGError> for Error {
+    fn from(src: MLSAGError) -> Self {
+        Self::MLSAG(src)
+    }
+}
+impl From<SignerError> for Error {
+    fn from(src: SignerError) -> Self {
+        Self::Signer(src)
     }
 }

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -113,7 +113,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of reduced TxOut's
+    // * `ring` - A ring of reduced TxOuts
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -6,6 +6,7 @@ use alloc::{vec, vec::Vec};
 use core::convert::TryFrom;
 
 use curve25519_dalek::ristretto::RistrettoPoint;
+use displaydoc::Display;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
@@ -16,11 +17,28 @@ use zeroize::Zeroizing;
 
 use crate::{
     domain_separators::RING_MLSAG_CHALLENGE_DOMAIN_TAG,
-    ring_signature::{
-        hash_to_point, CurveScalar, Error, KeyImage, PedersenGens, Scalar, B_BLINDING,
-    },
+    ring_signature::{hash_to_point, CurveScalar, KeyImage, PedersenGens, Scalar, B_BLINDING},
     Commitment, CompressedCommitment,
 };
+
+/// A trait which implies RNGCore and CryptoRng
+///
+/// This is needed because &mut (dyn RngCore + CryptoRng) is not valid in rust
+/// right now and we need this to make the ring signer trait work as desired
+pub trait CryptoRngCore: RngCore + CryptoRng {}
+
+impl<T> CryptoRngCore for T where T: RngCore + CryptoRng {}
+
+/// A reduced representation of a TxOut, appropriate for making MLSAG
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReducedTxOut {
+    /// The tx_out.public_key field
+    pub public_key: CompressedRistrettoPublic,
+    /// The tx_out.target_key field
+    pub target_key: CompressedRistrettoPublic,
+    /// The tx_out.masked_amount.commitment field
+    pub commitment: CompressedCommitment,
+}
 
 /// MLSAG for a ring of public keys and amount commitments.
 /// Note: Serialize and Deserialize appear to be cruft left over from
@@ -50,7 +68,7 @@ impl RingMLSAG {
     ///
     /// # Arguments
     /// * `message` - Message to be signed.
-    /// * `ring` - A ring of input onetime addresses and amount commitments.
+    /// * `ring` - A ring of reduced TxOut's
     /// * `real_index` - The index in the ring of the real input.
     /// * `onetime_private_key` - The real input's private key.
     /// * `value` - Value of the real input.
@@ -59,17 +77,17 @@ impl RingMLSAG {
     /// * `generator` - The pedersen generator to use for this commitment and
     ///   signature
     /// * `rng` - Randomness.
-    pub fn sign<CSPRNG: RngCore + CryptoRng>(
+    pub fn sign(
         message: &[u8],
-        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
+        ring: &[ReducedTxOut],
         real_index: usize,
         onetime_private_key: &RistrettoPrivate,
         value: u64,
         blinding: &Scalar,
         output_blinding: &Scalar,
         generator: &PedersenGens,
-        rng: &mut CSPRNG,
-    ) -> Result<Self, Error> {
+        rng: &mut dyn CryptoRngCore,
+    ) -> Result<Self, MLSAGError> {
         RingMLSAG::sign_with_balance_check(
             message,
             ring,
@@ -92,7 +110,7 @@ impl RingMLSAG {
     //
     // # Arguments
     // * `message` - Message to be signed.
-    // * `ring` - A ring of input onetime addresses and amount commitments.
+    // * `ring` - A ring of reduced TxOut's
     // * `real_index` - The index in the ring of the real input.
     // * `onetime_private_key` - The real input's private key.
     // * `value` - Value of the real input.
@@ -103,9 +121,9 @@ impl RingMLSAG {
     // * `check_value_is_preserved` - If true, check that the value of inputs equals
     //   value of outputs.
     // * `rng` - Randomness.
-    fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
+    fn sign_with_balance_check(
         message: &[u8],
-        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
+        ring: &[ReducedTxOut],
         real_index: usize,
         onetime_private_key: &RistrettoPrivate,
         value: u64,
@@ -113,12 +131,12 @@ impl RingMLSAG {
         output_blinding: &Scalar,
         generator: &PedersenGens,
         check_value_is_preserved: bool,
-        rng: &mut CSPRNG,
-    ) -> Result<Self, Error> {
+        mut rng: &mut dyn CryptoRngCore,
+    ) -> Result<Self, MLSAGError> {
         let ring_size = ring.len();
 
         if real_index >= ring_size {
-            return Err(Error::IndexOutOfBounds);
+            return Err(MLSAGError::IndexOutOfBounds);
         }
 
         let G = B_BLINDING;
@@ -130,7 +148,10 @@ impl RingMLSAG {
         let key_image = KeyImage::from(onetime_private_key);
 
         // The uncompressed key_image.
-        let I: RistrettoPoint = key_image.point.decompress().ok_or(Error::InvalidKeyImage)?;
+        let I: RistrettoPoint = key_image
+            .point
+            .decompress()
+            .ok_or(MLSAGError::InvalidKeyImage)?;
 
         // Uncompressed output commitment.
         // This ensures that each address and commitment encodes a valid Ristretto
@@ -149,12 +170,12 @@ impl RingMLSAG {
             if i == real_index {
                 continue;
             }
-            r[2 * i] = Scalar::random(rng);
-            r[2 * i + 1] = Scalar::random(rng);
+            r[2 * i] = Scalar::random(&mut rng);
+            r[2 * i + 1] = Scalar::random(&mut rng);
         }
 
-        let alpha_0 = Zeroizing::new(Scalar::random(rng));
-        let alpha_1 = Zeroizing::new(Scalar::random(rng));
+        let alpha_0 = Zeroizing::new(Scalar::random(&mut rng));
+        let alpha_1 = Zeroizing::new(Scalar::random(&mut rng));
 
         for n in 0..ring_size {
             // Iterate around the ring, starting at real_index.
@@ -210,7 +231,7 @@ impl RingMLSAG {
             let (_, input_commitment) = decompressed_ring[real_index];
             let difference: RistrettoPoint = output_commitment.point - input_commitment.point;
             if difference != (z * G) {
-                return Err(Error::ValueNotConserved);
+                return Err(MLSAGError::ValueNotConserved);
             }
         }
 
@@ -232,13 +253,16 @@ impl RingMLSAG {
     pub fn verify(
         &self,
         message: &[u8],
-        ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
+        ring: &[ReducedTxOut],
         output_commitment: &CompressedCommitment,
-    ) -> Result<(), Error> {
+    ) -> Result<(), MLSAGError> {
         let ring_size = ring.len();
         // `responses` must contain `2 * ring_size` elements.
         if self.responses.len() != 2 * ring_size {
-            return Err(Error::LengthMismatch(2 * ring_size, self.responses.len()));
+            return Err(MLSAGError::LengthMismatch(
+                2 * ring_size,
+                self.responses.len(),
+            ));
         }
 
         let G = B_BLINDING;
@@ -249,7 +273,7 @@ impl RingMLSAG {
             .key_image
             .point
             .decompress()
-            .ok_or(Error::InvalidKeyImage)?;
+            .ok_or(MLSAGError::InvalidKeyImage)?;
 
         let r: Vec<Scalar> = self
             .responses
@@ -267,13 +291,13 @@ impl RingMLSAG {
 
         // Scalars must be canonical.
         if !self.c_zero.scalar.is_canonical() {
-            return Err(Error::InvalidCurveScalar);
+            return Err(MLSAGError::InvalidCurveScalar);
         }
 
         // Scalars must be canonical.
         for response in &self.responses {
             if !response.scalar.is_canonical() {
-                return Err(Error::InvalidCurveScalar);
+                return Err(MLSAGError::InvalidCurveScalar);
             }
         }
 
@@ -308,7 +332,7 @@ impl RingMLSAG {
         if self.c_zero.scalar == recomputed_c[0] {
             Ok(())
         } else {
-            Err(Error::InvalidSignature)
+            Err(MLSAGError::InvalidSignature)
         }
     }
 }
@@ -332,17 +356,48 @@ fn challenge(
 }
 
 fn decompress_ring(
-    ring: &[(CompressedRistrettoPublic, CompressedCommitment)],
-) -> Result<Vec<(RistrettoPublic, Commitment)>, Error> {
+    ring: &[ReducedTxOut],
+) -> Result<Vec<(RistrettoPublic, Commitment)>, MLSAGError> {
     // Ring must decompress.
     let mut decompressed_ring: Vec<(RistrettoPublic, Commitment)> = Vec::new();
-    for (compressed_address, compressed_commitment) in ring {
-        let ristretto_public =
-            RistrettoPublic::try_from(compressed_address).map_err(|_e| Error::InvalidCurvePoint)?;
-        let commitment = Commitment::try_from(compressed_commitment)?;
+    for tx_out in ring {
+        let ristretto_public = RistrettoPublic::try_from(&tx_out.target_key)
+            .map_err(|_e| MLSAGError::InvalidCurvePoint)?;
+        let commitment = Commitment::try_from(&tx_out.commitment)?;
         decompressed_ring.push((ristretto_public, commitment));
     }
     Ok(decompressed_ring)
+}
+
+/// An error which can occur when signing or verifying
+#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum MLSAGError {
+    /// Incorrect length for array copy, provided `{0}`, required `{1}`.
+    LengthMismatch(usize, usize),
+
+    /// Index out of bounds
+    IndexOutOfBounds,
+
+    /// Invalid curve point
+    InvalidCurvePoint,
+
+    /// Invalid curve scalar
+    InvalidCurveScalar,
+
+    /// The signature was not able to be validated
+    InvalidSignature,
+
+    /// Failed to compress/decompress a KeyImage
+    InvalidKeyImage,
+
+    /// Value not conserved
+    ValueNotConserved,
+}
+
+impl From<mc_util_repr_bytes::LengthMismatch> for MLSAGError {
+    fn from(src: mc_util_repr_bytes::LengthMismatch) -> Self {
+        Self::LengthMismatch(src.found, src.expected)
+    }
 }
 
 #[cfg(test)]

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -71,7 +71,7 @@ impl RingMLSAG {
     ///
     /// # Arguments
     /// * `message` - Message to be signed.
-    /// * `ring` - A ring of reduced TxOut's
+    /// * `ring` - A ring of reduced TxOuts
     /// * `real_index` - The index in the ring of the real input.
     /// * `onetime_private_key` - The real input's private key.
     /// * `value` - Value of the real input.

--- a/transaction/core/src/ring_signature/mlsag.rs
+++ b/transaction/core/src/ring_signature/mlsag.rs
@@ -25,6 +25,9 @@ use crate::{
 ///
 /// This is needed because &mut (dyn RngCore + CryptoRng) is not valid in rust
 /// right now and we need this to make the ring signer trait work as desired
+//
+// Note: This trait can go away if it is upstreamed to rand-core:
+// https://github.com/rust-random/rand/pull/1230
 pub trait CryptoRngCore: RngCore + CryptoRng {}
 
 impl<T> CryptoRngCore for T where T: RngCore + CryptoRng {}
@@ -131,6 +134,8 @@ impl RingMLSAG {
         output_blinding: &Scalar,
         generator: &PedersenGens,
         check_value_is_preserved: bool,
+        // Note: this `mut rng` can just be `rng` if this is merged upstream:
+        // https://github.com/dalek-cryptography/curve25519-dalek/pull/394
         mut rng: &mut dyn CryptoRngCore,
     ) -> Result<Self, MLSAGError> {
         let ring_size = ring.len();

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -147,13 +147,13 @@ impl SignatureRctBulletproofs {
     ///   amount commitment.
     /// * `fee` - Value of the implicit fee output.
     /// * `token id` - This determines the pedersen generator for commitments
-    pub fn sign<CSPRNG: RngCore + CryptoRng>(
+    pub fn sign<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
         block_version: BlockVersion,
         message: &[u8; 32],
         input_rings: &[InputRing],
         output_secrets: &[OutputSecret],
         fee: Amount,
-        signer: &impl RingSigner,
+        signer: &S,
         rng: &mut CSPRNG,
     ) -> Result<Self, Error> {
         sign_with_balance_check(
@@ -449,14 +449,14 @@ impl SignatureRctBulletproofs {
 /// * `fee` - Amount of the implicit fee output.
 /// * `check_value_is_preserved` - If true, check that the value of inputs
 /// * `rng` - randomness
-fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng>(
+fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
     block_version: BlockVersion,
     message: &[u8; 32],
     rings: &[InputRing],
     output_secrets: &[OutputSecret],
     fee: Amount,
     check_value_is_preserved: bool,
-    signer: &impl RingSigner,
+    signer: &S,
     rng: &mut CSPRNG,
 ) -> Result<SignatureRctBulletproofs, Error> {
     if !block_version.masked_token_id_feature_is_supported() && fee.token_id != 0 {

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -853,7 +853,7 @@ mod rct_bulletproofs_tests {
     use crate::{
         range_proofs::generate_range_proofs,
         ring_signature::{generators, Error, KeyImage, MLSAGError, PedersenGens, ReducedTxOut},
-        signer::{DummyRingSigner, InputSecret, OneTimeKeyOrAlternative, SignableInputRing},
+        signer::{InputSecret, NoKeysRingSigner, OneTimeKeyDeriveData, SignableInputRing},
         CompressedCommitment, TokenId,
     };
     use alloc::vec::Vec;
@@ -966,14 +966,13 @@ mod rct_bulletproofs_tests {
                 let real_input_index = rng.next_u64() as usize % (num_mixins + 1);
                 ring_members.insert(real_input_index, reduced_tx_out);
 
-                let onetime_key_or_alternative =
-                    OneTimeKeyOrAlternative::OneTimeKey(onetime_private_key);
+                let onetime_key_derive_data = OneTimeKeyDeriveData::OneTimeKey(onetime_private_key);
 
                 rings.push(SignableInputRing {
                     members: ring_members,
                     real_input_index,
                     input_secret: InputSecret {
-                        onetime_key_or_alternative,
+                        onetime_key_derive_data,
                         amount: Amount::new(value, token_id),
                         blinding,
                     },
@@ -1037,7 +1036,7 @@ mod rct_bulletproofs_tests {
                 &self.get_input_rings(),
                 &self.output_secrets,
                 Amount::new(fee, self.fee_token_id),
-                &DummyRingSigner {},
+                &NoKeysRingSigner {},
                 rng,
             )
         }
@@ -1054,7 +1053,7 @@ mod rct_bulletproofs_tests {
                 &self.output_secrets,
                 Amount::new(fee, self.fee_token_id),
                 false,
-                &DummyRingSigner {},
+                &NoKeysRingSigner {},
                 rng,
             )
         }

--- a/transaction/core/src/ring_signature/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_signature/rct_bulletproofs.rs
@@ -674,7 +674,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
             |(ring, pseudo_output_blinding)| -> Result<RingMLSAG, Error> {
                 Ok(match ring {
                     InputRing::Signable(ring) => {
-                        signer.sign(&extended_message_digest, &ring, pseudo_output_blinding, rng)?
+                        signer.sign(&extended_message_digest, ring, pseudo_output_blinding, rng)?
                     }
                     InputRing::Presigned(ring) => ring.mlsag.clone(),
                 })

--- a/transaction/core/src/signed_contingent_input.rs
+++ b/transaction/core/src/signed_contingent_input.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     ring_signature::{
-        CurveScalar, Error as RingSignatureError, GeneratorCache, KeyImage, OutputSecret,
-        PresignedInputRing, RingMLSAG, SignedInputRing,
+        CurveScalar, GeneratorCache, KeyImage, MLSAGError, OutputSecret, PresignedInputRing,
+        RingMLSAG, SignedInputRing,
     },
     tx::TxIn,
     Amount, Commitment, CompressedCommitment, TokenId,
@@ -180,12 +180,12 @@ pub enum SignedContingentInputError {
     MissingRules,
     /// Proofs of membership are missing
     MissingProofs,
-    /// Invalid Ring Signature: {0}
-    RingSignature(RingSignatureError),
+    /// Invalid MLSAG: {0}
+    MLSAG(MLSAGError),
 }
 
-impl From<RingSignatureError> for SignedContingentInputError {
-    fn from(src: RingSignatureError) -> Self {
-        Self::RingSignature(src)
+impl From<MLSAGError> for SignedContingentInputError {
+    fn from(src: MLSAGError) -> Self {
+        Self::MLSAG(src)
     }
 }

--- a/transaction/core/src/signer/README.md
+++ b/transaction/core/src/signer/README.md
@@ -1,0 +1,15 @@
+transaction_signer
+==================
+
+NOTE: At this revision this is a module within transaction core.
+In a future revision, we should split this, and the ring signature implementation,
+out of core, into its own crate.
+
+An interface and implementation for creating RingMLSAGs.
+
+A RingMLSAG is a ring signature scheme used critically in the MobileCoin transaction
+design. In a transaction, each real input is spent by a RingMLSAG -- this is the
+signature that confers spending authority.
+
+This crate contains a generic interface for creating these MLSAGs as desired.
+This is intended to be useful for hardware wallets.

--- a/transaction/core/src/signer/local_signer.rs
+++ b/transaction/core/src/signer/local_signer.rs
@@ -37,7 +37,7 @@ impl RingSigner for LocalRingSigner {
 
                 recover_onetime_private_key(
                     &public_key,
-                    &self.key.view_private_key(),
+                    self.key.view_private_key(),
                     &self.key.subaddress_spend_private(subaddress_index),
                 )
             }
@@ -53,7 +53,7 @@ impl RingSigner for LocalRingSigner {
 
         // Sign the MLSAG
         Ok(RingMLSAG::sign(
-            &message,
+            message,
             &ring.members,
             ring.real_input_index,
             &onetime_private_key,

--- a/transaction/core/src/signer/local_signer.rs
+++ b/transaction/core/src/signer/local_signer.rs
@@ -1,4 +1,4 @@
-use super::{Error, OneTimeKeyOrAlternative, RingSigner, SignableInputRing};
+use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use crate::{
     onetime_keys::recover_onetime_private_key,
     ring_signature::{generators, CryptoRngCore, RingMLSAG, Scalar},
@@ -6,7 +6,8 @@ use crate::{
 use mc_account_keys::AccountKey;
 use mc_crypto_keys::RistrettoPublic;
 
-/// An implementation of RingSigner that holds private keys
+/// An implementation of RingSigner that holds private keys and derives one-time
+/// private keys
 #[derive(Clone, Debug)]
 pub struct LocalRingSigner {
     key: AccountKey,
@@ -27,9 +28,9 @@ impl RingSigner for LocalRingSigner {
         let target_key = RistrettoPublic::try_from(&real_input.target_key)?;
 
         // First, compute the one-time private key
-        let onetime_private_key = match ring.input_secret.onetime_key_or_alternative {
-            OneTimeKeyOrAlternative::OneTimeKey(key) => key,
-            OneTimeKeyOrAlternative::SubaddressIndex(subaddress_index) => {
+        let onetime_private_key = match ring.input_secret.onetime_key_derive_data {
+            OneTimeKeyDeriveData::OneTimeKey(key) => key,
+            OneTimeKeyDeriveData::SubaddressIndex(subaddress_index) => {
                 let public_key = RistrettoPublic::try_from(&real_input.public_key)?;
 
                 recover_onetime_private_key(

--- a/transaction/core/src/signer/local_signer.rs
+++ b/transaction/core/src/signer/local_signer.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use crate::{
     onetime_keys::recover_onetime_private_key,

--- a/transaction/core/src/signer/local_signer.rs
+++ b/transaction/core/src/signer/local_signer.rs
@@ -1,0 +1,66 @@
+use super::{Error, RingSigner};
+use crate::{
+    onetime_keys::recover_onetime_private_key,
+    ring_signature::{generators, CryptoRngCore, RingMLSAG, Scalar, SignableInputRing},
+};
+use mc_account_keys::AccountKey;
+use mc_crypto_keys::RistrettoPublic;
+
+/// An implementation of RingSigner that holds private keys
+#[derive(Clone, Debug)]
+pub struct LocalRingSigner {
+    key: AccountKey,
+}
+
+impl RingSigner for LocalRingSigner {
+    fn sign(
+        &self,
+        message: &[u8],
+        ring: &SignableInputRing,
+        pseudo_output_blinding: Scalar,
+        rng: &mut dyn CryptoRngCore,
+    ) -> Result<RingMLSAG, Error> {
+        // First, compute the one-time private key
+        let real_input = ring
+            .members
+            .get(ring.real_input_index)
+            .ok_or(Error::RealInputIndexOutOfBounds)?;
+        let target_key = RistrettoPublic::try_from(&real_input.target_key)?;
+        let public_key = RistrettoPublic::try_from(&real_input.public_key)?;
+
+        let onetime_private_key = recover_onetime_private_key(
+            &public_key,
+            &self.key.view_private_key(),
+            &self
+                .key
+                .subaddress_spend_private(ring.input_secret.subaddress_index),
+        );
+
+        // Check if this is the correct one-time private key
+        if RistrettoPublic::from(&onetime_private_key) != target_key {
+            return Err(Error::TrueInputNotOwned);
+        }
+
+        // Note: Some implementations might be able to cache this generator
+        let generator = generators(*ring.input_secret.amount.token_id);
+
+        // Sign the MLSAG
+        Ok(RingMLSAG::sign(
+            &message,
+            &ring.members,
+            ring.real_input_index,
+            &onetime_private_key,
+            ring.input_secret.amount.value,
+            &ring.input_secret.blinding,
+            &pseudo_output_blinding,
+            &generator,
+            rng,
+        )?)
+    }
+}
+
+impl From<&AccountKey> for LocalRingSigner {
+    fn from(src: &AccountKey) -> Self {
+        Self { key: src.clone() }
+    }
+}

--- a/transaction/core/src/signer/mod.rs
+++ b/transaction/core/src/signer/mod.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 //! Interfaces for signing transactions
 
 mod no_keys_ring_signer;

--- a/transaction/core/src/signer/mod.rs
+++ b/transaction/core/src/signer/mod.rs
@@ -1,10 +1,10 @@
 //! Interfaces for signing transactions
 
-mod dummy_signer;
-pub use dummy_signer::DummyRingSigner;
+mod no_keys_ring_signer;
+pub use no_keys_ring_signer::NoKeysRingSigner;
 
 mod local_signer;
 pub use local_signer::LocalRingSigner;
 
 mod traits;
-pub use traits::{Error, InputSecret, OneTimeKeyOrAlternative, RingSigner, SignableInputRing};
+pub use traits::{Error, InputSecret, OneTimeKeyDeriveData, RingSigner, SignableInputRing};

--- a/transaction/core/src/signer/mod.rs
+++ b/transaction/core/src/signer/mod.rs
@@ -1,7 +1,10 @@
 //! Interfaces for signing transactions
 
-mod traits;
-pub use traits::{Error, RingSigner};
+mod dummy_signer;
+pub use dummy_signer::DummyRingSigner;
 
 mod local_signer;
 pub use local_signer::LocalRingSigner;
+
+mod traits;
+pub use traits::{Error, InputSecret, OneTimeKeyOrAlternative, RingSigner, SignableInputRing};

--- a/transaction/core/src/signer/mod.rs
+++ b/transaction/core/src/signer/mod.rs
@@ -1,0 +1,7 @@
+//! Interfaces for signing transactions
+
+mod traits;
+pub use traits::{Error, RingSigner};
+
+mod local_signer;
+pub use local_signer::LocalRingSigner;

--- a/transaction/core/src/signer/no_keys_ring_signer.rs
+++ b/transaction/core/src/signer/no_keys_ring_signer.rs
@@ -1,8 +1,9 @@
-use super::{Error, OneTimeKeyOrAlternative, RingSigner, SignableInputRing};
+use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use crate::ring_signature::{generators, CryptoRngCore, RingMLSAG, Scalar};
 use mc_crypto_keys::RistrettoPublic;
 
-/// An implementation of RingSigner that holds nothing
+/// An implementation of RingSigner that holds no keys, and doesn't do any
+/// non-trivial derivation of the one-time private key.
 ///
 /// This version only works if the input secret actually includes the one-time
 /// private key, and returns an error if only the alternative is supplied.
@@ -11,9 +12,9 @@ use mc_crypto_keys::RistrettoPublic;
 /// software like SDKs that would not benefit from migrating to the
 /// LocalRingSigner, at least for now
 #[derive(Clone, Debug)]
-pub struct DummyRingSigner {}
+pub struct NoKeysRingSigner {}
 
-impl RingSigner for DummyRingSigner {
+impl RingSigner for NoKeysRingSigner {
     fn sign(
         &self,
         message: &[u8],
@@ -28,9 +29,9 @@ impl RingSigner for DummyRingSigner {
         let target_key = RistrettoPublic::try_from(&real_input.target_key)?;
 
         // First, get the one-time private key
-        let onetime_private_key = match ring.input_secret.onetime_key_or_alternative {
-            OneTimeKeyOrAlternative::OneTimeKey(key) => key,
-            OneTimeKeyOrAlternative::SubaddressIndex(_) => {
+        let onetime_private_key = match ring.input_secret.onetime_key_derive_data {
+            OneTimeKeyDeriveData::OneTimeKey(key) => key,
+            OneTimeKeyDeriveData::SubaddressIndex(_) => {
                 return Err(Error::NoPathToSpendKey);
             }
         };

--- a/transaction/core/src/signer/no_keys_ring_signer.rs
+++ b/transaction/core/src/signer/no_keys_ring_signer.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use crate::ring_signature::{generators, CryptoRngCore, RingMLSAG, Scalar};
 use mc_crypto_keys::RistrettoPublic;

--- a/transaction/core/src/signer/no_keys_ring_signer.rs
+++ b/transaction/core/src/signer/no_keys_ring_signer.rs
@@ -48,7 +48,7 @@ impl RingSigner for NoKeysRingSigner {
 
         // Sign the MLSAG
         Ok(RingMLSAG::sign(
-            &message,
+            message,
             &ring.members,
             ring.real_input_index,
             &onetime_private_key,

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -105,7 +105,7 @@ pub enum Error {
     TrueInputNotOwned,
     /// Connection failed: {0}
     ConnectionFailed(String),
-    /// Invalid Ristretto in TxOut: {0}
+    /// Invalid Ristretto key in TxOut: {0}
     Keys(KeyError),
     /// Real input index out of bounds
     RealInputIndexOutOfBounds,

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -57,6 +57,12 @@ pub enum OneTimeKeyDeriveData {
     SubaddressIndex(u64),
 }
 
+impl From<RistrettoPrivate> for OneTimeKeyDeriveData {
+    fn from(src: RistrettoPrivate) -> Self {
+        Self::OneTimeKey(src)
+    }
+}
+
 /// An abstraction over a set of private spend keys. This is intended to
 /// represent either "local" keys or keys living on a remote device.
 ///
@@ -95,6 +101,19 @@ pub trait RingSigner {
         output_blinding: Scalar,
         rng: &mut dyn CryptoRngCore,
     ) -> Result<RingMLSAG, Error>;
+}
+
+// Implement RingSigner for any &RingSigner
+impl<S: RingSigner> RingSigner for &S {
+    fn sign(
+        &self,
+        message: &[u8],
+        signable_ring: &SignableInputRing,
+        output_blinding: Scalar,
+        rng: &mut dyn CryptoRngCore,
+    ) -> Result<RingMLSAG, Error> {
+        (*self).sign(message, signable_ring, output_blinding, rng)
+    }
 }
 
 /// An error that can occur when using an abstract RingSigner

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -74,7 +74,7 @@ pub trait RingSigner {
     ///   pseudo-output.
     /// * rng: This is needed to create randomness during signing. For the case
     ///   of a remote device, it should ignore this parameter, and on the other
-    ///   side of bridge supply its own rng.
+    ///   side of bridge supply its own RNG.
     ///
     /// Returns:
     /// * A signed RingMLSAG, or an error. RingMLSAG signing itself is

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use crate::{
     ring_signature::{CryptoRngCore, MLSAGError, ReducedTxOut, RingMLSAG, Scalar},
     Amount,

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -29,9 +29,8 @@ pub struct SignableInputRing {
 #[derive(Clone, Debug, Zeroize)]
 #[zeroize(drop)]
 pub struct InputSecret {
-    /// Represents either the one-time private key, or an alternative route to
-    /// this
-    pub onetime_key_or_alternative: OneTimeKeyOrAlternative,
+    /// Represents either the one-time private key, or data to derive it
+    pub onetime_key_derive_data: OneTimeKeyDeriveData,
     /// The amount of the output
     pub amount: Amount,
     /// The blinding factor of the output we are trying to spend
@@ -51,7 +50,7 @@ pub struct InputSecret {
 /// This enum selects which path to the one-time private key is taken.
 #[derive(Clone, Debug, Zeroize)]
 #[zeroize(drop)]
-pub enum OneTimeKeyOrAlternative {
+pub enum OneTimeKeyDeriveData {
     /// The one-time private key for the output
     OneTimeKey(RistrettoPrivate),
     /// The subaddress index which owns the output

--- a/transaction/core/src/signer/traits.rs
+++ b/transaction/core/src/signer/traits.rs
@@ -1,0 +1,72 @@
+use crate::ring_signature::{CryptoRngCore, MLSAGError, RingMLSAG, Scalar, SignableInputRing};
+use alloc::string::String;
+use displaydoc::Display;
+use mc_crypto_keys::KeyError;
+use serde::{Deserialize, Serialize};
+
+/// An abstraction over a set of private spend keys. This is intended to
+/// represent either "local" keys or keys living on a remote device.
+///
+/// A transaction builder can be built around this.
+pub trait RingSigner {
+    /// Create an MLSAG signature. This is a signature that confers spending
+    /// authority of a TxOut.
+    ///
+    /// Arguments:
+    /// * message: The digest of transaction context to sign
+    /// * signable_ring: The ring which we are signing, as well as amounts and
+    ///   blinding factor of true input
+    /// * output_blinding: The desired blinding factor of the resulting
+    ///   pseudo-output.
+    /// * rng: This is needed to create randomness during signing. For the case
+    ///   of a remote device, it should ignore this parameter, and on the other
+    ///   side of bridge supply its own rng.
+    ///
+    /// Returns:
+    /// * A signed RingMLSAG, or an error. RingMLSAG signing itself is
+    ///   infallible but the error can occur if there is a logic error
+    ///   (input_secret did not have a onetime private key, but this tx signer
+    ///   has no way to derive it) or a connection error e.g. to hardware device
+    //
+    // FIXME: Should there be versioning here, in case we want to make changes to
+    // MLSAG scheme independently of the block version number? The main point of
+    // that would be that we could make breaking changes in a higher level of Tx
+    // without impacting hardware wallets, while still having a version number
+    // that hardware wallets could observe and respect if we do actually have to
+    // make changes to the MLSAG part. FIXME: Message argument should probably
+    // be a &[u8; 32] after block version < 2 has been deprecated
+    fn sign(
+        &self,
+        message: &[u8],
+        signable_ring: &SignableInputRing,
+        output_blinding: Scalar,
+        rng: &mut dyn CryptoRngCore,
+    ) -> Result<RingMLSAG, Error>;
+}
+
+/// An error that can occur when using an abstract TxSigner
+#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum Error {
+    /// True input not owned by this key
+    TrueInputNotOwned,
+    /// Connection failed: {0}
+    ConnectionFailed(String),
+    /// Invalid Ristretto in TxOut: {0}
+    Keys(KeyError),
+    /// Real input index out of bounds
+    RealInputIndexOutOfBounds,
+    /// MLSAG: {0}
+    MLSAG(MLSAGError),
+}
+
+impl From<KeyError> for Error {
+    fn from(src: KeyError) -> Self {
+        Self::Keys(src)
+    }
+}
+
+impl From<MLSAGError> for Error {
+    fn from(src: MLSAGError) -> Self {
+        Self::MLSAG(src)
+    }
+}

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -8,6 +8,7 @@ pub use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
+    signer::DummyRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
     Amount, Block, BlockID, BlockIndex, BlockVersion, Token,
@@ -208,7 +209,9 @@ pub fn create_transaction_with_amount_and_comparer<
     transaction_builder.set_tombstone_block(tombstone_block);
 
     // Build and return the transaction
-    transaction_builder.build_with_sorter::<R, O>(rng).unwrap()
+    transaction_builder
+        .build_with_sorter::<R, O, DummyRingSigner>(&DummyRingSigner {}, rng)
+        .unwrap()
 }
 
 /// Populates the LedgerDB with initial data.

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -8,7 +8,7 @@ pub use mc_transaction_core::{
     get_tx_out_shared_secret,
     onetime_keys::recover_onetime_private_key,
     ring_signature::KeyImage,
-    signer::DummyRingSigner,
+    signer::NoKeysRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipElement, TxOutMembershipHash},
     Amount, Block, BlockID, BlockIndex, BlockVersion, Token,
@@ -210,7 +210,7 @@ pub fn create_transaction_with_amount_and_comparer<
 
     // Build and return the transaction
     transaction_builder
-        .build_with_sorter::<R, O, DummyRingSigner>(&DummyRingSigner {}, rng)
+        .build_with_sorter::<_, O, _>(&NoKeysRingSigner {}, rng)
         .unwrap()
 }
 

--- a/transaction/std/src/error.rs
+++ b/transaction/std/src/error.rs
@@ -3,7 +3,8 @@
 use displaydoc::Display;
 use mc_fog_report_validation::FogPubkeyError;
 use mc_transaction_core::{
-    ring_signature, ring_signature::Error, AmountError, NewMemoError, NewTxError, TokenId,
+    ring_signature, ring_signature::Error, signer::Error as SignerError, AmountError, NewMemoError,
+    NewTxError, TokenId,
 };
 
 /// An error that can occur when using the TransactionBuilder
@@ -62,6 +63,9 @@ pub enum TxBuilderError {
 
     /// Missing membership proof
     MissingMembershipProofs,
+
+    /// Signer: {0}
+    Signer(SignerError),
 }
 
 impl From<mc_util_serial::encode::Error> for TxBuilderError {
@@ -97,6 +101,12 @@ impl From<mc_crypto_keys::KeyError> for TxBuilderError {
 impl From<ring_signature::Error> for TxBuilderError {
     fn from(src: Error) -> Self {
         TxBuilderError::RingSignatureFailed(src)
+    }
+}
+
+impl From<SignerError> for TxBuilderError {
+    fn from(src: SignerError) -> Self {
+        TxBuilderError::Signer(src)
     }
 }
 

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -101,8 +101,8 @@ impl InputCredentials {
         })
     }
 
-    // Get the one-time private key from the InputCredentials, panicking if
-    // it doesn't contain this. This makes many tests much shorter.
+    /// Get the one-time private key from the InputCredentials, panicking if
+    /// it doesn't contain this. This makes many tests much shorter.
     #[cfg(any(test, feature = "test-only"))]
     pub fn assert_has_onetime_private_key(&self) -> &RistrettoPrivate {
         match &self.input_secret.onetime_key_derive_data {

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -104,7 +104,7 @@ impl InputCredentials {
     #[cfg(any(test, feature = "test-only"))]
     pub fn assert_has_onetime_private_key(&self) -> &RistrettoPrivate {
         match &self.input_secret.onetime_key_derive_data {
-            OneTimeKeyDeriveData::OneTimeKey(key) => &key,
+            OneTimeKeyDeriveData::OneTimeKey(key) => key,
             OneTimeKeyDeriveData::SubaddressIndex(_) => panic!("missing one time private key"),
         }
     }

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -42,7 +42,7 @@ impl InputCredentials {
         ring: Vec<TxOut>,
         membership_proofs: Vec<TxOutMembershipProof>,
         real_index: usize,
-        onetime_private_key: RistrettoPrivate,
+        onetime_key_derive_data: impl Into<OneTimeKeyDeriveData>,
         view_private_key: RistrettoPrivate,
     ) -> Result<Self, TxBuilderError> {
         debug_assert_eq!(ring.len(), membership_proofs.len());
@@ -84,9 +84,7 @@ impl InputCredentials {
         let masked_amount = &ring[real_index].masked_amount;
         let (amount, blinding) = masked_amount.get_value(&tx_out_shared_secret)?;
 
-        // We always have the one-time key in this flow
-        let onetime_key_derive_data = OneTimeKeyDeriveData::OneTimeKey(onetime_private_key);
-
+        let onetime_key_derive_data = onetime_key_derive_data.into();
         let input_secret = InputSecret {
             onetime_key_derive_data,
             amount,

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -100,6 +100,16 @@ impl InputCredentials {
             input_secret,
         })
     }
+
+    // Get the one-time private key from the InputCredentials, panicking if
+    // it doesn't contain this. This makes many tests much shorter.
+    #[cfg(any(test, feature = "test-only"))]
+    pub fn assert_has_onetime_private_key(&self) -> &RistrettoPrivate {
+        match &self.input_secret.onetime_key_derive_data {
+            OneTimeKeyDeriveData::OneTimeKey(key) => &key,
+            OneTimeKeyDeriveData::SubaddressIndex(_) => panic!("missing one time private key"),
+        }
+    }
 }
 
 impl From<InputCredentials> for SignableInputRing {

--- a/transaction/std/src/input_credentials.rs
+++ b/transaction/std/src/input_credentials.rs
@@ -4,7 +4,7 @@ use crate::TxBuilderError;
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_transaction_core::{
     onetime_keys::create_shared_secret,
-    signer::{InputSecret, OneTimeKeyOrAlternative, SignableInputRing},
+    signer::{InputSecret, OneTimeKeyDeriveData, SignableInputRing},
     tx::{TxIn, TxOut, TxOutMembershipProof},
 };
 use std::convert::TryFrom;
@@ -85,10 +85,10 @@ impl InputCredentials {
         let (amount, blinding) = masked_amount.get_value(&tx_out_shared_secret)?;
 
         // We always have the one-time key in this flow
-        let onetime_key_or_alternative = OneTimeKeyOrAlternative::OneTimeKey(onetime_private_key);
+        let onetime_key_derive_data = OneTimeKeyDeriveData::OneTimeKey(onetime_private_key);
 
         let input_secret = InputSecret {
-            onetime_key_or_alternative,
+            onetime_key_derive_data,
             amount,
             blinding,
         };

--- a/transaction/std/src/signed_contingent_input_builder.rs
+++ b/transaction/std/src/signed_contingent_input_builder.rs
@@ -398,6 +398,7 @@ pub mod tests {
         fog_hint::FogHint,
         get_tx_out_shared_secret,
         ring_signature::{Error as RingSignatureError, KeyImage},
+        signer::NoKeysRingSigner,
         subaddress_matches_tx_out,
         tokens::Mob,
         validation::{
@@ -442,7 +443,7 @@ pub mod tests {
             let input_credentials =
                 get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
 
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -458,7 +459,7 @@ pub mod tests {
 
             builder.set_tombstone_block(2000);
 
-            let sci = builder.build(&mut rng).unwrap();
+            let sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -565,7 +566,7 @@ pub mod tests {
             let input_credentials =
                 get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
 
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -581,7 +582,7 @@ pub mod tests {
 
             builder.set_tombstone_block(2000);
 
-            let sci = builder.build(&mut rng).unwrap();
+            let sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -676,7 +677,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -691,7 +692,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -739,7 +740,7 @@ pub mod tests {
                 )
                 .unwrap();
 
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // tx should have a valid signature, and pass all input rule checks
             validate_signature(block_version, &tx, &mut rng).unwrap();
@@ -924,7 +925,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -939,7 +940,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -987,7 +988,7 @@ pub mod tests {
                 )
                 .unwrap();
 
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // tx should have a valid signature, and pass all input rule checks
             validate_signature(block_version, &tx, &mut rng).unwrap();
@@ -1162,7 +1163,7 @@ pub mod tests {
                 )
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1206,7 +1207,7 @@ pub mod tests {
                 )
                 .unwrap();
 
-            let mut sci2 = builder.build(&mut rng).unwrap();
+            let mut sci2 = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci2.validate().unwrap();
@@ -1252,7 +1253,7 @@ pub mod tests {
 
             builder.set_tombstone_block(8088);
 
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // tx should have a valid signature, and pass all input rule checks
             validate_signature(block_version, &tx, &mut rng).unwrap();
@@ -1450,7 +1451,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -1465,7 +1466,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1496,7 +1497,7 @@ pub mod tests {
 
             // The transaction is balanced, but it fails because all rings were presigned
             assert_matches!(
-                builder.build(&mut rng),
+                builder.build(&NoKeysRingSigner {}, &mut rng),
                 Err(TxBuilderError::RingSignatureFailed(
                     RingSignatureError::AllRingsPresigned
                 ))
@@ -1542,7 +1543,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -1557,7 +1558,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1602,7 +1603,7 @@ pub mod tests {
             builder.set_tombstone_block(1000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 1000);
 
@@ -1653,7 +1654,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -1668,7 +1669,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1709,7 +1710,7 @@ pub mod tests {
             builder.set_tombstone_block(1000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 1000);
 
@@ -1760,7 +1761,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -1775,7 +1776,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1820,7 +1821,7 @@ pub mod tests {
             builder.set_tombstone_block(1000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 1000);
 
@@ -1870,7 +1871,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -1885,7 +1886,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -1901,10 +1902,7 @@ pub mod tests {
 
             // (Sanity check: the sci fails its own validation now, because the signature is
             // invalid)
-            assert_matches!(
-                sci.validate(),
-                Err(SignedContingentInputError::RingSignature(_))
-            );
+            assert_matches!(sci.validate(), Err(SignedContingentInputError::MLSAG(_)));
 
             let mut builder = TransactionBuilder::new(
                 block_version,
@@ -1945,7 +1943,7 @@ pub mod tests {
             builder.set_tombstone_block(1000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 1000);
 
@@ -1995,7 +1993,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -2010,7 +2008,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -2065,7 +2063,7 @@ pub mod tests {
             builder.set_tombstone_block(1000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 1000);
 
@@ -2115,7 +2113,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -2130,7 +2128,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -2175,7 +2173,7 @@ pub mod tests {
             builder.set_tombstone_block(2000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 2000);
 
@@ -2226,7 +2224,7 @@ pub mod tests {
                 get_input_credentials(block_version, amount, &alice, &fog_resolver, &mut rng);
 
             let proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut builder = SignedContingentInputBuilder::new(
                 block_version,
@@ -2241,7 +2239,7 @@ pub mod tests {
                 .add_required_output(amount2, &alice.default_subaddress(), &mut rng)
                 .unwrap();
 
-            let mut sci = builder.build(&mut rng).unwrap();
+            let mut sci = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             // The contingent input should have a valid signature.
             sci.validate().unwrap();
@@ -2256,10 +2254,7 @@ pub mod tests {
 
             // (Sanity check: the sci fails its own validation now, because the signature is
             // invalid)
-            assert_matches!(
-                sci.validate(),
-                Err(SignedContingentInputError::RingSignature(_))
-            );
+            assert_matches!(sci.validate(), Err(SignedContingentInputError::MLSAG(_)));
 
             let mut builder = TransactionBuilder::new(
                 block_version,
@@ -2300,7 +2295,7 @@ pub mod tests {
             builder.set_tombstone_block(2000);
 
             // The transaction is balanced, so this should build
-            let tx = builder.build(&mut rng).unwrap();
+            let tx = builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
 
             assert_eq!(tx.prefix.tombstone_block, 2000);
 

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -12,6 +12,7 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{
     onetime_keys::*,
+    signer::DummyRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     Amount, BlockVersion, MemoContext, NewMemoError, Token, TokenId,
@@ -203,7 +204,7 @@ pub fn get_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver + Clone>
     let fee = num_inputs as u64 * input_value - num_outputs as u64 * output_value;
     transaction_builder.set_fee(fee).unwrap();
 
-    transaction_builder.build(rng)
+    transaction_builder.build(&DummyRingSigner {}, rng)
 }
 
 /// Build simulated change memo with zero amount

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -12,7 +12,7 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{
     onetime_keys::*,
-    signer::DummyRingSigner,
+    signer::NoKeysRingSigner,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     Amount, BlockVersion, MemoContext, NewMemoError, Token, TokenId,
@@ -204,7 +204,7 @@ pub fn get_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver + Clone>
     let fee = num_inputs as u64 * input_value - num_outputs as u64 * output_value;
     transaction_builder.set_fee(fee).unwrap();
 
-    transaction_builder.build(&DummyRingSigner {}, rng)
+    transaction_builder.build(&NoKeysRingSigner {}, rng)
 }
 
 /// Build simulated change memo with zero amount

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -12,7 +12,7 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{
     onetime_keys::*,
-    signer::NoKeysRingSigner,
+    signer::{NoKeysRingSigner, OneTimeKeyDeriveData},
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
     Amount, BlockVersion, MemoContext, NewMemoError, Token, TokenId,
@@ -133,6 +133,7 @@ pub fn get_input_credentials<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
         account.view_private_key(),
         &account.subaddress_spend_private(DEFAULT_SUBADDRESS_INDEX),
     );
+    let onetime_key_derive_data = OneTimeKeyDeriveData::OneTimeKey(onetime_private_key);
 
     let membership_proofs: Vec<TxOutMembershipProof> = ring
         .iter()
@@ -147,7 +148,7 @@ pub fn get_input_credentials<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
         ring,
         membership_proofs,
         real_index,
-        onetime_private_key,
+        onetime_key_derive_data,
         *account.view_private_key(),
     )
     .unwrap()

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -423,7 +423,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     }
 
     /// Consume the builder and return the transaction.
-    pub fn build<RNG: CryptoRng + RngCore, S: RingSigner>(
+    pub fn build<RNG: CryptoRng + RngCore, S: RingSigner + ?Sized>(
         self,
         ring_signer: &S,
         rng: &mut RNG,
@@ -434,7 +434,11 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     /// Consume the builder and return the transaction with a comparer.
     /// Used only in testing library.
     #[cfg(feature = "test-only")]
-    pub fn build_with_sorter<RNG: CryptoRng + RngCore, O: TxOutputsOrdering, S: RingSigner>(
+    pub fn build_with_sorter<
+        RNG: CryptoRng + RngCore,
+        O: TxOutputsOrdering,
+        S: RingSigner + ?Sized,
+    >(
         self,
         ring_signer: &S,
         rng: &mut RNG,
@@ -447,7 +451,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     fn build_with_comparer_internal<
         RNG: CryptoRng + RngCore,
         O: TxOutputsOrdering,
-        S: RingSigner,
+        S: RingSigner + ?Sized,
     >(
         mut self,
         ring_signer: &S,
@@ -644,8 +648,8 @@ pub mod transaction_builder_tests {
         constants::{MAX_INPUTS, MAX_OUTPUTS, MILLIMOB_TO_PICOMOB},
         get_tx_out_shared_secret,
         onetime_keys::*,
-        ring_signature::{KeyImage},
-        signer::{InputSecret, NoKeysRingSigner},
+        ring_signature::KeyImage,
+        signer::{NoKeysRingSigner, OneTimeKeyDeriveData, InputSecret},
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
         validation::{validate_signature, validate_tx_out},
@@ -2354,7 +2358,7 @@ pub mod transaction_builder_tests {
                 ring,
                 membership_proofs,
                 real_index,
-                onetime_private_key,
+                OneTimeKeyDeriveData::OneTimeKey(onetime_private_key),
                 *alice.view_private_key(),
             )
             .unwrap();

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -3202,7 +3202,7 @@ pub mod transaction_builder_tests {
             funding_transaction_builder.add_input(funding_input_credentials);
 
             // Fund gift code TxOut
-            // FIXME: This should be `.add_gift_code_output` or someting, so that
+            // FIXME #2003: This should be `.add_gift_code_output` or something, so that
             // it goes to the gift code subaddress, but the fog hint is using the
             // default subaddress
             // (or, make a special builder for gift code funding transactions?)

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -649,7 +649,7 @@ pub mod transaction_builder_tests {
         get_tx_out_shared_secret,
         onetime_keys::*,
         ring_signature::KeyImage,
-        signer::{NoKeysRingSigner, OneTimeKeyDeriveData, InputSecret},
+        signer::{InputSecret, NoKeysRingSigner, OneTimeKeyDeriveData},
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
         validation::{validate_signature, validate_tx_out},
@@ -3202,6 +3202,10 @@ pub mod transaction_builder_tests {
             funding_transaction_builder.add_input(funding_input_credentials);
 
             // Fund gift code TxOut
+            // FIXME: This should be `.add_gift_code_output` or someting, so that
+            // it goes to the gift code subaddress, but the fog hint is using the
+            // default subaddress
+            // (or, make a special builder for gift code funding transactions?)
             funding_transaction_builder
                 .add_output(
                     funding_output_amount,
@@ -3218,7 +3222,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let funding_tx = funding_transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
+            let funding_tx = funding_transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // The transaction should have exactly 2 outputs
             assert_eq!(funding_tx.prefix.outputs.len(), 2);
@@ -3298,7 +3304,7 @@ pub mod transaction_builder_tests {
             let global_index = 42;
             let gift_code_tx_out_private_key = recover_onetime_private_key(
                 funding_output_public_key,
-                sender.spend_private_key(),
+                sender.view_private_key(),
                 &sender.gift_code_subaddress_spend_private(),
             );
             let tx_out_gift_code = TxOutGiftCode {
@@ -3376,7 +3382,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // Verify the sender transaction was valid
             assert_eq!(tx.prefix.outputs.len(), 1);
@@ -3449,7 +3457,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // The transaction should have exactly 1 output
             assert_eq!(tx.prefix.outputs.len(), 1);

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -644,7 +644,8 @@ pub mod transaction_builder_tests {
         constants::{MAX_INPUTS, MAX_OUTPUTS, MILLIMOB_TO_PICOMOB},
         get_tx_out_shared_secret,
         onetime_keys::*,
-        ring_signature::{InputSecret, KeyImage},
+        ring_signature::{KeyImage},
+        signer::{InputSecret, NoKeysRingSigner},
         subaddress_matches_tx_out,
         tx::TxOutMembershipProof,
         validation::{validate_signature, validate_tx_out},
@@ -682,7 +683,7 @@ pub mod transaction_builder_tests {
                 get_input_credentials(block_version, amount, &sender, &fpr, &mut rng);
 
             let membership_proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
@@ -701,7 +702,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // The transaction should have a single input.
             assert_eq!(tx.prefix.inputs.len(), 1);
@@ -764,7 +767,7 @@ pub mod transaction_builder_tests {
                 get_input_credentials(block_version, amount, &sender, &fog_resolver, &mut rng);
 
             let membership_proofs = input_credentials.membership_proofs.clone();
-            let key_image = KeyImage::from(&input_credentials.input_secret.onetime_private_key);
+            let key_image = KeyImage::from(input_credentials.assert_has_onetime_private_key());
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
@@ -783,7 +786,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // The transaction should have a single input.
             assert_eq!(tx.prefix.inputs.len(), 1);
@@ -879,7 +884,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             // The transaction should have one output.
             assert_eq!(tx.prefix.outputs.len(), 1);
@@ -955,7 +962,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have one output.
                 assert_eq!(tx.prefix.outputs.len(), 1);
@@ -990,7 +999,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have one output.
                 assert_eq!(tx.prefix.outputs.len(), 1);
@@ -1067,7 +1078,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -1248,7 +1261,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -1410,7 +1425,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -1572,7 +1589,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -1734,7 +1753,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -1884,7 +1905,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -2059,7 +2082,9 @@ pub mod transaction_builder_tests {
                     )
                     .unwrap();
 
-                let tx = transaction_builder.build(&mut rng).unwrap();
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
 
                 // The transaction should have two output.
                 assert_eq!(tx.prefix.outputs.len(), 2);
@@ -2278,7 +2303,9 @@ pub mod transaction_builder_tests {
                     "Adding a second change output should be rejected"
                 );
 
-                transaction_builder.build(&mut rng).unwrap();
+                transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
             }
         }
     }
@@ -2350,7 +2377,7 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let result = transaction_builder.build(&mut rng);
+            let result = transaction_builder.build(&NoKeysRingSigner {}, &mut rng);
             // Signing should fail if value is not conserved.
             match result {
                 Err(TxBuilderError::RingSignatureFailed(_)) => {} // Expected.
@@ -2533,7 +2560,9 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             assert_eq!(tx.prefix.outputs.len(), 2);
             let idx = tx
@@ -2768,7 +2797,9 @@ pub mod transaction_builder_tests {
                 .add_output(Amount::new(110, token_id), &burn_address(), &mut rng)
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).expect("build tx");
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .expect("build tx");
 
             assert_eq!(tx.prefix.outputs.len(), 1);
             assert_eq!(burn_output, tx.prefix.outputs[0]);
@@ -2828,7 +2859,9 @@ pub mod transaction_builder_tests {
                 .add_change_output(Amount::new(10, token_id), &change_destination, &mut rng)
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).expect("build tx");
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .expect("build tx");
 
             assert_eq!(tx.prefix.outputs.len(), 2);
 
@@ -2968,7 +3001,9 @@ pub mod transaction_builder_tests {
                 .add_change_output(change_amount, &sender_change_dest, &mut rng)
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .unwrap();
 
             assert_eq!(tx.prefix.outputs.len(), 3);
             let idx1 = tx
@@ -3099,7 +3134,7 @@ pub mod transaction_builder_tests {
                 .add_change_output(change_amount, &sender_change_dest, &mut rng)
                 .unwrap();
 
-            transaction_builder.build(&mut rng)
+            transaction_builder.build(&NoKeysRingSigner {}, &mut rng)
         };
 
         for block_version in 3..=*BlockVersion::MAX {
@@ -3179,7 +3214,7 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let funding_tx = funding_transaction_builder.build(&mut rng).unwrap();
+            let funding_tx = funding_transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
 
             // The transaction should have exactly 2 outputs
             assert_eq!(funding_tx.prefix.outputs.len(), 2);
@@ -3320,7 +3355,7 @@ pub mod transaction_builder_tests {
                 membership_proofs,
                 real_index,
                 input_secret: InputSecret {
-                    onetime_private_key: gift_code_tx_out_private_key,
+                    onetime_key_derive_data: gift_code_tx_out_private_key.into(),
                     amount: sending_input_amount,
                     blinding,
                 },
@@ -3337,7 +3372,7 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
 
             // Verify the sender transaction was valid
             assert_eq!(tx.prefix.outputs.len(), 1);
@@ -3410,7 +3445,7 @@ pub mod transaction_builder_tests {
                 )
                 .unwrap();
 
-            let tx = transaction_builder.build(&mut rng).unwrap();
+            let tx = transaction_builder.build(&NoKeysRingSigner{}, &mut rng).unwrap();
 
             // The transaction should have exactly 1 output
             assert_eq!(tx.prefix.outputs.len(), 1);


### PR DESCRIPTION
The goal here is to create a `RingSigner` trait that takes arguments and produces a `RingMLSAG`.
The trait should be an appropriate API for a hardware wallet -- the caller need not have the private spend key, and the callee who does have the private spend key has everything they need to produce a `RingMLSAG` conferring spend authority.

There are fundamentally two changes

* Previously, an `InputSecret`, and an `InputCredentials`, contains the one-time-private key. However, in a hardware wallet world, it's not acceptable to have this on the online machine, since it can be used to spend the `TxOut`.
* Therefore, we changed `InputSecret` so that instead it contains the subaddress index of the true input, and the `RingSigner` has the responsibility for computing the one-time private key. Then, all the arguments to the `RingSigner` trait are safe to be on the online machine, so this is an appropriate API for a hardware wallet device.
* In `LocalRingSigner` we gave a proof of concept implementation that can be used by the hardware signing devices (or any device)
* Later we figured out that the new flow breaks gift codes. Therefore `InputSecret` contains an enum that is either the onetime private key or a path for the hardware wallet `RingSigner` to compute the onetime private key.
* In `DummyRingSigner` we made a `RingSigner` that only supports the old path. This can be used in existing software with minimal disruption.

There was some ambiguity around how to handle the `&mut impl RngCore + CryptoRng` argument.

Obviously, an RNG will not be passed across a serialization boundary. So an alternative would be that, the `RingSigner` object provides it's own RNG. However, this will not play well with current users of transaction builder, because then they need two RNGs, one for the transaction builder and one for the `RingSigner`.

In all our current code, the caller passes in an RNG through to the callee. In single threaded code this just works.

We decided to try to do this across the trait, so we effectively pass `&mut dyn (RngCore + CryptoRng)` across the `RingSigner` trait. In the case of a local signer, it just uses the passed RNG as before. In the case of a hardware wallet, it is expected that it discards the RNG argument, serializes the call and sends to the hardware device, and then the hardware device supplies an abstraction over its own randomness source.

---

The idea is that, we could get this PR to work and make all the existing `TransactionBuilder` objects switch to using a local signer.

Then, we should split the `mc-transaction-core` crate into two parts, one which contains `RingMLSAG` and all its dependencies, and the other which contains everything above that. The `RingSigner` part would go with `RingMLSAG` crate. That new crate, perhaps `mc-crypto-ring-signature`, would be the a small subset appropriate to port to a hardware wallet. (It wouldn't be the whole thing because there needs to be some solution for memo builder also.)

This experiment seems to have worked with only minor wrinkles, at least, transaction core is building.

Please LMK if you agree that this is a good direction
