### PR TITLE
Make `TxOut::new` take a block version

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -991,7 +991,7 @@ fn mint_output<T: Digestible>(
 ) -> Result<TxOut> {
     // Check if the token id makes sense right now
     if !block_version.masked_token_id_feature_is_supported() && amount.token_id != 0 {
-        return Err(Error::FormBlock(
+        return Err(Error::BlockVersion(
             "Cannot mint outputs for non-MOB tokens at this block version".to_string(),
         ));
     }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1010,16 +1010,17 @@ fn mint_output<T: Digestible>(
     };
 
     // Create a single TxOut
-    let mut output = TxOut::new(amount, recipient, &tx_private_key, Default::default())
-        .map_err(|e| Error::FormBlock(format!("AmountError: {:?}", e)))?;
+    let output = TxOut::new(
+        block_version,
+        amount,
+        recipient,
+        &tx_private_key,
+        Default::default(),
+    )
+    .map_err(|e| Error::FormBlock(format!("NewTxError: {}", e)))?;
 
-    // The output must conform to block version rules
-    if !block_version.e_memo_feature_is_supported() {
-        output.e_memo = None;
-    }
-
+    // Check if the token id makes sense right now
     if !block_version.masked_token_id_feature_is_supported() {
-        output.masked_amount.masked_token_id.clear();
         if amount.token_id != 0 {
             return Err(Error::FormBlock(
                 "Cannot mint outputs for non-MOB tokens until they are supported".to_string(),
@@ -1543,6 +1544,7 @@ mod tests {
             for token_id in [token_id1, token_id2] {
                 for _ in 0..5 {
                     let spendable_output = TxOut::new(
+                        block_version,
                         Amount {
                             value: 10_000_000_000,
                             token_id,

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -992,7 +992,7 @@ fn mint_output<T: Digestible>(
     // Check if the token id makes sense right now
     if !block_version.masked_token_id_feature_is_supported() && amount.token_id != 0 {
         return Err(Error::FormBlock(
-            "Cannot mint outputs for non-MOB tokens until they are supported".to_string(),
+            "Cannot mint outputs for non-MOB tokens at this block version".to_string(),
         ));
     }
 

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -243,6 +243,8 @@ mod mint_config_tx_tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
 
+    const BLOCK_VERSION: BlockVersion = BlockVersion::MAX;
+
     /// validate_mint_config_tx accepts a valid mint config tx when only a
     /// single token is configured.
     #[test_with_logger]
@@ -252,7 +254,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 1;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -263,7 +265,7 @@ mod mint_config_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         assert_eq!(
             mint_tx_manager.validate_mint_config_tx(&mint_config_tx),
@@ -282,7 +284,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 1;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -305,7 +307,7 @@ mod mint_config_tx_tests {
         ])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         assert_eq!(
             mint_tx_manager.validate_mint_config_tx(&mint_config_tx1),
@@ -344,16 +346,12 @@ mod mint_config_tx_tests {
         // setting n_blocks to tombstone_block - 1 means the transaction will be valid
         // for exactly 1 block, but once that's written it will exceed it.
         let n_blocks = mint_config_tx.prefix.tombstone_block - 1;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // At first we should succeed since we have not yet exceeded the tombstone
         // block.
@@ -366,13 +364,13 @@ mod mint_config_tx_tests {
         let parent_block = ledger.get_block(n_blocks - 1).unwrap();
 
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             key_images: vec![KeyImage::from(123)],
             ..Default::default()
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -398,7 +396,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 1;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -408,12 +406,8 @@ mod mint_config_tx_tests {
             SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
         )])
         .unwrap();
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // At first we should succeed since the nonce is not yet in the ledger.
         assert_eq!(
@@ -430,7 +424,7 @@ mod mint_config_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -457,7 +451,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -468,7 +462,7 @@ mod mint_config_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         let (mint_config_tx2, _signers) = create_mint_config_tx_and_signers(token_id_2, &mut rng);
         assert_eq!(
@@ -489,7 +483,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 1;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -500,7 +494,7 @@ mod mint_config_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         mint_config_tx.prefix.tombstone_block += 1;
 
@@ -521,7 +515,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -535,7 +529,7 @@ mod mint_config_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         let mut expected_result = vec![
             mint_config_tx1.clone(),
@@ -572,7 +566,7 @@ mod mint_config_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -588,7 +582,7 @@ mod mint_config_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         let mut expected_result = vec![
             mint_config_tx1.clone(),
@@ -636,6 +630,8 @@ mod mint_tx_tests {
     use rand::{rngs::StdRng, SeedableRng};
     use std::iter::FromIterator;
 
+    const BLOCK_VERSION: BlockVersion = BlockVersion::MAX;
+
     /// validate_mint_tx accepts a valid mint tx when a single token is
     /// configured.
     #[test_with_logger]
@@ -645,7 +641,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -660,7 +656,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -675,7 +671,7 @@ mod mint_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         // Create a valid MintTx signed by the governor.
         let mint_tx = create_mint_tx(
@@ -697,7 +693,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -716,7 +712,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -737,7 +733,7 @@ mod mint_tx_tests {
         ])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         // Check valid transactions.
         let mint_tx1 = create_mint_tx(
@@ -773,7 +769,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -792,7 +788,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -813,7 +809,7 @@ mod mint_tx_tests {
         ])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         // Sign the wrong signer.
         let mint_tx = create_mint_tx(
@@ -871,7 +867,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -886,7 +882,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -900,12 +896,8 @@ mod mint_tx_tests {
             SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
         )])
         .unwrap();
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // Create a MintTx that exceeds the mint limit
         let mint_tx = create_mint_tx(
@@ -937,12 +929,12 @@ mod mint_tx_tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx],
-            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -984,7 +976,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1001,7 +993,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1015,12 +1007,8 @@ mod mint_tx_tests {
             SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
         )])
         .unwrap();
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // Create a MintTx that exceeds the total mint limit
         let mint_tx = create_mint_tx(
@@ -1052,12 +1040,12 @@ mod mint_tx_tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx],
-            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1099,7 +1087,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1114,7 +1102,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1129,7 +1117,7 @@ mod mint_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         // Create a valid MintTx signed by the governor.
         let mut mint_tx = create_mint_tx(
@@ -1173,7 +1161,7 @@ mod mint_tx_tests {
         // for exactly 1 block, but once that's written it will exceed it. However, we
         // subtract 2 since we also need to add a block for the mint config tx.
         let n_blocks = mint_tx.prefix.tombstone_block - 2;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1186,7 +1174,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1200,12 +1188,8 @@ mod mint_tx_tests {
             SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
         )])
         .unwrap();
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // At first we should succeed since we have not yet exceeded the tombstone
         // block.
@@ -1215,13 +1199,13 @@ mod mint_tx_tests {
         let parent_block = block;
 
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             key_images: vec![KeyImage::from(123)],
             ..Default::default()
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1246,7 +1230,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1261,7 +1245,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1275,12 +1259,8 @@ mod mint_tx_tests {
             SignerSet::new(signers.iter().map(|s| s.public_key()).collect(), 1),
         )])
         .unwrap();
-        let mint_tx_manager = MintTxManagerImpl::new(
-            ledger.clone(),
-            BlockVersion::MAX,
-            token_id_to_governors,
-            logger,
-        );
+        let mint_tx_manager =
+            MintTxManagerImpl::new(ledger.clone(), BLOCK_VERSION, token_id_to_governors, logger);
 
         // Create a valid MintTx signed by the governor.
         let mint_tx = create_mint_tx(
@@ -1295,14 +1275,14 @@ mod mint_tx_tests {
 
         // Append to the ledger.
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             mint_txs: vec![mint_tx.clone()],
             ..Default::default()
         };
 
         let parent_block = block;
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1328,7 +1308,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1343,7 +1323,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1384,7 +1364,7 @@ mod mint_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         let mut expected_result = mint_txs.clone();
         expected_result.sort();
@@ -1420,7 +1400,7 @@ mod mint_tx_tests {
 
         let mut ledger = create_ledger();
         let n_blocks = 3;
-        let block_version = BlockVersion::MAX;
+        let block_version = BLOCK_VERSION;
         let sender = AccountKey::random(&mut rng);
         initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
 
@@ -1435,7 +1415,7 @@ mod mint_tx_tests {
         };
 
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1496,7 +1476,7 @@ mod mint_tx_tests {
         )])
         .unwrap();
         let mint_tx_manager =
-            MintTxManagerImpl::new(ledger, BlockVersion::MAX, token_id_to_governors, logger);
+            MintTxManagerImpl::new(ledger, BLOCK_VERSION, token_id_to_governors, logger);
 
         // The expected result is that we get 3 transactions, one for each
         // configuration. We use the amount to sanity check this.

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -366,7 +366,7 @@ mod mint_config_tx_tests {
         let parent_block = ledger.get_block(n_blocks - 1).unwrap();
 
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
             key_images: vec![KeyImage::from(123)],
             ..Default::default()
         };
@@ -937,7 +937,7 @@ mod mint_tx_tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
             ..Default::default()
         };
 
@@ -1052,7 +1052,7 @@ mod mint_tx_tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
             ..Default::default()
         };
 
@@ -1215,7 +1215,7 @@ mod mint_tx_tests {
         let parent_block = block;
 
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
             key_images: vec![KeyImage::from(123)],
             ..Default::default()
         };
@@ -1295,7 +1295,7 @@ mod mint_tx_tests {
 
         // Append to the ledger.
         let block_contents = BlockContents {
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BlockVersion::MAX, &mut rng)],
             mint_txs: vec![mint_tx.clone()],
             ..Default::default()
         };

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -538,6 +538,7 @@ mod combine_tests {
             let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
             let tx_out = TxOut::new(
+                block_version,
                 Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &tx_secret_key_for_txo,
@@ -624,6 +625,7 @@ mod combine_tests {
                     let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
 
                     let tx_out = TxOut::new(
+                        block_version,
                         Amount::new(88, Mob::ID),
                         &alice.default_subaddress(),
                         &tx_secret_key_for_txo,
@@ -708,6 +710,7 @@ mod combine_tests {
 
             // Create a TxOut that was sent to Alice.
             let tx_out = TxOut::new(
+                block_version,
                 Amount {
                     value: 123,
                     token_id: Mob::ID,
@@ -820,6 +823,7 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
+                    block_version,
                     Amount::new(123, Mob::ID),
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,
@@ -902,6 +906,7 @@ mod combine_tests {
 
             // Create two TxOuts that were sent to Alice.
             let tx_out1 = TxOut::new(
+                block_version,
                 Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
@@ -910,6 +915,7 @@ mod combine_tests {
             .unwrap();
 
             let tx_out2 = TxOut::new(
+                block_version,
                 Amount::new(123, Mob::ID),
                 &alice.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
@@ -1027,6 +1033,7 @@ mod combine_tests {
                 // The transaction keys.
                 let tx_secret_key_for_txo = RistrettoPrivate::from_random(&mut rng);
                 let tx_out = TxOut::new(
+                    block_version,
                     Amount::new(123, Mob::ID),
                     &alice.default_subaddress(),
                     &tx_secret_key_for_txo,

--- a/fog/distribution/tests/bootstrap.rs
+++ b/fog/distribution/tests/bootstrap.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use std::{
     env::{args, set_current_dir},
     path::PathBuf,
@@ -31,7 +33,7 @@ fn test_find_spendable_tx_outs() {
         .success());
 
     assert!(Command::new(bin.join("generate-sample-ledger"))
-        .args(["--txs", "10", "--max-token-id", "1"])
+        .args(["--txs", "10"])
         .status()
         .unwrap()
         .success());

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -18,7 +18,7 @@ use mc_transaction_core::{
     fog_hint::{FogHint, PlaintextArray},
     tokens::Mob,
     tx::TxOut,
-    Amount, Token,
+    Amount, BlockVersion, Token,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_logger_macros::test_with_logger;
@@ -59,6 +59,7 @@ fn test_ingest_enclave(logger: Logger) {
                 let tx_private_key = RistrettoPrivate::from_random(&mut rng);
                 let e_fog_hint = FogHint::from(&bob_public_address).encrypt(&fog_pubkey, &mut rng);
                 TxOut::new(
+                    BlockVersion::MAX,
                     Amount {
                         value: 10,
                         token_id,
@@ -233,6 +234,7 @@ fn test_ingest_enclave_malformed_txos(logger: Logger) {
                     _ => panic!("this should be unreachable"),
                 };
                 TxOut::new(
+                    BlockVersion::MAX,
                     Amount {
                         value: 10,
                         token_id,
@@ -379,6 +381,7 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                     let tx_private_key = RistrettoPrivate::from_random(&mut rng);
                     let e_fog_hint = FogHint::from(pub_addr).encrypt(&fog_pubkey, &mut rng);
                     TxOut::new(
+                        BlockVersion::MAX,
                         Amount {
                             value: 10,
                             token_id,

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -788,6 +788,7 @@ fn add_block_to_ledger_db(
         .iter()
         .map(|recipient| {
             TxOut::new(
+                block_version,
                 // TODO: allow for subaddress index!
                 Amount {
                     value,

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -166,6 +166,7 @@ fn main() {
 
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let tx_out = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: credit.amount,
                 token_id,

--- a/fog/view/protocol/src/user_private.rs
+++ b/fog/view/protocol/src/user_private.rs
@@ -111,7 +111,7 @@ mod testing {
     use mc_crypto_box::{CryptoBox, VersionedCryptoBox};
     use mc_crypto_keys::CompressedRistrettoPublic;
     use mc_fog_types::view::{FogTxOut, FogTxOutMetadata};
-    use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, Token};
+    use mc_transaction_core::{tokens::Mob, tx::TxOut, Amount, BlockVersion, Token};
     pub use rand_core::{CryptoRng, RngCore, SeedableRng};
     use rand_hc::Hc128Rng;
 
@@ -147,6 +147,7 @@ mod testing {
         let tx_private_key = RistrettoPrivate::from_random(&mut rng);
         let token_id = Mob::ID;
         let txo = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 10,
                 token_id,

--- a/ledger/db/src/ledger_db.rs
+++ b/ledger/db/src/ledger_db.rs
@@ -923,7 +923,8 @@ mod ledger_db_test {
         for block_index in 0..num_blocks {
             let outputs: Vec<TxOut> = (0..num_outputs_per_block)
                 .map(|_i| {
-                    let mut result = TxOut::new(
+                    TxOut::new(
+                        BLOCK_VERSION,
                         Amount {
                             value: initial_amount,
                             token_id: Mob::ID,
@@ -932,12 +933,7 @@ mod ledger_db_test {
                         &RistrettoPrivate::from_random(&mut rng),
                         Default::default(),
                     )
-                    .unwrap();
-                    // Origin block doesn't have memos
-                    if block_index == 0 {
-                        result.e_memo = None
-                    };
-                    result
+                    .unwrap()
                 })
                 .collect();
 
@@ -989,7 +985,8 @@ mod ledger_db_test {
     fn get_origin_block_and_contents(account_key: &AccountKey) -> (Block, BlockContents) {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
 
-        let mut output = TxOut::new(
+        let output = TxOut::new(
+            BlockVersion::ZERO,
             Amount {
                 value: 1000,
                 token_id: Mob::ID,
@@ -999,8 +996,6 @@ mod ledger_db_test {
             Default::default(),
         )
         .unwrap();
-        // Origin block transactions dont' have memos
-        output.e_memo = None;
 
         let outputs = vec![output];
         let block = Block::new_origin_block(&outputs);
@@ -1051,7 +1046,9 @@ mod ledger_db_test {
 
         // === Create and append a non-origin block. ===
 
-        let outputs: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+        let outputs: Vec<TxOut> = (0..4)
+            .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+            .collect();
 
         let key_images: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
 
@@ -1381,7 +1378,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -1446,7 +1443,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2.clone()],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -1510,7 +1507,7 @@ mod ledger_db_test {
 
         let block_contents4 = BlockContents {
             mint_txs: vec![mint_tx3.clone()],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -1583,7 +1580,10 @@ mod ledger_db_test {
 
         let block_contents5 = BlockContents {
             mint_txs: vec![mint_tx4.clone(), mint_tx5.clone()],
-            outputs: vec![create_test_tx_out(&mut rng), create_test_tx_out(&mut rng)],
+            outputs: vec![
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+            ],
             ..Default::default()
         };
 
@@ -1660,7 +1660,10 @@ mod ledger_db_test {
 
         let block_contents6 = BlockContents {
             mint_txs: vec![mint_tx6.clone(), mint_tx7.clone()],
-            outputs: vec![create_test_tx_out(&mut rng), create_test_tx_out(&mut rng)],
+            outputs: vec![
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+            ],
             ..Default::default()
         };
 
@@ -1745,7 +1748,9 @@ mod ledger_db_test {
             .unwrap();
 
         // === Create and append a non-origin block. ===
-        let outputs1: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+        let outputs1: Vec<TxOut> = (0..4)
+            .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+            .collect();
 
         let key_images1: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
         let mint_config_tx1 = create_mint_config_tx(token_id1, &mut rng);
@@ -1853,7 +1858,9 @@ mod ledger_db_test {
 
         //  === Write another block - this one has a MintTx in addition to all
         // the other txs.
-        let outputs2: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+        let outputs2: Vec<TxOut> = (0..4)
+            .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+            .collect();
 
         let key_images2: Vec<KeyImage> = (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
         let mint_config_tx3 = create_mint_config_tx(token_id1, &mut rng);
@@ -2007,7 +2014,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2070,7 +2077,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2098,7 +2105,10 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2, mint_tx1],
-            outputs: vec![create_test_tx_out(&mut rng), create_test_tx_out(&mut rng)],
+            outputs: vec![
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+                create_test_tx_out(BLOCK_VERSION, &mut rng),
+            ],
             ..Default::default()
         };
 
@@ -2166,7 +2176,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2237,7 +2247,7 @@ mod ledger_db_test {
 
         let block_contents2 = BlockContents {
             mint_txs: vec![mint_tx1.clone()],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2263,7 +2273,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx2],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2312,7 +2322,7 @@ mod ledger_db_test {
 
         let block_contents3 = BlockContents {
             mint_txs: vec![mint_tx3],
-            outputs: vec![create_test_tx_out(&mut rng)],
+            outputs: vec![create_test_tx_out(BLOCK_VERSION, &mut rng)],
             ..Default::default()
         };
 
@@ -2407,7 +2417,9 @@ mod ledger_db_test {
             .unwrap();
 
         // === Attempt to append a block without key images ===
-        let outputs: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+        let outputs: Vec<TxOut> = (0..4)
+            .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+            .collect();
 
         let block_contents = BlockContents {
             outputs,
@@ -2561,7 +2573,7 @@ mod ledger_db_test {
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let tx_out = create_test_tx_out(&mut rng);
+        let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
         let outputs = vec![tx_out];
 
         let block_contents = BlockContents {
@@ -2603,7 +2615,7 @@ mod ledger_db_test {
             .map(|_i| KeyImage::from(rng.next_u64()))
             .collect();
 
-        let tx_out = create_test_tx_out(&mut rng);
+        let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
         let outputs = vec![tx_out];
 
         let block_contents = BlockContents {
@@ -2712,7 +2724,9 @@ mod ledger_db_test {
         for block_version in BlockVersion::iterator() {
             // In each iteration we add a few blocks with the same version.
             for _ in 0..3 {
-                let outputs: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+                let outputs: Vec<TxOut> = (0..4)
+                    .map(|_i| create_test_tx_out(block_version, &mut rng))
+                    .collect();
 
                 let key_images: Vec<KeyImage> =
                     (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
@@ -2749,7 +2763,9 @@ mod ledger_db_test {
 
         // Appending a block with version < previous block version should fail.
         {
-            let outputs: Vec<TxOut> = (0..4).map(|_i| create_test_tx_out(&mut rng)).collect();
+            let outputs: Vec<TxOut> = (0..4)
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+                .collect();
 
             let key_images: Vec<KeyImage> =
                 (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
@@ -2801,7 +2817,7 @@ mod ledger_db_test {
 
         let key_images = vec![KeyImage::from(rng.next_u64())];
 
-        let tx_out = create_test_tx_out(&mut rng);
+        let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
         let outputs = vec![tx_out];
         let block_contents = BlockContents {
@@ -2855,7 +2871,7 @@ mod ledger_db_test {
             .collect();
 
         let block_one_contents = {
-            let tx_out = create_test_tx_out(&mut rng);
+            let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
             let outputs = vec![tx_out];
             BlockContents {
                 key_images: block_one_key_images.clone(),
@@ -2877,7 +2893,7 @@ mod ledger_db_test {
 
         // The next block reuses a key image.
         let block_two_contents = {
-            let tx_out = create_test_tx_out(&mut rng);
+            let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
             let outputs = vec![tx_out];
             BlockContents {
                 key_images: block_one_key_images,
@@ -2918,7 +2934,7 @@ mod ledger_db_test {
         let existing_tx_out = ledger_db.get_tx_out_by_index(0).unwrap();
 
         let block_one_contents = {
-            let mut tx_out = create_test_tx_out(&mut rng);
+            let mut tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
             tx_out.public_key = existing_tx_out.public_key;
             let outputs = vec![tx_out];
             let key_images = vec![KeyImage::from(rng.next_u64())];
@@ -2978,7 +2994,7 @@ mod ledger_db_test {
 
         // append_block rejects a block with non-existent parent.
         {
-            let tx_out = create_test_tx_out(&mut rng);
+            let tx_out = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
             let key_images = vec![KeyImage::from(rng.next_u64())];
             let outputs = vec![tx_out];

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -249,6 +249,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
         if block_index == 0 {
             // Create the origin block.
             let mut tx_out = TxOut::new(
+                BlockVersion::ZERO,
                 Amount { value, token_id },
                 &account_key.default_subaddress(),
                 &RistrettoPrivate::from_random(&mut rng),
@@ -269,6 +270,7 @@ pub fn get_test_ledger_blocks(n_blocks: usize) -> Vec<(Block, BlockContents)> {
         } else {
             // Create a normal block.
             let tx_out = TxOut::new(
+                BlockVersion::MAX,
                 Amount {
                     value: 16,
                     token_id,
@@ -348,7 +350,13 @@ pub fn get_custom_test_ledger_blocks(
                         value: picomob_per_output,
                         token_id: token_id.into(),
                     };
-                    let output = TxOut::new(amount, recipient, &tx_private_key, Default::default());
+                    let output = TxOut::new(
+                        BlockVersion::MAX,
+                        amount,
+                        recipient,
+                        &tx_private_key,
+                        Default::default(),
+                    );
                     outputs.push(output.unwrap());
                 }
             }

--- a/mint-auditor/src/db/mod.rs
+++ b/mint-auditor/src/db/mod.rs
@@ -317,7 +317,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2, mint_tx3],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 
@@ -351,6 +353,7 @@ mod tests {
         let burn_recipient = burn_address();
 
         let tx_out1 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 50,
                 token_id: token_id1,
@@ -362,6 +365,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 10,
                 token_id: token_id1,
@@ -372,7 +376,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(&mut rng);
+        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -412,6 +416,7 @@ mod tests {
         let mint_tx3 = create_mint_tx(token_id3, &signers3, 20000, &mut rng);
 
         let tx_out1 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 900,
                 token_id: token_id1,
@@ -423,6 +428,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 1000,
                 token_id: token_id2,
@@ -433,7 +439,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(&mut rng);
+        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -640,7 +646,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2, mint_tx3],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 
@@ -677,6 +685,7 @@ mod tests {
         let burn_recipient = burn_address();
 
         let tx_out1 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 50000,
                 token_id: token_id1,
@@ -688,6 +697,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
+            BlockVersion::MAX,
             Amount {
                 value: 2,
                 token_id: token_id2,
@@ -698,7 +708,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(&mut rng);
+        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -849,7 +859,7 @@ mod tests {
 
             let block_contents = BlockContents {
                 mint_txs: vec![mint_tx1],
-                outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+                outputs: (0..3).map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng)).collect(),
                 ..Default::default()
             };
 
@@ -905,6 +915,7 @@ mod tests {
 
         // Sync a block that contains a mint transaction with signers that refer to a no
         // longer valid mint config.
+<<<<<<< HEAD:mint-auditor/src/db/mod.rs
         {
             let mint_tx2 = create_mint_tx(token_id1, &signers1, 1, &mut rng);
 
@@ -920,6 +931,26 @@ mod tests {
                 &Default::default(),
                 &block_contents,
             );
+=======
+        let mint_tx2 = create_mint_tx(token_id1, &signers1, 1, &mut rng);
+
+        let block_contents = BlockContents {
+            mint_txs: vec![mint_tx2],
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
+            ..Default::default()
+        };
+
+        let block = Block::new_with_parent(
+            BlockVersion::MAX,
+            &block,
+            &Default::default(),
+            &block_contents,
+        );
+
+        mint_audit_db.sync_block(&block, &block_contents).unwrap();
+>>>>>>> Make `TxOut::new` take a block version:mint-auditor/src/db.rs
 
             let _ = transaction(&conn, |conn| -> Result<(), Error> {
                 mint_audit_db
@@ -947,7 +978,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx3],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 
@@ -1048,7 +1081,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 
@@ -1081,7 +1116,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 

--- a/mint-auditor/src/db/mod.rs
+++ b/mint-auditor/src/db/mod.rs
@@ -231,6 +231,8 @@ mod tests {
     use rand_hc::Hc128Rng;
     use std::iter::FromIterator;
 
+    const BLOCK_VERSION: BlockVersion = BlockVersion::MAX;
+
     #[test_with_logger]
     fn test_sync_block_happy_flow(logger: Logger) {
         let mut rng = Hc128Rng::from_seed([1u8; 32]);
@@ -246,7 +248,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -289,7 +291,7 @@ mod tests {
             .get_block(ledger_db.num_blocks().unwrap() - 1)
             .unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -318,17 +320,13 @@ mod tests {
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2, mint_tx3],
             outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
                 .collect(),
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -353,7 +351,7 @@ mod tests {
         let burn_recipient = burn_address();
 
         let tx_out1 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 50,
                 token_id: token_id1,
@@ -365,7 +363,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 10,
                 token_id: token_id1,
@@ -376,7 +374,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
+        let tx_out3 = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -384,12 +382,8 @@ mod tests {
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -416,7 +410,7 @@ mod tests {
         let mint_tx3 = create_mint_tx(token_id3, &signers3, 20000, &mut rng);
 
         let tx_out1 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 900,
                 token_id: token_id1,
@@ -428,7 +422,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 1000,
                 token_id: token_id2,
@@ -439,7 +433,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
+        let tx_out3 = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -447,12 +441,8 @@ mod tests {
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
         ledger_db
             .append_block(&block, &block_contents, None)
             .unwrap();
@@ -495,7 +485,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -527,7 +517,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -559,7 +549,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -597,7 +587,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -628,7 +618,7 @@ mod tests {
             .get_block(ledger_db.num_blocks().unwrap() - 1)
             .unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -647,17 +637,13 @@ mod tests {
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2, mint_tx3],
             outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
                 .collect(),
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -685,7 +671,7 @@ mod tests {
         let burn_recipient = burn_address();
 
         let tx_out1 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 50000,
                 token_id: token_id1,
@@ -697,7 +683,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             Amount {
                 value: 2,
                 token_id: token_id2,
@@ -708,7 +694,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(BlockVersion::MAX, &mut rng);
+        let tx_out3 = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -716,12 +702,8 @@ mod tests {
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -746,6 +728,7 @@ mod tests {
 
         // Over burn once again, see that counter increases.
         let tx_out1 = TxOut::new(
+            BLOCK_VERSION,
             Amount::new(50000, token_id1),
             &burn_recipient,
             &RistrettoPrivate::from_random(&mut rng),
@@ -754,6 +737,7 @@ mod tests {
         .unwrap();
 
         let tx_out2 = TxOut::new(
+            BLOCK_VERSION,
             Amount::new(2, token_id2),
             &burn_recipient,
             &RistrettoPrivate::from_random(&mut rng),
@@ -761,7 +745,7 @@ mod tests {
         )
         .unwrap();
 
-        let tx_out3 = create_test_tx_out(&mut rng);
+        let tx_out3 = create_test_tx_out(BLOCK_VERSION, &mut rng);
 
         let block_contents = BlockContents {
             outputs: vec![tx_out1, tx_out2, tx_out3],
@@ -769,12 +753,8 @@ mod tests {
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
         ledger_db
             .append_block(&block, &block_contents, None)
             .unwrap();
@@ -801,7 +781,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -834,7 +814,7 @@ mod tests {
             .get_block(ledger_db.num_blocks().unwrap() - 1)
             .unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -859,16 +839,14 @@ mod tests {
 
             let block_contents = BlockContents {
                 mint_txs: vec![mint_tx1],
-                outputs: (0..3).map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng)).collect(),
+                outputs: (0..3)
+                    .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+                    .collect(),
                 ..Default::default()
             };
 
-            let block = Block::new_with_parent(
-                BlockVersion::MAX,
-                &block,
-                &Default::default(),
-                &block_contents,
-            );
+            let block =
+                Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
             let _ = transaction(&conn, |conn| -> Result<(), Error> {
                 mint_audit_db
@@ -899,12 +877,8 @@ mod tests {
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -915,42 +889,19 @@ mod tests {
 
         // Sync a block that contains a mint transaction with signers that refer to a no
         // longer valid mint config.
-<<<<<<< HEAD:mint-auditor/src/db/mod.rs
         {
             let mint_tx2 = create_mint_tx(token_id1, &signers1, 1, &mut rng);
 
             let block_contents = BlockContents {
                 mint_txs: vec![mint_tx2],
-                outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+                outputs: (0..3)
+                    .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
+                    .collect(),
                 ..Default::default()
             };
 
-            let block = Block::new_with_parent(
-                BlockVersion::MAX,
-                &block,
-                &Default::default(),
-                &block_contents,
-            );
-=======
-        let mint_tx2 = create_mint_tx(token_id1, &signers1, 1, &mut rng);
-
-        let block_contents = BlockContents {
-            mint_txs: vec![mint_tx2],
-            outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
-                .collect(),
-            ..Default::default()
-        };
-
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
-
-        mint_audit_db.sync_block(&block, &block_contents).unwrap();
->>>>>>> Make `TxOut::new` take a block version:mint-auditor/src/db.rs
+            let block =
+                Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
             let _ = transaction(&conn, |conn| -> Result<(), Error> {
                 mint_audit_db
@@ -979,17 +930,13 @@ mod tests {
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx3],
             outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
                 .collect(),
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         ledger_db
             .append_block(&block, &block_contents, None)
@@ -1023,7 +970,7 @@ mod tests {
         let account_key = AccountKey::random(&mut rng);
         let initial_num_blocks = 3;
         initialize_ledger(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &mut ledger_db,
             initial_num_blocks,
             &account_key,
@@ -1058,7 +1005,7 @@ mod tests {
             .get_block(ledger_db.num_blocks().unwrap() - 1)
             .unwrap();
         let block = Block::new_with_parent(
-            BlockVersion::MAX,
+            BLOCK_VERSION,
             &parent_block,
             &Default::default(),
             &block_contents,
@@ -1082,17 +1029,13 @@ mod tests {
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1],
             outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
                 .collect(),
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         mint_audit_db
             .sync_block(&block, &block_contents, &ledger_db)
@@ -1117,17 +1060,13 @@ mod tests {
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1],
             outputs: (0..3)
-                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .map(|_i| create_test_tx_out(BLOCK_VERSION, &mut rng))
                 .collect(),
             ..Default::default()
         };
 
-        let block = Block::new_with_parent(
-            BlockVersion::MAX,
-            &block,
-            &Default::default(),
-            &block_contents,
-        );
+        let block =
+            Block::new_with_parent(BLOCK_VERSION, &block, &Default::default(), &block_contents);
 
         mint_audit_db
             .sync_block(&block, &block_contents, &ledger_db)

--- a/mint-auditor/src/service.rs
+++ b/mint-auditor/src/service.rs
@@ -250,7 +250,9 @@ mod tests {
 
         let block_contents = BlockContents {
             mint_txs: vec![mint_tx1, mint_tx2, mint_tx3],
-            outputs: (0..3).map(|_i| create_test_tx_out(&mut rng)).collect(),
+            outputs: (0..3)
+                .map(|_i| create_test_tx_out(BlockVersion::MAX, &mut rng))
+                .collect(),
             ..Default::default()
         };
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1097,6 +1097,7 @@ mod test {
         let token_id = Mob::ID;
 
         let tx_out = TxOut::new(
+            BlockVersion::MAX,
             Amount { value: 1, token_id },
             &alice.default_subaddress(),
             &tx_secret_key_for_txo,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2149,8 +2149,7 @@ mod test {
         str::FromStr,
     };
 
-    // None of these tests really depend on any of the new features
-    const BLOCK_VERSION: BlockVersion = BlockVersion::ZERO;
+    const BLOCK_VERSION: BlockVersion = BlockVersion::MAX;
 
     #[test_with_logger]
     fn test_add_monitor_impl(logger: Logger) {

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -164,6 +164,7 @@ pub fn add_block_to_ledger_db(
         .iter()
         .map(|recipient| {
             let mut result = TxOut::new(
+                block_version,
                 // TODO: allow for subaddress index!
                 output_amount,
                 recipient,

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -86,10 +86,10 @@ pub fn get_test_databases(
     let mut ledger_db = generate_ledger_db(ledger_db_path);
 
     for block_index in 0..num_blocks {
-        let key_images = if block_index == 0 {
-            vec![]
+        let (block_version, key_images) = if block_index == 0 {
+            (BlockVersion::ZERO, vec![])
         } else {
-            vec![KeyImage::from(rng.next_u64())]
+            (block_version, vec![KeyImage::from(rng.next_u64())])
         };
         let _new_block_height = add_block_to_ledger_db(
             block_version,
@@ -163,7 +163,7 @@ pub fn add_block_to_ledger_db(
     let outputs: Vec<_> = recipients
         .iter()
         .map(|recipient| {
-            let mut result = TxOut::new(
+            TxOut::new(
                 block_version,
                 // TODO: allow for subaddress index!
                 output_amount,
@@ -171,12 +171,7 @@ pub fn add_block_to_ledger_db(
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),
             )
-            .expect("Could not create TxOut");
-            // The origin block does not have memos
-            if num_blocks == 0 {
-                result.e_memo = None;
-            }
-            result
+            .expect("Could not create TxOut")
         })
         .collect();
 

--- a/test-vectors/tx-out-records/build.rs
+++ b/test-vectors/tx-out-records/build.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use mc_account_keys::AccountKey;
 use mc_common::ResponderId;
 use mc_crypto_keys::RistrettoPrivate;
@@ -12,7 +14,7 @@ use mc_oblivious_traits::HeapORAMStorageCreator;
 use mc_test_vectors_definitions::tx_out_records::{
     CorrectTxOutRecordData, IncorrectTxOutRecordData,
 };
-use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, Token};
+use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, BlockVersion, Token};
 use mc_util_from_random::FromRandom;
 use mc_util_test_vector::write_jsonl;
 use rand::{rngs::StdRng, SeedableRng};
@@ -100,6 +102,7 @@ fn generate_tx_out_record_data() -> TxOutRecordData {
             let e_fog_hint =
                 FogHint::from(&recipient_public_address).encrypt(&fog_pubkey, &mut rng);
             TxOut::new(
+                BlockVersion::TWO,
                 Amount {
                     value: 10,
                     token_id,

--- a/transaction/core/src/blockchain/block.rs
+++ b/transaction/core/src/blockchain/block.rs
@@ -237,7 +237,8 @@ mod block_tests {
 
         let outputs: Vec<TxOut> = (0..8)
             .map(|_i| {
-                let mut result = TxOut::new(
+                TxOut::new(
+                    BLOCK_VERSION,
                     Amount {
                         value: rng.next_u64(),
                         token_id: Mob::ID,
@@ -246,9 +247,7 @@ mod block_tests {
                     &RistrettoPrivate::from_random(rng),
                     EncryptedFogHint::fake_onetime_hint(rng),
                 )
-                .unwrap();
-                result.masked_amount.masked_token_id = Default::default();
-                result
+                .unwrap()
             })
             .collect();
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -398,7 +398,7 @@ impl TxOut {
         if !block_version.masked_token_id_feature_is_supported() {
             masked_amount.masked_token_id.clear();
             if amount.token_id != 0 {
-                return Err(NewTxError::TokenIdNotAllowedAtBlockVersion);
+                return Err(NewTxError::TokenIdNotAllowedAtBlockVersion(block_version));
             }
         }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -399,7 +399,7 @@ impl TxOut {
         if !block_version.masked_token_id_feature_is_supported() {
             masked_amount.masked_token_id.clear();
             if amount.token_id != 0 {
-                return Err(NewTxError::TokenIdNotAllowed);
+                return Err(NewTxError::TokenIdNotAllowedAtBlockVersion);
             }
         }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -2,6 +2,7 @@
 
 //! Definition of a MobileCoin transaction and a MobileCoin TxOut
 
+use crate::BlockVersion;
 use alloc::vec::Vec;
 use core::{convert::TryFrom, fmt};
 use mc_account_keys::PublicAddress;
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 use crate::{
-    amount::{AmountError, MaskedAmount},
+    amount::MaskedAmount,
     domain_separators::TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG,
     encrypted_fog_hint::EncryptedFogHint,
     get_tx_out_shared_secret,
@@ -333,24 +334,26 @@ impl TxOut {
     /// This uses a defaulted (all zeroes) MemoPayload.
     ///
     /// # Arguments
+    /// * `block_version` - Structural rules to target
     /// * `amount` - Amount contained within the TxOut
     /// * `recipient` - Recipient's address.
     /// * `tx_private_key` - The transaction's private key
     /// * `hint` - Encrypted Fog hint for this output.
     pub fn new(
+        block_version: BlockVersion,
         amount: Amount,
         recipient: &PublicAddress,
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
-    ) -> Result<Self, AmountError> {
-        TxOut::new_with_memo(amount, recipient, tx_private_key, hint, |_| {
-            Ok(Some(MemoPayload::default()))
-        })
-        .map_err(|err| match err {
-            NewTxError::Amount(err) => err,
-            // Memo error is unreachable because the memo_fn we passed is infallible
-            NewTxError::Memo(_) => unreachable!(),
-        })
+    ) -> Result<Self, NewTxError> {
+        TxOut::new_with_memo(
+            block_version,
+            amount,
+            recipient,
+            tx_private_key,
+            hint,
+            |_| Ok(MemoPayload::default()),
+        )
     }
 
     /// Creates a TxOut that sends `value` to `recipient`, with a custom memo
@@ -358,6 +361,7 @@ impl TxOut {
     /// passed the value and tx_public_key.
     ///
     /// # Arguments
+    /// * `block_version` - Structural rules to target
     /// * `amount` - Amount contained within the TxOut
     /// * `recipient` - Recipient's address.
     /// * `tx_private_key` - The transaction's private key
@@ -365,24 +369,39 @@ impl TxOut {
     /// * `memo_fn` - A callback taking MemoContext, which produces a
     ///   MemoPayload, or a NewMemo error
     pub fn new_with_memo(
+        block_version: BlockVersion,
         amount: Amount,
         recipient: &PublicAddress,
         tx_private_key: &RistrettoPrivate,
         hint: EncryptedFogHint,
-        memo_fn: impl FnOnce(MemoContext) -> Result<Option<MemoPayload>, NewMemoError>,
+        memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
     ) -> Result<Self, NewTxError> {
         let target_key = create_tx_out_target_key(tx_private_key, recipient).into();
         let public_key = create_tx_out_public_key(tx_private_key, recipient.spend_public_key());
 
         let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
 
-        let masked_amount = MaskedAmount::new(amount, &shared_secret)?;
+        let mut masked_amount = MaskedAmount::new(amount, &shared_secret)?;
 
         let memo_ctxt = MemoContext {
             tx_public_key: &public_key,
         };
-        let memo = memo_fn(memo_ctxt).map_err(NewTxError::Memo)?;
-        let e_memo = memo.map(|memo| memo.encrypt(&shared_secret));
+
+        // Only build a memo if memos are supported
+        let e_memo = if block_version.e_memo_feature_is_supported() {
+            let memo = memo_fn(memo_ctxt).map_err(NewTxError::Memo)?;
+            Some(memo.encrypt(&shared_secret))
+        } else {
+            None
+        };
+
+        // Conform to block version rules
+        if !block_version.masked_token_id_feature_is_supported() {
+            masked_amount.masked_token_id.clear();
+            if amount.token_id != 0 {
+                return Err(NewTxError::TokenIdNotAllowed);
+            }
+        }
 
         Ok(TxOut {
             masked_amount,
@@ -662,7 +681,7 @@ mod tests {
         subaddress_matches_tx_out,
         tokens::Mob,
         tx::{Tx, TxIn, TxOut, TxPrefix},
-        Amount, MaskedAmount, Token,
+        Amount, BlockVersion, MaskedAmount, Token,
     };
     use alloc::vec::Vec;
     use core::convert::TryFrom;
@@ -816,6 +835,7 @@ mod tests {
 
             // A tx out with an empty memo
             let mut tx_out = TxOut::new(
+                BlockVersion::MAX,
                 Amount {
                     value: 13,
                     token_id: Mob::ID,
@@ -858,6 +878,7 @@ mod tests {
             let memo_val = MemoPayload::new([2u8; 2], [4u8; 64]);
             // A tx out with a memo
             let tx_out = TxOut::new_with_memo(
+                BlockVersion::MAX,
                 Amount {
                     value: 13,
                     token_id: Mob::ID,
@@ -865,7 +886,7 @@ mod tests {
                 &bob_addr,
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(Some(memo_val)),
+                |_| Ok(memo_val),
             )
             .unwrap();
 
@@ -894,6 +915,7 @@ mod tests {
             let memo_val = MemoPayload::new([4u8; 2], [9u8; 64]);
             // A tx out with a memo
             let tx_out = TxOut::new_with_memo(
+                BlockVersion::MAX,
                 Amount {
                     value: 13,
                     token_id: Mob::ID,
@@ -901,7 +923,7 @@ mod tests {
                 &bob.change_subaddress(),
                 &tx_private_key,
                 Default::default(),
-                |_| Ok(Some(memo_val)),
+                |_| Ok(memo_val),
             )
             .unwrap();
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -383,12 +383,11 @@ impl TxOut {
 
         let mut masked_amount = MaskedAmount::new(amount, &shared_secret)?;
 
-        let memo_ctxt = MemoContext {
-            tx_public_key: &public_key,
-        };
-
         // Only build a memo if memos are supported
         let e_memo = if block_version.e_memo_feature_is_supported() {
+            let memo_ctxt = MemoContext {
+                tx_public_key: &public_key,
+            };
             let memo = memo_fn(memo_ctxt).map_err(NewTxError::Memo)?;
             Some(memo.encrypt(&shared_secret))
         } else {

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -2,7 +2,7 @@
 
 //! Errors that can occur when creating a new TxOut
 
-use crate::{AmountError, MemoError};
+use crate::{AmountError, BlockVersion, MemoError};
 use alloc::{format, string::String};
 use core::str::Utf8Error;
 use displaydoc::Display;

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -16,7 +16,7 @@ pub enum NewTxError {
     /// Memo: {0}
     Memo(NewMemoError),
     /// Token Id not allowed at this block version
-    TokenIdNotAllowed,
+    TokenIdNotAllowedAtBlockVersion,
 }
 
 impl From<AmountError> for NewTxError {

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -15,8 +15,8 @@ pub enum NewTxError {
     Amount(AmountError),
     /// Memo: {0}
     Memo(NewMemoError),
-    /// Token Id not allowed at this block version
-    TokenIdNotAllowedAtBlockVersion,
+    /// Token Id not allowed at block version: {0}
+    TokenIdNotAllowedAtBlockVersion(BlockVersion),
 }
 
 impl From<AmountError> for NewTxError {

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -15,6 +15,8 @@ pub enum NewTxError {
     Amount(AmountError),
     /// Memo: {0}
     Memo(NewMemoError),
+    /// Token Id not allowed at this block version
+    TokenIdNotAllowed,
 }
 
 impl From<AmountError> for NewTxError {

--- a/transaction/core/test-utils/src/lib.rs
+++ b/transaction/core/test-utils/src/lib.rs
@@ -333,16 +333,14 @@ pub fn initialize_ledger<L: Ledger, R: RngCore + CryptoRng>(
                 // Create an origin block.
                 let outputs: Vec<TxOut> = (0..RING_SIZE)
                     .map(|_i| {
-                        let mut tx_out = TxOut::new(
+                        TxOut::new(
+                            BlockVersion::ZERO,
                             Amount { value, token_id },
                             &account_key.default_subaddress(),
                             &RistrettoPrivate::from_random(rng),
                             Default::default(),
                         )
-                        .expect("Could not create origin block TxOut");
-                        // The origin block did not historically have memo fields
-                        tx_out.e_memo = None;
-                        tx_out
+                        .expect("Could not create origin block TxOut")
                     })
                     .collect();
 
@@ -434,7 +432,8 @@ pub fn get_outputs<T: RngCore + CryptoRng>(
     recipient_and_amount
         .iter()
         .map(|(recipient, value)| {
-            let mut result = TxOut::new(
+            TxOut::new(
+                block_version,
                 Amount {
                     value: *value,
                     token_id: Mob::ID,
@@ -443,20 +442,19 @@ pub fn get_outputs<T: RngCore + CryptoRng>(
                 &RistrettoPrivate::from_random(rng),
                 Default::default(),
             )
-            .unwrap();
-            if !block_version.e_memo_feature_is_supported() {
-                result.e_memo = None;
-            }
-            result.masked_amount.masked_token_id = Default::default();
-            result
+            .unwrap()
         })
         .collect()
 }
 
 /// Generate a dummy txout for testing.
-pub fn create_test_tx_out(rng: &mut (impl RngCore + CryptoRng)) -> TxOut {
+pub fn create_test_tx_out(
+    block_version: BlockVersion,
+    rng: &mut (impl RngCore + CryptoRng),
+) -> TxOut {
     let account_key = AccountKey::random(rng);
     TxOut::new(
+        block_version,
         Amount {
             value: rng.next_u64(),
             token_id: Mob::ID,

--- a/transaction/core/tests/digest-test-vectors.rs
+++ b/transaction/core/tests/digest-test-vectors.rs
@@ -23,7 +23,8 @@ fn test_origin_tx_outs() -> Vec<TxOut> {
     accounts
         .iter()
         .map(|acct| {
-            let mut tx_out = TxOut::new(
+            TxOut::new(
+                BlockVersion::ZERO,
                 Amount {
                     value: rng.next_u32() as u64,
                     token_id: Mob::ID,
@@ -32,12 +33,7 @@ fn test_origin_tx_outs() -> Vec<TxOut> {
                 &RistrettoPrivate::from_random(&mut rng),
                 EncryptedFogHint::fake_onetime_hint(&mut rng),
             )
-            .expect("Could not create TxOut");
-            // Origin TxOuts do not have encrypted memo fields.
-            tx_out.e_memo = None;
-            // Origin TxOuts do not have masked token id
-            tx_out.masked_amount.masked_token_id = Default::default();
-            tx_out
+            .expect("Could not create TxOut")
         })
         .collect()
 }

--- a/transaction/std/src/signed_contingent_input_builder.rs
+++ b/transaction/std/src/signed_contingent_input_builder.rs
@@ -145,18 +145,11 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
             .memo_builder
             .take()
             .expect("memo builder is missing, this is a logic error");
-        let block_version = self.block_version;
         let result = self.add_required_output_with_fog_hint_address(
             amount,
             recipient,
             recipient,
-            |memo_ctxt| {
-                if block_version.e_memo_feature_is_supported() {
-                    Some(mb.make_memo_for_output(amount, recipient, memo_ctxt)).transpose()
-                } else {
-                    Ok(None)
-                }
-            },
+            |memo_ctxt| mb.make_memo_for_output(amount, recipient, memo_ctxt),
             rng,
         );
         // Put the memo builder back
@@ -204,19 +197,11 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
             .memo_builder
             .take()
             .expect("memo builder is missing, this is a logic error");
-        let block_version = self.block_version;
         let result = self.add_required_output_with_fog_hint_address(
             amount,
             &change_destination.change_subaddress,
             &change_destination.primary_address,
-            |memo_ctxt| {
-                if block_version.e_memo_feature_is_supported() {
-                    Some(mb.make_memo_for_change_output(amount, change_destination, memo_ctxt))
-                        .transpose()
-                } else {
-                    Ok(None)
-                }
-            },
+            |memo_ctxt| mb.make_memo_for_change_output(amount, change_destination, memo_ctxt),
             rng,
         );
         // Put the memo builder back
@@ -247,7 +232,7 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
         amount: Amount,
         recipient: &PublicAddress,
         fog_hint_address: &PublicAddress,
-        memo_fn: impl FnOnce(MemoContext) -> Result<Option<MemoPayload>, NewMemoError>,
+        memo_fn: impl FnOnce(MemoContext) -> Result<MemoPayload, NewMemoError>,
         rng: &mut RNG,
     ) -> Result<(TxOut, TxOutConfirmationNumber), TxBuilderError> {
         let (hint, pubkey_expiry) =

--- a/transaction/std/src/test_utils.rs
+++ b/transaction/std/src/test_utils.rs
@@ -46,11 +46,7 @@ pub fn create_output<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
         amount,
         recipient,
         hint,
-        |_| {
-            Ok(block_version
-                .e_memo_feature_is_supported()
-                .then(MemoPayload::default))
-        },
+        |_| Ok(MemoPayload::default()),
         rng,
     )
 }

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -168,7 +168,7 @@ fn create_output(
         EncryptedFogHint::fake_onetime_hint(rng)
     };
 
-    let output = TxOut::new(amount, recipient, &tx_private_key, hint).unwrap();
+    let output = TxOut::new(BLOCK_VERSION, amount, recipient, &tx_private_key, hint).unwrap();
     log::debug!(logger, "Creating output: {:?}", output);
     output
 }


### PR DESCRIPTION
This makes it easier to make `TxOut` that conform to certain
structural rules, which is important for compatibility testing.

Fixes #1749

This will make it easier to execute #2081