### PR TITLE
make drain accounts script handle defragmentation errors

### DIFF
--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -113,7 +113,7 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                     mobilecoind_api_pb2.GenerateOptimizationTxRequest(
                         monitor_id=monitor_id,
                         subaddress=0,
-                        fee=0
+                        fee=0,
                         token_id=token_id,
                     ))
                 tx_resp = stub.SubmitTx(

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -106,7 +106,7 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                     token_id=token_id,
                 ))
             break
-         except grpc.RpcError as e:
+        except grpc.RpcError as e:
             if "insufficient funds due to utxo fragmentation" in e.details.lower():
                 logging.info("Got defragmentation error, building an optimization transaction")
                 opt_tx = stub.GenerateOptimizationTx(

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -132,7 +132,6 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                 # Subtract fee from amount, so that we don't get an insufficient funds error
                 # in the next cycle (since it costs us a fee to defragment)
                 amount = amount - opt_tx.tx_proposal.fee
-                continue
             else:
                 logging.error("RPC Error encountered")
                 raise

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -133,7 +133,9 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                 # in the next cycle (since it costs us a fee to defragment)
                 amount = amount - opt_tx.tx_proposal.fee
                 continue
-
+            else:
+                logging.error("RPC Error encountered")
+                raise
 
     tx_stats[0] = {
         'start': time.time(),

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -107,7 +107,7 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                 ))
             break
          except grpc.RpcError as e:
-            if "Insufficient funds due to UTXO fragmentation" in e.details:
+            if "insufficient funds due to utxo fragmentation" in e.details.lower():
                 logging.info("Got defragmentation error, building an optimization transaction")
                 opt_tx = stub.GenerateOptimizationTx(
                     mobilecoind_api_pb2.GenerateOptimizationTxRequest(

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -129,11 +129,9 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
                     'receipt': tx_resp,
                 }
                 stats = poll(monitor_id, tx_stats, stub)
-                # FIXME: Subtract the fee from amount, so that we don't get insufficient
-                # funds in the next cycle (since it costs us money to defragment)
-                # However, currently we don't know the fee. So this has to be compensated
-                # for by setting the fee in the command line large enough to account
-                # for many possible defragmentation operations.
+                # Subtract fee from amount, so that we don't get an insufficient funds error
+                # in the next cycle (since it costs us a fee to defragment)
+                amount = amount - opt_tx.tx_proposal.fee
                 continue
 
 

--- a/mobilecoind/strategies/drain-accounts.py
+++ b/mobilecoind/strategies/drain-accounts.py
@@ -85,20 +85,57 @@ def run_test(stub, amount, monitor_id, dest, max_seconds, token_id):
         mobilecoind_api_pb2.GetBalanceRequest(monitor_id=monitor_id, token_id=token_id))
     starting_balance = resp.balance
     logging.info("Starting balance prior to transfer: %s", starting_balance)
-    tx_resp = stub.SendPayment(
-        mobilecoind_api_pb2.SendPaymentRequest(
-            sender_monitor_id=monitor_id,
-            sender_subaddress=0,
-            outlay_list=[
-                mobilecoind_api_pb2.Outlay(
-                    value=amount,
-                    receiver=dest,
-                )
-            ],
-            fee=0,
-            tombstone=0,
-            token_id=token_id,
-        ))
+
+    # Try building a payment that sends all of our balance
+    # We may get a defragmentation error -- if we do, then submit optimization Tx outs
+    # until we don't get that error anymore
+    while True:
+        try:
+            tx_resp = stub.SendPayment(
+                mobilecoind_api_pb2.SendPaymentRequest(
+                    sender_monitor_id=monitor_id,
+                    sender_subaddress=0,
+                    outlay_list=[
+                        mobilecoind_api_pb2.Outlay(
+                            value=amount,
+                            receiver=dest,
+                        )
+                    ],
+                    fee=0,
+                    tombstone=0,
+                    token_id=token_id,
+                ))
+            break
+         except grpc.RpcError as e:
+            if "Insufficient funds due to UTXO fragmentation" in e.details:
+                logging.info("Got defragmentation error, building an optimization transaction")
+                opt_tx = stub.GenerateOptimizationTx(
+                    mobilecoind_api_pb2.GenerateOptimizationTxRequest(
+                        monitor_id=monitor_id,
+                        subaddress=0,
+                        fee=0
+                        token_id=token_id,
+                    ))
+                tx_resp = stub.SubmitTx(
+                    mobilecoind_api_pb2.SubmitTxRequest(
+                        tx_proposal=opt_tx.tx_proposal
+                    ))
+                tx_stats[0] = {
+                    'start': time.time(),
+                    'time_delta': None,
+                    'tombstone': tx_resp.sender_tx_receipt.tombstone,
+                    'block_delta': None,
+                    'status': TransferStatus.pending,
+                    'receipt': tx_resp,
+                }
+                stats = poll(monitor_id, tx_stats, stub)
+                # FIXME: Subtract the fee from amount, so that we don't get insufficient
+                # funds in the next cycle (since it costs us money to defragment)
+                # However, currently we don't know the fee. So this has to be compensated
+                # for by setting the fee in the command line large enough to account
+                # for many possible defragmentation operations.
+                continue
+
 
     tx_stats[0] = {
         'start': time.time(),


### PR DESCRIPTION
I am not sure if there's a better way to detect the error than searching for strings in the details, but this currently seems to me like the best available way.

we may backport this to 1.2

additional context:

This is what an insufficient funds error looks like, in release testing:

```
INFO:drain-accounts:82: Time to sync: 3.0057718753814697
INFO:drain-accounts:87: Starting balance prior to transfer: 237500000000000000
Traceback (most recent call last):
  File "drain-accounts.py", line 162, in <module>
    run_test(stub, amount, src_account.monitor_id, dest, args.max_seconds, args.token_id)
  File "drain-accounts.py", line 88, in run_test
    tx_resp = stub.SendPayment(
  File "/usr/local/lib/python3.8/dist-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/usr/local/lib/python3.8/dist-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INTERNAL
	details = "transactions_manager.build_transaction: Insufficient funds"
	debug_error_string = "{"created":"@1653184158.286040845","description":"Error received from peer ipv4:10.43.188.128:3229","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"transactions_manager.build_transaction: Insufficient funds","grpc_status":13}"
```

This is what it looks like when it's a fragmentation error:

```
debug_error_string = "{"created":"@1653232420.516201609","description":"Error received from peer ipv4:10.43.188.128:3229","file":"src/core/lib/surface/call.cc","file_line":903,"grpc_message":"transactions_manager.build_transaction: Insufficient funds due to UTXO fragmentation","grpc_status":13}"
```

This is where these strings come from in rust code: https://github.com/mobilecoinfoundation/mobilecoin/blob/3412a3d1210ad1baacf6bd406c3c4e8d932bff20/mobilecoind/src/error.rs#L91