### PR TITLE
make permission denied log level be info (#1997)

### DIFF
--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -111,7 +111,7 @@ impl From<ConsensusGrpcError> for RpcStatus {
                 "Temporarily not serving requests".into(),
             ),
             ConsensusGrpcError::Enclave(EnclaveError::Attest(err)) => {
-                global_log::error!("Permission denied: {}", err);
+                global_log::info!("Permission denied: {}", err);
                 RpcStatus::with_message(
                     RpcStatusCode::PERMISSION_DENIED,
                     "Permission Denied (attestation)".into(),


### PR DESCRIPTION
Logging at error causes a sentry alert, and so if a client like
fog distro is in a retry loop submitting transactions and getting
this error, it can blow out our sentry quota

---

This cherry-picks #1997 from master, there were no conflicts