### PR TITLE
Implement some improvements to the `mc-consensus-mint-client` utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,7 @@ name = "mc-consensus-mint-client"
 version = "1.3.0-pre0"
 dependencies = [
  "clap 3.1.18",
+ "displaydoc",
  "grpcio",
  "hex",
  "mc-account-keys",

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -27,6 +27,7 @@ mc-util-parse = { path = "../../util/parse" }
 mc-util-uri = { path = "../../util/uri" }
 
 clap = { version = "3.1", features = ["derive", "env"] }
+displaydoc = "0.2"
 grpcio = "0.10.2"
 hex = "0.4"
 pem = "1.0"

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -88,7 +88,6 @@ pub struct MintConfigTxParams {
         long = "signing-key",
         use_value_delimiter = true,
         parse(try_from_str = load_key_from_pem),
-        required_unless_present = "signatures",
         env = "MC_MINTING_SIGNING_KEYS"
     )]
     signing_keys: Vec<Ed25519Private>,
@@ -97,7 +96,8 @@ pub struct MintConfigTxParams {
     #[clap(
         long = "signature",
         use_value_delimiter = true,
-        parse(try_from_str = load_or_parse_ed25519_signature), env = "MC_MINTING_SIGNATURES"
+        parse(try_from_str = load_or_parse_ed25519_signature),
+        env = "MC_MINTING_SIGNATURES"
     )]
     signatures: Vec<Ed25519Signature>,
 
@@ -182,7 +182,6 @@ pub struct MintTxParams {
         long = "signing-key",
         use_value_delimiter = true,
         parse(try_from_str = load_key_from_pem),
-        required_unless_present = "signatures",
         env = "MC_MINTING_SIGNING_KEYS"
     )]
     signing_keys: Vec<Ed25519Private>,
@@ -346,6 +345,32 @@ pub enum Commands {
         /// The file to load
         #[clap(long, parse(try_from_str = load_tx_file_from_path), env = "MC_MINTING_TX_FILE")]
         tx_file: TxFile,
+    },
+
+    /// Sign a transaction file produced by this tool, rewriting the file with
+    /// the appended signature(s).
+    Sign {
+        /// The file to sign
+        #[clap(long, env = "MC_MINTING_TX_FILE")]
+        tx_file: PathBuf,
+
+        /// The key(s) to sign the transaction with.
+        #[clap(
+            long = "signing-key",
+            required_unless_present = "signatures",
+            parse(try_from_str = load_key_from_pem),
+            env = "MC_MINTING_SIGNING_KEY"
+        )]
+        signing_keys: Vec<Ed25519Private>,
+
+        /// Pre-generated signature(s) to use, either in hex format or a PEM
+        /// file.
+        #[clap(
+            long = "signature",
+            use_value_delimiter = true,
+            parse(try_from_str = load_or_parse_ed25519_signature), env = "MC_MINTING_SIGNATURES"
+        )]
+        signatures: Vec<Ed25519Signature>,
     },
 }
 

--- a/consensus/mint-client/src/lib.rs
+++ b/consensus/mint-client/src/lib.rs
@@ -1,5 +1,9 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 mod config;
+mod tx_file;
+
+pub mod printers;
 
 pub use config::{Commands, Config};
+pub use tx_file::TxFile;

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Utility functions for printing objects in a human-friendly way.
+
+use mc_account_keys::PublicAddress;
+use mc_api::printable::PrintableWrapper;
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public, Ed25519Signature};
+use mc_crypto_multisig::{MultiSig, SignerSet};
+use mc_transaction_core::mint::{
+    MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx, MintTxPrefix,
+};
+use pem::Pem;
+
+const INDENT_STR: &str = "    ";
+const PEM_TAG_SIGNATURE: &str = "SIGNATURE";
+const PEM_TAG_PUBLIC_KEY: &str = "PUBLIC KEY";
+
+pub fn print_mint_config_tx(tx: &MintConfigTx, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfigTx:", indent_str);
+    print_mint_config_tx_prefix(&tx.prefix, indent + 1);
+    print_multi_sig(&tx.signature, indent + 1);
+}
+
+pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfigTxPrefix:", indent_str);
+
+    indent_str.push_str(INDENT_STR);
+    println!(
+        "{}Configs ({} config(s)):",
+        indent_str,
+        prefix.configs.len()
+    );
+    for config in &prefix.configs {
+        print_mint_config(config, indent + 2);
+    }
+    println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
+    println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
+    println!(
+        "{}Total mint limit: {}",
+        indent_str, prefix.total_mint_limit
+    );
+}
+
+pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfig:", indent_str);
+
+    indent_str.push_str(INDENT_STR);
+    println!("{}Token id: {}", indent_str, mint_config.token_id);
+    println!("{}Mint limit: {}", indent_str, mint_config.mint_limit);
+    print_signer_set(&mint_config.signer_set, indent + 1);
+}
+
+pub fn print_mint_tx(tx: &MintTx, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintTx:", indent_str);
+    print_mint_tx_prefix(&tx.prefix, indent + 1);
+    print_multi_sig(&tx.signature, indent + 1);
+}
+
+pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
+    let recipient = PublicAddress::new(&prefix.spend_public_key, &prefix.view_public_key);
+    let mut wrapper = PrintableWrapper::new();
+    wrapper.set_public_address((&recipient).into());
+    let b58_recipient = wrapper.b58_encode().expect("failed encoding b58 address");
+
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintTxPrefix:", indent_str);
+    indent_str.push_str(INDENT_STR);
+    println!("{}Token id: {}", indent_str, prefix.token_id);
+    println!("{}Mint amount: {}", indent_str, prefix.amount);
+    println!("{}View public key: {}", indent_str, prefix.view_public_key,);
+    println!(
+        "{}Spend public key: {}",
+        indent_str, prefix.spend_public_key
+    );
+    println!("{}Recipient B58 address: {}", indent_str, b58_recipient);
+    println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
+    println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
+}
+
+pub fn print_signer_set(signer_set: &SignerSet<Ed25519Public>, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!(
+        "{}Signer set ({} signer(s)):",
+        indent_str,
+        signer_set.signers().len()
+    );
+    indent_str.push_str(INDENT_STR);
+    for signer in signer_set.signers() {
+        print_pem(signer, PEM_TAG_PUBLIC_KEY, indent + 2);
+    }
+    println!("{}Threshold: {}", indent_str, signer_set.threshold());
+}
+
+pub fn print_multi_sig(multi_sig: &MultiSig<Ed25519Signature>, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!(
+        "{}Multisig ({} signature(s)):",
+        indent_str,
+        multi_sig.signatures().len()
+    );
+    for sig in multi_sig.signatures() {
+        print_pem(sig, PEM_TAG_SIGNATURE, indent + 2);
+    }
+}
+
+pub fn print_pem(obj: &impl DistinguishedEncoding, tag: &str, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    let pem_str = pem::encode(&Pem {
+        tag: tag.into(),
+        contents: obj.to_der(),
+    });
+    for line in pem_str.lines() {
+        println!("{}{}", indent_str, line);
+    }
+}

--- a/consensus/mint-client/src/tx_file.rs
+++ b/consensus/mint-client/src/tx_file.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A file format for serializing/deserializing objects used by by the mint
+//! client. This is used instead of serializing/deserializing the actual objects
+//! so that if the users confuses one file type with another we are guaranteed
+//! to get a deserialization error.
+
+use displaydoc::Display;
+use mc_transaction_core::mint::{MintConfigTx, MintTx};
+use serde::{Deserialize, Serialize};
+use serde_json::Error as JsonError;
+use std::{
+    fs,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+};
+
+/// An enum for holding all possible objects the mint client needs to store in a
+/// file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum TxFile {
+    MintConfigTx(MintConfigTx),
+    MintTx(MintTx),
+}
+
+impl From<MintConfigTx> for TxFile {
+    fn from(tx: MintConfigTx) -> Self {
+        Self::MintConfigTx(tx)
+    }
+}
+
+impl TryFrom<TxFile> for MintConfigTx {
+    type Error = TxFileError;
+
+    fn try_from(tx_file: TxFile) -> Result<Self, Self::Error> {
+        match tx_file {
+            TxFile::MintConfigTx(tx) => Ok(tx),
+            TxFile::MintTx(_) => Err(TxFileError::WrongFileContents("MintConfigTx", "MintTx")),
+        }
+    }
+}
+
+impl From<MintTx> for TxFile {
+    fn from(tx: MintTx) -> Self {
+        Self::MintTx(tx)
+    }
+}
+
+impl TryFrom<TxFile> for MintTx {
+    type Error = TxFileError;
+
+    fn try_from(tx_file: TxFile) -> Result<MintTx, Self::Error> {
+        match tx_file {
+            TxFile::MintTx(tx) => Ok(tx),
+            TxFile::MintConfigTx(_) => {
+                Err(TxFileError::WrongFileContents("MintTx", "MintConfigTx"))
+            }
+        }
+    }
+}
+
+impl TxFile {
+    /// Write the contents of this object to the given file.
+    pub fn write_json(&self, path: &impl AsRef<Path>) -> Result<(), TxFileError> {
+        let json = serde_json::to_string_pretty(&self)?;
+        fs::write(path, json)?;
+        Ok(())
+    }
+
+    /// Load a [TxFile] from a JSON file.
+    pub fn from_json_file<P: AsRef<Path>>(path: P) -> Result<Self, TxFileError> {
+        let json = fs::read_to_string(path)?;
+        let tx = serde_json::from_str(&json)?;
+        Ok(tx)
+    }
+
+    /// Attempt to load multiple files where all files contain a specific object
+    /// type.
+    pub fn load_multiple<T>(filenames: &[PathBuf]) -> Result<Vec<T>, TxFileError>
+    where
+        T: TryFrom<TxFile, Error = TxFileError>,
+    {
+        filenames
+            .iter()
+            .map(|filename| T::try_from(TxFile::from_json_file(filename)?))
+            .collect::<Result<Vec<T>, TxFileError>>()
+    }
+}
+
+/// Error type for TxFile operations.
+#[derive(Debug, Display)]
+pub enum TxFileError {
+    /// IO error: {0}
+    Io(IoError),
+
+    /// JSON error: {0}
+    Json(JsonError),
+
+    /// Wrong file contents: Expected {0} but found {1}
+    WrongFileContents(&'static str, &'static str),
+}
+
+impl From<IoError> for TxFileError {
+    fn from(err: IoError) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<JsonError> for TxFileError {
+    fn from(err: JsonError) -> Self {
+        Self::Json(err)
+    }
+}


### PR DESCRIPTION
### Motivation

While planning out potential flows for the minting process, we realized there are some missing features in the minting client that will make it more ergonomic. This PR:
* Makes it so that the `MintConfigTx` and `MintTx` JSON files that are read/written by the utility are now using a unified `TxFile` enum. This guarantees the correct file is passed, and provides a user-friendly error message if the user mixes the two unintentionally. 
* Adds a `Dump` sub-command that prints a human-friendly representation of whats in a given json file. This makes it easier for users to verify they are operating on the file they think they're operating on.
* Adds a `Sign` sub-command that takes a tx file, and a list of signer keys or signatures and appends them to the multisig.
* Allows omitting signers/signatures when generating transaction files. Together with the previous change this enables the flow of:
    1. Someone generates a `MintTx` or `MintConfigTx` tx file without needing any private signing keys.
    2. They hand the file to one of the signers, who sign it using the new `Sign`command and hands it to the next signer
    3. The 2nd signer also uses the `Sign` command to add their signature
    4. The file is handed back to someone to submit to the network.