### PR TITLE
Add libmobilecoin support for gift codes

### DIFF
--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -243,6 +243,28 @@ MC_ATTRIBUTE_NONNULL(1, 2, 4, 6);
 
 /// # Preconditions
 ///
+/// * `account_key` - must be a valid account key as the gift code subaddress
+///   is computed from the account key
+/// * `transaction_builder` - must not have been previously consumed by a call
+///   to `build`.
+/// * `out_tx_out_confirmation_number` - length must be >= 32.
+///
+/// # Errors
+///
+/// * `LibMcError::AttestationVerification`
+/// * `LibMcError::InvalidInput`
+McData* MC_NULLABLE mc_transaction_builder_fund_gift_code_output(
+        const McAccountKey* MC_NONNULL account_key,
+        McTransactionBuilder* MC_NONNULL transaction_builder,
+        uint64_t amount,
+        McRngCallback* MC_NULLABLE rng_callback,
+        McMutableBuffer* MC_NONNULL out_tx_out_confirmation_number,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2, 4, 6);
+
+/// # Preconditions
+///
 /// * `transaction_builder` - must not have been previously consumed by a call to `build`.
 /// * `recipient_address` - must be a valid `PublicAddress`.
 /// * `fog_hint_address` - must be a valid `PublicAddress` with `fog_info`.
@@ -515,29 +537,6 @@ bool mc_memo_sender_with_payment_request_memo_get_payment_request_id(
 )
 MC_ATTRIBUTE_NONNULL(1, 2);
 
-
-/* ==== Decrypt Memo Payload ==== */
-
-
-/// # Preconditions
-///
-/// * `encrypted_memo` - must be 66 bytes
-/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
-/// * `account_key` - must be a valid account key
-/// * `out_memo_payload` - length must be >= 16 bytes
-///
-/// # Errors
-///
-/// * `LibMcError::InvalidInput`
-bool mc_memo_decrypt_e_memo_payload(
-  const McBuffer* MC_NONNULL encrypted_memo,
-  const McBuffer* MC_NONNULL tx_out_public_key,
-  const McAccountKey* MC_NONNULL account_key,
-  McMutableBuffer* MC_NONNULL out_memo_data,
-  McError* MC_NULLABLE * MC_NULLABLE out_error
-)
-MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
-
 /* ==== Gift Code Memo Builders ==== */
 
 /// # Preconditions
@@ -549,7 +548,7 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 /// exactly 54 bytes, the last byte MUST be null and that byte will be
 /// removed prior to storage on chain.
 McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_funding_create(
-  const char* MC_NONNULL gift_code_funding_note
+        const char* MC_NONNULL gift_code_funding_note
 )
 MC_ATTRIBUTE_NONNULL(1);
 
@@ -562,16 +561,16 @@ MC_ATTRIBUTE_NONNULL(1);
 /// exactly 58 bytes, the last byte MUST be null and that byte will be
 /// removed prior to storage on chain.
 McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_sender_create(
-  const char* MC_NONNULL gift_code_sender_note
+        const char* MC_NONNULL gift_code_sender_note
 )
 MC_ATTRIBUTE_NONNULL(1);
 
 /// # Preconditions
 ///
 /// * `global_index` - must be the global TxOut index of the originally funded
-/// gift code TxOut
+///   gift code TxOut
 McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_sender_create(
-  uint64_t global_index
+        uint64_t global_index
 );
 
 /* ==== GiftCodeFundingMemo ==== */
@@ -690,7 +689,8 @@ MC_ATTRIBUTE_NONNULL(1, 2);
 /// # Preconditions
 ///
 /// * `fee` - must be an integer less than or equal to 2^56
-/// * `global_index` - must be the global TxOut index of the originally funded gift code TxOut
+/// * `global_index` - must be the global TxOut index of the originally funded
+///   gift code TxOut
 /// * `out_memo_data` - length must be >= 64.
 ///
 /// # Errors
@@ -731,6 +731,27 @@ bool mc_memo_get_gift_code_cancellation_fee(
         McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1, 2);
+
+/* ==== Decrypt Memo Payload ==== */
+
+/// # Preconditions
+///
+/// * `encrypted_memo` - must be 66 bytes
+/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+/// * `account_key` - must be a valid account key
+/// * `out_memo_payload` - length must be >= 16 bytes
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_decrypt_e_memo_payload(
+  const McBuffer* MC_NONNULL encrypted_memo,
+  const McBuffer* MC_NONNULL tx_out_public_key,
+  const McAccountKey* MC_NONNULL account_key,
+  McMutableBuffer* MC_NONNULL out_memo_data,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 
 #ifdef __cplusplus
 }

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -261,7 +261,7 @@ McData* MC_NULLABLE mc_transaction_builder_fund_gift_code_output(
         McMutableBuffer* MC_NONNULL out_tx_out_confirmation_number,
         McError* MC_NULLABLE * MC_NULLABLE out_error
 )
-MC_ATTRIBUTE_NONNULL(1, 2, 4, 6);
+MC_ATTRIBUTE_NONNULL(1, 2, 5);
 
 /// # Preconditions
 ///
@@ -569,7 +569,7 @@ MC_ATTRIBUTE_NONNULL(1);
 ///
 /// * `global_index` - must be the global TxOut index of the originally funded
 ///   gift code TxOut
-McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_sender_create(
+McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_cancellation_create(
         uint64_t global_index
 );
 
@@ -607,7 +607,7 @@ MC_ATTRIBUTE_NONNULL(1, 3, 4);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_memo_validate_gift_code_funding_tx_out(
+bool mc_memo_gift_code_funding_memo_validate_tx_out(
         const McBuffer* MC_NONNULL gift_code_funding_memo_data,
         const McBuffer* MC_NONNULL tx_out_public_key,
         bool* MC_NONNULL out_valid,
@@ -619,7 +619,7 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3);
 /// # Preconditions
 ///
 /// * `gift_code_funding_memo_data` - must be 64 bytes
-char* MC_NULLABLE mc_memo_get_gift_code_funding_note(
+char* MC_NULLABLE mc_memo_gift_code_funding_memo_get_note(
         const McBuffer* MC_NONNULL gift_code_funding_memo_data
 )
 MC_ATTRIBUTE_NONNULL(1);
@@ -631,7 +631,7 @@ MC_ATTRIBUTE_NONNULL(1);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_memo_get_gift_code_funding_fee(
+bool mc_memo_gift_code_funding_memo_get_fee(
         const McBuffer* MC_NONNULL gift_code_funding_memo_data,
         uint64_t* MC_NONNULL out_fee,
         McError* MC_NULLABLE * MC_NULLABLE out_error
@@ -665,7 +665,7 @@ MC_ATTRIBUTE_NONNULL(2, 3);
 /// # Preconditions
 ///
 /// * `gift_code_sender_memo_data` - must be 64 bytes
-char* MC_NULLABLE mc_memo_get_gift_code_sender_note(
+char* MC_NULLABLE mc_memo_gift_code_sender_memo_get_note(
         const McBuffer* MC_NONNULL gift_code_sender_memo_data
 )
 MC_ATTRIBUTE_NONNULL(1);
@@ -677,7 +677,7 @@ MC_ATTRIBUTE_NONNULL(1);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_memo_get_gift_code_sender_fee(
+bool mc_memo_get_gift_code_sender_memo_get_fee(
         const McBuffer* MC_NONNULL gift_code_sender_memo_data,
         uint64_t* MC_NONNULL out_fee,
         McError* MC_NULLABLE * MC_NULLABLE out_error
@@ -711,7 +711,7 @@ MC_ATTRIBUTE_NONNULL(3);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_memo_get_cancelled_gift_code_tx_out_index(
+bool mc_memo_gift_code_cancellation_memo_get_gift_code_tx_out_index(
         const McBuffer* MC_NONNULL gift_code_cancellation_memo_data,
         uint64_t* MC_NONNULL out_index,
         McError* MC_NULLABLE * MC_NULLABLE out_error
@@ -725,7 +725,7 @@ MC_ATTRIBUTE_NONNULL(1, 2);
 /// # Errors
 ///
 /// * `LibMcError::InvalidInput`
-bool mc_memo_get_gift_code_cancellation_fee(
+bool mc_memo_gift_code_cancellation_memo_get_fee(
         const McBuffer* MC_NONNULL gift_code_cancellation_memo_data,
         uint64_t* MC_NONNULL out_fee,
         McError* MC_NULLABLE * MC_NULLABLE out_error

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -538,6 +538,199 @@ bool mc_memo_decrypt_e_memo_payload(
 )
 MC_ATTRIBUTE_NONNULL(1, 2, 3, 4);
 
+/* ==== Gift Code Memo Builders ==== */
+
+/// # Preconditions
+///
+/// * `gift_code_funding_note` - must be a null-terminated C string containing
+/// up to 54 valid UTF-8 bytes. The actual note stored on chain is up to 53 null
+/// terminated UTF-8 bytes unless the note is exactly 53 utf-8 bytes long,
+/// in which case, no null bytes are stored. If the C string passed here is
+/// exactly 54 bytes, the last byte MUST be null and that byte will be
+/// removed prior to storage on chain.
+McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_funding_create(
+  const char* MC_NONNULL gift_code_funding_note
+)
+MC_ATTRIBUTE_NONNULL(1);
+
+/// # Preconditions
+///
+/// * `gift_code_sender_note` - must be a null-terminated C string containing up
+/// to 58 valid UTF-8 bytes. The actual note stored on chain is up to 57 null
+/// terminated UTF-8 bytes unless the note is exactly 57 utf-8 bytes long,
+/// in which case, no null bytes are stored. If the C string passed here is
+/// exactly 58 bytes, the last byte MUST be null and that byte will be
+/// removed prior to storage on chain.
+McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_sender_create(
+  const char* MC_NONNULL gift_code_sender_note
+)
+MC_ATTRIBUTE_NONNULL(1);
+
+/// # Preconditions
+///
+/// * `global_index` - must be the global TxOut index of the originally funded
+/// gift code TxOut
+McTxOutMemoBuilder* MC_NULLABLE mc_memo_builder_gift_code_sender_create(
+  uint64_t global_index
+);
+
+/* ==== GiftCodeFundingMemo ==== */
+
+/// # Preconditions
+///
+/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+/// * `fee` - must be an integer less than or equal to 2^56
+/// * `gift_code_funding_note` - must be a null-terminated C string containing
+/// up to 54 valid UTF-8 bytes. The actual note stored on chain is up to 53 null
+/// terminated UTF-8 bytes unless the note is exactly 53 utf-8 bytes long,
+/// in which case, no null bytes are stored. If the C string passed here is
+/// exactly 54 bytes, the last byte MUST be null and that byte will be
+/// removed prior to storage on chain.
+/// * `out_memo_data` - length must be >= 64.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_gift_code_funding_memo_create(
+        const McBuffer* MC_NONNULL tx_out_public_key,
+        uint64_t fee,
+        const char* MC_NONNULL gift_code_funding_note
+        McMutableBuffer* MC_NONNULL out_memo_data,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 3, 4);
+
+/// # Preconditions
+///
+/// * `gift_code_funding_memo_data` - must be 64 bytes
+/// * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_validate_gift_code_funding_tx_out(
+        const McBuffer* MC_NONNULL gift_code_funding_memo_data,
+        const McBuffer* MC_NONNULL tx_out_public_key,
+        bool* MC_NONNULL out_valid,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2, 3);
+
+
+/// # Preconditions
+///
+/// * `gift_code_funding_memo_data` - must be 64 bytes
+char* MC_NULLABLE mc_memo_get_gift_code_funding_note(
+        const McBuffer* MC_NONNULL gift_code_funding_memo_data
+)
+MC_ATTRIBUTE_NONNULL(1);
+
+/// # Preconditions
+///
+/// * `gift_code_funding_memo_data` - must be 64 bytes
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_get_gift_code_funding_fee(
+        const McBuffer* MC_NONNULL gift_code_funding_memo_data,
+        uint64_t* MC_NONNULL out_fee,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/* ==== GiftCodeSenderMemo ==== */
+
+/// # Preconditions
+///
+/// * `fee` - must be an integer less than or equal to 2^56
+/// * `gift_code_sender_note` - must be a null-terminated C string containing up
+/// to 58 valid UTF-8 bytes. The actual note stored on chain is up to 57 null
+/// terminated UTF-8 bytes unless the note is exactly 57 utf-8 bytes long,
+/// in which case, no null bytes are stored. If the C string passed here is
+/// exactly 58 bytes, the last byte MUST be null and that byte will be
+/// removed prior to storage on chain.
+/// * `out_memo_data` - length must be >= 64.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_gift_code_sender_memo_create(
+        uint64_t fee,
+        const char* MC_NONNULL gift_code_sender_note,
+        McMutableBuffer* MC_NONNULL out_memo_data,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(2, 3);
+
+/// # Preconditions
+///
+/// * `gift_code_sender_memo_data` - must be 64 bytes
+char* MC_NULLABLE mc_memo_get_gift_code_sender_note(
+        const McBuffer* MC_NONNULL gift_code_sender_memo_data
+)
+MC_ATTRIBUTE_NONNULL(1);
+
+/// # Preconditions
+///
+/// * `gift_code_sender_memo_data` - must be 64 bytes
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_get_gift_code_sender_fee(
+        const McBuffer* MC_NONNULL gift_code_sender_memo_data,
+        uint64_t* MC_NONNULL out_fee,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/* ==== GiftCodeCancellationMemo ==== */
+
+/// # Preconditions
+///
+/// * `fee` - must be an integer less than or equal to 2^56
+/// * `global_index` - must be the global TxOut index of the originally funded gift code TxOut
+/// * `out_memo_data` - length must be >= 64.
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_gift_code_cancellation_memo_create(
+        uint64_t fee,
+        uint64_t global_index,
+        McMutableBuffer* MC_NONNULL out_memo_data,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(3);
+
+/// # Preconditions
+///
+/// * `gift_code_cancellation_memo_data` - must be 64 bytes
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_get_cancelled_gift_code_tx_out_index(
+        const McBuffer* MC_NONNULL gift_code_cancellation_memo_data,
+        uint64_t* MC_NONNULL out_index,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
+
+/// # Preconditions
+///
+/// * `gift_code_cancellation_memo_data` - must be 64 bytes
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
+bool mc_memo_get_gift_code_cancellation_fee(
+        const McBuffer* MC_NONNULL gift_code_cancellation_memo_data,
+        uint64_t* MC_NONNULL out_fee,
+        McError* MC_NULLABLE * MC_NULLABLE out_error
+)
+MC_ATTRIBUTE_NONNULL(1, 2);
 
 #ifdef __cplusplus
 }

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -1143,7 +1143,7 @@ FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_cancellation_create
  */
 bool mc_memo_gift_code_funding_memo_create(FfiRefPtr<McBuffer> tx_out_public_key,
                                            uint64_t fee,
-                                           gift_code_funding_note FfiStr,
+                                           FfiStr gift_code_funding_note,
                                            FfiMutPtr<McMutableBuffer> out_memo_data,
                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
@@ -1248,7 +1248,7 @@ bool mc_memo_gift_code_cancellation_memo_create(uint64_t fee,
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_get_gift_code_cancellation_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
+bool mc_memo_get_cancelled_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
                                             FfiMutPtr<uint64_t> out_index,
                                             FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -811,6 +811,26 @@ FfiOptOwnedPtr<McData> mc_transaction_builder_add_change_output(FfiRefPtr<McAcco
 /**
  * # Preconditions
  *
+ * * `account_key` - must be a valid account key as the gift code subaddress is
+ *   computed from the account key
+ * * `transaction_builder` - must not have been previously consumed by a call
+ *   to `build`.
+ * * `out_tx_out_confirmation_number` - length must be >= 32.
+ *
+ * # Errors
+ *
+ * * `LibMcError::AttestationVerification`
+ * * `LibMcError::InvalidInput`
+ */
+FfiOptOwnedPtr<McData> mc_transaction_builder_fund_gift_code_output(FfiMutPtr<McTransactionBuilder> transaction_builder,
+                                                                    uint64_t amount,
+                                                                    FfiOptMutPtr<McRngCallback> rng_callback,
+                                                                    FfiMutPtr<McMutableBuffer> out_tx_out_confirmation_number,
+                                                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
  * * `transaction_builder` - must not have been previously consumed by a call
  *   to `build`.
  * * `recipient_address` - must be a valid `PublicAddress`.
@@ -1072,3 +1092,175 @@ bool mc_memo_decrypt_e_memo_payload(FfiRefPtr<McBuffer> encrypted_memo,
                                     FfiRefPtr<McAccountKey> account_key,
                                     FfiMutPtr<McMutableBuffer> out_memo_payload,
                                     FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_funding_note` - must be a null-terminated C string containing
+ * up to 54 valid UTF-8 bytes. The actual note stored on chain is up to 53 null
+ * terminated UTF-8 bytes unless the note is exactly 53 utf-8 bytes long,
+ * in which case, no null bytes are stored. If the C string passed here is
+ * exactly 54 bytes, the last byte MUST be null and that byte will be
+ * removed prior to storage on chain.
+ */
+FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_funding_create(FfiStr gift_code_funding_note);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_sender_note` - must be a null-terminated C string containing up
+ * to 58 valid UTF-8 bytes. The actual note stored on chain is up to 57 null
+ * terminated UTF-8 bytes unless the note is exactly 57 utf-8 bytes long,
+ * in which case, no null bytes are stored. If the C string passed here is
+ * exactly 58 bytes, the last byte MUST be null and that byte will be
+ * removed prior to storage on chain.
+*/
+FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_sender_create(FfiStr gift_code_sender_note);
+
+/**
+ * # Preconditions
+ * * `global_index` - must be the global TxOut index of the originally funded
+ * gift code TxOut
+ */
+FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_cancellation_create(uint64_t global_index);
+
+/**
+ * # Preconditions
+ *
+ * * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+ * * `fee` - must be an integer less than or equal to 2^56
+ * * `gift_code_funding_note` - must be a null-terminated C string containing
+ * up to 54 valid UTF-8 bytes. The actual note stored on chain is up to 53 null
+ * terminated UTF-8 bytes unless the note is exactly 53 utf-8 bytes long,
+ * in which case, no null bytes are stored. If the C string passed here is
+ * exactly 54 bytes, the last byte MUST be null and that byte will be
+ * removed prior to storage on chain.
+ * * `out_memo_data` - length must be >= 64.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_gift_code_funding_memo_create(FfiRefPtr<McBuffer> tx_out_public_key,
+                                           uint64_t fee,
+                                           gift_code_funding_note FfiStr,
+                                           FfiMutPtr<McMutableBuffer> out_memo_data,
+                                           FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_funding_memo_data` - must be 64 bytes
+ * * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_validate_gift_code_funding_tx_out(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
+                                               FfiRefPtr<McBuffer> tx_out_public_key,
+                                               FfiMutPtr<bool> out_valid,
+                                               FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_funding_memo_data` - must be 64 bytes
+ */
+FfiOptOwnedStr mc_memo_get_gift_code_funding_note(FfiRefPtr<McBuffer> gift_code_funding_memo_data);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_funding_memo_data` - must be 64 bytes
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_get_gift_code_funding_fee(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
+                                       FfiMutPtr<u64> out_fee,
+                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `fee` - must be an integer less than or equal to 2^56
+ * * `gift_code_sender_note` - must be a null-terminated C string containing up
+ * to 58 valid UTF-8 bytes. The actual note stored on chain is up to 57 null
+ * terminated UTF-8 bytes unless the note is exactly 57 utf-8 bytes long,
+ * in which case, no null bytes are stored. If the C string passed here is
+ * exactly 58 bytes, the last byte MUST be null and that byte will be
+ * removed prior to storage on chain.
+ * * `out_memo_data` - length must be >= 64.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_gift_code_sender_memo_create(uint64_t fee,
+                                          FfiStr gift_code_sender_note,
+                                          FfiMutPtr<McMutableBuffer> out_memo_data,
+                                          FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_sender_memo_data` - must be 64 bytes
+ */
+FfiOptOwnedStr mc_memo_get_gift_code_sender_note(FfiRefPtr<McBuffer> gift_code_sender_memo_data);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_sender_memo_data` - must be 64 bytes
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_get_gift_code_sender_fee(FfiRefPtr<McBuffer> gift_code_sender_memo_data,
+                                      FfiMutPtr<uint64_t> out_fee,
+                                      FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `fee` - must be an integer less than or equal to 2^56
+ * * `global_index` - must be the global TxOut index of the originally funded gift code TxOut
+ * * `out_memo_data` - length must be >= 64.
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_gift_code_cancellation_memo_create(uint64_t fee,
+                                                uint64_t global_index,
+                                                FfiMutPtr<McMutableBuffer> out_memo_data,
+                                                FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_cancellation_memo_data` - must be 64 bytes
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_get_gift_code_cancellation_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
+                                            FfiMutPtr<uint64_t> out_index,
+                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `gift_code_cancellation_memo_data` - must be 64 bytes
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_get_gift_code_cancellation_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
+                                            FfiMutPtr<uint64_t> out_fee,
+                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -1141,17 +1141,17 @@ bool mc_memo_gift_code_funding_memo_create(FfiRefPtr<McBuffer> tx_out_public_key
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_validate_gift_code_funding_tx_out(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
-                                               FfiRefPtr<McBuffer> tx_out_public_key,
-                                               FfiMutPtr<bool> out_valid,
-                                               FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_memo_gift_code_funding_memo_validate_tx_out(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
+                                                    FfiRefPtr<McBuffer> tx_out_public_key,
+                                                    FfiMutPtr<bool> out_valid,
+                                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
  *
  * * `gift_code_funding_memo_data` - must be 64 bytes
  */
-FfiOptOwnedStr mc_memo_get_gift_code_funding_note(FfiRefPtr<McBuffer> gift_code_funding_memo_data);
+FfiOptOwnedStr mc_memo_gift_code_funding_memo_get_note(FfiRefPtr<McBuffer> gift_code_funding_memo_data);
 
 /**
  * # Preconditions
@@ -1162,9 +1162,9 @@ FfiOptOwnedStr mc_memo_get_gift_code_funding_note(FfiRefPtr<McBuffer> gift_code_
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_get_gift_code_funding_fee(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
-                                       FfiMutPtr<uint64_t> out_fee,
-                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_memo_gift_code_funding_memo_get_fee(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
+                                            FfiMutPtr<uint64_t> out_fee,
+                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
@@ -1192,7 +1192,7 @@ bool mc_memo_gift_code_sender_memo_create(uint64_t fee,
  *
  * * `gift_code_sender_memo_data` - must be 64 bytes
  */
-FfiOptOwnedStr mc_memo_get_gift_code_sender_note(FfiRefPtr<McBuffer> gift_code_sender_memo_data);
+FfiOptOwnedStr mc_memo_gift_code_sender_memo_get_note(FfiRefPtr<McBuffer> gift_code_sender_memo_data);
 
 /**
  * # Preconditions
@@ -1203,9 +1203,9 @@ FfiOptOwnedStr mc_memo_get_gift_code_sender_note(FfiRefPtr<McBuffer> gift_code_s
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_get_gift_code_sender_fee(FfiRefPtr<McBuffer> gift_code_sender_memo_data,
-                                      FfiMutPtr<uint64_t> out_fee,
-                                      FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_memo_gift_code_sender_memo_get_fee(FfiRefPtr<McBuffer> gift_code_sender_memo_data,
+                                           FfiMutPtr<uint64_t> out_fee,
+                                           FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
@@ -1233,9 +1233,9 @@ bool mc_memo_gift_code_cancellation_memo_create(uint64_t fee,
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_get_cancelled_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
-                                                  FfiMutPtr<uint64_t> out_index,
-                                                  FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_memo_gift_code_cancellation_memo_get_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
+                                                                    FfiMutPtr<uint64_t> out_index,
+                                                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
@@ -1246,9 +1246,9 @@ bool mc_memo_get_cancelled_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_
  *
  * * `LibMcError::InvalidInput`
  */
-bool mc_memo_get_gift_code_cancellation_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
-                                            FfiMutPtr<uint64_t> out_fee,
-                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_memo_gift_code_cancellation_memo_get_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
+                                                 FfiMutPtr<uint64_t> out_fee,
+                                                 FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -822,7 +822,8 @@ FfiOptOwnedPtr<McData> mc_transaction_builder_add_change_output(FfiRefPtr<McAcco
  * * `LibMcError::AttestationVerification`
  * * `LibMcError::InvalidInput`
  */
-FfiOptOwnedPtr<McData> mc_transaction_builder_fund_gift_code_output(FfiMutPtr<McTransactionBuilder> transaction_builder,
+FfiOptOwnedPtr<McData> mc_transaction_builder_fund_gift_code_output(FfiRefPtr<McAccountKey> account_key,
+                                                                    FfiMutPtr<McTransactionBuilder> transaction_builder,
                                                                     uint64_t amount,
                                                                     FfiOptMutPtr<McRngCallback> rng_callback,
                                                                     FfiMutPtr<McMutableBuffer> out_tx_out_confirmation_number,
@@ -1078,24 +1079,6 @@ bool mc_memo_sender_with_payment_request_memo_get_payment_request_id(FfiRefPtr<M
 /**
  * # Preconditions
  *
- * * `encrypted_memo` - must be 66 bytes
- * * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
- * * `account_key` - must be a valid account key
- * * `out_memo_payload` - length must be >= 16 bytes
- *
- * # Errors
- *
- * * `LibMcError::InvalidInput`
- */
-bool mc_memo_decrypt_e_memo_payload(FfiRefPtr<McBuffer> encrypted_memo,
-                                    FfiRefPtr<McBuffer> tx_out_public_key,
-                                    FfiRefPtr<McAccountKey> account_key,
-                                    FfiMutPtr<McMutableBuffer> out_memo_payload,
-                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
-
-/**
- * # Preconditions
- *
  * * `gift_code_funding_note` - must be a null-terminated C string containing
  * up to 54 valid UTF-8 bytes. The actual note stored on chain is up to 53 null
  * terminated UTF-8 bytes unless the note is exactly 53 utf-8 bytes long,
@@ -1114,13 +1097,14 @@ FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_funding_create(FfiS
  * in which case, no null bytes are stored. If the C string passed here is
  * exactly 58 bytes, the last byte MUST be null and that byte will be
  * removed prior to storage on chain.
-*/
+ */
 FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_sender_create(FfiStr gift_code_sender_note);
 
 /**
  * # Preconditions
+ *
  * * `global_index` - must be the global TxOut index of the originally funded
- * gift code TxOut
+ *   gift code TxOut
  */
 FfiOptOwnedPtr<McTxOutMemoBuilder> mc_memo_builder_gift_code_cancellation_create(uint64_t global_index);
 
@@ -1179,7 +1163,7 @@ FfiOptOwnedStr mc_memo_get_gift_code_funding_note(FfiRefPtr<McBuffer> gift_code_
  * * `LibMcError::InvalidInput`
  */
 bool mc_memo_get_gift_code_funding_fee(FfiRefPtr<McBuffer> gift_code_funding_memo_data,
-                                       FfiMutPtr<u64> out_fee,
+                                       FfiMutPtr<uint64_t> out_fee,
                                        FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
@@ -1227,7 +1211,8 @@ bool mc_memo_get_gift_code_sender_fee(FfiRefPtr<McBuffer> gift_code_sender_memo_
  * # Preconditions
  *
  * * `fee` - must be an integer less than or equal to 2^56
- * * `global_index` - must be the global TxOut index of the originally funded gift code TxOut
+ * * `global_index` - must be the global TxOut index of the originally funded
+ *   gift code TxOut
  * * `out_memo_data` - length must be >= 64.
  *
  * # Errors
@@ -1249,8 +1234,8 @@ bool mc_memo_gift_code_cancellation_memo_create(uint64_t fee,
  * * `LibMcError::InvalidInput`
  */
 bool mc_memo_get_cancelled_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
-                                            FfiMutPtr<uint64_t> out_index,
-                                            FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+                                                  FfiMutPtr<uint64_t> out_index,
+                                                  FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * # Preconditions
@@ -1264,3 +1249,21 @@ bool mc_memo_get_cancelled_gift_code_tx_out_index(FfiRefPtr<McBuffer> gift_code_
 bool mc_memo_get_gift_code_cancellation_fee(FfiRefPtr<McBuffer> gift_code_cancellation_memo_data,
                                             FfiMutPtr<uint64_t> out_fee,
                                             FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * # Preconditions
+ *
+ * * `encrypted_memo` - must be 66 bytes
+ * * `tx_out_public_key` - must be a valid 32-byte Ristretto-format scalar.
+ * * `account_key` - must be a valid account key
+ * * `out_memo_payload` - length must be >= 16 bytes
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
+bool mc_memo_decrypt_e_memo_payload(FfiRefPtr<McBuffer> encrypted_memo,
+                                    FfiRefPtr<McBuffer> tx_out_public_key,
+                                    FfiRefPtr<McAccountKey> account_key,
+                                    FfiMutPtr<McMutableBuffer> out_memo_payload,
+                                    FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -1248,7 +1248,6 @@ pub extern "C" fn mc_memo_builder_gift_code_sender_create(
 ///
 /// * `global_index` - must be the global TxOut index of the originally funded
 ///   gift code TxOut
-/// gift code TxOut
 #[no_mangle]
 pub extern "C" fn mc_memo_builder_gift_code_cancellation_create(
     global_index: u64,

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -1210,7 +1210,7 @@ pub extern "C" fn mc_memo_builder_gift_code_funding_create(
         let note = <&str>::try_from_ffi(gift_code_funding_note)
             .expect("Failed to decode gift code funding note");
         let gift_code_funding_memo_builder = GiftCodeFundingMemoBuilder::new(note)
-            .expect("Gift code funding note had invalid utf-8 or was more than 53 bytes long");
+            .expect("Gift code funding note was more than 53 bytes long");
 
         let memo_builder_box: Box<dyn MemoBuilder + Sync + Send> =
             Box::new(gift_code_funding_memo_builder);
@@ -1235,7 +1235,7 @@ pub extern "C" fn mc_memo_builder_gift_code_sender_create(
         let note = <&str>::try_from_ffi(gift_code_sender_note)
             .expect("Failed to decode gift_code_sender note");
         let gift_code_sender_memo_builder = GiftCodeSenderMemoBuilder::new(note)
-            .expect("Gift code sender note had invalid utf-8 or was more than 57 bytes long");
+            .expect("Gift code sender note was more than 57 bytes long");
 
         let memo_builder_box: Box<dyn MemoBuilder + Sync + Send> =
             Box::new(gift_code_sender_memo_builder);
@@ -1314,7 +1314,7 @@ pub extern "C" fn mc_memo_gift_code_funding_memo_create(
 ///
 /// * `LibMcError::InvalidInput`
 #[no_mangle]
-pub extern "C" fn mc_memo_validate_gift_code_funding_tx_out(
+pub extern "C" fn mc_memo_gift_code_funding_memo_validate_tx_out(
     gift_code_funding_memo_data: FfiRefPtr<McBuffer>,
     tx_out_public_key: FfiRefPtr<McBuffer>,
     out_valid: FfiMutPtr<bool>,
@@ -1337,7 +1337,7 @@ pub extern "C" fn mc_memo_validate_gift_code_funding_tx_out(
 ///
 /// * `gift_code_funding_memo_data` - must be 64 bytes
 #[no_mangle]
-pub extern "C" fn mc_memo_get_gift_code_funding_note(
+pub extern "C" fn mc_memo_gift_code_funding_memo_get_note(
     gift_code_funding_memo_data: FfiRefPtr<McBuffer>,
 ) -> FfiOptOwnedStr {
     ffi_boundary(|| {
@@ -1361,7 +1361,7 @@ pub extern "C" fn mc_memo_get_gift_code_funding_note(
 ///
 /// * `LibMcError::InvalidInput`
 #[no_mangle]
-pub extern "C" fn mc_memo_get_gift_code_funding_fee(
+pub extern "C" fn mc_memo_gift_code_funding_memo_get_fee(
     gift_code_funding_memo_data: FfiRefPtr<McBuffer>,
     out_fee: FfiMutPtr<u64>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
@@ -1419,7 +1419,7 @@ pub extern "C" fn mc_memo_gift_code_sender_memo_create(
 ///
 /// * `gift_code_sender_memo_data` - must be 64 bytes
 #[no_mangle]
-pub extern "C" fn mc_memo_get_gift_code_sender_note(
+pub extern "C" fn mc_memo_gift_code_sender_memo_get_note(
     gift_code_sender_memo_data: FfiRefPtr<McBuffer>,
 ) -> FfiOptOwnedStr {
     ffi_boundary(|| {
@@ -1443,7 +1443,7 @@ pub extern "C" fn mc_memo_get_gift_code_sender_note(
 ///
 /// * `LibMcError::InvalidInput`
 #[no_mangle]
-pub extern "C" fn mc_memo_get_gift_code_sender_fee(
+pub extern "C" fn mc_memo_gift_code_sender_memo_get_fee(
     gift_code_sender_memo_data: FfiRefPtr<McBuffer>,
     out_fee: FfiMutPtr<u64>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
@@ -1500,7 +1500,7 @@ pub extern "C" fn mc_memo_gift_code_cancellation_memo_create(
 ///
 /// * `LibMcError::InvalidInput`
 #[no_mangle]
-pub extern "C" fn mc_memo_get_cancelled_gift_code_tx_out_index(
+pub extern "C" fn mc_memo_gift_code_cancellation_memo_get_gift_code_tx_out_index(
     gift_code_cancellation_memo_data: FfiRefPtr<McBuffer>,
     out_index: FfiMutPtr<u64>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
@@ -1523,7 +1523,7 @@ pub extern "C" fn mc_memo_get_cancelled_gift_code_tx_out_index(
 ///
 /// * `LibMcError::InvalidInput`
 #[no_mangle]
-pub extern "C" fn mc_memo_get_gift_code_cancellation_fee(
+pub extern "C" fn mc_memo_gift_code_cancellation_memo_get_fee(
     gift_code_cancellation_memo_data: FfiRefPtr<McBuffer>,
     out_fee: FfiMutPtr<u64>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,


### PR DESCRIPTION
### Changelog
In libmobilecoin:
* Added transaction builder method for funding gift code outputs
* Added methods for creating gift code memo builders
* Added methods for creating & reading gift code memos
* Added corresponding cbindgen bindings

### Still needs
* FFI method for discovery of gift code TxOuts
* libmobilecoin binding test coverage

### Motivation
Adding these methods adds the ability for the iOS mobile SDK to enable the functionality for TxOut gift codes

### Future Work
* Add Android bindings
* Add mobilecoind gift code support
* Assist full service in supporting TxOut gift codes
* Do end to end testing