### PR TITLE
Add fees to gift code memos

### DIFF
--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -230,6 +230,9 @@ pub enum MemoError {
 
     /// Utf-8 did not properly decode
     Utf8Decoding,
+
+    /// Max fee of {0} exceeded. Attempted to set fee amount: {1}
+    MaxFeeExceeded(u64, u64),
 }
 
 impl From<Utf8Error> for MemoError {

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -84,7 +84,7 @@ pub enum NewMemoError {
     Creation(MemoError),
     /// Utf-8 did not properly decode
     Utf8Decoding,
-    /// Max fee of {0} exceeded. Attempted to set fee amount: {1}
+    /// Attempted value: {1} > Max Value: {0}
     MaxFeeExceeded(u64, u64),
     /// Other: {0}
     Other(String),

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -84,6 +84,8 @@ pub enum NewMemoError {
     Creation(MemoError),
     /// Utf-8 did not properly decode
     Utf8Decoding,
+    /// Max fee of {0} exceeded. Attempted to set fee amount: {1}
+    MaxFeeExceeded(u64, u64),
     /// Other: {0}
     Other(String),
 }
@@ -96,6 +98,9 @@ impl From<MemoError> for NewMemoError {
                 "Input of length: {} exceeded max byte length",
                 byte_len
             )),
+            MemoError::MaxFeeExceeded(max_fee, attempted_fee) => {
+                Self::MaxFeeExceeded(max_fee, attempted_fee)
+            }
         }
     }
 }

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -5,13 +5,16 @@
 //! This was proposed for standardization in mobilecoinfoundation/mcips/pull/32
 
 use crate::{impl_memo_type_conversions, RegisteredMemoType};
+use mc_transaction_core::MemoError;
 use std::convert::TryInto;
 
 /// Memo representing the cancellation of a gift code. If a gift code is
 /// never redeemed, the sender may cancel it by sending the TxOut back
 /// to their primary address. This memo will be written to the
-/// reserved change address with 8 bytes reserved for a u64 that
-/// represents the index of the cancelled gift code TxOut
+/// reserved change address with 8 little endian bytes reserved for a u64
+/// that represents the index of the cancelled gift code TxOut and 7 big
+/// endian bytes reserved for recording the fee paid to cancel the gift
+/// code as a 56 bit number.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GiftCodeCancellationMemo {
     /// The data representing the gift code memo
@@ -23,17 +26,52 @@ impl RegisteredMemoType for GiftCodeCancellationMemo {
 }
 
 impl GiftCodeCancellationMemo {
-    /// The length of the custom memo data
+    /// Number of bytes in the memo
     pub const MEMO_DATA_LEN: usize = 64;
 
-    /// Create a new gift code memo
-    pub fn new(global_index: u64) -> Self {
-        GiftCodeCancellationMemo::from(global_index)
+    /// Number of bytes used to represent the global index of the TxOut used to
+    /// fund the cancelled gift code
+    pub const INDEX_DATA_LEN: usize = 8;
+
+    /// Number of bytes used to represent the fee paid for gift code
+    /// cancellation
+    pub const FEE_DATA_LEN: usize = 7;
+
+    /// Maximum value of the fee we can record
+    pub const MAX_FEE: u64 = u64::MAX >> 8;
+
+    /// Create a new gift code cancellation memo
+    pub fn new(global_index: u64, fee: u64) -> Result<Self, MemoError> {
+        // Check if the fee we're setting is greater than the max fee
+        if fee > Self::MAX_FEE {
+            return Err(MemoError::MaxFeeExceeded(Self::MAX_FEE, fee));
+        }
+
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+
+        // Put global index of the previously funded gift code into memo
+        memo_data[..Self::INDEX_DATA_LEN]
+            .copy_from_slice(&global_index.to_le_bytes()[..Self::INDEX_DATA_LEN]);
+
+        // Put fee into memo
+        memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)]
+            .copy_from_slice(&fee.to_be_bytes()[1..(Self::FEE_DATA_LEN + 1)]);
+
+        Ok(Self { memo_data })
     }
 
-    /// Get global TxOut index of the cancelled gift code
+    /// Get global index of the TxOut used to fund the gift code
     pub fn cancelled_gift_code_index(&self) -> u64 {
-        u64::from_le_bytes(self.memo_data[0..8].try_into().unwrap())
+        u64::from_le_bytes(self.memo_data[..8].try_into().unwrap())
+    }
+
+    /// Get fee amount paid to cancel the gift code
+    pub fn get_fee(&self) -> u64 {
+        let mut fee_bytes = [0u8; 8];
+        fee_bytes[1..8].copy_from_slice(
+            &self.memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)],
+        );
+        u64::from_be_bytes(fee_bytes)
     }
 }
 
@@ -63,50 +101,115 @@ impl_memo_type_conversions! { GiftCodeCancellationMemo }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]
     fn test_gift_code_cancellation_memo_to_and_from_u64() {
-        let index: u64 = 666;
-        let memo = GiftCodeCancellationMemo::from(index);
+        // Set cancellation index and fee
+        let index = 666;
+        let fee = 20;
+        let memo = GiftCodeCancellationMemo::new(index, fee).unwrap();
 
         // Check recovered index is correct
         assert_eq!(memo.cancelled_gift_code_index(), index);
+
+        // Check recovered fee is correct
+        assert_eq!(memo.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_cancellation_memo_at_min_max_bounds_succeed() {
-        let index_min: u64 = 0;
+        // Set fee and minimum and maximum indices
+        let index_min = 0;
         let index_max = u64::MAX;
-        let memo_min = GiftCodeCancellationMemo::new(index_min);
-        let memo_max = GiftCodeCancellationMemo::new(index_max);
+        let fee = 20;
+        let memo_min = GiftCodeCancellationMemo::new(index_min, fee).unwrap();
+        let memo_max = GiftCodeCancellationMemo::new(index_max, fee).unwrap();
 
         // Check recovered indices are correct
         assert_eq!(memo_min.cancelled_gift_code_index(), index_min);
         assert_eq!(memo_max.cancelled_gift_code_index(), index_max);
+
+        // Check recovered fees are correct
+        assert_eq!(memo_min.get_fee(), fee);
+        assert_eq!(memo_max.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_cancellation_memo_from_corrupted_bytes_fails() {
+        // Insert bytes representing the index and the fee into an empty array
         let index: u64 = 666;
+        let fee: u64 = 20;
+        let fee_bytes = fee.to_be_bytes();
         let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
-        memo_bytes[0..8].copy_from_slice(&index.to_le_bytes());
+        memo_bytes[0..GiftCodeCancellationMemo::INDEX_DATA_LEN]
+            .copy_from_slice(&index.to_le_bytes());
+        memo_bytes[GiftCodeCancellationMemo::INDEX_DATA_LEN
+            ..(GiftCodeCancellationMemo::INDEX_DATA_LEN + GiftCodeCancellationMemo::FEE_DATA_LEN)]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeCancellationMemo::FEE_DATA_LEN + 1)]);
+
+        // Corrupt the bytes
         memo_bytes[5] = 124;
+        memo_bytes[10] = 124;
+
+        // Recover the memo
         let memo = GiftCodeCancellationMemo::from(&memo_bytes);
 
-        // Check recovered index is erroneous
+        // Check recovered index is incorrect
         assert_ne!(memo.cancelled_gift_code_index(), index);
+
+        // Check recovered fee is incorrect
+        assert_ne!(memo.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_cancellation_memo_from_valid_bytes_is_ok() {
+        // Insert bytes representing the index and the fee into an empty array
         let index: u64 = 666;
+        let fee: u64 = 20;
+        let fee_bytes = fee.to_be_bytes();
         let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
-        memo_bytes[0..8].copy_from_slice(&index.to_le_bytes());
+        memo_bytes[0..GiftCodeCancellationMemo::INDEX_DATA_LEN]
+            .copy_from_slice(&index.to_le_bytes());
+        memo_bytes[GiftCodeCancellationMemo::INDEX_DATA_LEN
+            ..(GiftCodeCancellationMemo::INDEX_DATA_LEN + GiftCodeCancellationMemo::FEE_DATA_LEN)]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeCancellationMemo::FEE_DATA_LEN + 1)]);
+
+        // Recover the memo
         let memo = GiftCodeCancellationMemo::from(&memo_bytes);
 
-        // Check recovered index is okay
+        // Check recovered index is correct
         assert_eq!(memo.cancelled_gift_code_index(), index);
+
+        // Check recovered fee is correct
+        assert_eq!(memo.get_fee(), fee);
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_fee_boundaries() {
+        // Create index and create fees close to the maximum
+        let index = 666;
+        let fee_max_minus_one = GiftCodeCancellationMemo::MAX_FEE - 1;
+        let fee_max = GiftCodeCancellationMemo::MAX_FEE;
+        let fee_max_plus_one: u64 = GiftCodeCancellationMemo::MAX_FEE + 1;
+
+        // Attempt to instantiate cancellation memos
+        let memo_max_minus_one = GiftCodeCancellationMemo::new(index, fee_max_minus_one).unwrap();
+        let memo_max = GiftCodeCancellationMemo::new(index, fee_max).unwrap();
+        let memo_max_plus_one = GiftCodeCancellationMemo::new(index, fee_max_plus_one);
+
+        // Check recovered index is correct from memos initialized with valid fees
+        assert_eq!(memo_max_minus_one.cancelled_gift_code_index(), index);
+        assert_eq!(memo_max.cancelled_gift_code_index(), index);
+
+        // Check recovered fee is correct from memos initialized with valid fees
+        assert_eq!(memo_max_minus_one.get_fee(), fee_max_minus_one);
+        assert_eq!(memo_max.get_fee(), fee_max);
+
+        // Check memo initialized with bad fee fails
+        assert!(matches!(
+            memo_max_plus_one,
+            Err(MemoError::MaxFeeExceeded(_, _))
+        ));
     }
 }

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -68,7 +68,7 @@ impl GiftCodeCancellationMemo {
     /// Get fee amount paid to cancel the gift code
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
-        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant byte 0
         fee_bytes[1..].copy_from_slice(
             &self.memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)],
         );

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -10,7 +10,7 @@ use mc_transaction_core::MemoError;
 /// Memo representing the cancellation of a gift code. If a gift code is
 /// never redeemed, the sender may cancel it by sending the TxOut back
 /// to their primary address. This memo will be written to the
-/// reserved change address with 8 little endian bytes reserved for a u64
+/// reserved change address with 8 big endian bytes reserved for a u64
 /// that represents the index of the cancelled gift code TxOut and 7 big
 /// endian bytes reserved for recording the fee paid to cancel the gift
 /// code as a 56 bit number.
@@ -60,7 +60,7 @@ impl GiftCodeCancellationMemo {
 
     /// Get global index of the TxOut used to fund the gift code
     pub fn cancelled_gift_code_index(&self) -> u64 {
-        let mut index_bytes = [0u8; 8];
+        let mut index_bytes = [0u8; Self::INDEX_DATA_LEN];
         index_bytes.copy_from_slice(&self.memo_data[..Self::INDEX_DATA_LEN]);
         u64::from_be_bytes(index_bytes)
     }
@@ -68,6 +68,7 @@ impl GiftCodeCancellationMemo {
     /// Get fee amount paid to cancel the gift code
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
         fee_bytes[1..].copy_from_slice(
             &self.memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)],
         );

--- a/transaction/std/src/memo/gift_code_cancellation.rs
+++ b/transaction/std/src/memo/gift_code_cancellation.rs
@@ -6,7 +6,6 @@
 
 use crate::{impl_memo_type_conversions, RegisteredMemoType};
 use mc_transaction_core::MemoError;
-use std::convert::TryInto;
 
 /// Memo representing the cancellation of a gift code. If a gift code is
 /// never redeemed, the sender may cancel it by sending the TxOut back
@@ -50,25 +49,26 @@ impl GiftCodeCancellationMemo {
         let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
 
         // Put global index of the previously funded gift code into memo
-        memo_data[..Self::INDEX_DATA_LEN]
-            .copy_from_slice(&global_index.to_le_bytes()[..Self::INDEX_DATA_LEN]);
+        memo_data[..Self::INDEX_DATA_LEN].copy_from_slice(&global_index.to_be_bytes());
 
         // Put fee into memo
         memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)]
-            .copy_from_slice(&fee.to_be_bytes()[1..(Self::FEE_DATA_LEN + 1)]);
+            .copy_from_slice(&fee.to_be_bytes()[1..]);
 
         Ok(Self { memo_data })
     }
 
     /// Get global index of the TxOut used to fund the gift code
     pub fn cancelled_gift_code_index(&self) -> u64 {
-        u64::from_le_bytes(self.memo_data[..8].try_into().unwrap())
+        let mut index_bytes = [0u8; 8];
+        index_bytes.copy_from_slice(&self.memo_data[..Self::INDEX_DATA_LEN]);
+        u64::from_be_bytes(index_bytes)
     }
 
     /// Get fee amount paid to cancel the gift code
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
-        fee_bytes[1..8].copy_from_slice(
+        fee_bytes[1..].copy_from_slice(
             &self.memo_data[Self::INDEX_DATA_LEN..(Self::INDEX_DATA_LEN + Self::FEE_DATA_LEN)],
         );
         u64::from_be_bytes(fee_bytes)
@@ -86,14 +86,6 @@ impl From<&[u8; Self::MEMO_DATA_LEN]> for GiftCodeCancellationMemo {
 impl From<GiftCodeCancellationMemo> for [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
     fn from(src: GiftCodeCancellationMemo) -> [u8; GiftCodeCancellationMemo::MEMO_DATA_LEN] {
         src.memo_data
-    }
-}
-
-impl From<u64> for GiftCodeCancellationMemo {
-    fn from(src: u64) -> Self {
-        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
-        memo_data[0..8].copy_from_slice(&src.to_le_bytes());
-        Self { memo_data }
     }
 }
 
@@ -136,44 +128,17 @@ mod tests {
     }
 
     #[test]
-    fn test_gift_code_cancellation_memo_from_corrupted_bytes_fails() {
-        // Insert bytes representing the index and the fee into an empty array
-        let index: u64 = 666;
-        let fee: u64 = 20;
-        let fee_bytes = fee.to_be_bytes();
-        let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
-        memo_bytes[0..GiftCodeCancellationMemo::INDEX_DATA_LEN]
-            .copy_from_slice(&index.to_le_bytes());
-        memo_bytes[GiftCodeCancellationMemo::INDEX_DATA_LEN
-            ..(GiftCodeCancellationMemo::INDEX_DATA_LEN + GiftCodeCancellationMemo::FEE_DATA_LEN)]
-            .copy_from_slice(&fee_bytes[1..(GiftCodeCancellationMemo::FEE_DATA_LEN + 1)]);
-
-        // Corrupt the bytes
-        memo_bytes[5] = 124;
-        memo_bytes[10] = 124;
-
-        // Recover the memo
-        let memo = GiftCodeCancellationMemo::from(&memo_bytes);
-
-        // Check recovered index is incorrect
-        assert_ne!(memo.cancelled_gift_code_index(), index);
-
-        // Check recovered fee is incorrect
-        assert_ne!(memo.get_fee(), fee);
-    }
-
-    #[test]
     fn test_gift_code_cancellation_memo_from_valid_bytes_is_ok() {
         // Insert bytes representing the index and the fee into an empty array
         let index: u64 = 666;
         let fee: u64 = 20;
         let fee_bytes = fee.to_be_bytes();
         let mut memo_bytes = [0u8; GiftCodeCancellationMemo::MEMO_DATA_LEN];
-        memo_bytes[0..GiftCodeCancellationMemo::INDEX_DATA_LEN]
-            .copy_from_slice(&index.to_le_bytes());
+        memo_bytes[..GiftCodeCancellationMemo::INDEX_DATA_LEN]
+            .copy_from_slice(&index.to_be_bytes());
         memo_bytes[GiftCodeCancellationMemo::INDEX_DATA_LEN
             ..(GiftCodeCancellationMemo::INDEX_DATA_LEN + GiftCodeCancellationMemo::FEE_DATA_LEN)]
-            .copy_from_slice(&fee_bytes[1..(GiftCodeCancellationMemo::FEE_DATA_LEN + 1)]);
+            .copy_from_slice(&fee_bytes[1..]);
 
         // Recover the memo
         let memo = GiftCodeCancellationMemo::from(&memo_bytes);
@@ -207,9 +172,9 @@ mod tests {
         assert_eq!(memo_max.get_fee(), fee_max);
 
         // Check memo initialized with bad fee fails
-        assert!(matches!(
+        assert_eq!(
             memo_max_plus_one,
-            Err(MemoError::MaxFeeExceeded(_, _))
-        ));
+            Err(MemoError::MaxFeeExceeded(fee_max, fee_max_plus_one))
+        );
     }
 }

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -74,7 +74,7 @@ impl GiftCodeFundingMemo {
 
         // Put fee into memo
         memo_data[Self::HASH_DATA_LEN..Self::NOTE_OFFSET]
-            .copy_from_slice(&fee.to_be_bytes()[1..(Self::FEE_DATA_LEN + 1)]);
+            .copy_from_slice(&fee.to_be_bytes()[1..=Self::FEE_DATA_LEN]);
 
         // Put note into memo
         memo_data[Self::NOTE_OFFSET..(Self::NOTE_OFFSET + note.len())]
@@ -91,7 +91,8 @@ impl GiftCodeFundingMemo {
     /// Get fee amount paid to fund the gift code
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
-        fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
+        fee_bytes[1..=GiftCodeFundingMemo::FEE_DATA_LEN]
             .copy_from_slice(&self.memo_data[Self::HASH_DATA_LEN..Self::NOTE_OFFSET]);
         u64::from_be_bytes(fee_bytes)
     }
@@ -286,10 +287,10 @@ mod tests {
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.funding_note().unwrap(), note_len_exact);
-        assert!(matches!(
+        assert_eq!(
             memo_len_plus_one,
             Err(MemoError::BadLength(LEN_PLUS_ONE))
-        ));
+        );
 
         // Check fees are correct for successful memos
         assert_eq!(memo_len_minus_one.get_fee(), fee);
@@ -351,10 +352,10 @@ mod tests {
         // Check fees reconstruct correctly or cause error
         assert_eq!(memo_max_fee_minus_one.get_fee(), MAX_FEE_MINUS_ONE);
         assert_eq!(memo_max_fee.get_fee(), MAX_FEE);
-        assert!(matches!(
+        assert_eq!(
             memo_max_fee_plus_one,
             Err(MemoError::MaxFeeExceeded(MAX_FEE, MAX_FEE_PLUS_ONE))
-        ));
+        );
 
         // Check notes are correct for successful memos
         assert_eq!(memo_max_fee.funding_note().unwrap(), note);

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -10,15 +10,17 @@ use mc_crypto_keys::RistrettoPublic;
 use mc_transaction_core::MemoError;
 use std::{convert::TryInto, str};
 
-/// Mobilecoin account owners can create a special TxOut called a "gift code".
-/// This TxOut is sent to a special subaddress at index u64::MAX - 2 and the
-/// TxOut private key is sent to the intended recipient. This allows people who
-/// don't yet have a Mobilecoin account to receive Mobilecoin. When the sender
-/// makes the initial TxOut to the gift code subaddress, this memo will be
-/// written to the subaddress reserved for change TxOuts indicating that a gift
-/// code was funded. It includes the first 4 bytes of the hash of the TxOut to
-/// indicate which TxOut the gift code is at and 60 bytes representing a null
-/// terminated utf-8 string
+/// MobileCoin account owners can create a special TxOut called a "gift code".
+/// This TxOut is sent to a special subaddress at index u64::MAX - 2 reserved
+/// for gift codes. After this is done, the onetime private key, shared secret
+/// and universal index of the TxOut is sent to the intended recipient.
+/// This allows people who don't yet have a MobileCoin account to receive
+/// MobileCoin. When the sender makes the initial TxOut to the gift code
+/// subaddress, this memo will be written to the subaddress reserved for change
+/// TxOuts indicating that a gift code was funded. It includes the first 4
+/// bytes of the hash of the TxOut to indicate which TxOut the gift code is,
+/// the next 7 big endian bytes to track the fee paid to fund the gift code and
+/// the remaining 53 bytes used to represent an optional utf-8 string.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GiftCodeFundingMemo {
     /// The data representing the gift code memo
@@ -30,36 +32,68 @@ impl RegisteredMemoType for GiftCodeFundingMemo {
 }
 
 impl GiftCodeFundingMemo {
-    /// Create a new gift funding code memo
-    pub fn new(tx_out_public_key: &RistrettoPublic, note: &str) -> Result<Self, MemoError> {
+    /// Number of bytes in the memo
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// Number of bytes used to represent the gift code TxOut hash
+    pub const HASH_DATA_LEN: usize = 4;
+
+    /// Number of bytes used to represent the fee paid when funding the gift
+    /// code
+    pub const FEE_DATA_LEN: usize = 7;
+
+    /// Number of bytes used to represent the utf-8 note
+    pub const NOTE_DATA_LEN: usize = 53;
+
+    /// Byte offset of the note
+    pub const NOTE_OFFSET: usize = Self::HASH_DATA_LEN + Self::FEE_DATA_LEN;
+
+    /// The max fee (i.e. the maximum value a 56 bit number can contain)
+    pub const MAX_FEE: u64 = u64::MAX >> 8;
+
+    /// Create a new gift funding memo
+    pub fn new(
+        tx_out_public_key: &RistrettoPublic,
+        fee: u64,
+        note: &str,
+    ) -> Result<Self, MemoError> {
+        // Check if the fee we're setting is greater than the max fee
+        if fee > Self::MAX_FEE {
+            return Err(MemoError::MaxFeeExceeded(Self::MAX_FEE, fee));
+        }
         // Check if note is of valid length and initialize memo data
         if note.len() > Self::NOTE_DATA_LEN {
             return Err(MemoError::BadLength(note.len()));
         }
+
         let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
-        // Compute TxOut hash and store it into the memo data
+
+        // Compute TxOut hash and put it into the memo data
         memo_data[0..Self::HASH_DATA_LEN]
             .copy_from_slice(&tx_out_public_key_short_hash(tx_out_public_key));
 
+        // Put fee into memo
+        memo_data[Self::HASH_DATA_LEN..Self::NOTE_OFFSET]
+            .copy_from_slice(&fee.to_be_bytes()[1..(Self::FEE_DATA_LEN + 1)]);
+
         // Put note into memo
-        let offset = Self::HASH_DATA_LEN;
-        memo_data[offset..(offset + note.len())].copy_from_slice(note.as_bytes());
+        memo_data[Self::NOTE_OFFSET..(Self::NOTE_OFFSET + note.len())]
+            .copy_from_slice(note.as_bytes());
 
         Ok(Self { memo_data })
     }
 
-    /// The Length of the TxOut hash
-    pub const HASH_DATA_LEN: usize = 4;
-
-    /// The length of the custom memo data
-    pub const MEMO_DATA_LEN: usize = 64;
-
-    /// Length of the utf-8 note
-    pub const NOTE_DATA_LEN: usize = 60;
-
-    /// Check if a given public key matches
+    /// Check if a given public key matches the hash of the gift code TxOut
     pub fn public_key_matches(&self, tx_out_public_key: &RistrettoPublic) -> bool {
         tx_out_public_key_short_hash(tx_out_public_key) == self.memo_data[0..Self::HASH_DATA_LEN]
+    }
+
+    /// Get fee amount paid to fund the gift code
+    pub fn get_fee(&self) -> u64 {
+        let mut fee_bytes = [0u8; 8];
+        fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]
+            .copy_from_slice(&self.memo_data[Self::HASH_DATA_LEN..Self::NOTE_OFFSET]);
+        u64::from_be_bytes(fee_bytes)
     }
 
     /// Get funding note from memo
@@ -68,14 +102,14 @@ impl GiftCodeFundingMemo {
             .memo_data
             .iter()
             .enumerate()
-            .position(|(i, b)| i >= Self::HASH_DATA_LEN && b == &0u8)
+            .position(|(i, b)| i >= Self::NOTE_OFFSET && b == &0u8)
         {
             *terminator
         } else {
             Self::MEMO_DATA_LEN
         };
 
-        str::from_utf8(&self.memo_data[Self::HASH_DATA_LEN..index]).map_err(Into::into)
+        str::from_utf8(&self.memo_data[Self::NOTE_OFFSET..index]).map_err(Into::into)
     }
 }
 
@@ -119,13 +153,17 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let note = "Cash money MeowbleCoin for Kitty";
         let key = RistrettoPublic::from_random(&mut rng);
-        let memo = GiftCodeFundingMemo::new(&key, note).unwrap();
-
-        // Check that the note is extracted properly
-        assert_eq!(memo.funding_note().unwrap(), note);
+        let fee = 666;
+        let memo = GiftCodeFundingMemo::new(&key, fee, note).unwrap();
 
         // Check that the public key can be verified
         assert!(memo.public_key_matches(&key));
+
+        // Check the fee is correct
+        assert_eq!(memo.get_fee(), 666);
+
+        // Check that the note is correct
+        assert_eq!(memo.funding_note().unwrap(), note);
     }
 
     #[test]
@@ -136,60 +174,78 @@ mod tests {
 
         // Create memo with blank note
         let note = "";
-        let memo = GiftCodeFundingMemo::new(&key, note).unwrap();
-
-        // Check that the note is extracted properly
-        assert_eq!(memo.funding_note().unwrap(), note);
+        let fee = 666;
+        let memo = GiftCodeFundingMemo::new(&key, fee, note).unwrap();
 
         // Check that the public key can be verified
         assert!(memo.public_key_matches(&key));
+
+        // Check the fee is correct
+        assert_eq!(memo.get_fee(), 666);
+
+        // Check that the note is correct
+        assert_eq!(memo.funding_note().unwrap(), note);
     }
 
     #[test]
-    fn test_gift_code_funding_memo_with_only_null_memo_bytes_is_okay() {
+    fn test_gift_code_funding_memo_note_with_only_null_memo_bytes_is_okay() {
         // Initialize hash bytes
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
+        let fee: u64 = 666;
         let hash_bytes = tx_out_public_key_short_hash(&key);
+        let fee_bytes = fee.to_be_bytes();
 
-        // Put only hash bytes into memo_bytes, leaving the rest empty & make memo
-        // object
+        // Put only hash and fee bytes into memo_bytes, leaving note bytes empty
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
-        let memo = GiftCodeFundingMemo::from(&memo_bytes);
+        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..GiftCodeFundingMemo::NOTE_OFFSET]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]);
 
-        // Check that a blank note is extracted properly
-        let note = "";
-        assert_eq!(memo.funding_note().unwrap(), note);
+        let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the public key can be verified
         assert!(memo.public_key_matches(&key));
+
+        // Check that the fee is correct
+        assert_eq!(memo.get_fee(), fee);
+
+        // Check that a blank note is extracted correctly
+        let note = "";
+        assert_eq!(memo.funding_note().unwrap(), note);
     }
 
     #[test]
-    fn test_gift_code_funding_note_terminates_at_first_null() {
+    fn test_gift_code_funding_memo_note_terminates_at_first_null() {
         // Create note from bytes and put two nulls in it
         let mut note_bytes = [b'6'; 8];
         note_bytes[3] = 0;
         note_bytes[6] = 0;
         let note = "666";
 
-        // Create hash bytes
+        // Create hash & fee bytes
+        let fee: u64 = 666;
+        let fee_bytes = fee.to_be_bytes();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
         let hash_bytes = tx_out_public_key_short_hash(&key);
 
-        // Create memo from hash & note bytes
+        // Create memo from hash, fee & note bytes
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
-        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..(GiftCodeFundingMemo::HASH_DATA_LEN + 8)]
+        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..GiftCodeFundingMemo::NOTE_OFFSET]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]);
+        memo_bytes[GiftCodeFundingMemo::NOTE_OFFSET..(GiftCodeFundingMemo::NOTE_OFFSET + 8)]
             .copy_from_slice(&note_bytes);
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash is correctly verified
         assert!(memo.public_key_matches(&key));
 
-        // Check that the note is extracted properly and terminated at first null
+        // Check that the fee is correct
+        assert_eq!(memo.get_fee(), fee);
+
+        // Check that the note is correct and terminated at first null
         assert_eq!(memo.funding_note().unwrap(), note);
     }
 
@@ -197,9 +253,10 @@ mod tests {
     fn test_gift_code_funding_memo_verified_with_wrong_public_key_doesnt_match() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let note = "Cash money MeowbleCoin for Kitty";
+        let fee = 666;
         let key = RistrettoPublic::from_random(&mut rng);
         let other_key = RistrettoPublic::from_random(&mut rng);
-        let memo = GiftCodeFundingMemo::new(&key, note).unwrap();
+        let memo = GiftCodeFundingMemo::new(&key, fee, note).unwrap();
 
         // Check that a non-matching public key cannot be correctly verified
         assert!(!memo.public_key_matches(&other_key));
@@ -216,13 +273,14 @@ mod tests {
         let note_len_plus_one = str::from_utf8(&[b'6'; LEN_PLUS_ONE]).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
+        let fee = 666;
 
         // Create memos from notes
-        let memo_len_minus_one = GiftCodeFundingMemo::new(&key, note_len_minus_one).unwrap();
-        let memo_len_exact = GiftCodeFundingMemo::new(&key, note_len_exact).unwrap();
-        let memo_len_plus_one = GiftCodeFundingMemo::new(&key, note_len_plus_one);
+        let memo_len_minus_one = GiftCodeFundingMemo::new(&key, fee, note_len_minus_one).unwrap();
+        let memo_len_exact = GiftCodeFundingMemo::new(&key, fee, note_len_exact).unwrap();
+        let memo_len_plus_one = GiftCodeFundingMemo::new(&key, fee, note_len_plus_one);
 
-        // Check note lengths match or error on creation if note is too large
+        // Check notes are correct or error on creation if note is too large
         assert_eq!(
             memo_len_minus_one.funding_note().unwrap(),
             note_len_minus_one
@@ -233,39 +291,54 @@ mod tests {
             Err(MemoError::BadLength(LEN_PLUS_ONE))
         ));
 
-        // Check public keys match for successful memo lengths for memos that didn't
-        // error
+        // Check fees are correct for successful memos
+        assert_eq!(memo_len_minus_one.get_fee(), fee);
+        assert_eq!(memo_len_exact.get_fee(), fee);
+
+        // Check public keys are correct for successful memos
         assert!(memo_len_minus_one.public_key_matches(&key));
         assert!(memo_len_exact.public_key_matches(&key));
     }
 
     #[test]
     fn test_gift_code_funding_memo_created_with_overlapping_byte_allocations_fail() {
-        // Create hash bytes and note
-        let note = str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
+        // Create hash bytes, fee bytes, and note
+        let note = str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN]).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
+        let fee: u64 = 666;
         let hash_bytes = tx_out_public_key_short_hash(&key);
+        let fee_bytes = fee.to_be_bytes();
 
-        // Purposely overlap memo and public key bytes
+        // Purposely overlap public key, fee, and note bytes
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
         memo_bytes
-            [(GiftCodeFundingMemo::HASH_DATA_LEN - 1)..(GiftCodeFundingMemo::MEMO_DATA_LEN - 2)]
-            .copy_from_slice(note.as_bytes());
+            [(GiftCodeFundingMemo::HASH_DATA_LEN - 1)..(GiftCodeFundingMemo::NOTE_OFFSET - 1)]
+            .copy_from_slice(&fee_bytes[1..8]);
+        memo_bytes
+            [(GiftCodeFundingMemo::NOTE_OFFSET - 1)..(GiftCodeFundingMemo::MEMO_DATA_LEN - 1)]
+            .copy_from_slice(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN]);
+
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash isn't correctly verified
         assert!(!memo.public_key_matches(&key));
 
-        // Check that the note is erroneous
+        // Check that fee isn't correct
+        assert_ne!(fee, memo.get_fee());
+
+        // Check that the note isn't correct
         assert_ne!(memo.funding_note().unwrap(), note);
     }
 
     #[test]
     fn test_gift_code_funding_memo_created_with_corrupted_bytes_fail() {
         // Initialize note and hash bytes
-        let note = str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
+        let fee: u64 = 666;
+        let fee_bytes = fee.to_be_bytes();
+        let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN];
+        let note = str::from_utf8(&note_bytes).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
         let hash_bytes = tx_out_public_key_short_hash(&key);
@@ -273,40 +346,87 @@ mod tests {
         // Populate memo with hash and note bytes
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
-        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..(GiftCodeFundingMemo::MEMO_DATA_LEN - 1)]
-            .copy_from_slice(note.as_bytes());
+        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..GiftCodeFundingMemo::NOTE_OFFSET]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]);
+        memo_bytes[GiftCodeFundingMemo::NOTE_OFFSET..GiftCodeFundingMemo::MEMO_DATA_LEN]
+            .copy_from_slice(&note_bytes);
 
         // Corrupt bytes
         memo_bytes[2] = 42;
+        memo_bytes[6] = 42;
         memo_bytes[55] = 42;
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash isn't correctly verified
         assert!(!memo.public_key_matches(&key));
 
-        // Check that the note is erroneous
+        // Check that the fee isn't correct
+        assert_ne!(memo.get_fee(), fee);
+
+        // Check that the note isn't correct
         assert_ne!(memo.funding_note().unwrap(), note);
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_fees_close_to_max_fee_process_as_expected() {
+        // Create notes near max length
+        const MAX_FEE: u64 = GiftCodeFundingMemo::MAX_FEE;
+        const MAX_FEE_MINUS_ONE: u64 = GiftCodeFundingMemo::MAX_FEE - 1;
+        const MAX_FEE_PLUS_ONE: u64 = GiftCodeFundingMemo::MAX_FEE + 1;
+        let note = "noted";
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let key = RistrettoPublic::from_random(&mut rng);
+
+        // Create memos from notes
+        let memo_max_fee_minus_one =
+            GiftCodeFundingMemo::new(&key, MAX_FEE_MINUS_ONE, note).unwrap();
+        let memo_max_fee = GiftCodeFundingMemo::new(&key, MAX_FEE, note).unwrap();
+        let memo_max_fee_plus_one = GiftCodeFundingMemo::new(&key, MAX_FEE_PLUS_ONE, note);
+
+        // Check fees reconstruct correctly or cause error
+        assert_eq!(memo_max_fee_minus_one.get_fee(), MAX_FEE_MINUS_ONE);
+        assert_eq!(memo_max_fee.get_fee(), MAX_FEE);
+        assert!(matches!(
+            memo_max_fee_plus_one,
+            Err(MemoError::MaxFeeExceeded(MAX_FEE, MAX_FEE_PLUS_ONE))
+        ));
+
+        // Check notes are correct for successful memos
+        assert_eq!(memo_max_fee.funding_note().unwrap(), note);
+        assert_eq!(memo_max_fee_minus_one.funding_note().unwrap(), note);
+
+        // Check public keys are verified for successful memos
+        assert!(memo_max_fee.public_key_matches(&key));
+        assert!(memo_max_fee_minus_one.public_key_matches(&key))
     }
 
     #[test]
     fn test_gift_code_funding_memo_from_valid_bytes_is_okay() {
         // Initialize note and hash bytes
-        let note = str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN - 1]).unwrap();
+        let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN];
+        let note = str::from_utf8(&note_bytes).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let key = RistrettoPublic::from_random(&mut rng);
         let hash_bytes = tx_out_public_key_short_hash(&key);
+        let fee: u64 = 666;
+        let fee_bytes = fee.to_be_bytes();
 
         // Populate memo with hash and note bytes
         let mut memo_bytes = [0u8; GiftCodeFundingMemo::MEMO_DATA_LEN];
         memo_bytes[0..GiftCodeFundingMemo::HASH_DATA_LEN].copy_from_slice(&hash_bytes);
-        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..(GiftCodeFundingMemo::MEMO_DATA_LEN - 1)]
-            .copy_from_slice(note.as_bytes());
+        memo_bytes[GiftCodeFundingMemo::HASH_DATA_LEN..GiftCodeFundingMemo::NOTE_OFFSET]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeFundingMemo::FEE_DATA_LEN + 1)]);
+        memo_bytes[GiftCodeFundingMemo::NOTE_OFFSET..GiftCodeFundingMemo::MEMO_DATA_LEN]
+            .copy_from_slice(&note_bytes);
         let memo = GiftCodeFundingMemo::from(&memo_bytes);
 
         // Check that the hash is correctly verified
         assert!(memo.public_key_matches(&key));
 
-        // Check that the note is correctly verified
+        // Check that the fee is correct
+        assert_eq!(memo.get_fee(), fee);
+
+        // Check that the note is correct
         assert_eq!(memo.funding_note().unwrap(), note);
     }
 }

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -91,7 +91,7 @@ impl GiftCodeFundingMemo {
     /// Get fee amount paid to fund the gift code
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
-        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant byte 0
         fee_bytes[1..=GiftCodeFundingMemo::FEE_DATA_LEN]
             .copy_from_slice(&self.memo_data[Self::HASH_DATA_LEN..Self::NOTE_OFFSET]);
         u64::from_be_bytes(fee_bytes)

--- a/transaction/std/src/memo/gift_code_funding.rs
+++ b/transaction/std/src/memo/gift_code_funding.rs
@@ -287,10 +287,7 @@ mod tests {
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.funding_note().unwrap(), note_len_exact);
-        assert_eq!(
-            memo_len_plus_one,
-            Err(MemoError::BadLength(LEN_PLUS_ONE))
-        );
+        assert_eq!(memo_len_plus_one, Err(MemoError::BadLength(LEN_PLUS_ONE)));
 
         // Check fees are correct for successful memos
         assert_eq!(memo_len_minus_one.get_fee(), fee);

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -83,6 +83,7 @@ impl GiftCodeSenderMemo {
     /// Get fee amount paid
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
         fee_bytes[1..].copy_from_slice(&self.memo_data[..Self::FEE_DATA_LEN]);
         u64::from_be_bytes(fee_bytes)
     }
@@ -191,10 +192,10 @@ mod tests {
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.sender_note().unwrap(), note_len_exact);
-        assert!(matches!(
+        assert_eq!(
             memo_len_plus_one,
             Err(MemoError::BadLength(LEN_PLUS_ONE))
-        ));
+        );
 
         // Assert derived fees match for successful memos
         assert_eq!(memo_len_minus_one.get_fee(), fee);

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -192,10 +192,7 @@ mod tests {
             note_len_minus_one
         );
         assert_eq!(memo_len_exact.sender_note().unwrap(), note_len_exact);
-        assert_eq!(
-            memo_len_plus_one,
-            Err(MemoError::BadLength(LEN_PLUS_ONE))
-        );
+        assert_eq!(memo_len_plus_one, Err(MemoError::BadLength(LEN_PLUS_ONE)));
 
         // Assert derived fees match for successful memos
         assert_eq!(memo_len_minus_one.get_fee(), fee);

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -6,16 +6,18 @@
 
 use crate::{impl_memo_type_conversions, RegisteredMemoType};
 use mc_transaction_core::MemoError;
-use std::{convert::TryFrom, str};
+use std::str;
 
 /// A gift code is considered "redeemed" when the receiver of
 /// a gift code message uses the private spend key of the gift
 /// code TxOut (originally sent to the sender's reserved gift
 /// subaddress) to send the TxOut to them themselves. When that
-/// happens, the receiver can write an optional 64 byte null
-/// terminated utf-8 string in the memo field of an associated
-/// change TxOut to record any desired info about the gift code
-/// redemption.
+/// happens, the gift code sender memo is written to the change
+/// TxOut that the receiver sends the gift code to. The sender
+/// memo includes 7 big endian bytes to store a 56 bit number
+/// representing the fee paid to send the gift code to
+/// themselves and 57 bytes representing a utf-8 string used
+/// to record any desired information about the gift code.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct GiftCodeSenderMemo {
     /// The data representing the gift code memo
@@ -27,23 +29,64 @@ impl RegisteredMemoType for GiftCodeSenderMemo {
 }
 
 impl GiftCodeSenderMemo {
-    /// The length of the custom memo data.
+    /// Number of bytes in the memo
     pub const MEMO_DATA_LEN: usize = 64;
 
-    /// Create a new gift code memo
-    pub fn new(note_data: &str) -> Result<Self, MemoError> {
-        GiftCodeSenderMemo::try_from(note_data)
+    /// Number of bytes used to represent the fee paid for gift code redemption
+    pub const FEE_DATA_LEN: usize = 7;
+
+    /// Number of bytes used to represent the utf-8 note
+    pub const NOTE_DATA_LEN: usize = 57;
+
+    /// The max fee (i.e. the maximum value a 56 bit number can contain)
+    pub const MAX_FEE: u64 = u64::MAX >> 8;
+
+    /// Create a new gift code sender memo
+    pub fn new(fee: u64, note: &str) -> Result<Self, MemoError> {
+        // Check if the fee we're setting is greater than the max fee
+        if fee > Self::MAX_FEE {
+            return Err(MemoError::MaxFeeExceeded(Self::MAX_FEE, fee));
+        }
+        // Check if note is of valid length
+        if note.len() > Self::NOTE_DATA_LEN {
+            return Err(MemoError::BadLength(note.len()));
+        }
+
+        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
+
+        // Put fee into memo
+        memo_data[0..Self::FEE_DATA_LEN]
+            .copy_from_slice(&fee.to_be_bytes()[1..(Self::FEE_DATA_LEN + 1)]);
+
+        // Put note into memo
+        memo_data[Self::FEE_DATA_LEN..(Self::FEE_DATA_LEN + note.len())]
+            .copy_from_slice(note.as_bytes());
+
+        Ok(Self { memo_data })
     }
 
     /// Get the sender note
     pub fn sender_note(&self) -> Result<&str, MemoError> {
-        let index = if let Some(terminator) = &self.memo_data.iter().position(|b| b == &0u8) {
+        let index = if let Some(terminator) = &self
+            .memo_data
+            .iter()
+            .enumerate()
+            .position(|(i, b)| i >= Self::FEE_DATA_LEN && b == &0u8)
+        {
             *terminator
         } else {
             Self::MEMO_DATA_LEN
         };
 
-        str::from_utf8(&self.memo_data[0..index]).map_err(Into::into)
+        str::from_utf8(&self.memo_data[Self::FEE_DATA_LEN..index]).map_err(Into::into)
+    }
+
+    /// Get fee amount paid
+    pub fn get_fee(&self) -> u64 {
+        let mut fee_bytes = [0u8; 8];
+        fee_bytes[1..(GiftCodeSenderMemo::FEE_DATA_LEN + 1)]
+            .copy_from_slice(&self.memo_data[..Self::FEE_DATA_LEN]);
+        u64::from_be_bytes(fee_bytes)
     }
 }
 
@@ -61,20 +104,6 @@ impl From<GiftCodeSenderMemo> for [u8; GiftCodeSenderMemo::MEMO_DATA_LEN] {
     }
 }
 
-impl TryFrom<&str> for GiftCodeSenderMemo {
-    type Error = MemoError;
-
-    fn try_from(src: &str) -> Result<Self, MemoError> {
-        if src.len() > Self::MEMO_DATA_LEN {
-            return Err(MemoError::BadLength(src.len()));
-        }
-
-        let mut memo_data = [0u8; Self::MEMO_DATA_LEN];
-        memo_data[0..src.len()].copy_from_slice(src.as_bytes());
-        Ok(Self { memo_data })
-    }
-}
-
 impl_memo_type_conversions! { GiftCodeSenderMemo }
 
 #[cfg(test)]
@@ -84,21 +113,29 @@ mod tests {
     #[test]
     fn test_gift_code_sender_memo_to_and_from_str() {
         // Create memo with note
+        let fee = 10;
         let note = "Dear Kitty, you received cash money MeowbleCoin UwU";
-        let memo = GiftCodeSenderMemo::new(note).unwrap();
+        let memo = GiftCodeSenderMemo::new(fee, note).unwrap();
 
-        // Check that the note is extracted properly
+        // Check that the note is extracted correctly
         assert_eq!(memo.sender_note().unwrap(), note);
+
+        // Check that the fee is extracted correctly
+        assert_eq!(memo.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_sender_memo_with_blank_note_is_ok() {
-        // Create memo with blank note
+        // Create memo with blank
+        let fee = 10;
         let note = "";
-        let memo = GiftCodeSenderMemo::new(note).unwrap();
+        let memo = GiftCodeSenderMemo::new(fee, note).unwrap();
 
-        // Check that the note is extracted properly
+        // Check that the note is extracted correctly
         assert_eq!(memo.sender_note().unwrap(), note);
+
+        // Check that the fee is extracted correctly
+        assert_eq!(memo.get_fee(), fee);
     }
 
     #[test]
@@ -106,10 +143,14 @@ mod tests {
         // Create memo from null bytes
         let memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
         let memo = GiftCodeSenderMemo::from(&memo_bytes);
+        let fee = 0;
         let note = "";
 
         // Check that the note is extracted properly to a blank note
         assert_eq!(memo.sender_note().unwrap(), note);
+
+        // Check that the fee is extracted correctly
+        assert_eq!(memo.get_fee(), fee);
     }
 
     #[test]
@@ -122,27 +163,29 @@ mod tests {
 
         // Create memo from note bytes
         let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
-        memo_bytes[0..8].copy_from_slice(&note_bytes);
+        memo_bytes[GiftCodeSenderMemo::FEE_DATA_LEN..(GiftCodeSenderMemo::FEE_DATA_LEN + 8)]
+            .copy_from_slice(&note_bytes);
         let memo = GiftCodeSenderMemo::from(&memo_bytes);
 
-        // Check that the note is extracted properly and terminated at first null
+        // Check that the note is extracted correctly and terminated at first null
         assert_eq!(memo.sender_note().unwrap(), note);
     }
 
     #[test]
     fn test_gift_code_sender_memo_created_with_notes_near_max_byte_lengths() {
         // Create notes near max length
-        const LEN_EXACT: usize = GiftCodeSenderMemo::MEMO_DATA_LEN;
-        const LEN_MINUS_ONE: usize = GiftCodeSenderMemo::MEMO_DATA_LEN - 1;
-        const LEN_PLUS_ONE: usize = GiftCodeSenderMemo::MEMO_DATA_LEN + 1;
+        const LEN_EXACT: usize = GiftCodeSenderMemo::NOTE_DATA_LEN;
+        const LEN_MINUS_ONE: usize = GiftCodeSenderMemo::NOTE_DATA_LEN - 1;
+        const LEN_PLUS_ONE: usize = GiftCodeSenderMemo::NOTE_DATA_LEN + 1;
         let note_len_minus_one = str::from_utf8(&[b'6'; LEN_MINUS_ONE]).unwrap();
         let note_len_exact = str::from_utf8(&[b'6'; LEN_EXACT]).unwrap();
         let note_len_plus_one = str::from_utf8(&[b'6'; LEN_PLUS_ONE]).unwrap();
+        let fee = 42;
 
         // Create memos from notes
-        let memo_len_minus_one = GiftCodeSenderMemo::new(note_len_minus_one).unwrap();
-        let memo_len_exact = GiftCodeSenderMemo::new(note_len_exact).unwrap();
-        let memo_len_plus_one = GiftCodeSenderMemo::new(note_len_plus_one);
+        let memo_len_minus_one = GiftCodeSenderMemo::new(fee, note_len_minus_one).unwrap();
+        let memo_len_exact = GiftCodeSenderMemo::new(fee, note_len_exact).unwrap();
+        let memo_len_plus_one = GiftCodeSenderMemo::new(fee, note_len_plus_one);
 
         // Check note lengths match or error on creation if too large
         assert_eq!(
@@ -154,36 +197,83 @@ mod tests {
             memo_len_plus_one,
             Err(MemoError::BadLength(LEN_PLUS_ONE))
         ));
+
+        // Assert derived fees match for successful memos
+        assert_eq!(memo_len_minus_one.get_fee(), fee);
+        assert_eq!(memo_len_exact.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_sender_memo_with_corrupted_bytes_fails() {
         // Create note bytes and corrupt them
-        let mut note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1];
-        let note = str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
+        let fee = 0;
+        let mut note_bytes = [b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN - 1];
+        let note = str::from_utf8(&[b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN - 1]).unwrap();
         note_bytes[42] = 42;
+        note_bytes[2] = 42;
 
         // Create memo from corrupted bytes
         let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
-        memo_bytes[0..(GiftCodeSenderMemo::MEMO_DATA_LEN - 1)].copy_from_slice(&note_bytes);
+        memo_bytes[2] = 42;
+        memo_bytes[GiftCodeSenderMemo::FEE_DATA_LEN
+            ..(GiftCodeSenderMemo::FEE_DATA_LEN + GiftCodeSenderMemo::NOTE_DATA_LEN - 1)]
+            .copy_from_slice(&note_bytes);
         let memo = GiftCodeSenderMemo::from(&memo_bytes);
 
-        // Check that the note is erroneous
+        // Check that the note is incorrect
         assert_ne!(memo.sender_note().unwrap(), note);
+
+        // Check that the fee is incorrect
+        assert_ne!(memo.get_fee(), fee);
     }
 
     #[test]
     fn test_gift_code_sender_memo_from_valid_bytes_is_okay() {
         // Create note from bytes
-        let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1];
+        let note_bytes = [b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN - 1];
+        let fee: u64 = 666;
+        let fee_bytes = fee.to_be_bytes();
         let note = str::from_utf8(&note_bytes).unwrap();
 
         // Create memo from note bytes
         let mut memo_bytes = [0u8; GiftCodeSenderMemo::MEMO_DATA_LEN];
-        memo_bytes[0..(GiftCodeSenderMemo::MEMO_DATA_LEN - 1)].copy_from_slice(&note_bytes);
+        memo_bytes[..GiftCodeSenderMemo::FEE_DATA_LEN]
+            .copy_from_slice(&fee_bytes[1..(GiftCodeSenderMemo::FEE_DATA_LEN + 1)]);
+        memo_bytes[GiftCodeSenderMemo::FEE_DATA_LEN
+            ..(GiftCodeSenderMemo::FEE_DATA_LEN + GiftCodeSenderMemo::NOTE_DATA_LEN - 1)]
+            .copy_from_slice(&note_bytes);
         let memo = GiftCodeSenderMemo::from(&memo_bytes);
 
-        // Check that the note is extracted properly
+        // Check that the note is extracted correctly
         assert_eq!(memo.sender_note().unwrap(), note);
+
+        // Check that the fee is extracted correctly
+        assert_eq!(memo.get_fee(), fee);
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_created_with_fees_near_max_fee() {
+        // Create notes near max length
+        const MAX_FEE: u64 = GiftCodeSenderMemo::MAX_FEE;
+        const MAX_FEE_MINUS_ONE: u64 = GiftCodeSenderMemo::MAX_FEE - 1;
+        const MAX_FEE_PLUS_ONE: u64 = GiftCodeSenderMemo::MAX_FEE + 1;
+        let note = "noted";
+
+        // Create memos from notes
+        let memo_max_fee_minus_one = GiftCodeSenderMemo::new(MAX_FEE_MINUS_ONE, note).unwrap();
+        let memo_max_fee = GiftCodeSenderMemo::new(MAX_FEE, note).unwrap();
+        let memo_max_fee_plus_one = GiftCodeSenderMemo::new(MAX_FEE_PLUS_ONE, note);
+
+        // Check fees reconstruct correctly or cause error
+        assert_eq!(memo_max_fee_minus_one.get_fee(), MAX_FEE_MINUS_ONE);
+        assert_eq!(memo_max_fee.get_fee(), MAX_FEE);
+        assert!(matches!(
+            memo_max_fee_plus_one,
+            Err(MemoError::MaxFeeExceeded(MAX_FEE, MAX_FEE_PLUS_ONE))
+        ));
+
+        // Check notes match for successful memos
+        assert_eq!(memo_max_fee.sender_note().unwrap(), note);
+        assert_eq!(memo_max_fee_minus_one.sender_note().unwrap(), note);
     }
 }

--- a/transaction/std/src/memo/gift_code_sender.rs
+++ b/transaction/std/src/memo/gift_code_sender.rs
@@ -83,7 +83,7 @@ impl GiftCodeSenderMemo {
     /// Get fee amount paid
     pub fn get_fee(&self) -> u64 {
         let mut fee_bytes = [0u8; 8];
-        // Copy the 7 fee bytes into a u64 array, leaving the most significant bit 0
+        // Copy the 7 fee bytes into a u64 array, leaving the most significant byte 0
         fee_bytes[1..].copy_from_slice(&self.memo_data[..Self::FEE_DATA_LEN]);
         u64::from_be_bytes(fee_bytes)
     }

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -50,6 +50,12 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
         if self.wrote_change_memo {
             return Err(NewMemoError::FeeAfterChange);
         }
+        if fee.value > GiftCodeCancellationMemo::MAX_FEE {
+            return Err(NewMemoError::MaxFeeExceeded(
+                GiftCodeCancellationMemo::MAX_FEE,
+                fee.value,
+            ));
+        }
         self.fee = fee;
         Ok(())
     }
@@ -154,5 +160,22 @@ mod tests {
 
         // Ensure memo creation fails
         assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_builder_set_fee_fails_when_exceeding_max_fee() {
+        let index = 666;
+        let mut builder = GiftCodeCancellationMemoBuilder::new(index);
+        let fee = Amount::new(u64::MAX, 0.into());
+
+        // Try to set a fee above max allowed
+        let result = builder.set_fee(fee);
+        assert_eq!(
+            result,
+            Err(NewMemoError::MaxFeeExceeded(
+                GiftCodeCancellationMemo::MAX_FEE,
+                fee.value
+            ))
+        );
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -139,10 +139,7 @@ mod tests {
         assert_eq!(fee.value, memo.get_fee());
 
         // Assert failure for the second attempted change output
-        assert_eq!(
-            memo_payload_2,
-            Err(NewMemoError::MultipleChangeOutputs)
-        );
+        assert_eq!(memo_payload_2, Err(NewMemoError::MultipleChangeOutputs));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -139,10 +139,10 @@ mod tests {
         assert_eq!(fee.value, memo.get_fee());
 
         // Assert failure for the second attempted change output
-        assert!(matches!(
+        assert_eq!(
             memo_payload_2,
             Err(NewMemoError::MultipleChangeOutputs)
-        ));
+        );
     }
 
     #[test]
@@ -159,7 +159,7 @@ mod tests {
         let memo_payload = build_change_memo_with_amount(&mut builder, amount);
 
         // Ensure memo creation fails
-        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
+        assert_eq!(memo_payload, Err(NewMemoError::MixedTokenIds));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -5,7 +5,7 @@
 
 use super::{memo::GiftCodeCancellationMemo, MemoBuilder, ReservedSubaddresses};
 use mc_account_keys::PublicAddress;
-use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
 /// There are three possible gift code memo types specified in MCIP #32
 /// | Memo type bytes | Name                        |
@@ -18,13 +18,18 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// gift code subaddress to their change address prior to it being spent by
 /// the receiver. When that happens a gift code cancellation memo is
 /// written to the change TxOut that stores the index of the TxOut originally
-/// sent to the gift code subaddress when the gift code was funded.
+/// sent to the gift code subaddress when the gift code was funded as well
+/// as the fee paid to cancel the gift code. The gift code memo uses 8 bytes
+/// to represent the cancellation index as a 64 bit number and the next 7 bytes
+/// to represent the fee as a 56 bit number.
 #[derive(Clone, Debug)]
 pub struct GiftCodeCancellationMemoBuilder {
     // Index of the gift code TxOut that was originally funded
     gift_code_tx_out_global_index: u64,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
+    // Fee paid for gift code cancellation
+    fee: Amount,
 }
 
 impl GiftCodeCancellationMemoBuilder {
@@ -34,13 +39,18 @@ impl GiftCodeCancellationMemoBuilder {
         Self {
             gift_code_tx_out_global_index,
             wrote_change_memo: false,
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         }
     }
 }
 
 impl MemoBuilder for GiftCodeCancellationMemoBuilder {
     /// Set the fee
-    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        if self.wrote_change_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
         Ok(())
     }
 
@@ -57,53 +67,92 @@ impl MemoBuilder for GiftCodeCancellationMemoBuilder {
     /// Write the cancellation memo to the change output
     fn make_memo_for_change_output(
         &mut self,
-        _amount: Amount,
+        amount: Amount,
         _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
         }
+        // fee and change amount token id must match
+        if self.fee.token_id != amount.token_id {
+            return Err(NewMemoError::MixedTokenIds);
+        }
         self.wrote_change_memo = true;
-        Ok(GiftCodeCancellationMemo::from(self.gift_code_tx_out_global_index).into())
+        Ok(
+            GiftCodeCancellationMemo::new(self.gift_code_tx_out_global_index, self.fee.value)?
+                .into(),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::build_zero_value_change_memo;
-    use std::convert::TryInto;
+    use crate::test_utils::build_change_memo_with_amount;
 
     #[test]
     fn test_gift_code_cancellation_memo_built_successfully_with_index() {
-        // Set the cancellation index and create memo builder
+        // Set the cancellation index and fee and create the memo builder
         let index = 666;
+        let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(1, 0.into());
         let mut builder = GiftCodeCancellationMemoBuilder::new(index);
+        builder.set_fee(fee).unwrap();
 
         // Build the memo payload and get the data
-        let memo_payload = build_zero_value_change_memo(&mut builder).unwrap();
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
         let memo_data = memo_payload.get_memo_data();
 
-        // Verify memo data
-        let derived_index = u64::from_le_bytes(memo_data[0..8].try_into().unwrap());
-        assert_eq!(index, derived_index);
+        // Recover memo
+        let memo = GiftCodeCancellationMemo::from(memo_data);
+
+        // Check recovered index is correct
+        assert_eq!(index, memo.cancelled_gift_code_index());
+
+        // Check recovered fee is correct
+        assert_eq!(fee.value, memo.get_fee());
     }
 
     #[test]
     fn test_gift_code_cancellation_memo_fails_for_more_than_one_change_memo() {
-        // Set the cancellation index and create memo builder
+        // Set the cancellation index and fee and create the memo builder
         let index = 666;
+        let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(20, 0.into());
         let mut builder = GiftCodeCancellationMemoBuilder::new(index);
+        builder.set_fee(fee).unwrap();
 
         // Attempt to build two change outputs
-        build_zero_value_change_memo(&mut builder).unwrap();
-        let memo_payload = build_zero_value_change_memo(&mut builder);
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
+        let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount);
 
-        // Assert failure for the second output
+        // Ensure we can recover the index and fee for the first change output
+        let memo = GiftCodeCancellationMemo::from(memo_payload.get_memo_data());
+        assert_eq!(index, memo.cancelled_gift_code_index());
+        assert_eq!(fee.value, memo.get_fee());
+
+        // Assert failure for the second attempted change output
         assert!(matches!(
-            memo_payload,
+            memo_payload_2,
             Err(NewMemoError::MultipleChangeOutputs)
         ));
+    }
+
+    #[test]
+    fn test_gift_code_cancellation_memo_builder_fee_token_cannot_be_different_from_change_token() {
+        let index = 666;
+        let mut builder = GiftCodeCancellationMemoBuilder::new(index);
+        let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(1, 9001.into());
+
+        // Set a fee with a different token id
+        builder.set_fee(fee).unwrap();
+
+        // Attempt to build the memo
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
+
+        // Ensure memo creation fails
+        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_cancellation_memo_builder.rs
@@ -163,15 +163,21 @@ mod tests {
     fn test_gift_code_cancellation_memo_builder_set_fee_fails_when_exceeding_max_fee() {
         let index = 666;
         let mut builder = GiftCodeCancellationMemoBuilder::new(index);
-        let fee = Amount::new(u64::MAX, 0.into());
+        let fee_max_minus_one = Amount::new(GiftCodeCancellationMemo::MAX_FEE - 1, 0.into());
+        let fee_max = Amount::new(GiftCodeCancellationMemo::MAX_FEE, 0.into());
+        let fee_max_plus_one = Amount::new(GiftCodeCancellationMemo::MAX_FEE + 1, 0.into());
 
-        // Try to set a fee above max allowed
-        let result = builder.set_fee(fee);
+        // Try to set fees near the maximum
+        builder.set_fee(fee_max_minus_one).unwrap();
+        builder.set_fee(fee_max).unwrap();
+        let result = builder.set_fee(fee_max_plus_one);
+
+        // Ensure amount above max fee fails
         assert_eq!(
             result,
             Err(NewMemoError::MaxFeeExceeded(
                 GiftCodeCancellationMemo::MAX_FEE,
-                fee.value
+                fee_max_plus_one.value
             ))
         );
     }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use mc_account_keys::PublicAddress;
 use mc_crypto_keys::RistrettoPublic;
-use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
 /// There are three possible gift code memo types specified in MCIP #32
 /// | Memo type bytes | Name                        |
@@ -21,25 +21,28 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 /// code is funded, the amount of the gift code is sent to a TxOut at the
 /// Sender's reserved gift code subaddress and a second (potentially zero
 /// valued) change TxOut is sent to the sender's reserved change subaddress
-/// with the gift code funding memo attached. The funding memo will include
-/// the first 4 bytes of the hash of the gift code TxOut sent to the
-/// sender's reserved gift code subaddress and 60 bytes for an optional
-/// utf-8 memo.
+/// with the gift code funding memo attached. The funding memo has 4 bytes
+/// reserved for the first 4 bytes of the hash of the gift code TxOut sent
+/// to the sender's reserved gift code subaddress, 7 bytes for a 56 bit
+/// unsigned big endian integer representing the fee paid for the TxOut and
+/// 53 bytes for an optional utf-8 note.
 #[derive(Clone, Debug)]
 pub struct GiftCodeFundingMemoBuilder {
-    // Utf-8 note within the memo that can be up to 60 bytes long
-    note: String,
     // TxOut Public Key of the gift code TxOut sent to the gift code subaddress.
     // This is populated when the output is created
     gift_code_tx_out_public_key: Option<RistrettoPublic>,
+    // Fee paid for gift code funding transaction
+    fee: Amount,
+    // Utf-8 note within the memo that can be up to 53 bytes long
+    note: String,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
 }
 
 impl GiftCodeFundingMemoBuilder {
-    /// Initialize memo builder with a utf-8 note (up to 60 bytes), This
-    /// method will enforce the 60 byte limit with a NewMemoErr if the
-    /// note passed is longer than 60 bytes.
+    /// Initialize memo builder with a utf-8 note (up to 53 bytes), This
+    /// method will enforce the 53 byte limit with a NewMemoErr if the
+    /// note passed is longer than 53 bytes.
     pub fn new(note: &str) -> Result<Self, NewMemoError> {
         if note.len() > GiftCodeFundingMemo::NOTE_DATA_LEN {
             return Err(NewMemoError::BadInputs(format!(
@@ -48,8 +51,9 @@ impl GiftCodeFundingMemoBuilder {
             )));
         }
         Ok(Self {
-            note: note.into(),
             gift_code_tx_out_public_key: None,
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
+            note: note.into(),
             wrote_change_memo: false,
         })
     }
@@ -57,7 +61,11 @@ impl GiftCodeFundingMemoBuilder {
 
 impl MemoBuilder for GiftCodeFundingMemoBuilder {
     /// Set the fee
-    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        if self.wrote_change_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
         Ok(())
     }
 
@@ -85,7 +93,7 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
     /// Write the funding memo onto the change output of the gift code TxOut
     fn make_memo_for_change_output(
         &mut self,
-        _amount: Amount,
+        amount: Amount,
         _change_destination: &ReservedSubaddresses,
         memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
@@ -95,9 +103,16 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
         if self.gift_code_tx_out_public_key.as_ref() == Some(memo_context.tx_public_key) {
             return Err(NewMemoError::BadInputs("The public_key in the memo should be the TxOut at the gift code subaddress and not that of the memo TxOut".into()));
         }
+        // Fee must be the same token_id as the gift code token_id
+        if self.fee.token_id != amount.token_id {
+            return Err(NewMemoError::MixedTokenIds);
+        }
         if let Some(tx_out_public_key) = self.gift_code_tx_out_public_key.take() {
             self.wrote_change_memo = true;
-            Ok(GiftCodeFundingMemo::new(&tx_out_public_key, self.note.as_str())?.into())
+            Ok(
+                GiftCodeFundingMemo::new(&tx_out_public_key, self.fee.value, self.note.as_str())?
+                    .into(),
+            )
         } else {
             Err(NewMemoError::MissingOutput)
         }
@@ -114,6 +129,7 @@ mod tests {
     fn build_gift_code_memos(
         builder: &mut impl MemoBuilder,
         funding_tx_pubkey: &RistrettoPublic,
+        fee: Amount,
     ) -> Result<MemoPayload, NewMemoError> {
         // Create simulated context
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
@@ -129,6 +145,7 @@ mod tests {
             tx_public_key: &change_tx_pubkey,
         };
 
+        builder.set_fee(fee).unwrap();
         // Build blank output memo for TxOut at gift code address & funding memo to
         // change output
         builder
@@ -148,13 +165,17 @@ mod tests {
         let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
         let note = "It's MEMO TIME!!";
         let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+        let fee = Amount::new(1, 0.into());
 
-        // Build the memo payload and get the data
-        let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+        // Set fee and build the memo payload
+        builder.set_fee(fee).unwrap();
+        let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key, fee).unwrap();
 
         // Verify memo data
         let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
         let derived_note = memo.funding_note().unwrap();
+        let derived_fee = memo.get_fee();
+        assert_eq!(fee.value, derived_fee);
         assert_eq!(note, derived_note);
         assert!(memo.public_key_matches(&gift_code_public_key));
     }
@@ -168,18 +189,22 @@ mod tests {
         let note_exact = std::str::from_utf8(&[b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN]).unwrap();
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
         let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
-
+        let fee = Amount::new(1, 0.into());
         // Test blank note is okay
         {
             let mut builder = GiftCodeFundingMemoBuilder::new(blank_note).unwrap();
 
-            // Build the memo payload and get the data
-            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+            // Set fee and build the memo payload
+            builder.set_fee(fee).unwrap();
+            let memo_payload =
+                build_gift_code_memos(&mut builder, &gift_code_public_key, fee).unwrap();
 
             // Verify memo data
             let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
             let derived_note = memo.funding_note().unwrap();
             assert_eq!(blank_note, derived_note);
+            let derived_fee = memo.get_fee();
+            assert_eq!(fee.value, derived_fee);
             assert!(memo.public_key_matches(&gift_code_public_key));
         }
 
@@ -187,13 +212,17 @@ mod tests {
         {
             let mut builder = GiftCodeFundingMemoBuilder::new(note_minus_one).unwrap();
 
-            // Build the memo payload and get the data
-            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+            // Set fee and build the memo payload
+            builder.set_fee(fee).unwrap();
+            let memo_payload =
+                build_gift_code_memos(&mut builder, &gift_code_public_key, fee).unwrap();
 
             // Verify memo data
             let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
             let derived_note = memo.funding_note().unwrap();
             assert_eq!(note_minus_one, derived_note);
+            let derived_fee = memo.get_fee();
+            assert_eq!(fee.value, derived_fee);
             assert!(memo.public_key_matches(&gift_code_public_key));
         }
 
@@ -201,13 +230,17 @@ mod tests {
         {
             let mut builder = GiftCodeFundingMemoBuilder::new(note_exact).unwrap();
 
-            // Build the memo payload and get the data
-            let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key).unwrap();
+            // Set fee and build the memo payload
+            builder.set_fee(fee).unwrap();
+            let memo_payload =
+                build_gift_code_memos(&mut builder, &gift_code_public_key, fee).unwrap();
 
             // Verify memo data
             let memo = GiftCodeFundingMemo::from(memo_payload.get_memo_data());
             let derived_note = memo.funding_note().unwrap();
             assert_eq!(note_exact, derived_note);
+            let derived_fee = memo.get_fee();
+            assert_eq!(fee.value, derived_fee);
             assert!(memo.public_key_matches(&gift_code_public_key));
         }
     }
@@ -217,6 +250,7 @@ mod tests {
         // Create memo builder with note
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
         let note = "It's MEMO TIME!!";
+        let fee = Amount::new(1, 0.into());
         let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
 
         // Build a memo
@@ -226,6 +260,7 @@ mod tests {
 
         // Erroneously set funding TxOut pubkey to the change TxOut pubkey
         let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
+        builder.set_fee(fee).unwrap();
         builder
             .make_memo_for_output(
                 change_amount,
@@ -253,16 +288,18 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
         let note = "It's MEMO TIME!!";
         let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+        let fee = Amount::new(1, 0.into());
 
         // Build a memo
         let alice = AccountKey::random_with_fog(&mut rng);
         let alice_address_book = ReservedSubaddresses::from(&alice);
-        let change_amount = Amount::new(666, 666.into());
+        let change_amount = Amount::new(666, 0.into());
 
         // Write 2 change outputs
         let funding_tx_out_public_key = RistrettoPublic::from_random(&mut rng);
         let change_tx_public_key = RistrettoPublic::from_random(&mut rng);
         let change_tx_public_key_2 = RistrettoPublic::from_random(&mut rng);
+        builder.set_fee(fee).unwrap();
         builder
             .make_memo_for_output(
                 change_amount,
@@ -297,13 +334,31 @@ mod tests {
     }
 
     #[test]
-    fn test_gift_code_sender_note_builder_creation_fails_with_invalid_note() {
-        // Create Memo Builder with Bad Inputs
+    fn test_gift_code_funding_memo_builder_creation_fails_with_invalid_note() {
+        // Create Memo Builder with note length exceeding max length
         let note_bytes = [b'6'; GiftCodeFundingMemo::NOTE_DATA_LEN + 1];
         let note = std::str::from_utf8(&note_bytes).unwrap();
         let builder = GiftCodeFundingMemoBuilder::new(note);
 
         //Assert memo creation fails
         assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
+    }
+
+    #[test]
+    fn test_gift_code_funding_memo_builder_fee_token_cannot_be_different_from_change_token() {
+        let mut rng: StdRng = SeedableRng::from_seed([0u8; 32]);
+        let gift_code_public_key = RistrettoPublic::from_random(&mut rng);
+        let note = "It's MEMO TIME!!";
+        let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
+        let fee = Amount::new(1, 9001.into());
+
+        // Set a fee with a different token id
+        builder.set_fee(fee).unwrap();
+
+        // Attempt to build the memo
+        let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key, fee);
+
+        // Ensure memo creation fails
+        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -368,15 +368,21 @@ mod tests {
     fn test_gift_code_funding_memo_builder_set_fee_fails_when_exceeding_max_fee() {
         let note = "It's MEMO TIME!!";
         let mut builder = GiftCodeFundingMemoBuilder::new(note).unwrap();
-        let fee = Amount::new(u64::MAX, 0.into());
+        let fee_max_minus_one = Amount::new(GiftCodeFundingMemo::MAX_FEE - 1, 0.into());
+        let fee_max = Amount::new(GiftCodeFundingMemo::MAX_FEE, 0.into());
+        let fee_max_plus_one = Amount::new(GiftCodeFundingMemo::MAX_FEE + 1, 0.into());
 
-        // Try to set a fee above max allowed
-        let result = builder.set_fee(fee);
+        // Try to set fees near the maximum
+        builder.set_fee(fee_max_minus_one).unwrap();
+        builder.set_fee(fee_max).unwrap();
+        let result = builder.set_fee(fee_max_plus_one);
+
+        // Ensure amount above max fee fails
         assert_eq!(
             result,
             Err(NewMemoError::MaxFeeExceeded(
                 GiftCodeFundingMemo::MAX_FEE,
-                fee.value
+                fee_max_plus_one.value
             ))
         );
     }

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -127,8 +127,8 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use super::*;
+    use assert_matches::assert_matches;
     use mc_account_keys::AccountKey;
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
@@ -332,10 +332,7 @@ mod tests {
         );
 
         // Assert memo creation fails for second change output
-        assert_eq!(
-            memo_payload,
-            Err(NewMemoError::MultipleChangeOutputs)
-        );
+        assert_eq!(memo_payload, Err(NewMemoError::MultipleChangeOutputs));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_funding_memo_builder.rs
@@ -127,6 +127,7 @@ impl MemoBuilder for GiftCodeFundingMemoBuilder {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use super::*;
     use mc_account_keys::AccountKey;
     use mc_util_from_random::FromRandom;
@@ -282,7 +283,7 @@ mod tests {
         );
 
         // Assert memo creation fails
-        assert!(matches!(memo_payload, Err(NewMemoError::BadInputs(_))));
+        assert_matches!(memo_payload, Err(NewMemoError::BadInputs(_)));
     }
 
     #[test]
@@ -331,10 +332,10 @@ mod tests {
         );
 
         // Assert memo creation fails for second change output
-        assert!(matches!(
+        assert_eq!(
             memo_payload,
             Err(NewMemoError::MultipleChangeOutputs)
-        ));
+        );
     }
 
     #[test]
@@ -345,7 +346,7 @@ mod tests {
         let builder = GiftCodeFundingMemoBuilder::new(note);
 
         //Assert memo creation fails
-        assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
+        assert_matches!(builder, Err(NewMemoError::BadInputs(_)));
     }
 
     #[test]
@@ -363,7 +364,7 @@ mod tests {
         let memo_payload = build_gift_code_memos(&mut builder, &gift_code_public_key, fee);
 
         // Ensure memo creation fails
-        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
+        assert_eq!(memo_payload, Err(NewMemoError::MixedTokenIds));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -228,15 +228,21 @@ mod tests {
     fn test_gift_code_sender_memo_builder_set_fee_fails_when_exceeding_max_fee() {
         let note = "It's MEMO TIME!!";
         let mut builder = GiftCodeSenderMemoBuilder::new(note).unwrap();
-        let fee = Amount::new(u64::MAX, 0.into());
+        let fee_max_minus_one = Amount::new(GiftCodeSenderMemo::MAX_FEE - 1, 0.into());
+        let fee_max = Amount::new(GiftCodeSenderMemo::MAX_FEE, 0.into());
+        let fee_max_plus_one = Amount::new(GiftCodeSenderMemo::MAX_FEE + 1, 0.into());
 
-        // Try to set a fee above max allowed
-        let result = builder.set_fee(fee);
+        // Try to set fees near the maximum
+        builder.set_fee(fee_max_minus_one).unwrap();
+        builder.set_fee(fee_max).unwrap();
+        let result = builder.set_fee(fee_max_plus_one);
+
+        // Ensure amount above max fee fails
         assert_eq!(
             result,
             Err(NewMemoError::MaxFeeExceeded(
                 GiftCodeSenderMemo::MAX_FEE,
-                fee.value
+                fee_max_plus_one.value
             ))
         );
     }

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -5,7 +5,7 @@
 
 use crate::{memo::GiftCodeSenderMemo, MemoBuilder, ReservedSubaddresses};
 use mc_account_keys::PublicAddress;
-use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
+use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 
 /// There are three possible gift code memo types specified in MCIP #32
 /// | Memo type bytes | Name                        |
@@ -27,6 +27,8 @@ pub struct GiftCodeSenderMemoBuilder {
     note: String,
     // Whether we've already written the change memo
     wrote_change_memo: bool,
+    // Fee paid to redeem gift code
+    fee: Amount,
 }
 
 impl GiftCodeSenderMemoBuilder {
@@ -34,22 +36,27 @@ impl GiftCodeSenderMemoBuilder {
     /// method will enforce the 64 byte limit with a NewMemoErr if the
     /// note passed is longer than 64 bytes.
     pub fn new(note: &str) -> Result<Self, NewMemoError> {
-        if note.len() > GiftCodeSenderMemo::MEMO_DATA_LEN {
+        if note.len() > GiftCodeSenderMemo::NOTE_DATA_LEN {
             return Err(NewMemoError::BadInputs(format!(
                 "Note memo cannot be greater than {} bytes",
-                GiftCodeSenderMemo::MEMO_DATA_LEN
+                GiftCodeSenderMemo::NOTE_DATA_LEN
             )));
         }
         Ok(Self {
             note: note.into(),
             wrote_change_memo: false,
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         })
     }
 }
 
 impl MemoBuilder for GiftCodeSenderMemoBuilder {
     /// Set the fee
-    fn set_fee(&mut self, _fee: Amount) -> Result<(), NewMemoError> {
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        if self.wrote_change_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
         Ok(())
     }
 
@@ -67,15 +74,19 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
     /// address when the gift code is redeemed
     fn make_memo_for_change_output(
         &mut self,
-        _amount: Amount,
+        amount: Amount,
         _change_destination: &ReservedSubaddresses,
         _memo_context: MemoContext,
     ) -> Result<MemoPayload, NewMemoError> {
         if self.wrote_change_memo {
             return Err(NewMemoError::MultipleChangeOutputs);
         };
+        // fee and change amount token id must match
+        if self.fee.token_id != amount.token_id {
+            return Err(NewMemoError::MixedTokenIds);
+        }
         self.wrote_change_memo = true;
-        Ok(GiftCodeSenderMemo::new(self.note.as_str())?.into())
+        Ok(GiftCodeSenderMemo::new(self.fee.value, self.note.as_str())?.into())
     }
 }
 
@@ -92,11 +103,15 @@ mod tests {
 
         // Build the memo payload and get the data
         let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(10, 0.into());
+        builder.set_fee(fee).unwrap();
+
         let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
         // Verify memo data
-        let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
-        assert_eq!(note, derived_note.sender_note().unwrap());
+        let derived_memo = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+        assert_eq!(note, derived_memo.sender_note().unwrap());
+        assert_eq!(fee.value, derived_memo.get_fee());
     }
 
     #[test]
@@ -104,45 +119,52 @@ mod tests {
     {
         // Create edge case notes
         let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(10, 0.into());
         let blank_note = "";
         let note_minus_one =
-            std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN - 1]).unwrap();
-        let note_exact = std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN]).unwrap();
+            std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN - 1]).unwrap();
+        let note_exact = std::str::from_utf8(&[b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN]).unwrap();
 
         // Verify blank note is okay
         {
             let mut builder = GiftCodeSenderMemoBuilder::new(blank_note).unwrap();
+            builder.set_fee(fee).unwrap();
 
             // Build the memo payload and get the data
             let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
             // Verify memo data
-            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
-            assert_eq!(blank_note, derived_note.sender_note().unwrap());
+            let derived_memo = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(blank_note, derived_memo.sender_note().unwrap());
+            assert_eq!(fee.value, derived_memo.get_fee());
         }
 
         // Verify note with max length minus one is okay
         {
             let mut builder = GiftCodeSenderMemoBuilder::new(note_minus_one).unwrap();
+            builder.set_fee(fee).unwrap();
 
             // Build the memo payload and get the data
             let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
             // Verify memo data
-            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
-            assert_eq!(note_minus_one, derived_note.sender_note().unwrap());
+            let derived_memo = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(note_minus_one, derived_memo.sender_note().unwrap());
+            assert_eq!(fee.value, derived_memo.get_fee());
         }
 
         // Verify note with max length okay
         {
             let mut builder = GiftCodeSenderMemoBuilder::new(note_exact).unwrap();
+            builder.set_fee(fee).unwrap();
 
             // Build the memo payload and get the data
             let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
             // Verify memo data
-            let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
-            assert_eq!(note_exact, derived_note.sender_note().unwrap());
+            let derived_memo = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+            assert_eq!(note_exact, derived_memo.sender_note().unwrap());
+            assert_eq!(fee.value, derived_memo.get_fee());
         }
     }
 
@@ -154,11 +176,15 @@ mod tests {
 
         // Build the memo payload and get the data
         let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(10, 0.into());
+        builder.set_fee(fee).unwrap();
+
         let memo_payload = build_change_memo_with_amount(&mut builder, amount).unwrap();
 
         // Verify memo data can be verified after writing the first change memo
-        let derived_note = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
-        assert_eq!(note, derived_note.sender_note().unwrap());
+        let derived_memo = GiftCodeSenderMemo::from(memo_payload.get_memo_data());
+        assert_eq!(note, derived_memo.sender_note().unwrap());
+        assert_eq!(fee.value, derived_memo.get_fee());
 
         // Verify attempting to write two change memos fail
         let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount);
@@ -171,9 +197,26 @@ mod tests {
     #[test]
     fn test_gift_code_sender_note_builder_creation_fails_with_invalid_note() {
         // Create Memo Builder with an input longer than allowed
-        let note_bytes = [b'6'; GiftCodeSenderMemo::MEMO_DATA_LEN + 1];
+        let note_bytes = [b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN + 1];
         let note = std::str::from_utf8(&note_bytes).unwrap();
         let builder = GiftCodeSenderMemoBuilder::new(note);
         assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
+    }
+
+    #[test]
+    fn test_gift_code_sender_memo_builder_fee_token_cannot_be_different_from_change_token() {
+        let note = "It's MEMO TIME!!";
+        let mut builder = GiftCodeSenderMemoBuilder::new(note).unwrap();
+        let amount = Amount::new(42, 0.into());
+        let fee = Amount::new(1, 9001.into());
+
+        // Set a fee with a different token id
+        builder.set_fee(fee).unwrap();
+
+        // Attempt to build the memo
+        let memo_payload = build_change_memo_with_amount(&mut builder, amount);
+
+        // Ensure memo creation fails
+        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
     }
 }

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -98,9 +98,9 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use super::*;
     use crate::test_utils::build_change_memo_with_amount;
+    use assert_matches::assert_matches;
 
     #[test]
     fn test_gift_code_sender_memo_built_successfully_with_note() {
@@ -195,10 +195,7 @@ mod tests {
 
         // Verify attempting to write two change memos fail
         let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount);
-        assert_eq!(
-            memo_payload_2,
-            Err(NewMemoError::MultipleChangeOutputs)
-        );
+        assert_eq!(memo_payload_2, Err(NewMemoError::MultipleChangeOutputs));
     }
 
     #[test]

--- a/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
+++ b/transaction/std/src/memo_builder/gift_code_sender_memo_builder.rs
@@ -98,6 +98,7 @@ impl MemoBuilder for GiftCodeSenderMemoBuilder {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
     use super::*;
     use crate::test_utils::build_change_memo_with_amount;
 
@@ -194,10 +195,10 @@ mod tests {
 
         // Verify attempting to write two change memos fail
         let memo_payload_2 = build_change_memo_with_amount(&mut builder, amount);
-        assert!(matches!(
+        assert_eq!(
             memo_payload_2,
             Err(NewMemoError::MultipleChangeOutputs)
-        ));
+        );
     }
 
     #[test]
@@ -206,7 +207,7 @@ mod tests {
         let note_bytes = [b'6'; GiftCodeSenderMemo::NOTE_DATA_LEN + 1];
         let note = std::str::from_utf8(&note_bytes).unwrap();
         let builder = GiftCodeSenderMemoBuilder::new(note);
-        assert!(matches!(builder, Err(NewMemoError::BadInputs(_))));
+        assert_matches!(builder, Err(NewMemoError::BadInputs(_)));
     }
 
     #[test]
@@ -223,7 +224,7 @@ mod tests {
         let memo_payload = build_change_memo_with_amount(&mut builder, amount);
 
         // Ensure memo creation fails
-        assert!(matches!(memo_payload, Err(NewMemoError::MixedTokenIds)))
+        assert_eq!(memo_payload, Err(NewMemoError::MixedTokenIds))
     }
 
     #[test]

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -208,13 +208,6 @@ pub fn get_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver + Clone>
     transaction_builder.build(&NoKeysRingSigner {}, rng)
 }
 
-/// Build simulated change memo with zero amount
-pub fn build_zero_value_change_memo(
-    builder: &mut impl MemoBuilder,
-) -> Result<MemoPayload, NewMemoError> {
-    build_change_memo_with_amount(builder, Amount::new(0, 0.into()))
-}
-
 /// Build simulated change memo with amount
 pub fn build_change_memo_with_amount(
     builder: &mut impl MemoBuilder,

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -3282,6 +3282,7 @@ pub mod transaction_builder_tests {
                     MemoType::GiftCodeFunding(memo) => {
                         assert!(memo.public_key_matches(funding_output_public_key),);
                         assert_eq!(memo.funding_note().unwrap(), note,);
+                        assert_eq!(memo.get_fee(), fee);
                     }
                     _ => {
                         panic!("unexpected memo type")
@@ -3413,7 +3414,8 @@ pub mod transaction_builder_tests {
                 let memo = change.e_memo.unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                     MemoType::GiftCodeSender(memo) => {
-                        assert_eq!(memo.sender_note().unwrap(), note,);
+                        assert_eq!(memo.sender_note().unwrap(), note);
+                        assert_eq!(memo.get_fee(), fee);
                     }
                     _ => {
                         panic!("unexpected memo type")
@@ -3488,7 +3490,8 @@ pub mod transaction_builder_tests {
                 let memo = change.e_memo.unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                     MemoType::GiftCodeCancellation(memo) => {
-                        assert_eq!(memo.cancelled_gift_code_index(), sample_index,);
+                        assert_eq!(memo.cancelled_gift_code_index(), sample_index);
+                        assert_eq!(memo.get_fee(), fee);
                     }
                     _ => {
                         panic!("unexpected memo type")

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -3282,7 +3282,6 @@ pub mod transaction_builder_tests {
                     MemoType::GiftCodeFunding(memo) => {
                         assert!(memo.public_key_matches(funding_output_public_key),);
                         assert_eq!(memo.funding_note().unwrap(), note,);
-                        assert_eq!(memo.get_fee(), fee);
                     }
                     _ => {
                         panic!("unexpected memo type")
@@ -3414,8 +3413,7 @@ pub mod transaction_builder_tests {
                 let memo = change.e_memo.unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                     MemoType::GiftCodeSender(memo) => {
-                        assert_eq!(memo.sender_note().unwrap(), note);
-                        assert_eq!(memo.get_fee(), fee);
+                        assert_eq!(memo.sender_note().unwrap(), note,);
                     }
                     _ => {
                         panic!("unexpected memo type")
@@ -3490,8 +3488,7 @@ pub mod transaction_builder_tests {
                 let memo = change.e_memo.unwrap().decrypt(&ss);
                 match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                     MemoType::GiftCodeCancellation(memo) => {
-                        assert_eq!(memo.cancelled_gift_code_index(), sample_index);
-                        assert_eq!(memo.get_fee(), fee);
+                        assert_eq!(memo.cancelled_gift_code_index(), sample_index,);
                     }
                     _ => {
                         panic!("unexpected memo type")


### PR DESCRIPTION
### Summary of Changes
* Added fee bytes to gift code memos
* Added methods for setting/extracting fees
* Added extra tests & error checking

### Motivation

It was determined that fees should be added to gift code memos. This PR adds fee bytes to gift code memos and updates tests, checks, and documentation to reflect those changes.

### Points to discuss
* The fees are tracked in big endian bytes, but the index on the gift code cancellation memo was originally in little endian bytes. Shall we just make the index tracked in big endian bytes as well?

### Future Work
* Add method in transaction builder to allow gift codes to be funded
* Work Remaining in: #1735 