### PR TITLE
Add placeholders for testnet/mainnet build automation.

### DIFF
--- a/.github/workflows/mobilecoin-dispatch-mainnet-build.yaml
+++ b/.github/workflows/mobilecoin-dispatch-mainnet-build.yaml
@@ -1,0 +1,18 @@
+# placeholder for "pushbutton" mainnet build with pre-signed enclaves
+name: mobilecoin-dispatch-mainnet-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-testnet-build.yaml
+++ b/.github/workflows/mobilecoin-dispatch-testnet-build.yaml
@@ -1,0 +1,18 @@
+# placeholder for "pushbutton" testnet build with pre-signed enclaves
+name: mobilecoin-dispatch-testnet-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+
+jobs:
+  list-values:
+    runs-on: [self-hosted, small, Linux]
+    steps:
+    - name: values
+      run: |
+        echo namespace ${{ github.event.inputs.namespace }}


### PR DESCRIPTION
### Motivation

Run testnet/mainnet builds and release from automation with prebuilt and signed enclaves.  This will be a manual run process.

- GitHub actions require a dispatch (manual run) action to be defined in the repo default branch to activate runs. 
- Add placeholder dispatch actions so we can develop/run this automation from another branch.


