### PR TITLE
Bump enclave security versions

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.16.100.4";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
-const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 3;
+const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 4;
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.16.100.4";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
-const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 2;
+const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 3;
 const INGEST_ENCLAVE_NAME: &str = "ingest-enclave";
 const INGEST_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.16.100.4";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
-const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 2;
+const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 3;
 const LEDGER_ENCLAVE_NAME: &str = "ledger-enclave";
 const LEDGER_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.16.100.4";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
-const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 2;
+const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 3;
 const VIEW_ENCLAVE_NAME: &str = "view-enclave";
 const VIEW_ENCLAVE_DIR: &str = "../trusted";
 


### PR DESCRIPTION
- Increase consensus enclave isv_svn to 4.
- Increase view, ingest, and ledger enclave isv_svn to 3.

### Motivation

This is how MRSIGNER-based validators select minimum supported versions.

