### PR TITLE
Clean up some test helpers

### DIFF
--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! Utilities for Stellar Consensus Protocol tests.
+#![allow(unused)]
+
 use crate::{core_types::Value, slot::Slot, QuorumSet, SlotIndex};
 use mc_common::{logger::Logger, NodeID, ResponderId};
 use mc_crypto_keys::Ed25519Pair;
@@ -32,7 +34,7 @@ pub fn trivial_combine_fn<V: Value>(values: &[V]) -> Result<Vec<V>, TransactionV
 }
 
 /// Returns at most the first `n` values.
-#[allow(unused)]
+
 pub fn get_bounded_combine_fn<V: Value>(
     max_elements: usize,
 ) -> impl Fn(&[V]) -> Result<Vec<V>, TransactionValidationError> {

--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -2,8 +2,9 @@
 
 //! Utilities for Stellar Consensus Protocol tests.
 
-// Not all integration tests use all of the common code. https://github.com/rust-lang/rust/issues/46379
-#![allow(unused)]
+// We allow dead code because not all integration tests use all of the common
+// code. https://github.com/rust-lang/rust/issues/46379
+#![allow(dead_code)]
 
 use crate::{core_types::Value, slot::Slot, QuorumSet, SlotIndex};
 use mc_common::{logger::Logger, NodeID, ResponderId};

--- a/consensus/scp/src/test_utils.rs
+++ b/consensus/scp/src/test_utils.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! Utilities for Stellar Consensus Protocol tests.
+
+// Not all integration tests use all of the common code. https://github.com/rust-lang/rust/issues/46379
 #![allow(unused)]
 
 use crate::{core_types::Value, slot::Slot, QuorumSet, SlotIndex};

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -4,7 +4,7 @@
 
 // We allow dead code because not all integration tests use all of the common
 // code. https://github.com/rust-lang/rust/issues/46379
-#![allow(dead_code)]
+#![allow(unused)]
 
 use mc_common::{
     logger::{log, Logger},

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -4,7 +4,7 @@
 
 // We allow dead code because not all integration tests use all of the common
 // code. https://github.com/rust-lang/rust/issues/46379
-#![allow(unused)]
+#![allow(dead_code)]
 
 use mc_common::{
     logger::{log, Logger},

--- a/crypto/noise/src/symmetric_state.rs
+++ b/crypto/noise/src/symmetric_state.rs
@@ -152,7 +152,7 @@ where
     ///
     /// MobileCoin does not currently utilize pre-shared keys anywhere, so
     /// this is unused,
-    #[allow(unused)]
+    #[allow(dead_code)]
     pub fn mix_key_and_hash(
         &mut self,
         input_key_material: KexAlgo::Secret,

--- a/fog/ingest/enclave/impl/src/rng_store.rs
+++ b/fog/ingest/enclave/impl/src/rng_store.rs
@@ -52,7 +52,7 @@ pub struct RngStore<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> {
     /// Desired capacity for the oblivious map
     desired_capacity: u64,
     /// Logger object
-    #[allow(unused)]
+    #[allow(dead_code)]
     logger: Logger,
 }
 

--- a/fog/ledger/connection/src/block.rs
+++ b/fog/ledger/connection/src/block.rs
@@ -15,7 +15,7 @@ pub struct FogBlockGrpcClient {
     blocks_client: FogBlockApiClient,
     creds: BasicCredentials,
     grpc_retry_config: GrpcRetryConfig,
-    #[allow(unused)]
+    #[allow(dead_code)]
     logger: Logger,
 }
 

--- a/fog/ledger/connection/src/untrusted.rs
+++ b/fog/ledger/connection/src/untrusted.rs
@@ -18,7 +18,7 @@ pub struct FogUntrustedLedgerGrpcClient {
     tx_out_client: ledger_grpc::FogUntrustedTxOutApiClient,
     creds: BasicCredentials,
     grpc_retry_config: GrpcRetryConfig,
-    #[allow(unused)]
+    #[allow(dead_code)]
     logger: Logger,
 }
 

--- a/fog/ocall_oram_storage/trusted/src/lib.rs
+++ b/fog/ocall_oram_storage/trusted/src/lib.rs
@@ -628,7 +628,7 @@ mod helpers {
     // Test version of UntrustedAllocation (see Untrusted crate)
     #[derive(Default)]
     struct Allocation {
-        #[allow(unused)]
+        #[allow(dead_code)]
         count: u64,
         data_size: u64,
         meta_size: u64,

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -67,7 +67,7 @@ pub struct ETxOutStore<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>
     last_ciphertext_size_byte: u8,
 
     /// The logger object
-    #[allow(unused)]
+    #[allow(dead_code)]
     logger: Logger,
 }
 

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Mock Peer test utilities
 
+pub use mc_consensus_scp::test_utils::{test_node_id, test_node_id_and_signer};
+
 use mc_common::{NodeID, ResponderId};
 use mc_connection::{
     BlockInfo, BlockchainConnection, Connection, Error as ConnectionError,
@@ -14,16 +16,13 @@ use mc_consensus_scp::{
     quorum_set::QuorumSet,
     SlotIndex, Topic,
 };
-use mc_crypto_keys::Ed25519Pair;
+use mc_crypto_keys::{Ed25519Pair, Ed25519Public};
 use mc_ledger_db::{test_utils::mock_ledger::MockLedger, Ledger};
 use mc_peers::{
     ConsensusConnection, ConsensusMsg, ConsensusValue, Error as PeerError, Result as PeerResult,
 };
 use mc_transaction_core::{tx::TxHash, Block, BlockID, BlockIndex};
-use mc_util_from_random::FromRandom;
 use mc_util_uri::{ConnectionUri, ConsensusPeerUri as PeerUri};
-use rand::SeedableRng;
-use rand_hc::Hc128Rng as FixedRng;
 use sha2::{Digest, Sha512_256};
 use std::{
     cmp::{min, Ordering},
@@ -245,34 +244,16 @@ pub fn create_consensus_msg(
         .expect("Could not create consensus message")
 }
 
-pub fn test_node_id(node_id: u32) -> NodeID {
-    let (node_id, _signer) = test_node_id_and_signer(node_id);
-    node_id
+pub fn test_peer_uri(node_id: u32) -> PeerUri {
+    let (_node_id, signer) = test_node_id_and_signer(node_id);
+    test_peer_uri_with_key(node_id, &signer.public_key())
 }
 
-pub fn test_node_id_and_signer(node_id: u32) -> (NodeID, Ed25519Pair) {
-    let mut seed_bytes = [0u8; 32];
-    let node_id_bytes = node_id.to_be_bytes();
-    seed_bytes[..node_id_bytes.len()].copy_from_slice(&node_id_bytes[..]);
-
-    let mut seeded_rng: FixedRng = SeedableRng::from_seed(seed_bytes);
-    let signer_keypair = Ed25519Pair::from_random(&mut seeded_rng);
-    (
-        NodeID {
-            responder_id: ResponderId::from_str(&format!("node{}.test.com:8443", node_id)).unwrap(),
-            public_key: signer_keypair.public_key(),
-        },
-        signer_keypair,
-    )
-}
-
-pub fn test_peer_uri(node_id_int: u32) -> PeerUri {
-    let (_node_id, signer_keypair) = test_node_id_and_signer(node_id_int);
-
+pub fn test_peer_uri_with_key(node_id: u32, public_key: &Ed25519Public) -> PeerUri {
     PeerUri::from_str(&format!(
         "mcp://node{}.test.com?consensus-msg-key={}",
-        node_id_int,
-        hex::encode(signer_keypair.public_key()),
+        node_id,
+        hex::encode(public_key),
     ))
     .expect("Could not construct peer URI from string")
 }
@@ -284,6 +265,9 @@ mod peer_manager_tests {
     use mc_connection::ConnectionManager;
     use mc_ledger_db::test_utils::get_mock_ledger;
     use mc_peers::RetryableConsensusConnection;
+    use mc_util_from_random::FromRandom;
+    use rand::SeedableRng;
+    use rand_hc::Hc128Rng as FixedRng;
     use retry::delay::Fibonacci;
 
     #[test]
@@ -408,6 +392,9 @@ mod threaded_broadcaster_tests {
         ThreadedBroadcasterFibonacciRetryPolicy as FibonacciRetryPolicy,
         DEFAULT_RETRY_MAX_ATTEMPTS,
     };
+    use mc_util_from_random::FromRandom;
+    use rand::SeedableRng;
+    use rand_hc::Hc128Rng as FixedRng;
 
     #[test_with_logger]
     // A message from a local node (who is not in the peers list) should be

--- a/transaction/core/tests/util/mod.rs
+++ b/transaction/core/tests/util/mod.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
+#![allow(unused)]
+
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{tx::Tx, BlockVersion};
 use mc_transaction_core_test_utils::{
@@ -34,7 +36,6 @@ pub fn create_test_tx(block_version: BlockVersion) -> (Tx, LedgerDB) {
     (tx, ledger)
 }
 
-#[allow(unused)]
 pub fn create_test_tx_with_amount(
     block_version: BlockVersion,
     amount: u64,
@@ -43,7 +44,6 @@ pub fn create_test_tx_with_amount(
     create_test_tx_with_amount_and_comparer::<DefaultTxOutputsOrdering>(block_version, amount, fee)
 }
 
-#[allow(unused)]
 pub fn create_test_tx_with_amount_and_comparer<O: TxOutputsOrdering>(
     block_version: BlockVersion,
     amount: u64,

--- a/transaction/core/tests/util/mod.rs
+++ b/transaction/core/tests/util/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
+// Not all integration tests use all of the common code. https://github.com/rust-lang/rust/issues/46379
 #![allow(unused)]
 
 use mc_ledger_db::{Ledger, LedgerDB};

--- a/transaction/core/tests/util/mod.rs
+++ b/transaction/core/tests/util/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-// Not all integration tests use all of the common code. https://github.com/rust-lang/rust/issues/46379
-#![allow(unused)]
+// We allow dead code because not all integration tests use all of the common
+// code. https://github.com/rust-lang/rust/issues/46379
+#![allow(dead_code)]
 
 use mc_ledger_db::{Ledger, LedgerDB};
 use mc_transaction_core::{tx::Tx, BlockVersion};


### PR DESCRIPTION
* Dedupe `test_node_id` and `test_peer_uri`
* Change `allow(unused)` to the more specific `allow(dead_code)`
* Rearrange some `allow` instances
