### PR TITLE
build 1.2.0 without an upgrade

### DIFF
--- a/.internal-ci/docker/Dockerfile.node_hw
+++ b/.internal-ci/docker/Dockerfile.node_hw
@@ -20,6 +20,7 @@ COPY ${RUST_BIN_PATH}/mc-util-grpc-admin-tool /usr/bin/
 COPY ${RUST_BIN_PATH}/sample-keys /usr/local/bin/
 COPY ${RUST_BIN_PATH}/generate-sample-ledger /usr/local/bin/
 COPY .internal-ci/util/generate_origin_data.sh /usr/local/bin/
+COPY .internal-ci/util/sample-keys.1.1.3 /util/
 
 # Populate origin data
 # We should pull origin data at runtime from an external source, like a public s3 url, but keep this for legacy.

--- a/.internal-ci/docker/Dockerfile.node_hw
+++ b/.internal-ci/docker/Dockerfile.node_hw
@@ -19,9 +19,9 @@ COPY ${RUST_BIN_PATH}/mc-util-grpc-admin-tool /usr/bin/
 
 COPY ${RUST_BIN_PATH}/sample-keys /usr/local/bin/
 COPY ${RUST_BIN_PATH}/generate-sample-ledger /usr/local/bin/
+COPY ${RUST_BIN_PATH}/read-pubfile /usr/local/bin/
 COPY .internal-ci/util/generate_origin_data.sh /usr/local/bin/
 COPY .internal-ci/util/sample-keys.1.1.3 /util/
-
 # Populate origin data
 # We should pull origin data at runtime from an external source, like a public s3 url, but keep this for legacy.
 ARG ORIGIN_DATA_DIR=.internal-ci/sample_data


### PR DESCRIPTION
### Motivation

- Forgot to put the sample-keys.1.1.3 binary to re-hydrate root entropy wallet keys from seeds.  

### Future Work

- After we do the full release we can deprecate these older binaries/methods.

