### PR TITLE
mobilecoind: only attempt to migrate the ledger if it exists

### DIFF
--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -171,8 +171,8 @@ fn create_or_open_ledger_db(
 ) -> LedgerDB {
     let ledger_db_file = Path::new(&config.ledger_db).join("data.mdb");
 
-    // Attempt to run migrations, if requested.
-    if config.ledger_db_migrate {
+    // Attempt to run migrations, if requested and ledger is available.
+    if config.ledger_db_migrate && ledger_db_file.exists() {
         mc_ledger_migration::migrate(&config.ledger_db, logger);
     }
 

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -95,7 +95,8 @@ pub struct Config {
     #[clap(long, parse(try_from_str = load_css_file), env = "MC_FOG_INGEST_ENCLAVE_CSS")]
     pub fog_ingest_enclave_css: Option<Signature>,
 
-    /// Automatically migrate the ledger db into the most recent version.
+    /// Automatically migrate the ledger db (if it exists) into the most recent
+    /// version.
     #[clap(long, env = "MC_LEDGER_DB_MIGRATE")]
     pub ledger_db_migrate: bool,
 


### PR DESCRIPTION
### Motivation

This simplifies the ops aspect of running `mobilecoind`: with this change there doesn't need to be logic on whether to run mobilecoind with the migration flag when the ledger already exists or without it when `mobilecoind` is started for the first time and is bootstrapping the ledger.