### PR TITLE
make test-client and fog-distro able to read keyfiles in both formats (#2019)

### DIFF
--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -123,12 +123,12 @@ fn main() {
     let config = Config::parse();
 
     // Read account keys from disk
-    let src_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_mnemonics(
+    let src_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_keyfiles(
         config.sample_data_dir.join(Path::new("keys")),
     )
     .expect("Could not read default mnemonics from keys");
 
-    let dest_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_mnemonics(
+    let dest_accounts: Vec<AccountKey> = mc_util_keyfile::keygen::read_default_keyfiles(
         config
             .sample_data_dir
             .join(Path::new(&config.fog_keys_subdir)),

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -145,7 +145,7 @@ impl TestClientConfig {
 
         // Load the key files
         log::info!(logger, "Loading account keys from {:?}", key_dir);
-        mc_util_keyfile::keygen::read_default_mnemonics(&key_dir)
+        mc_util_keyfile::keygen::read_default_keyfiles(&key_dir)
             .unwrap()
             .into_iter()
             .take(self.num_clients)

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -112,8 +112,8 @@ pub fn read_default_pubfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PublicAddres
     Ok(result)
 }
 
-/// Read default keyfiles
-pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Error> {
+/// Get default keyfile paths
+pub fn get_default_keyfile_paths<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Error> {
     let mut entries = Vec::new();
     for entry in fs::read_dir(path)? {
         let filename = entry?.path();
@@ -127,7 +127,7 @@ pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<PathBuf>, Er
 
 /// Read default mnemonic keyfiles
 pub fn read_default_mnemonics<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>, Error> {
-    read_default_keyfiles(path)?
+    get_default_keyfile_paths(path)?
         .into_iter()
         .map(read_keyfile)
         .collect()
@@ -136,9 +136,17 @@ pub fn read_default_mnemonics<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>
 /// Read default root entropies
 #[deprecated]
 pub fn read_default_root_entropies<P: AsRef<Path>>(path: P) -> Result<Vec<RootIdentity>, Error> {
-    read_default_keyfiles(path)?
+    get_default_keyfile_paths(path)?
         .into_iter()
         .map(read_root_entropy_keyfile)
+        .collect()
+}
+
+/// Read default key files in either format
+pub fn read_default_keyfiles<P: AsRef<Path>>(path: P) -> Result<Vec<AccountKey>, Error> {
+    get_default_keyfile_paths(path)?
+        .into_iter()
+        .map(read_keyfile)
         .collect()
 }
 
@@ -273,12 +281,8 @@ mod test {
         write_default_keyfiles(&dir1, 10, None, "", None, DEFAULT_SEED)
             .expect("Could not write example keyfiles");
 
-        let mut actual = read_default_keyfiles(&dir1)
-            .expect("Could not read default keyfiles dir")
-            .into_iter()
-            .map(read_keyfile)
-            .collect::<Result<Vec<_>, Error>>()
-            .expect("Could not read keyfiles just written");
+        let mut actual =
+            read_default_keyfiles(&dir1).expect("Could not read keyfiles just written");
         actual.sort();
 
         assert_eq!(expected, actual);

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -16,7 +16,7 @@ use bip39::Mnemonic;
 use mc_account_keys::{AccountKey, PublicAddress, RootIdentity};
 use mc_api::printable::PrintableWrapper;
 use std::{
-    convert::TryInto,
+    convert::{TryFrom, TryInto},
     fs::File,
     io::{Read, Write},
     path::Path,
@@ -53,14 +53,36 @@ pub fn read_root_entropy_keyfile_data<R: Read>(buffer: R) -> Result<RootIdentity
     Ok(serde_json::from_reader::<R, RootIdentityJson>(buffer)?.into())
 }
 
-/// Read user root identity from disk
+/// Read user mnemonic from disk
+pub fn read_mnemonic_keyfile<P: AsRef<Path>>(path: P) -> Result<AccountKey, Error> {
+    read_mnemonic_keyfile_data(File::open(path)?)
+}
+
+/// Read user root identity from any implementor of `Read`
+pub fn read_mnemonic_keyfile_data<R: Read>(buffer: R) -> Result<AccountKey, Error> {
+    Ok(serde_json::from_reader::<R, UncheckedMnemonicAccount>(buffer)?.try_into()?)
+}
+
+/// Read an account either in the RootIdentity format or the mnemonic format
+/// from disk
 pub fn read_keyfile<P: AsRef<Path>>(path: P) -> Result<AccountKey, Error> {
     read_keyfile_data(File::open(path)?)
 }
 
-/// Read user root identity from any implementor of `Read`
+/// Read an account key file in either format
 pub fn read_keyfile_data<R: Read>(buffer: R) -> Result<AccountKey, Error> {
-    Ok(serde_json::from_reader::<R, UncheckedMnemonicAccount>(buffer)?.try_into()?)
+    let value = serde_json::from_reader::<R, serde_json::Value>(buffer)?;
+    let obj = value
+        .as_object()
+        .ok_or_else(|| Error::Json("Expected json object".to_string()))?;
+    if obj.contains_key("root_entropy") {
+        let root_identity_json: RootIdentityJson = serde_json::from_value(value)?;
+        let root_id = RootIdentity::from(root_identity_json);
+        Ok(AccountKey::from(&root_id))
+    } else {
+        let mnemonic_json: UncheckedMnemonicAccount = serde_json::from_value(value)?;
+        Ok(AccountKey::try_from(mnemonic_json)?)
+    }
 }
 
 /// Write user public address to disk


### PR DESCRIPTION
* make test-client and fog-distro able to read keyfiles in both formats

* clippy

this is a cherrypick of #2019 , there were no conflicts