### PR TITLE
Fix json to grpc gw ports.

### DIFF
--- a/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
@@ -126,7 +126,7 @@ spec:
         imagePullPolicy: Always
         command:
         - /usr/bin/go-grpc-gateway
-        - -grpc-server-endpoint=127.0.0.1:3228
+        - -grpc-server-endpoint=127.0.0.1:3222
         - -grpc-insecure
         - -http-server-listen=:8222
         - -logtostderr

--- a/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
@@ -137,7 +137,7 @@ spec:
         imagePullPolicy: Always
         command:
         - /usr/bin/go-grpc-gateway
-        - -grpc-server-endpoint=127.0.0.1:3228
+        - -grpc-server-endpoint=127.0.0.1:3225
         - -grpc-insecure
         - -http-server-listen=:8225
         - -logtostderr


### PR DESCRIPTION
### Motivation

Gateways were misconfigured to try and reach their downstream services on the wrong ports. 