### PR TITLE
make test-client and fog-distro able to read keyfiles in both formats

### DIFF
--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -122,12 +122,12 @@ fn main() {
     let config = Config::parse();
 
     // Read account keys from disk
-    let src_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_mnemonics(
+    let src_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_keyfiles(
         config.sample_data_dir.join(Path::new("keys")),
     )
     .expect("Could not read default mnemonics from keys");
 
-    let dest_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_mnemonics(
+    let dest_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_keyfiles(
         config
             .sample_data_dir
             .join(Path::new(&config.fog_keys_subdir)),

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -140,7 +140,7 @@ impl TestClientConfig {
 
         // Load the key files
         log::info!(logger, "Loading account keys from {:?}", key_dir);
-        mc_util_keyfile::keygen::read_default_mnemonics(&key_dir)
+        mc_util_keyfile::keygen::read_default_keyfiles(&key_dir)
             .unwrap()
             .into_iter()
             .take(self.num_clients)

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -112,8 +112,8 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PublicAddres
     Ok(result)
 }
 
-/// Read default keyfiles
-pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Error> {
+/// Get default keyfile paths
+pub fn get_default_keyfile_paths<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Error> {
     let mut entries = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
@@ -127,7 +127,7 @@ pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Er
 
 /// Read default mnemonic keyfiles
 pub fn read_default_mnemonics<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>, Error> {
-    read_default_keyfiles(path)?
+    get_default_keyfile_paths(path)?
         .into_iter()
         .map(read_keyfile)
         .collect()
@@ -136,9 +136,17 @@ pub fn read_default_mnemonics<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>
 /// Read default root entropies
 #[deprecated]
 pub fn read_default_root_entropies<P: AsRef<Path>>(path: P) -> Result<Vec<RootIdentity>, Error> {
-    read_default_keyfiles(path)?
+    get_default_keyfile_paths(path)?
         .into_iter()
         .map(read_root_entropy_keyfile)
+        .collect()
+}
+
+/// Read default key files in either format
+pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>, Error> {
+    get_default_keyfile_paths(path)?
+        .into_iter()
+        .map(read_keyfile)
         .collect()
 }
 
@@ -273,12 +281,8 @@ mod test {
         write_default_keyfiles(&dir1, 10, None, "", None, DEFAULT_SEED)
             .expect("Could not write example keyfiles");
 
-        let mut actual = read_default_keyfiles(&dir1)
-            .expect("Could not read default keyfiles dir")
-            .into_iter()
-            .map(read_keyfile)
-            .collect::<Result<Vec<_>, Error>>()
-            .expect("Could not read keyfiles just written");
+        let mut actual =
+            read_default_keyfiles(&dir1).expect("Could not read keyfiles just written");
         actual.sort();
 
         assert_eq!(expected, actual);

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -74,7 +74,7 @@ pub fn read_keyfile_data<R: Read>(buffer: R) -> Result<AccountKey, Error> {
     let value = serde_json::from_reader::<R, serde_json::Value>(buffer)?;
     let obj = value
         .as_object()
-        .ok_or(Error::Json("Expected json object".to_string()))?;
+        .ok_or_else(|| Error::Json("Expected json object".to_string()))?;
     if obj.contains_key("root_entropy") {
         let root_identity_json: RootIdentityJson = serde_json::from_value(value)?;
         let root_id = RootIdentity::from(root_identity_json);


### PR DESCRIPTION
this was requested by ops to ease release testing