### PR TITLE
fix a regression that prevented clients from re-attesting (#2038)

### DIFF
--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -114,7 +114,11 @@ impl AuthenticationError for ThickClientAttestationError {
     }
 }
 
-impl AttestationError for ThickClientAttestationError {}
+impl AttestationError for ThickClientAttestationError {
+    fn should_reattest(&self) -> bool {
+        matches!(self, Self::Grpc(_) | Self::Ake(_) | Self::Cipher(_))
+    }
+}
 
 /// A connection from a client to a consensus enclave.
 pub struct ThickClient<CP: CredentialsProvider> {
@@ -182,7 +186,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
         // Make the actual RPC call.
         let result = func(self, self.call_option()?);
         if let Err(err) = &result {
-            self.reset_if_unauthenticated(err);
+            self.handle_rpc_error(err);
         }
 
         // Block on the call, and update cookies before passing on the response.
@@ -205,7 +209,7 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
             })
             .map_err(|err| {
                 let err = ThickClientAttestationError::from(err);
-                self.reset_if_unauthenticated(&err);
+                self.handle_rpc_error(&err);
                 err
             })
     }
@@ -242,11 +246,17 @@ impl<CP: CredentialsProvider> ThickClient<CP> {
         Ok(CallOption::default().headers(metadata_builder.build()))
     }
 
-    fn reset_if_unauthenticated(&mut self, err: &impl AuthenticationError) {
+    fn handle_rpc_error(&mut self, err: &(impl AuthenticationError + AttestationError)) {
         // If the call failed due to authentication (credentials) error, reset creds so
         // that it gets re-created on the next call.
         if err.is_unauthenticated() {
             self.credentials_provider.clear();
+        }
+
+        // If the call failed due to attestation error, reset attestation so that we
+        // re-attest on the next call.
+        if err.should_reattest() {
+            self.deattest();
         }
     }
 }

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -26,9 +26,12 @@ pub trait Connection: Display + Eq + Hash + Ord + PartialEq + PartialOrd + Send 
     fn uri(&self) -> Self::Uri;
 }
 
-/// A marker trait used to encapsulate connection-impl-specific attestation
+/// A trait used to encapsulate connection-impl-specific attestation
 /// errors.
-pub trait AttestationError: Debug + Display + Send + Sync {}
+pub trait AttestationError: Debug + Display + Send + Sync {
+    /// Should the error result in re-attestation?
+    fn should_reattest(&self) -> bool;
+}
 
 pub trait AttestedConnection: Connection {
     type Error: AttestationError + From<GrpcError>;

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -29,7 +29,11 @@ impl Error {
     }
 }
 
-impl AttestationError for Error {}
+impl AttestationError for Error {
+    fn should_reattest(&self) -> bool {
+        matches!(self, Self::Rpc(_) | Self::Ake(_) | Self::Cipher(_))
+    }
+}
 
 impl From<grpcio::Error> for Error {
     fn from(err: grpcio::Error) -> Self {

--- a/fog/ingest/server/src/connection_error.rs
+++ b/fog/ingest/server/src/connection_error.rs
@@ -114,4 +114,8 @@ impl From<EnclaveError> for PeerAttestationError {
     }
 }
 
-impl AttestationError for PeerAttestationError {}
+impl AttestationError for PeerAttestationError {
+    fn should_reattest(&self) -> bool {
+        true
+    }
+}

--- a/peers/src/error.rs
+++ b/peers/src/error.rs
@@ -152,4 +152,8 @@ impl From<EnclaveError> for PeerAttestationError {
     }
 }
 
-impl AttestationError for PeerAttestationError {}
+impl AttestationError for PeerAttestationError {
+    fn should_reattest(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
Cherrypick a fix to `ThickClient`. Without this, re-attestation does not take place.