### PR TITLE
Adjust max tombstone blocks

### DIFF
--- a/transaction/core/src/constants.rs
+++ b/transaction/core/src/constants.rs
@@ -18,7 +18,21 @@ pub const MAX_OUTPUTS: u64 = 16;
 
 /// Maximum number of blocks in the future a transaction's tombstone block can
 /// be set to.
-pub const MAX_TOMBSTONE_BLOCKS: u64 = 100;
+///
+/// This is the limit enforced in the enclave as part of transaction
+/// validation rules. However, untrusted may decide to evict pending
+/// transactions from the queue before this point, so this is only a maximum on
+/// how long a Tx can actually be pending.
+///
+/// Note that clients are still in charge of setting the actual tombstone value.
+/// For normal transactions, clients at time of writing are defaulting to
+/// something like current block height + 100, so that they can know quickly if
+/// a Tx succeeded or failed.
+///
+/// Rationale for this number is, at a rate of 2 blocks / minute, this is 7
+/// days, which eases operations for minting agents which must perform a
+/// multi-sig.
+pub const MAX_TOMBSTONE_BLOCKS: u64 = 20160;
 
 /// The MobileCoin network will contain a fixed supply of 250 million
 /// mobilecoins (MOB).


### PR DESCRIPTION
The rationale for this change is as follows:

* We need to greatly increase the time that mint agents have to complete multisig transactions
* There may also be exchanges doing off-line transaction flows that are impacted by the 100 number
* It's fine to have a limit like this but putting it in the signed enclave makes it extremely difficult to change
* In a 1.2.1 release we can make it so that this max tombstone limit is primarily enforced in the transaction queue rather than in the enclave -- if we don't want to have normal transactions that might wait around for 20,000 blocks, then we can do that in an untrusted side release at our leisure.

Client impact of the change:

A git grep in mobilecoin repo reveals the following consumers:
```
consensus/enclave/impl/src/lib.rs:                    block_index + mc_transaction_core::constants::MAX_TOMBSTONE_BLOCKS,
consensus/mint-client/src/bin/main.rs:    constants::MAX_TOMBSTONE_BLOCKS,
consensus/mint-client/src/bin/main.rs:                    last_block_info.index + MAX_TOMBSTONE_BLOCKS - 1
consensus/mint-client/src/bin/main.rs:                    last_block_info.index + MAX_TOMBSTONE_BLOCKS - 1
consensus/mint-client/src/config.rs:    #[clap(long, env = "MC_MINTING_TOMBSTONE")]
consensus/mint-client/src/config.rs:    #[clap(long, env = "MC_MINTING_TOMBSTONE")]
consensus/service/src/validators.rs:        constants::MAX_TOMBSTONE_BLOCKS, validation::TransactionValidationError,
consensus/service/src/validators.rs:            num_blocks + MAX_TOMBSTONE_BLOCKS + 1,
fog/distribution/src/config.rs:    #[clap(long, default_value = "50", env = "MC_TOMBSTONE_BLOCK")]
mobilecoind/clients/java/mob_client/src/main/java/com/mobilecoin/mob_client/App.java:                System.out.println("The transfer receipt format is KEYIMAGE:TOMBSTONE");
mobilecoind/clients/java/mob_client/src/main/java/com/mobilecoin/mob_client/App.java:                System.out.println("The transfer receipt format is KEYIMAGE:TOMBSTONE");
mobilecoind/clients/java/mob_client/src/main/java/com/mobilecoin/mob_client/App.java:     * @return A string to use in a future call to see if the transfer succeeded, consisting of KEYIMAGE:TOMBSTONE
transaction/core/src/constants.rs:pub const MAX_TOMBSTONE_BLOCKS: u64 = 20160;
transaction/core/src/validation/validate.rs:    let limit = current_block_index + MAX_TOMBSTONE_BLOCKS;
transaction/core/src/validation/validate.rs:            let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS;
transaction/core/src/validation/validate.rs:            let tombstone_block_index = current_block_index + MAX_TOMBSTONE_BLOCKS + 1;
```

So, the consensus mint client is directly affected. (However, we think this is desirable.)

The transaction builder does not actually use this constant:

https://github.com/mobilecoinfoundation/mobilecoin/blob/d9790020b8a8b4dd6f9d80f7aa40a541fc099ece/transaction/std/src/transaction_builder.rs#L132

Instead, it sets tombstone block to `u64::MAX` unless a fog key imposes a shorter limit, or the user sets a limit.
This means that in practice, all the clients provide a tombstone block, since consensus rejects `u64::MAX`.

Android-bindings is currently setting tombstone block to block index + 50:

https://github.com/mobilecoinfoundation/mobilecoin/blob/d9790020b8a8b4dd6f9d80f7aa40a541fc099ece/android-bindings/src/bindings.rs#L1795

https://github.com/mobilecoinofficial/android-sdk/blob/04447be1035d9c07f1a9f6489adbb2f2cbd90b39/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java#L324

https://github.com/mobilecoinofficial/android-sdk/blob/04447be1035d9c07f1a9f6489adbb2f2cbd90b39/android-sdk/src/main/java/com/mobilecoin/lib/MobileCoinClient.java#L71

Mobilecoin swift is similarly setting it to block index + 50:

https://github.com/mobilecoinofficial/MobileCoin-Swift/blob/c2f3273ce47e921cdba200dd4cdb32b4bf7279b0/Sources/Account/Account%2BTransactionOperations.swift#L88

Mobilecoind is currently using a limit of block index + 50:

https://github.com/mobilecoinfoundation/mobilecoin/blob/d9790020b8a8b4dd6f9d80f7aa40a541fc099ece/mobilecoind/src/payments.rs#L47

Full-service is currently using a limit of block index + 10:
```
chris@chris-ThinkPad-X1-Carbon-7th:~/mobilecoinofficial/full-service$ git grep "DEFAULT_NEW_TX_BLOCK_ATTEMPTS"
full-service/src/service/gift_code.rs:        transaction_builder::DEFAULT_NEW_TX_BLOCK_ATTEMPTS,
full-service/src/service/gift_code.rs:            .set_tombstone_block(num_blocks_in_ledger + DEFAULT_NEW_TX_BLOCK_ATTEMPTS);
full-service/src/service/transaction_builder.rs:pub const DEFAULT_NEW_TX_BLOCK_ATTEMPTS: u64 = 10;
full-service/src/service/transaction_builder.rs:            num_blocks_in_ledger + DEFAULT_NEW_TX_BLOCK_ATTEMPTS
```

Mob-cli is using a limit of 100:
```
chris@chris-ThinkPad-X1-Carbon-7th:~/mobilecoinofficial/full-service$ git grep "MAX_TOMBSTONE"
cli/mobilecoin/cli.py:    MAX_TOMBSTONE_BLOCKS,
cli/mobilecoin/cli.py:        hi = lo + MAX_TOMBSTONE_BLOCKS - 1
cli/mobilecoin/client.py:MAX_TOMBSTONE_BLOCKS = 100
```

Mixin-network/Mobilecoin-go is using a limit of 100:

https://github.com/MixinNetwork/mobilecoin-go/blob/6dd3c4eaade2ec7746405661135eae5100095590/transaction_builder.go#L23

---

Therefore, we don't expect any visible impact on clients (other than the mint client) from increasing this number.

This change can be followed up in a 1.2.1 release (potentially) with adding a configurable option to consensus nodes to filter the queue based on a smaller number if desired, or to change what happens when the transaction queue gets full. (But this needs further investigation.) Any change like that would not require signing a new enclave in order to deploy it, so we could react to any problems by reconfiguring the nodes and redeploying right away.