### PR TITLE
Rename ReservedDestination to ReservedSubaddresses

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -53,7 +53,7 @@ use mc_transaction_core::{
 
 use mc_transaction_std::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedDestination,
+    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedSubaddresses,
     SenderMemoCredential, TransactionBuilder,
 };
 
@@ -1747,7 +1747,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
                 env.get_rust_field(source_account_key, RUST_OBJ_FIELD)?;
 
             let value = jni_big_int_to_u64(env, value)?;
-            let change_destination = ReservedDestination::from(&*source_account_key);
+            let change_destination = ReservedSubaddresses::from(&*source_account_key);
             let mut rng = McRng::default();
 
             // TODO (GH #1867): If you want to do mixed transactions, use something other

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -34,7 +34,7 @@ mod tests {
         constants::MILLIMOB_TO_PICOMOB, tokens::Mob, tx::Tx, Amount, BlockVersion, Token, TokenId,
     };
     use mc_transaction_std::{
-        test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
+        test_utils::get_input_credentials, EmptyMemoBuilder, ReservedSubaddresses,
         SignedContingentInputBuilder, TransactionBuilder,
     };
     use protobuf::Message;
@@ -187,7 +187,7 @@ mod tests {
             transaction_builder
                 .add_change_output(
                     Amount::new(475 * MILLIMOB_TO_PICOMOB - Mob::MINIMUM_FEE, Mob::ID),
-                    &ReservedDestination::from(&alice),
+                    &ReservedSubaddresses::from(&alice),
                     &mut rng,
                 )
                 .unwrap();

--- a/api/tests/prost.rs
+++ b/api/tests/prost.rs
@@ -7,7 +7,7 @@ use mc_api::external;
 use mc_fog_report_validation_test_utils::{FullyValidatedFogPubkey, MockFogResolver};
 use mc_transaction_core::{Amount, BlockVersion, SignedContingentInput};
 use mc_transaction_std::{
-    test_utils::get_input_credentials, EmptyMemoBuilder, ReservedDestination,
+    test_utils::get_input_credentials, EmptyMemoBuilder, ReservedSubaddresses,
     SignedContingentInputBuilder,
 };
 use mc_util_from_random::FromRandom;
@@ -53,7 +53,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
     let sender = AccountKey::random(rng);
     let recipient = AccountKey::random(rng).default_subaddress();
     let recipient2 = AccountKey::random_with_fog(rng).default_subaddress();
-    let sender_change_dest = ReservedDestination::from(&sender);
+    let sender_change_dest = ReservedSubaddresses::from(&sender);
 
     let fpr = MockFogResolver(btreemap! {
                         recipient2

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -32,7 +32,7 @@ use mc_transaction_core::{
     Amount, BlockIndex, BlockVersion, SignedContingentInput, TokenId,
 };
 use mc_transaction_std::{
-    EmptyMemoBuilder, InputCredentials, MemoType, RTHMemoBuilder, ReservedDestination,
+    EmptyMemoBuilder, InputCredentials, MemoType, RTHMemoBuilder, ReservedSubaddresses,
     SenderMemoCredential, SignedContingentInputBuilder, TransactionBuilder,
 };
 use mc_util_telemetry::{block_span_builder, telemetry_static_key, tracer, Key, Span};
@@ -435,7 +435,7 @@ impl Client {
             .add_required_output(requested, &self.account_key.default_subaddress(), rng)
             .map_err(Error::AddOutput)?;
 
-        let change_destination = ReservedDestination::from(&self.account_key);
+        let change_destination = ReservedSubaddresses::from(&self.account_key);
 
         sci_builder
             .add_required_change_output(change, &change_destination, rng)
@@ -589,7 +589,7 @@ impl Client {
 
         let block_version = BlockVersion::try_from(self.tx_data.get_latest_block_version())?;
 
-        let change_destination = ReservedDestination::from(&self.account_key);
+        let change_destination = ReservedSubaddresses::from(&self.account_key);
 
         // Make transaction builder
         // TODO: Use RTH memos
@@ -913,7 +913,7 @@ fn build_transaction_helper<T: RngCore + CryptoRng, FPR: FogPubkeyResolver>(
         .map_err(Error::AddOutput)?;
 
     // Add change output
-    let change_destination = ReservedDestination::from(source_account_key);
+    let change_destination = ReservedSubaddresses::from(source_account_key);
     tx_builder
         .add_change_output(
             Amount::new(change, amount.token_id),

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -24,7 +24,7 @@ use mc_transaction_core::{
 
 use mc_transaction_std::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedDestination,
+    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedSubaddresses,
     SenderMemoCredential, TransactionBuilder,
 };
 
@@ -539,7 +539,7 @@ pub extern "C" fn mc_transaction_builder_add_change_output(
             .into_mut()
             .as_mut()
             .expect("McTransactionBuilder instance has already been used to build a Tx");
-        let change_destination = ReservedDestination::from(&account_key_obj);
+        let change_destination = ReservedSubaddresses::from(&account_key_obj);
         let mut rng = SdkRng::from_ffi(rng_callback);
         let out_tx_out_confirmation_number = out_tx_out_confirmation_number
             .into_mut()

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -24,7 +24,7 @@ use mc_transaction_core::{
     Amount, BlockIndex, BlockVersion, TokenId,
 };
 use mc_transaction_std::{
-    EmptyMemoBuilder, InputCredentials, MemoBuilder, ReservedDestination, TransactionBuilder,
+    EmptyMemoBuilder, InputCredentials, MemoBuilder, ReservedSubaddresses, TransactionBuilder,
 };
 use mc_util_uri::FogUri;
 use rand::Rng;
@@ -1006,7 +1006,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 token_id,
             };
 
-            let change_dest = ReservedDestination::from_subaddress_index(
+            let change_dest = ReservedSubaddresses::from_subaddress_index(
                 from_account_key,
                 Some(change_subaddress),
                 None,

--- a/transaction/std/src/lib.rs
+++ b/transaction/std/src/lib.rs
@@ -12,7 +12,7 @@ mod input_credentials;
 mod input_materials;
 mod memo;
 mod memo_builder;
-mod reserved_destination;
+mod reserved_subaddresses;
 mod signed_contingent_input_builder;
 mod transaction_builder;
 
@@ -31,7 +31,7 @@ pub use memo_builder::{
     BurnRedemptionMemoBuilder, EmptyMemoBuilder, GiftCodeCancellationMemoBuilder,
     GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder, MemoBuilder, RTHMemoBuilder,
 };
-pub use reserved_destination::ReservedDestination;
+pub use reserved_subaddresses::ReservedSubaddresses;
 pub use signed_contingent_input_builder::SignedContingentInputBuilder;
 pub use transaction_builder::{DefaultTxOutputsOrdering, TransactionBuilder, TxOutputsOrdering};
 

--- a/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
+++ b/transaction/std/src/memo_builder/burn_redemption_memo_builder.rs
@@ -8,7 +8,7 @@ use super::{
     memo::{BurnRedemptionMemo, DestinationMemo, DestinationMemoError, UnusedMemo},
     MemoBuilder,
 };
-use crate::ReservedDestination;
+use crate::ReservedSubaddresses;
 use mc_account_keys::{burn_address, PublicAddress, ShortAddressHash};
 use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
@@ -107,7 +107,7 @@ impl MemoBuilder for BurnRedemptionMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         change_amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if !self.destination_memo_enabled {

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -3,7 +3,7 @@
 //! Defines the Memo Builder for the gift code cancellation memo (0x0202)
 //! specified in MCIP #32
 
-use super::{memo::GiftCodeCancellationMemo, MemoBuilder, ReservedDestination};
+use super::{memo::GiftCodeCancellationMemo, MemoBuilder, ReservedSubaddresses};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -58,7 +58,7 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if self.wrote_change_memo {

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     memo::{GiftCodeFundingMemo, UnusedMemo},
-    MemoBuilder, ReservedDestination,
+    MemoBuilder, ReservedSubaddresses,
 };
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::RistrettoPublic;
@@ -86,7 +86,7 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if self.wrote_change_memo {
@@ -118,7 +118,7 @@ mod tests {
         // Create simulated context
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
         let alice = AccountKey::random_with_fog(&mut rng);
-        let alice_address_book = ReservedDestination::from(&alice);
+        let alice_address_book = ReservedSubaddresses::from(&alice);
         let change_tx_pubkey = RistrettoPublic::from_random(&mut rng);
         let change_amount = Amount::new(1, 0.into());
         let funding_amount = Amount::new(10, 0.into());
@@ -221,7 +221,7 @@ mod tests {
 
         // Build a memo
         let alice = AccountKey::random_with_fog(&mut rng);
-        let alice_address_book = ReservedDestination::from(&alice);
+        let alice_address_book = ReservedSubaddresses::from(&alice);
         let change_amount = Amount::new(666, 666.into());
 
         // Erroneously set funding TxOut pubkey to the change TxOut pubkey
@@ -256,7 +256,7 @@ mod tests {
 
         // Build a memo
         let alice = AccountKey::random_with_fog(&mut rng);
-        let alice_address_book = ReservedDestination::from(&alice);
+        let alice_address_book = ReservedSubaddresses::from(&alice);
         let change_amount = Amount::new(666, 666.into());
 
         // Write 2 change outputs

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -3,7 +3,7 @@
 //! Defines the Memo Builder for the gift code sender memo (0x0002)
 //! specified in MCIP #32
 
-use crate::{memo::GiftCodeSenderMemo, MemoBuilder, ReservedDestination};
+use crate::{memo::GiftCodeSenderMemo, MemoBuilder, ReservedSubaddresses};
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 
@@ -68,7 +68,7 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         _amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if self.wrote_change_memo {

--- a/transaction/std/src/memo_builder/mod.rs
+++ b/transaction/std/src/memo_builder/mod.rs
@@ -4,7 +4,7 @@
 //! The memo builder for recoverable transaction history is defined in a
 //! submodule.
 
-use super::{memo, ReservedDestination};
+use super::{memo, ReservedSubaddresses};
 use core::fmt::Debug;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
@@ -53,7 +53,7 @@ pub trait MemoBuilder: Debug {
     fn make_memo_for_change_output(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &ReservedSubaddresses,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError>;
 }
@@ -80,7 +80,7 @@ impl MemoBuilder for EmptyMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         _value: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         Ok(memo::UnusedMemo {}.into())

--- a/transaction/std/src/memo_builder/rth_memo_builder.rs
+++ b/transaction/std/src/memo_builder/rth_memo_builder.rs
@@ -12,7 +12,7 @@ use super::{
     },
     MemoBuilder,
 };
-use crate::ReservedDestination;
+use crate::ReservedSubaddresses;
 use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_transaction_core::{
     tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token, TokenId,
@@ -200,7 +200,7 @@ impl MemoBuilder for RTHMemoBuilder {
     fn make_memo_for_change_output(
         &mut self,
         amount: Amount,
-        _change_destination: &ReservedDestination,
+        _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if !self.destination_memo_enabled {

--- a/transaction/std/src/reserved_subaddresses.rs
+++ b/transaction/std/src/reserved_subaddresses.rs
@@ -15,7 +15,7 @@ use mc_account_keys::{AccountKey, PublicAddress};
 /// This object can be created from an AccountKey, but it can also be created
 /// offline and then serialized and sent to a different machine.
 #[derive(Clone, Debug)]
-pub struct ReservedDestination {
+pub struct ReservedSubaddresses {
     /// This is normally the default subaddress of an account. It is used to
     /// create the fog hint for the change output.
     pub primary_address: PublicAddress,
@@ -34,7 +34,7 @@ pub struct ReservedDestination {
     pub gift_code_subaddress: PublicAddress,
 }
 
-impl From<&AccountKey> for ReservedDestination {
+impl From<&AccountKey> for ReservedSubaddresses {
     fn from(src: &AccountKey) -> Self {
         Self {
             primary_address: src.default_subaddress(),
@@ -44,7 +44,7 @@ impl From<&AccountKey> for ReservedDestination {
     }
 }
 
-impl ReservedDestination {
+impl ReservedSubaddresses {
     /// Set alternate subaddresseses for reserved addresses. This is useful in
     /// some things like mobilecoind
     pub fn from_subaddress_index(

--- a/transaction/std/src/signed_contingent_input_builder.rs
+++ b/transaction/std/src/signed_contingent_input_builder.rs
@@ -4,7 +4,7 @@
 //! This plays a similar role to the transaction builder.
 
 use crate::{
-    InputCredentials, MemoBuilder, ReservedDestination, SignedContingentInputBuilderError,
+    InputCredentials, MemoBuilder, ReservedSubaddresses, SignedContingentInputBuilderError,
     TxBuilderError,
 };
 use core::cmp::min;
@@ -192,7 +192,7 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
     pub fn add_required_change_output<RNG: CryptoRng + RngCore>(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &ReservedSubaddresses,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         // Taking self.memo_builder here means that we can call functions on &mut self,
@@ -729,7 +729,7 @@ pub mod tests {
             sci.tx_in.proofs = proofs;
             builder.add_presigned_input(sci).unwrap();
 
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = ReservedSubaddresses::from(&bob);
 
             // Bob keeps the change from token id 2
             builder
@@ -977,7 +977,7 @@ pub mod tests {
             sci.tx_in.proofs = proofs;
             builder.add_presigned_input(sci).unwrap();
 
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = ReservedSubaddresses::from(&bob);
 
             // Bob keeps the change from token id 2
             builder
@@ -1194,7 +1194,7 @@ pub mod tests {
             .unwrap();
 
             // Bob keeps the change from token id 2
-            let bob_change_dest = ReservedDestination::from(&bob);
+            let bob_change_dest = ReservedSubaddresses::from(&bob);
             builder
                 .add_required_change_output(
                     Amount::new(200_000, token2),
@@ -1242,7 +1242,7 @@ pub mod tests {
             ));
 
             // Charlie keeps 333 as change, leaving 666 for Bob
-            let charlie_change_dest = ReservedDestination::from(&charlie);
+            let charlie_change_dest = ReservedSubaddresses::from(&charlie);
             builder
                 .add_change_output(Amount::new(333, token3), &charlie_change_dest, &mut rng)
                 .unwrap();

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -3,7 +3,7 @@
 //! Utilities that help with testing the transaction builder and related objects
 
 use crate::{
-    EmptyMemoBuilder, InputCredentials, MemoBuilder, MemoPayload, ReservedDestination,
+    EmptyMemoBuilder, InputCredentials, MemoBuilder, MemoPayload, ReservedSubaddresses,
     TransactionBuilder, TxBuilderError,
 };
 use core::convert::TryFrom;
@@ -221,7 +221,7 @@ pub fn build_change_memo_with_amount(
     // Create simulated context
     let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
     let alice = AccountKey::random_with_fog(&mut rng);
-    let alice_address_book = ReservedDestination::from(&alice);
+    let alice_address_book = ReservedSubaddresses::from(&alice);
     let change_tx_pubkey = RistrettoPublic::from_random(&mut rng);
     let memo_context = MemoContext {
         tx_public_key: &change_tx_pubkey,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -5,7 +5,7 @@
 //! See https://cryptonote.org/img/cryptonote_transaction.png
 
 use crate::{
-    input_materials::InputMaterials, InputCredentials, MemoBuilder, ReservedDestination,
+    input_materials::InputMaterials, InputCredentials, MemoBuilder, ReservedSubaddresses,
     TxBuilderError,
 };
 use core::{cmp::min, fmt::Debug};
@@ -290,7 +290,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
     pub fn add_change_output<RNG: CryptoRng + RngCore>(
         &mut self,
         amount: Amount,
-        change_destination: &ReservedDestination,
+        change_destination: &ReservedSubaddresses,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         // Taking self.memo_builder here means that we can call functions on &mut self,
@@ -1000,7 +1000,7 @@ pub mod transaction_builder_tests {
 
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let sender = AccountKey::random_with_fog(&mut rng);
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = ReservedSubaddresses::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -1176,7 +1176,7 @@ pub mod transaction_builder_tests {
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let sender = AccountKey::random_with_fog(&mut rng);
             let sender_addr = sender.default_subaddress();
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = ReservedSubaddresses::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -1984,7 +1984,7 @@ pub mod transaction_builder_tests {
 
         for (block_version, token_id) in get_block_version_token_id_pairs() {
             let alice = AccountKey::random_with_fog(&mut rng);
-            let alice_change_dest = ReservedDestination::from(&alice);
+            let alice_change_dest = ReservedSubaddresses::from(&alice);
             let bob = AccountKey::random_with_fog(&mut rng);
             let bob_address = bob.default_subaddress();
             let charlie = AccountKey::random_with_fog(&mut rng);
@@ -2179,7 +2179,7 @@ pub mod transaction_builder_tests {
             }
 
             let sender = AccountKey::random_with_fog(&mut rng);
-            let sender_change_dest = ReservedDestination::from(&sender);
+            let sender_change_dest = ReservedSubaddresses::from(&sender);
             let recipient = AccountKey::random_with_fog(&mut rng);
             let recipient_address = recipient.default_subaddress();
             let ingest_private_key = RistrettoPrivate::from_random(&mut rng);
@@ -2475,7 +2475,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = ReservedSubaddresses::from(&sender);
         let recipient = burn_address();
 
         let value = 1475 * MILLIMOB_TO_PICOMOB;
@@ -2574,7 +2574,7 @@ pub mod transaction_builder_tests {
         let token_id = TokenId::from(5);
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let change_destination = ReservedDestination::from(&sender);
+        let change_destination = ReservedSubaddresses::from(&sender);
 
         // Adding an output that is not to the burn address is not allowed.
         {
@@ -2911,7 +2911,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = ReservedSubaddresses::from(&sender);
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 
@@ -3041,7 +3041,7 @@ pub mod transaction_builder_tests {
 
         let fog_resolver = MockFogResolver::default();
         let sender = AccountKey::random(&mut rng);
-        let sender_change_dest = ReservedDestination::from(&sender);
+        let sender_change_dest = ReservedSubaddresses::from(&sender);
         let recipient = AccountKey::random(&mut rng);
         let recipient_addr = recipient.default_subaddress();
 
@@ -3120,8 +3120,8 @@ pub mod transaction_builder_tests {
         let sender = AccountKey::random(&mut rng);
         let receiver = AccountKey::random(&mut rng);
         let (funding_input_amt, funding_output_amt, fee) = (1000, 10, 1);
-        let sender_reserved_destinations = ReservedDestination::from(&sender);
-        let receiver_reserved_destinations = ReservedDestination::from(&receiver);
+        let sender_reserved_destinations = ReservedSubaddresses::from(&sender);
+        let receiver_reserved_destinations = ReservedSubaddresses::from(&receiver);
         let note = "It's funding time";
 
         // Test gift code funding and sending
@@ -3443,7 +3443,7 @@ pub mod transaction_builder_tests {
         // Test funding multiple gift at once codes fails
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let sender = AccountKey::random(&mut rng);
-        let sender_reserved_destinations = ReservedDestination::from(&sender);
+        let sender_reserved_destinations = ReservedSubaddresses::from(&sender);
         let token_id = TokenId::from(5);
         let note = "I'm a note";
 


### PR DESCRIPTION
*ReservedDestination renamed to ReservedSubaddresses

### Motivation

ReservedDestination is a struct that resolves reserved subaddresses for a given set of account keys. Its naming has led to some confusion. This rename clarifies the purpose of the struct by.