### PR TITLE
Instead of logging the URL struct with debug formatting, log it with no formatting since it implements the Display printer

### DIFF
--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -190,8 +190,8 @@ impl Watcher {
                     Ok(block_data) => {
                         log::info!(
                             self.logger,
-                            "Archive block retrieved for {:?} {:?}",
-                            src_url.as_str(),
+                            "Archive block retrieved for {} {}",
+                            src_url,
                             block_index
                         );
                         if self.store_block_data {

--- a/watcher/src/watcher.rs
+++ b/watcher/src/watcher.rs
@@ -191,7 +191,7 @@ impl Watcher {
                         log::info!(
                             self.logger,
                             "Archive block retrieved for {:?} {:?}",
-                            src_url,
+                            src_url.as_str(),
                             block_index
                         );
                         if self.store_block_data {


### PR DESCRIPTION
### Motivation
Logging URLs in watcher currently is unnecessarily human-unreadable. `as_str()` makes it human readable to decrease cognitive load of reading logs.

Resolves #2021 
