### PR TITLE
Use new TokenId class to create Amount

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -406,15 +406,20 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_MaskedAmount_unmask_1amount(
                         .into(),
                 ],
             )?;
-            let token_id = env.new_object(
+            let token_id_ul = env.new_object(
                 "com/mobilecoin/lib/UnsignedLong",
                 "(J)V",
                 &[jni::objects::JValue::Long(*amount.token_id as i64)],
             )?;
+            let token_id = env.new_object(
+                "com/mobilecoin/lib/TokenId",
+                "(Lcom/mobilecoin/lib/UnsignedLong;)V",
+                &[jni::objects::JValue::Object(token_id_ul)],
+            )?;
             Ok(env
                 .new_object(
                     "com/mobilecoin/lib/Amount",
-                    "(Ljava/math/BigInteger;Lcom/mobilecoin/lib/UnsignedLong;)V",
+                    "(Ljava/math/BigInteger;Lcom/mobilecoin/lib/TokenId;)V",
                     &[
                         jni::objects::JValue::Object(value),
                         jni::objects::JValue::Object(token_id),


### PR DESCRIPTION
Update unmask_amount binding to use the new Amount constructor so the old one can be removed

### Motivation

Between the tagging of the 1.2.0 release in the MobileCoin repo and the android-sdk repo, the Amount constructor signature was changed. A private constructor matching the old signature was added to the SDK for compatibility with the MobileCoin 1.2.0 bindings release. This PR just updates the bindings so that the extra private constructor is no longer needed.