### PR TITLE
Make mobilecoind python able to load both root entropy and mnemonic accounts

### DIFF
--- a/mobilecoind/strategies/accounts.py
+++ b/mobilecoind/strategies/accounts.py
@@ -41,9 +41,17 @@ def connect(host, port):
 
 def register_account(key_data, stub) -> AccountData:
     # Generate an account key from this root entropy
-    resp = stub.GetAccountKeyFromMnemonic(
-        mobilecoind_api_pb2.GetAccountKeyFromMnemonicRequest(
-            mnemonic=key_data['mnemonic']))
+    if 'mnemonic' in key_data:
+        resp = stub.GetAccountKeyFromMnemonic(
+            mobilecoind_api_pb2.GetAccountKeyFromMnemonicRequest(
+                mnemonic=key_data['mnemonic']))
+    elif 'root_entropy' in key_data:
+        resp = stub.GetAccountKeyFromRootEntropy(
+            mobilecoind_api_pb2.GetAccountKeyFromRootEntropyRequest(
+                root_entropy=bytes(key_data['root_entropy'])))
+    else:
+        raise Exception('unknown key format')
+
     account_key = resp.account_key
 
     # Add this account to the wallet


### PR DESCRIPTION
```
    We decided that we probably don't have to make it load the old non-b58
    pub address file format, because we don't need it to be able to send to
    old accounts, only send from old accounts to new accounts. So we didn't
    change that.
```