### PR TITLE
Update ledger/streaming crates to use Rust edition 2021

### DIFF
--- a/ledger/streaming/api/Cargo.toml
+++ b/ledger/streaming/api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "MIT OR Apache-2.0"
 links = "mc-ledger-streaming-api"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [features]
 test_utils = ["mc-consensus-scp/test_utils"]

--- a/ledger/streaming/client/Cargo.toml
+++ b/ledger/streaming/client/Cargo.toml
@@ -3,7 +3,7 @@ name = "mc-ledger-streaming-client"
 version = "1.3.0-pre0"
 authors = ["MobileCoin"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 test_utils = []

--- a/ledger/streaming/publisher/Cargo.toml
+++ b/ledger/streaming/publisher/Cargo.toml
@@ -3,7 +3,7 @@ name = "mc-ledger-streaming-publisher"
 version = "1.3.0-pre0"
 authors = ["MobileCoin"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 


### PR DESCRIPTION
Complements #1960 for this feature branch.