### PR TITLE
Cherry-pick updates from master.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "ed25519"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "serde",
  "signature",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -256,12 +256,6 @@ dependencies = [
  "aligned-cmov",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "base-x"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -725,28 +719,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
-name = "cookie"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
-dependencies = [
- "percent-encoding",
- "time 0.2.27",
- "version_check",
-]
-
-[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
+ "aes-gcm",
+ "base64",
+ "hkdf",
+ "hmac 0.12.1",
+ "percent-encoding",
+ "rand 0.8.5",
+ "sha2 0.10.2",
+ "subtle",
  "time 0.3.9",
  "version_check",
 ]
@@ -1147,12 +1132,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
@@ -1585,7 +1564,7 @@ dependencies = [
  "grpcio-sys",
  "libc",
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
 ]
 
@@ -1629,7 +1608,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -2076,10 +2055,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2497,7 +2477,7 @@ name = "mc-connection"
 version = "1.3.0-pre0"
 dependencies = [
  "aes-gcm",
- "cookie 0.16.0",
+ "cookie",
  "displaydoc",
  "grpcio",
  "mc-attest-ake",
@@ -3129,7 +3109,7 @@ name = "mc-fog-enclave-connection"
 version = "1.3.0-pre0"
 dependencies = [
  "aes-gcm",
- "cookie 0.16.0",
+ "cookie",
  "displaydoc",
  "grpcio",
  "mc-attest-ake",
@@ -4986,7 +4966,7 @@ version = "1.3.0-pre0"
 dependencies = [
  "base64",
  "clap 3.1.18",
- "cookie 0.16.0",
+ "cookie",
  "displaydoc",
  "futures",
  "grpcio",
@@ -5421,7 +5401,7 @@ dependencies = [
  "mime",
  "spin 0.9.3",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "version_check",
 ]
 
@@ -5648,7 +5628,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -5663,6 +5653,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5881,12 +5884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5918,7 +5915,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.11.2",
  "protobuf",
  "thiserror",
 ]
@@ -6042,7 +6039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.11.2",
  "scheduled-thread-pool",
 ]
 
@@ -6302,7 +6299,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -6343,9 +6340,9 @@ checksum = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 
 [[package]]
 name = "rocket"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a71c18c42a0eb15bf3816831caf0dad11e7966f2a41aaf486a701979c4dd1f2"
+checksum = "98ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6361,7 +6358,7 @@ dependencies = [
  "memchr",
  "multer",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "rand 0.8.5",
  "ref-cast",
@@ -6371,10 +6368,10 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.2.27",
+ "time 0.3.9",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.2",
  "ubyte",
  "version_check",
  "yansi",
@@ -6382,9 +6379,9 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f5fa462f7eb958bba8710c17c5d774bbbd59809fa76fb1957af7e545aea8bb"
+checksum = "d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47"
 dependencies = [
  "devise",
  "glob 0.3.0",
@@ -6398,19 +6395,18 @@ dependencies = [
 
 [[package]]
 name = "rocket_http"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c8b7d512d2fcac2316ebe590cde67573844b99e6cc9ee0f53375fa16e25ebd"
+checksum = "2ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2"
 dependencies = [
- "cookie 0.15.1",
+ "cookie",
  "either",
+ "futures",
  "http",
  "hyper",
  "indexmap",
  "log",
  "memchr",
- "mime",
- "parking_lot",
  "pear",
  "percent-encoding",
  "pin-project-lite",
@@ -6419,7 +6415,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.2.27",
+ "time 0.3.9",
  "tokio",
  "uncased",
 ]
@@ -6636,7 +6632,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -6921,7 +6917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -6937,21 +6933,6 @@ dependencies = [
  "rustversion",
  "syn",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -7240,15 +7221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "state"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7256,55 +7228,6 @@ checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
 dependencies = [
  "loom",
 ]
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -7485,21 +7408,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -7507,17 +7415,7 @@ dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
- "time-macros 0.2.4",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
+ "time-macros",
 ]
 
 [[package]]
@@ -7525,19 +7423,6 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
 
 [[package]]
 name = "tiny-bip39"
@@ -7644,6 +7529,19 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -8076,6 +7974,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,16 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bigint"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
-dependencies = [
- "byteorder",
- "crunchy",
-]
-
-[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +352,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
+
+[[package]]
 name = "bytecount"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,9 +454,9 @@ checksum = "b92204551573580e078dc80017f36a213eb77a0450e4ddd8cfa0f3f2d1f0178f"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -867,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -1292,6 +1300,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1365,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1803,6 +1829,26 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2691,7 +2737,6 @@ dependencies = [
 name = "mc-consensus-scp"
 version = "1.3.0-pre0"
 dependencies = [
- "bigint",
  "crossbeam-channel",
  "maplit",
  "mc-common",
@@ -2702,6 +2747,7 @@ dependencies = [
  "mc-util-serial",
  "mc-util-test-helper",
  "mockall",
+ "primitive-types",
  "rand 0.8.5",
  "rand_hc 0.3.1",
  "serde",
@@ -5355,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -5370,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
+checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -5613,6 +5659,32 @@ checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5859,6 +5931,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6043,6 +6136,12 @@ dependencies = [
  "parking_lot 0.11.2",
  "scheduled-thread-pool",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -6523,6 +6622,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -7225,6 +7330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7281,6 +7392,12 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -7656,6 +7773,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8020,6 +8149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,7 +2117,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2129,14 +2129,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.3",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bindgen 0.58.1",
  "cc",
@@ -7193,12 +7193,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,9 +6165,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ name = "mc-consensus-mint-client"
 version = "1.3.0-pre0"
 dependencies = [
  "clap 3.1.18",
+ "displaydoc",
  "grpcio",
  "hex",
  "mc-account-keys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,8 +199,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # mbedtls patched to allow certificate verification with a profile
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
 
 # Override lmdb-rkv for a necessary bugfix (see https://github.com/mozilla/lmdb-rs/pull/80)
 lmdb-rkv = { git = "https://github.com/mozilla/lmdb-rs", rev = "df1c2f5" }

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -11,7 +11,7 @@ mc-util-uri = { path = "../util/uri" }
 
 clap = { version = "3.1", features = ["derive", "env"] }
 grpcio = "0.10.2"
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -46,8 +46,8 @@ struct State {
 }
 
 #[get("/")]
-fn index() -> content::Html<String> {
-    content::Html(include_str!("../templates/index.html").to_owned())
+fn index() -> content::RawHtml<String> {
+    content::RawHtml(include_str!("../templates/index.html").to_owned())
 }
 
 #[derive(Serialize)]
@@ -144,9 +144,11 @@ async fn main() -> Result<(), rocket::Error> {
         .merge(("port", config.listen_port))
         .merge(("address", config.listen_host.clone()));
 
-    rocket::custom(figment)
+    let _rocket = rocket::custom(figment)
         .mount("/", routes![index, info, set_rust_log, metrics])
         .manage(State { admin_api_client })
         .launch()
-        .await
+        .await?;
+
+    Ok(())
 }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -615,7 +615,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -627,14 +627,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.3",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bindgen",
  "cc",
@@ -1625,15 +1625,15 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-
-[[package]]
-name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 
 [[package]]
 name = "strsim"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "serde",
  "signature",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -72,8 +72,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # Our patches for newer bindgen, no-std
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
 
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -27,6 +27,7 @@ mc-util-parse = { path = "../../util/parse" }
 mc-util-uri = { path = "../../util/uri" }
 
 clap = { version = "3.1", features = ["derive", "env"] }
+displaydoc = "0.2"
 grpcio = "0.10.2"
 hex = "0.4"
 pem = "1.0"

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -10,8 +10,8 @@ use mc_consensus_api::{
     empty::Empty,
 };
 use mc_consensus_enclave_api::GovernorsSigner;
-use mc_consensus_mint_client::{Commands, Config};
-use mc_crypto_keys::Ed25519Pair;
+use mc_consensus_mint_client::{printers, Commands, Config, TxFile};
+use mc_crypto_keys::{Ed25519Pair, Signer};
 use mc_crypto_multisig::MultiSig;
 use mc_transaction_core::{
     constants::MAX_TOMBSTONE_BLOCKS,
@@ -19,8 +19,7 @@ use mc_transaction_core::{
 };
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use protobuf::ProtobufEnum;
-use serde::de::DeserializeOwned;
-use std::{fs, path::PathBuf, process::exit, sync::Arc};
+use std::{fs, process::exit, sync::Arc};
 
 fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
@@ -42,6 +41,10 @@ fn main() {
                 })
                 .expect("failed creating tx");
 
+            if tx.signature.signatures().is_empty() {
+                panic!("tx contains no signatures");
+            }
+
             let resp = client_api
                 .propose_mint_config_tx(&(&tx).into())
                 .expect("propose tx");
@@ -58,9 +61,9 @@ fn main() {
                 .try_into_mint_config_tx(|| panic!("missing tombstone block"))
                 .expect("failed creating tx");
 
-            let json = serde_json::to_string_pretty(&tx).expect("failed serializing tx");
-
-            fs::write(out, json).expect("failed writing output file");
+            TxFile::from(tx)
+                .write_json(&out)
+                .expect("failed writing output file");
         }
 
         Commands::HashMintConfigTx { params } => {
@@ -78,7 +81,8 @@ fn main() {
 
         Commands::SubmitMintConfigTx { node, tx_filenames } => {
             // Load all txs.
-            let txs: Vec<MintConfigTx> = load_json_files(&tx_filenames);
+            let txs =
+                TxFile::load_multiple::<MintConfigTx>(&tx_filenames).expect("failed loading txs");
 
             // All tx prefixes should be the same.
             if !txs.windows(2).all(|pair| pair[0].prefix == pair[1].prefix) {
@@ -93,6 +97,9 @@ fn main() {
                 .collect::<Vec<_>>();
             signatures.sort();
             signatures.dedup();
+            if signatures.is_empty() {
+                panic!("tx contains no signatures");
+            }
 
             let merged_tx = MintConfigTx {
                 prefix: txs[0].prefix.clone(),
@@ -128,6 +135,11 @@ fn main() {
                     last_block_info.index + MAX_TOMBSTONE_BLOCKS - 1
                 })
                 .expect("failed creating tx");
+
+            if tx.signature.signatures().is_empty() {
+                panic!("tx contains no signatures");
+            }
+
             let resp = client_api
                 .propose_mint_tx(&(&tx).into())
                 .expect("propose tx");
@@ -144,9 +156,9 @@ fn main() {
                 .try_into_mint_tx(|| panic!("missing tombstone block"))
                 .expect("failed creating tx");
 
-            let json = serde_json::to_string_pretty(&tx).expect("failed serializing tx");
-
-            fs::write(out, json).expect("failed writing output file");
+            TxFile::from(tx)
+                .write_json(&out)
+                .expect("failed writing output file");
         }
 
         Commands::HashMintTx { params } => {
@@ -164,7 +176,7 @@ fn main() {
 
         Commands::SubmitMintTx { node, tx_filenames } => {
             // Load all txs.
-            let txs: Vec<MintTx> = load_json_files(&tx_filenames);
+            let txs = TxFile::load_multiple::<MintTx>(&tx_filenames).expect("failed loading txs");
 
             // All tx prefixes should be the same.
             if !txs.windows(2).all(|pair| pair[0].prefix == pair[1].prefix) {
@@ -179,6 +191,9 @@ fn main() {
                 .collect::<Vec<_>>();
             signatures.sort();
             signatures.dedup();
+            if signatures.is_empty() {
+                panic!("tx contains no signatures");
+            }
 
             let merged_tx = MintTx {
                 prefix: txs[0].prefix.clone(),
@@ -228,17 +243,68 @@ fn main() {
                 fs::write(path, json_str).expect("failed writing output file");
             }
         }
-    }
-}
 
-fn load_json_files<T: DeserializeOwned>(filenames: &[PathBuf]) -> Vec<T> {
-    filenames
-        .iter()
-        .map(|filename| {
-            let json = fs::read_to_string(filename)
-                .unwrap_or_else(|err| panic!("Failed reading file {:?}: {}", filename, err));
-            serde_json::from_str(&json)
-                .unwrap_or_else(|err| panic!("Failed parsing tx from file {:?}: {}", filename, err))
-        })
-        .collect()
+        Commands::Dump { tx_file } => match tx_file {
+            TxFile::MintConfigTx(tx) => {
+                printers::print_mint_config_tx(&tx, 0);
+            }
+            TxFile::MintTx(tx) => {
+                printers::print_mint_tx(&tx, 0);
+            }
+        },
+
+        Commands::Sign {
+            tx_file: tx_file_path,
+            signing_keys,
+            mut signatures,
+        } => {
+            let mut tx_file =
+                TxFile::from_json_file(&tx_file_path).expect("failed loading tx file");
+
+            // Append any existing signatures.
+            signatures.extend(match &tx_file {
+                TxFile::MintConfigTx(tx) => tx.signature.signatures().to_vec(),
+                TxFile::MintTx(tx) => tx.signature.signatures().to_vec(),
+            });
+
+            // The message we are signing.
+            let message = match &tx_file {
+                TxFile::MintConfigTx(tx) => tx.prefix.hash(),
+                TxFile::MintTx(tx) => tx.prefix.hash(),
+            };
+
+            // Append signatures using the keys provided.
+            signatures.extend(
+                signing_keys
+                    .into_iter()
+                    .map(|signer| {
+                        Ed25519Pair::from(signer)
+                            .try_sign(message.as_ref())
+                            .map_err(|e| format!("Failed to sign: {}", e))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .expect("failed signing"),
+            );
+
+            // De-dupe.
+            signatures.sort();
+            signatures.dedup();
+
+            // Update the tx file signature.
+            let signature = MultiSig::new(signatures);
+            match &mut tx_file {
+                TxFile::MintConfigTx(ref mut tx) => {
+                    tx.signature = signature;
+                }
+                TxFile::MintTx(ref mut tx) => {
+                    tx.signature = signature;
+                }
+            }
+
+            // Write the file.
+            tx_file
+                .write_json(&tx_file_path)
+                .expect("failed writing tx file");
+        }
+    }
 }

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -359,7 +359,7 @@ pub enum Commands {
             long = "signing-key",
             required_unless_present = "signatures",
             parse(try_from_str = load_key_from_pem),
-            env = "MC_MINTING_SIGNING_KEY"
+            env = "MC_MINTING_SIGNING_KEYS"
         )]
         signing_keys: Vec<Ed25519Private>,
 

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -2,6 +2,7 @@
 
 //! Command line configuration for the consensus mint client.
 
+use crate::TxFile;
 use clap::{Args, Parser, Subcommand};
 use hex::FromHex;
 use mc_account_keys::PublicAddress;
@@ -87,7 +88,6 @@ pub struct MintConfigTxParams {
         long = "signing-key",
         use_value_delimiter = true,
         parse(try_from_str = load_key_from_pem),
-        required_unless_present = "signatures",
         env = "MC_MINTING_SIGNING_KEYS"
     )]
     signing_keys: Vec<Ed25519Private>,
@@ -96,7 +96,8 @@ pub struct MintConfigTxParams {
     #[clap(
         long = "signature",
         use_value_delimiter = true,
-        parse(try_from_str = load_or_parse_ed25519_signature), env = "MC_MINTING_SIGNATURES"
+        parse(try_from_str = load_or_parse_ed25519_signature),
+        env = "MC_MINTING_SIGNATURES"
     )]
     signatures: Vec<Ed25519Signature>,
 
@@ -181,7 +182,6 @@ pub struct MintTxParams {
         long = "signing-key",
         use_value_delimiter = true,
         parse(try_from_str = load_key_from_pem),
-        required_unless_present = "signatures",
         env = "MC_MINTING_SIGNING_KEYS"
     )]
     signing_keys: Vec<Ed25519Private>,
@@ -264,12 +264,12 @@ pub enum Commands {
         node: ConsensusClientUri,
 
         /// Paths for the JSON-formatted mint configuration tx files, each
-        /// containing a serde-serialized MintConfigTx object.
+        /// containing a serde-serialized TxFile holding a MintConfigTx object.
         #[clap(
-            long = "tx",
+            long = "tx-file",
             required = true,
             use_value_delimiter = true,
-            env = "MC_MINTING_CONFIG_TXS"
+            env = "MC_MINTING_CONFIG_TX_FILES"
         )]
         tx_filenames: Vec<PathBuf>,
     },
@@ -310,12 +310,12 @@ pub enum Commands {
         node: ConsensusClientUri,
 
         /// Paths for the JSON-formatted mint tx files, each containing a
-        /// serde-serialized MintTx object.
+        /// serde-serialized TxFile holding a MintTx object.
         #[clap(
-            long = "tx",
+            long = "tx-file",
             required = true,
             use_value_delimiter = true,
-            env = "MC_MINTING_TXS"
+            env = "MC_MINTING_TX_FILES"
         )]
         tx_filenames: Vec<PathBuf>,
     },
@@ -337,6 +337,40 @@ pub enum Commands {
         /// Optionally write a new tokens.json file containing the signature.
         #[clap(long, env = "MC_MINTING_OUTPUT_JSON")]
         output_json: Option<PathBuf>,
+    },
+
+    /// Load a previously-serialized file produced by this tool and print its
+    /// contents in a human-friendly way.
+    Dump {
+        /// The file to load
+        #[clap(long, parse(try_from_str = load_tx_file_from_path), env = "MC_MINTING_TX_FILE")]
+        tx_file: TxFile,
+    },
+
+    /// Sign a transaction file produced by this tool, rewriting the file with
+    /// the appended signature(s).
+    Sign {
+        /// The file to sign
+        #[clap(long, env = "MC_MINTING_TX_FILE")]
+        tx_file: PathBuf,
+
+        /// The key(s) to sign the transaction with.
+        #[clap(
+            long = "signing-key",
+            required_unless_present = "signatures",
+            parse(try_from_str = load_key_from_pem),
+            env = "MC_MINTING_SIGNING_KEY"
+        )]
+        signing_keys: Vec<Ed25519Private>,
+
+        /// Pre-generated signature(s) to use, either in hex format or a PEM
+        /// file.
+        #[clap(
+            long = "signature",
+            use_value_delimiter = true,
+            parse(try_from_str = load_or_parse_ed25519_signature), env = "MC_MINTING_SIGNATURES"
+        )]
+        signatures: Vec<Ed25519Signature>,
     },
 }
 
@@ -471,4 +505,8 @@ fn get_or_generate_nonce(nonce: Option<[u8; NONCE_LENGTH]>) -> Vec<u8> {
         rng.fill_bytes(&mut nonce);
         nonce
     })
+}
+
+fn load_tx_file_from_path(path: &str) -> Result<TxFile, String> {
+    TxFile::from_json_file(path).map_err(|e| format!("failed loading file {:?}: {}", path, e))
 }

--- a/consensus/mint-client/src/lib.rs
+++ b/consensus/mint-client/src/lib.rs
@@ -1,5 +1,9 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 mod config;
+mod tx_file;
+
+pub mod printers;
 
 pub use config::{Commands, Config};
+pub use tx_file::TxFile;

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -1,0 +1,119 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Utility functions for printing objects in a human-friendly way.
+
+use mc_account_keys::PublicAddress;
+use mc_api::printable::PrintableWrapper;
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public, Ed25519Signature};
+use mc_crypto_multisig::{MultiSig, SignerSet};
+use mc_transaction_core::mint::{
+    MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx, MintTxPrefix,
+};
+use pem::Pem;
+
+const INDENT_STR: &str = "    ";
+const PEM_TAG_SIGNATURE: &str = "SIGNATURE";
+const PEM_TAG_PUBLIC_KEY: &str = "PUBLIC KEY";
+
+pub fn print_mint_config_tx(tx: &MintConfigTx, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfigTx:", indent_str);
+    print_mint_config_tx_prefix(&tx.prefix, indent + 1);
+    print_multi_sig(&tx.signature, indent + 1);
+}
+
+pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfigTxPrefix:", indent_str);
+
+    indent_str.push_str(INDENT_STR);
+    println!(
+        "{}Configs ({} config(s)):",
+        indent_str,
+        prefix.configs.len()
+    );
+    for config in &prefix.configs {
+        print_mint_config(config, indent + 2);
+    }
+    println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
+    println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
+    println!(
+        "{}Total mint limit: {}",
+        indent_str, prefix.total_mint_limit
+    );
+}
+
+pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintConfig:", indent_str);
+
+    indent_str.push_str(INDENT_STR);
+    println!("{}Token id: {}", indent_str, mint_config.token_id);
+    println!("{}Mint limit: {}", indent_str, mint_config.mint_limit);
+    print_signer_set(&mint_config.signer_set, indent + 1);
+}
+
+pub fn print_mint_tx(tx: &MintTx, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintTx:", indent_str);
+    print_mint_tx_prefix(&tx.prefix, indent + 1);
+    print_multi_sig(&tx.signature, indent + 1);
+}
+
+pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
+    let recipient = PublicAddress::new(&prefix.spend_public_key, &prefix.view_public_key);
+    let mut wrapper = PrintableWrapper::new();
+    wrapper.set_public_address((&recipient).into());
+    let b58_recipient = wrapper.b58_encode().expect("failed encoding b58 address");
+
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!("{}MintTxPrefix:", indent_str);
+    indent_str.push_str(INDENT_STR);
+    println!("{}Token id: {}", indent_str, prefix.token_id);
+    println!("{}Mint amount: {}", indent_str, prefix.amount);
+    println!("{}View public key: {}", indent_str, prefix.view_public_key,);
+    println!(
+        "{}Spend public key: {}",
+        indent_str, prefix.spend_public_key
+    );
+    println!("{}Recipient B58 address: {}", indent_str, b58_recipient);
+    println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
+    println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
+}
+
+pub fn print_signer_set(signer_set: &SignerSet<Ed25519Public>, indent: usize) {
+    let mut indent_str = INDENT_STR.repeat(indent);
+    println!(
+        "{}Signer set ({} signer(s)):",
+        indent_str,
+        signer_set.signers().len()
+    );
+    indent_str.push_str(INDENT_STR);
+    for signer in signer_set.signers() {
+        print_pem(signer, PEM_TAG_PUBLIC_KEY, indent + 2);
+    }
+    println!("{}Threshold: {}", indent_str, signer_set.threshold());
+}
+
+pub fn print_multi_sig(multi_sig: &MultiSig<Ed25519Signature>, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    println!(
+        "{}Multisig ({} signature(s)):",
+        indent_str,
+        multi_sig.signatures().len()
+    );
+    for sig in multi_sig.signatures() {
+        print_pem(sig, PEM_TAG_SIGNATURE, indent + 2);
+    }
+}
+
+pub fn print_pem(obj: &impl DistinguishedEncoding, tag: &str, indent: usize) {
+    let indent_str = INDENT_STR.repeat(indent);
+    let pem_str = pem::encode(&Pem {
+        tag: tag.into(),
+        contents: obj.to_der(),
+    });
+    for line in pem_str.lines() {
+        println!("{}{}", indent_str, line);
+    }
+}

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -103,7 +103,7 @@ pub fn print_multi_sig(multi_sig: &MultiSig<Ed25519Signature>, indent: usize) {
         multi_sig.signatures().len()
     );
     for sig in multi_sig.signatures() {
-        print_pem(sig, PEM_TAG_SIGNATURE, indent + 2);
+        print_pem(sig, PEM_TAG_SIGNATURE, indent + 1);
     }
 }
 

--- a/consensus/mint-client/src/tx_file.rs
+++ b/consensus/mint-client/src/tx_file.rs
@@ -10,7 +10,7 @@ use mc_transaction_core::mint::{MintConfigTx, MintTx};
 use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
 use std::{
-    compare::TryFrom,
+    convert::TryFrom,
     fs,
     io::Error as IoError,
     path::{Path, PathBuf},

--- a/consensus/mint-client/src/tx_file.rs
+++ b/consensus/mint-client/src/tx_file.rs
@@ -10,6 +10,7 @@ use mc_transaction_core::mint::{MintConfigTx, MintTx};
 use serde::{Deserialize, Serialize};
 use serde_json::Error as JsonError;
 use std::{
+    compare::TryFrom,
     fs,
     io::Error as IoError,
     path::{Path, PathBuf},

--- a/consensus/mint-client/src/tx_file.rs
+++ b/consensus/mint-client/src/tx_file.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A file format for serializing/deserializing objects used by by the mint
+//! client. This is used instead of serializing/deserializing the actual objects
+//! so that if the users confuses one file type with another we are guaranteed
+//! to get a deserialization error.
+
+use displaydoc::Display;
+use mc_transaction_core::mint::{MintConfigTx, MintTx};
+use serde::{Deserialize, Serialize};
+use serde_json::Error as JsonError;
+use std::{
+    fs,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+};
+
+/// An enum for holding all possible objects the mint client needs to store in a
+/// file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum TxFile {
+    MintConfigTx(MintConfigTx),
+    MintTx(MintTx),
+}
+
+impl From<MintConfigTx> for TxFile {
+    fn from(tx: MintConfigTx) -> Self {
+        Self::MintConfigTx(tx)
+    }
+}
+
+impl TryFrom<TxFile> for MintConfigTx {
+    type Error = TxFileError;
+
+    fn try_from(tx_file: TxFile) -> Result<Self, Self::Error> {
+        match tx_file {
+            TxFile::MintConfigTx(tx) => Ok(tx),
+            TxFile::MintTx(_) => Err(TxFileError::WrongFileContents("MintConfigTx", "MintTx")),
+        }
+    }
+}
+
+impl From<MintTx> for TxFile {
+    fn from(tx: MintTx) -> Self {
+        Self::MintTx(tx)
+    }
+}
+
+impl TryFrom<TxFile> for MintTx {
+    type Error = TxFileError;
+
+    fn try_from(tx_file: TxFile) -> Result<MintTx, Self::Error> {
+        match tx_file {
+            TxFile::MintTx(tx) => Ok(tx),
+            TxFile::MintConfigTx(_) => {
+                Err(TxFileError::WrongFileContents("MintTx", "MintConfigTx"))
+            }
+        }
+    }
+}
+
+impl TxFile {
+    /// Write the contents of this object to the given file.
+    pub fn write_json(&self, path: &impl AsRef<Path>) -> Result<(), TxFileError> {
+        let json = serde_json::to_string_pretty(&self)?;
+        fs::write(path, json)?;
+        Ok(())
+    }
+
+    /// Load a [TxFile] from a JSON file.
+    pub fn from_json_file<P: AsRef<Path>>(path: P) -> Result<Self, TxFileError> {
+        let json = fs::read_to_string(path)?;
+        let tx = serde_json::from_str(&json)?;
+        Ok(tx)
+    }
+
+    /// Attempt to load multiple files where all files contain a specific object
+    /// type.
+    pub fn load_multiple<T>(filenames: &[PathBuf]) -> Result<Vec<T>, TxFileError>
+    where
+        T: TryFrom<TxFile, Error = TxFileError>,
+    {
+        filenames
+            .iter()
+            .map(|filename| T::try_from(TxFile::from_json_file(filename)?))
+            .collect::<Result<Vec<T>, TxFileError>>()
+    }
+}
+
+/// Error type for TxFile operations.
+#[derive(Debug, Display)]
+pub enum TxFileError {
+    /// IO error: {0}
+    Io(IoError),
+
+    /// JSON error: {0}
+    Json(JsonError),
+
+    /// Wrong file contents: Expected {0} but found {1}
+    WrongFileContents(&'static str, &'static str),
+}
+
+impl From<IoError> for TxFileError {
+    fn from(err: IoError) -> Self {
+        Self::Io(err)
+    }
+}
+
+impl From<JsonError> for TxFileError {
+    fn from(err: JsonError) -> Self {
+        Self::Json(err)
+    }
+}

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mc-consensus-scp"
 version = "1.3.0-pre0"
 authors = ["MobileCoin"]
-edition = "2018"
+edition = "2021"
 description = "Stellar Consensus Protocol"
 keywords = ["SCP", "Stellar Consensus Protocol", "Consensus", "Stellar", "Byzantine"]
 readme = "README.md"
@@ -17,9 +17,9 @@ mc-crypto-keys = { path = "../../crypto/keys" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 
-bigint = "4.4"
 maplit = "1.0.2"
-mockall = "0.11.0"
+mockall = "0.11.1"
+primitive-types = "0.11.1"
 rand = "0.8"
 rand_hc = "0.3"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -22,9 +22,11 @@ use mc_common::{
 };
 #[cfg(test)]
 use mockall::*;
+use primitive_types::{U256, U512};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
+    convert::TryFrom,
     fmt::Display,
     sync::Arc,
     time::{Duration, Instant},
@@ -494,10 +496,11 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
             // weight256 is the node's weight, scaled to 0..<max uint256>
             // (weight256 = <max uint256> * <num> / <denom>)
             let (num, denom) = self.weight(node_id);
-            let mut tmp = bigint::U512::from(bigint::U256::max_value());
-            tmp = tmp.saturating_mul(bigint::U512::from(num));
-            tmp = tmp.overflowing_div(bigint::U512::from(denom)).0;
-            let weight256 = bigint::U256::from(tmp);
+            let mut tmp = U512::from(U256::max_value());
+            tmp = tmp.saturating_mul(U512::from(num));
+            tmp /= U512::from(denom);
+            let weight256 = U256::try_from(tmp)
+                .expect("failure calculating weight (max_u256 * k -> 2^512) / n");
 
             let gi_one = utils::slot_round_salted_keccak(
                 slot_index,
@@ -518,7 +521,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
     fn find_max_priority_peer(&self, round: u32) -> NodeID {
         let neighbors = self.neighbors(self.slot_index, round);
         let mut result = self.node_id.clone();
-        let mut max_priority = bigint::U256::zero();
+        let mut max_priority = U256::zero();
 
         for node_id in neighbors.iter() {
             // NOTE: this deviates from the spec. Without doing this we may have nomination

--- a/consensus/scp/src/utils.rs
+++ b/consensus/scp/src/utils.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use crate::core_types::SlotIndex;
-use bigint::U256;
 use mc_common::fast_hash;
+use primitive_types::U256;
 
 /// A "salted" Keccak hash function, parametrized by slot, round, and an extra
 /// value.

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -635,7 +635,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -647,14 +647,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.3",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bindgen",
  "cc",
@@ -1730,15 +1730,15 @@ checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-
-[[package]]
-name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 
 [[package]]
 name = "strsim"

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -77,8 +77,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # Our patches for newer bindgen, no-std
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
 
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -639,7 +639,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -651,14 +651,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.3",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bindgen",
  "cc",
@@ -1714,15 +1714,15 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-
-[[package]]
-name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 
 [[package]]
 name = "strsim"

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -78,8 +78,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # Our patches for newer bindgen, no-std
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
 
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -17,7 +17,7 @@ grpcio = "0.10.2"
 lazy_static = "1.4"
 prometheus = "0.13.0"
 retry = "1.3"
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = "1"
 
 # mc

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -42,5 +42,6 @@ async fn main() -> Result<(), rocket::Error> {
         .merge(("address", config.overseer_listen_host.clone()));
 
     let rocket = server::initialize_rocket_server(rocket_config, overseer_state);
-    rocket.launch().await
+    let _rocket = rocket.launch().await?;
+    Ok(())
 }

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
  "serde",
  "signature",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -645,7 +645,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 [[package]]
 name = "mbedtls"
 version = "0.8.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -657,14 +657,14 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
- "spin 0.4.10",
+ "spin 0.9.3",
  "yasna",
 ]
 
 [[package]]
 name = "mbedtls-sys-auto"
 version = "2.26.1"
-source = "git+https://github.com/mobilecoinofficial/rust-mbedtls.git?rev=49a293a5f4b1ef571c71174e3fa1f301925f3915#49a293a5f4b1ef571c71174e3fa1f301925f3915"
+source = "git+https://github.com/mobilecoinfoundation/rust-mbedtls.git?rev=ac6ee17a31e37311ce7f4fa0649c340e5d85258d#ac6ee17a31e37311ce7f4fa0649c340e5d85258d"
 dependencies = [
  "bindgen",
  "cc",
@@ -1749,15 +1749,15 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-
-[[package]]
-name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
 
 [[package]]
 name = "strsim"

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -83,8 +83,8 @@ curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-d
 ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
 
 # Our patches for newer bindgen, no-std
-mbedtls = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
-mbedtls-sys-auto = { git = "https://github.com/mobilecoinofficial/rust-mbedtls.git", rev = "49a293a5f4b1ef571c71174e3fa1f301925f3915" }
+mbedtls = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
+mbedtls-sys-auto = { git = "https://github.com/mobilecoinfoundation/rust-mbedtls.git", rev = "ac6ee17a31e37311ce7f4fa0649c340e5d85258d" }
 
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "3.1", features = ["derive", "env"] }
 grpcio = "0.10.2"
 hex = "0.4"
 protobuf = "2.27.1"
-rocket = { version = "0.5.0-rc.1", features = ["json"] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -824,7 +824,7 @@ async fn main() -> Result<(), rocket::Error> {
         .merge(("port", config.listen_port))
         .merge(("address", config.listen_host.clone()));
 
-    rocket::custom(figment)
+    let _rocket = rocket::custom(figment)
         .mount(
             "/",
             routes![
@@ -864,5 +864,6 @@ async fn main() -> Result<(), rocket::Error> {
             mobilecoind_api_client,
         })
         .launch()
-        .await
+        .await?;
+    Ok(())
 }


### PR DESCRIPTION
- Bump ed25519
- Bump rayon 
- Bump rocket
- Bump mbedtls
- mint-client improvements
- Remove bigint in favor of primitive-types