### PR TITLE
Add get shared_secret & root_entropy FFIs to LibMobileCoin

### DIFF
--- a/libmobilecoin/include/keys.h
+++ b/libmobilecoin/include/keys.h
@@ -56,6 +56,18 @@ MC_ATTRIBUTE_NONNULL(1, 2, 4, 5);
 
 /// # Preconditions
 ///
+/// * `root_entropy` - must be 32 bytes in length.
+/// * `out_view_private_key` - length must be >= 32.
+/// * `out_spend_private_key` - length must be >= 32.
+bool mc_account_private_keys_from_root_entropy(
+  const McBuffer* MC_NONNULL root_entropy,
+  McMutableBuffer* MC_NONNULL out_view_private_key,
+  McMutableBuffer* MC_NONNULL out_spend_private_key
+)
+MC_ATTRIBUTE_NONNULL(1, 2, 3);
+
+/// # Preconditions
+///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
 /// * `out_subaddress_view_public_key` - length must be >= 32.

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -186,7 +186,7 @@ McTransactionBuilder* MC_NULLABLE mc_transaction_builder_create(
   const McFogResolver* MC_NULLABLE fog_resolver,
   McTxOutMemoBuilder* MC_NONNULL memo_builder,
   uint32_t block_version
-);
+)
 MC_ATTRIBUTE_NONNULL(5);
 
 void mc_transaction_builder_free(

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -34,6 +34,23 @@ typedef struct _McTxOutMemoBuilder McTxOutMemoBuilder;
 /// # Preconditions
 ///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+/// * `LibMcError::TransactionCrypto`
+bool mc_tx_out_get_shared_secret(
+  const McBuffer* MC_NONNULL view_private_key,
+  const McBuffer* MC_NONNULL tx_out_public_key,
+  McMutableBuffer* MC_NONNULL out_shared_secret,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2, 3);
+
+/// # Preconditions
+///
+/// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 ///
 /// # Errors
 ///

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -557,6 +557,17 @@ bool mc_fog_rng_advance(FfiMutPtr<McFogRng> fog_rng, FfiOptMutPtr<McMutableBuffe
 /**
  * # Preconditions
  *
+ * * `root_entropy` - must be 32 bytes in length.
+ * * `out_view_private_key` - length must be >= 32.
+ * * `out_spend_private_key` - length must be >= 32.
+ */
+bool mc_account_private_keys_from_root_entropy(FfiRefPtr<McBuffer> root_entropy,
+                                               FfiMutPtr<McMutableBuffer> out_view_private_key,
+                                               FfiMutPtr<McMutableBuffer> out_spend_private_key);
+
+/**
+ * # Preconditions
+ *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  * * `spend_private_key` - must be a valid 32-byte Ristretto-format scalar.
  * * `out_subaddress_view_private_key` - length must be >= 32.

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -627,6 +627,17 @@ bool mc_slip10_account_private_keys_from_mnemonic(FfiStr mnemonic,
  * # Preconditions
  *
  * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+ * * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+ */
+bool mc_tx_out_get_shared_secret(FfiRefPtr<McBuffer> view_private_key,
+                                 FfiRefPtr<McBuffer> tx_out_public_key,
+                                 FfiMutPtr<McMutableBuffer> out_shared_secret,
+                                 FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
  */
 bool mc_tx_out_reconstruct_commitment(FfiRefPtr<McTxOutMaskedAmount> tx_out_masked_amount,
                                       FfiRefPtr<McBuffer> tx_out_public_key,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -64,6 +64,34 @@ impl_into_ffi!(Option<Box<dyn MemoBuilder + Sync + Send>>);
 /// # Preconditions
 ///
 /// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
+/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+#[no_mangle]
+pub extern "C" fn mc_tx_out_get_shared_secret(
+    view_private_key: FfiRefPtr<McBuffer>,
+    tx_out_public_key: FfiRefPtr<McBuffer>,
+    out_shared_secret: FfiMutPtr<McMutableBuffer>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
+) -> bool {
+    ffi_boundary_with_error(out_error, || {
+        let view_private_key = RistrettoPrivate::try_from_ffi(&view_private_key)?;
+
+        let tx_out_public_key = RistrettoPublic::try_from_ffi(&tx_out_public_key)?;
+
+        let shared_secret = get_tx_out_shared_secret(&view_private_key, &tx_out_public_key);
+
+        let out_shared_secret = out_shared_secret
+            .into_mut()
+            .as_slice_mut_of_len(RistrettoPrivate::size())
+            .expect("out_shared_secret length is insufficient");
+
+        out_shared_secret.copy_from_slice(&shared_secret.to_bytes());
+        Ok(())
+    })
+}
+
+/// # Preconditions
+///
+/// * `view_private_key` - must be a valid 32-byte Ristretto-format scalar.
 #[no_mangle]
 pub extern "C" fn mc_tx_out_reconstruct_commitment(
     tx_out_masked_amount: FfiRefPtr<McTxOutMaskedAmount>,


### PR DESCRIPTION
Add getters for shared_secret and root_entropy to LibMobileCoin

### Motivation

Getters are needed for shared_secret, and root_entropy requirements have changed so the removed implementation has been re-added.

[Loose Ends - Lets Wax a Fatty](https://www.youtube.com/watch?v=CBN5c1E8nZI)
