### PR TITLE
fix a regression that prevented clients from re-attesting

### DIFF
--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -186,7 +186,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
         // Make the actual RPC call.
         let result = func(self, self.call_option()?);
         if let Err(err) = &result {
-            self.reset_if_unauthenticated(err);
+            self.handle_rpc_error(err);
         }
 
         // Block on the call, and update cookies before passing on the response.
@@ -209,7 +209,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
             })
             .map_err(|err| {
                 let err = ThickClientAttestationError::from(err);
-                self.reset_if_unauthenticated(&err);
+                self.handle_rpc_error(&err);
                 err
             })
     }
@@ -246,7 +246,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
         Ok(CallOption::default().headers(metadata_builder.build()))
     }
 
-    fn reset_if_unauthenticated(&mut self, err: &(impl AuthenticationError + AttestationError)) {
+    fn handle_rpc_error(&mut self, err: &(impl AuthenticationError + AttestationError)) {
         // If the call failed due to authentication (credentials) error, reset creds so
         // that it gets re-created on the next call.
         if err.is_unauthenticated() {

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -26,9 +26,12 @@ pub trait Connection: Display + Eq + Hash + Ord + PartialEq + PartialOrd + Send 
     fn uri(&self) -> Self::Uri;
 }
 
-/// A marker trait used to encapsulate connection-impl-specific attestation
+/// A trait used to encapsulate connection-impl-specific attestation
 /// errors.
-pub trait AttestationError: Debug + Display + Send + Sync {}
+pub trait AttestationError: Debug + Display + Send + Sync {
+    /// Should the error result in re-attestation?
+    fn should_reattest(&self) -> bool;
+}
 
 pub trait AttestedConnection: Connection {
     type Error: AttestationError + From<GrpcError>;

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -29,7 +29,11 @@ impl Error {
     }
 }
 
-impl AttestationError for Error {}
+impl AttestationError for Error {
+    fn should_reattest(&self) -> bool {
+        matches!(self, Self::Rpc(_) | Self::Ake(_) | Self::Cipher(_))
+    }
+}
 
 impl From<grpcio::Error> for Error {
     fn from(err: grpcio::Error) -> Self {

--- a/fog/ingest/server/src/connection_error.rs
+++ b/fog/ingest/server/src/connection_error.rs
@@ -114,4 +114,8 @@ impl From<EnclaveError> for PeerAttestationError {
     }
 }
 
-impl AttestationError for PeerAttestationError {}
+impl AttestationError for PeerAttestationError {
+    fn should_reattest(&self) -> bool {
+        true
+    }
+}

--- a/peers/src/error.rs
+++ b/peers/src/error.rs
@@ -152,4 +152,8 @@ impl From<EnclaveError> for PeerAttestationError {
     }
 }
 
-impl AttestationError for PeerAttestationError {}
+impl AttestationError for PeerAttestationError {
+    fn should_reattest(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
### Motivation

A change introduced in https://github.com/mobilecoinfoundation/mobilecoin/pull/1592 results in clients not re-attesting. This happens because the code in https://github.com/mobilecoinfoundation/mobilecoin/blob/eran/async-reattest-bugfix/connection/src/traits.rs#L53 now only runs of if the async call (e.g. `client_tx_propose_async_opt`) fails to queue a request. If it succeeds, then the actual result returned from the server would only get checked in https://github.com/mobilecoinfoundation/mobilecoin/blob/eran/async-reattest-bugfix/connection/src/thick.rs#L211 and currently that does not handle re-attestation.

### Future Work
Unit tests...
