### PR TITLE
make mobilecoind-json integration test work with root entropy accounts (#2043)

### DIFF
--- a/mobilecoind-json/tests/integration_test.py
+++ b/mobilecoind-json/tests/integration_test.py
@@ -57,8 +57,20 @@ class MobilecoindJsonClient:
     def get_ledger_local(self):
         return self.request(f"ledger/local")
 
-    def account_key_from_mnemonic(self, mnemonic):
-        return self.request("account-key-from-mnemonic", {"mnemonic": mnemonic})
+    # Takes the json loaded from a private key file, tests if it is mnemnonic or root entropy
+    #
+    # If it is mnemonic, we pass the mnemonic to `account-key-from-mnemonic` route
+    # Otherwise, we hit the `entropy/{root_entropy}` route.
+    # Both return Json account key response.
+    def account_key_from_json(self, obj):
+        if "mnemonic" in obj:
+            return self.request("account-key-from-mnemonic", {"mnemonic": obj["mnemonic"]})
+        elif "root_entropy" in obj:
+            # Take the integer array in obj["root_entropy"], convert it to builtin bytes, then
+            # get hex string of that.
+            return self.request("entropy/{}".format(bytes(obj["root_entropy"]).hex()))
+        else:
+            raise Exception("unknown key format", obj)
 
     def get_public_address(self, monitor_id, subaddress_index=0):
         return self.request(f"monitors/{monitor_id}/subaddresses/{subaddress_index}/public-address")
@@ -113,7 +125,7 @@ def run_test(mobilecoind_json_url, keys_dir, max_seconds):
     # Add two monitors and wait for them to sync
     monitor_ids = []
     for i in range(2):
-        account_key = client.account_key_from_mnemonic(keys[i]["mnemonic"])
+        account_key = client.account_key_from_json(keys[i])
         monitor = client.create_monitor(account_key)
         logging.info(f"{i}: Monitor created: {monitor}, waiting to sync...")
         monitor_id = monitor["monitor_id"]


### PR DESCRIPTION
This picks #2043 from release 1.2, there were no conflicts

---

* make mobilecoind-json integration test work with mnemonics

* fix mistakes

* remoun improvement

* derp

* simplify