### PR TITLE
fix formatting check in pre-commit

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -133,7 +133,9 @@ elif [[ -n "$diff" ]]; then
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
 			echo -e "$diff" | sort -u | while read file; do
-				$CARGOFMT $file
+				if [[ -n "$file" ]]; then
+					$CARGOFMT $file
+                fi
 			done
 			echo "You should attempt this commit again to pick up these changes."
 		else

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -132,11 +132,7 @@ elif [[ -n "$diff" ]]; then
 		echo "Do you want to fix all these files automatically? (y/N) "
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
-			echo -e "$diff" | sort -u | while read file; do
-				if [[ -n "$file" ]]; then
-					$CARGOFMT $file
-				fi
-			done
+			echo -e "$diff" | xargs -n 1 $CARGOFMT
 			echo "You should attempt this commit again to pick up these changes."
 		else
 			echo -e "Run ${BOLD}$CARGOFMT -- <file>${NC} to format the files you have staged."
@@ -175,11 +171,7 @@ elif [[ -n "$diff" ]]; then
 		echo "Do you want to fix all these files automatically? (y/N) "
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
-			echo -e "$diff" | sort -u | while read file; do
-				if [[ -n "$file" ]]; then
-					sed -i "1s;^;${COPYRIGHT_LINE}\n\n;" $file
-				fi
-			done
+			echo -e "$diff" | xargs -n 1 sed -i "1s;^;${COPYRIGHT_LINE}\n\n;"
 			echo "You should attempt this commit again to pick up these changes."
 		else
 			echo -e "Add copyright statements to the files."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -135,7 +135,7 @@ elif [[ -n "$diff" ]]; then
 			echo -e "$diff" | sort -u | while read file; do
 				if [[ -n "$file" ]]; then
 					$CARGOFMT $file
-                fi
+				fi
 			done
 			echo "You should attempt this commit again to pick up these changes."
 		else

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -132,7 +132,7 @@ elif [[ -n "$diff" ]]; then
 		echo "Do you want to fix all these files automatically? (y/N) "
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
-			echo -e "$diff" | xargs -n 1 $CARGOFMT
+			echo -e "$diff" | sort -u | xargs -n 1 $CARGOFMT
 			echo "You should attempt this commit again to pick up these changes."
 		else
 			echo -e "Run ${BOLD}$CARGOFMT -- <file>${NC} to format the files you have staged."
@@ -171,7 +171,7 @@ elif [[ -n "$diff" ]]; then
 		echo "Do you want to fix all these files automatically? (y/N) "
 		read YESNO
 		if [[ -n "$YESNO" ]] && [[ "$(echo "${YESNO:0:1}" | tr '[[:lower:]]' '[[:upper:]]')" = "Y" ]]; then
-			echo -e "$diff" | xargs -n 1 sed -i "1s;^;${COPYRIGHT_LINE}\n\n;"
+			echo -e "$diff" | sort -u | xargs -n 1 sed -i "1s;^;${COPYRIGHT_LINE}\n\n;"
 			echo "You should attempt this commit again to pick up these changes."
 		else
 			echo -e "Add copyright statements to the files."


### PR DESCRIPTION
There is a subtle issue where, whenever formatting is necessary,
the `$diff` variable starts with a blank line. This is because
we add things to `$diff` by setting `$diff = $diff\n$next`, so
the first item always sticks a new line in there even though it
is the first one.

(I discovered this first when doing the copyright check work.)

I think this means that when doing a formatting check, we do a
`cargo fmt` call over the entire repo first, then over each individual
file in the diff. It will probably be a lot faster if we don't do
the entire repo first, and only do the individual files of the diff,
which I think was the original intent.