### PR TITLE
Mark fee_token_id as `omit_when = 0` (#1978)

### DIFF
--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -168,6 +168,7 @@ pub struct TxPrefix {
 
     /// Token id for the fee output of this transaction
     #[prost(fixed64, tag = "5")]
+    #[digestible(omit_when = 0)]
     pub fee_token_id: u64,
 }
 


### PR DESCRIPTION
The fee token id, which is a new field in 1.2, needs to be marked
`omit_when = 0`, otherwise there is no way for clients to be
compatible with 1.1 and 1.2.

This needs to be done whenever we add a numeric field to a proto
that is hashed into the blockchain, otherwise the schema evolution
strategy for hashing doesn't work.

(It really should have been the default for hashing integers,
because it's so easy to miss this,
but it's probably too late to change that now.)

---

This is a cherry-pick of 19f0aeb8625e865f4ce992b7d40427774ba33936
There were no conflicts