### PR TITLE
Bump all versions to 1.2.1, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
 
+## [1.2.1] - 2022-06-06
+
+### Changed
+
+- Expose the ability to get a TX shared secret to iOS SDK
+- Restore the ability to derive an account from legacy root entropy to iOS SDK
+- Improve the construction of `Amount` objects from Android SDK
+
+### Fixed
+
+- Fix panic when consensus service is configured for multiple tokens but still running in MOB-only block-version 0 mode.
+
 
 ## [1.2.0] - 2022-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libmobilecoin"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "mc-android-bindings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "bincode",
@@ -2404,7 +2404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "backtrace",
  "binascii",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-connection",
  "mc-consensus-enclave-api",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "mc-common",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "chrono",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "clap 3.1.18",
@@ -2857,7 +2857,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "digest 0.10.3",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "digest 0.10.3",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -2940,7 +2940,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake2",
  "digest 0.10.3",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3031,7 +3031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.6",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "clap 3.1.18",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "crossbeam-channel",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_cmd",
  "clap 3.1.18",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "dirs",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "digest 0.10.3",
  "displaydoc",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -3605,14 +3605,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3640,7 +3640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -3803,7 +3803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "clap 3.1.18",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "clap 3.1.18",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "digest 0.10.3",
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4110,7 +4110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "dirs",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "mc-api",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "lmdb-rkv",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mint-auditor"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mint-auditor-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "clap 3.1.18",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "grpcio",
  "hex",
@@ -4625,7 +4625,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "sha2 0.10.2",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "hex_fmt",
@@ -4669,21 +4669,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -4720,18 +4720,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4754,7 +4754,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -4773,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "hex",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.14.2",
@@ -4921,7 +4921,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "json",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -4979,18 +4979,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "hex",
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "clap 3.1.18",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "grpcio",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "hex",
@@ -5065,11 +5065,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "clap 3.1.18",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5107,7 +5107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "itertools",
  "mc-sgx-css",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "hex",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "prost",
  "serde",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "itertools",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/account-keys/slip10/Cargo.toml
+++ b/account-keys/slip10/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-slip10"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-android-bindings"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.3.0-pre0'
+version '1.2.1'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "hex",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "digest",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake2",
  "digest",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1061,11 +1061,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1096,29 +1096,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1147,14 +1147,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1162,11 +1162,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1232,14 +1232,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "prost",
  "serde",

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "digest",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake2",
  "digest",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -902,7 +902,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1054,14 +1054,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1165,11 +1165,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1200,36 +1200,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1258,14 +1258,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1273,11 +1273,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1343,14 +1343,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "prost",
  "serde",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Mobilecoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "cfg-if",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "digest",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake2",
  "digest",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "digest",
  "displaydoc",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1053,14 +1053,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1150,11 +1150,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1185,36 +1185,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1243,14 +1243,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1258,11 +1258,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1328,14 +1328,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "prost",
  "serde",
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 resolver = "2"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Mobilecoin"]
 edition = "2018"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Mobilecoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "bitflags",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "cfg-if 1.0.0",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "digest",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -859,7 +859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "blake2",
  "digest",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "binascii",
  "curve25519-dalek",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "digest",
  "displaydoc",
@@ -979,14 +979,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1175,11 +1175,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1219,36 +1219,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1277,14 +1277,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1292,11 +1292,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 
 [[package]]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "binascii",
@@ -1362,14 +1362,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "generic-array",
  "prost",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "prost",
  "serde",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libmobilecoin"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mint-auditor/Cargo.toml
+++ b/mint-auditor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mint-auditor"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mint-auditor/api/Cargo.toml
+++ b/mint-auditor/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mint-auditor-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "1.2.0"
+version = "1.2.1"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-std"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2018"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "README.md"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["MobileCoin"]
 edition = "2018"
 


### PR DESCRIPTION
- Bump all versions to 1.2.1
- Update changelog.md

### Motivation

This is the 1.2.1 release containing last-minute fixes discovered after tagging 1.2.0, this will be tagged as v1.2.1, and will be the version we sign/release to mainnet.
