### PR TITLE
Masked amount v2

### DIFF
--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -207,6 +207,15 @@ impl AuthorityVerifier for PublicAddress {
     }
 }
 
+impl FromRandom for PublicAddress {
+    fn from_random<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
+        PublicAddress::new(
+            &RistrettoPublic::from_random(rng),
+            &RistrettoPublic::from_random(rng),
+        )
+    }
+}
+
 /// Complete AccountKey, containing the pair of secret keys, which can be used
 /// for spending, and optionally some fog-related info,
 /// can be used for spending. This should only ever be present in client code.

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -202,8 +202,14 @@ message EncryptedMemo {
 
 // A Transaction Output.
 message TxOut {
-    // Amount.
-    MaskedAmount masked_amount = 1;
+    // Masked Amount.
+    // The versioning indicates which shared secret derivation we are using.
+    // For v1, the TxOut shared secret is used directly.
+    // For v2, an intermediate secret called amount shared secret is used.
+    oneof masked_amount {
+        MaskedAmount v1 = 1;
+        MaskedAmount v2 = 6;
+    };
 
     // Public key.
     CompressedRistretto target_key = 2;

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -207,8 +207,8 @@ message TxOut {
     // For v1, the TxOut shared secret is used directly.
     // For v2, an intermediate secret called amount shared secret is used.
     oneof masked_amount {
-        MaskedAmount v1 = 1;
-        MaskedAmount v2 = 6;
+        MaskedAmount masked_amount_v1 = 1;
+        MaskedAmount masked_amount_v2 = 6;
     };
 
     // Public key.

--- a/api/src/convert/amount.rs
+++ b/api/src/convert/amount.rs
@@ -1,11 +1,17 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 //! Convert to/from external::Amount
 
 use crate::{external, ConversionError};
-use mc_transaction_core::{CompressedCommitment, MaskedAmount};
+use mc_transaction_core::{CompressedCommitment, MaskedAmount, MaskedAmountV1, MaskedAmountV2};
 use mc_util_repr_bytes::ReprBytes;
 
-impl From<&MaskedAmount> for external::MaskedAmount {
-    fn from(source: &MaskedAmount) -> Self {
+// Note:
+// external::MaskedAmount is a proto message
+// external::TxOut_oneof_masked_amount is a proto oneof
+
+impl From<&MaskedAmountV1> for external::MaskedAmount {
+    fn from(source: &MaskedAmountV1) -> Self {
         let commitment_bytes = source.commitment.to_bytes().to_vec();
         let mut amount = external::MaskedAmount::new();
         amount.mut_commitment().set_data(commitment_bytes);
@@ -15,18 +21,73 @@ impl From<&MaskedAmount> for external::MaskedAmount {
     }
 }
 
-impl TryFrom<&external::MaskedAmount> for MaskedAmount {
+impl From<&MaskedAmountV2> for external::MaskedAmount {
+    fn from(source: &MaskedAmountV2) -> Self {
+        let commitment_bytes = source.commitment.to_bytes().to_vec();
+        let mut amount = external::MaskedAmount::new();
+        amount.mut_commitment().set_data(commitment_bytes);
+        amount.set_masked_value(source.masked_value);
+        amount.set_masked_token_id(source.masked_token_id.clone());
+        amount
+    }
+}
+
+impl From<&MaskedAmount> for external::TxOut_oneof_masked_amount {
+    fn from(source: &MaskedAmount) -> Self {
+        match source {
+            MaskedAmount::V1(masked_amount) => {
+                external::TxOut_oneof_masked_amount::v1(masked_amount.into())
+            }
+            MaskedAmount::V2(masked_amount) => {
+                external::TxOut_oneof_masked_amount::v2(masked_amount.into())
+            }
+        }
+    }
+}
+
+impl TryFrom<&external::MaskedAmount> for MaskedAmountV1 {
     type Error = ConversionError;
 
     fn try_from(source: &external::MaskedAmount) -> Result<Self, Self::Error> {
         let commitment = CompressedCommitment::try_from(source.get_commitment())?;
         let masked_value = source.get_masked_value();
         let masked_token_id = source.get_masked_token_id();
-        let amount = MaskedAmount {
+        let amount = MaskedAmountV1 {
             commitment,
             masked_value,
             masked_token_id: masked_token_id.to_vec(),
         };
         Ok(amount)
+    }
+}
+
+impl TryFrom<&external::MaskedAmount> for MaskedAmountV2 {
+    type Error = ConversionError;
+
+    fn try_from(source: &external::MaskedAmount) -> Result<Self, Self::Error> {
+        let commitment = CompressedCommitment::try_from(source.get_commitment())?;
+        let masked_value = source.get_masked_value();
+        let masked_token_id = source.get_masked_token_id().to_vec();
+        let amount = MaskedAmountV2 {
+            commitment,
+            masked_value,
+            masked_token_id,
+        };
+        Ok(amount)
+    }
+}
+
+impl TryFrom<&external::TxOut_oneof_masked_amount> for MaskedAmount {
+    type Error = ConversionError;
+
+    fn try_from(source: &external::TxOut_oneof_masked_amount) -> Result<Self, Self::Error> {
+        match source {
+            external::TxOut_oneof_masked_amount::v1(masked_amount) => {
+                Ok(MaskedAmount::V1(masked_amount.try_into()?))
+            }
+            external::TxOut_oneof_masked_amount::v2(masked_amount) => {
+                Ok(MaskedAmount::V2(masked_amount.try_into()?))
+            }
+        }
     }
 }

--- a/api/src/convert/amount.rs
+++ b/api/src/convert/amount.rs
@@ -36,10 +36,10 @@ impl From<&MaskedAmount> for external::TxOut_oneof_masked_amount {
     fn from(source: &MaskedAmount) -> Self {
         match source {
             MaskedAmount::V1(masked_amount) => {
-                external::TxOut_oneof_masked_amount::v1(masked_amount.into())
+                external::TxOut_oneof_masked_amount::masked_amount_v1(masked_amount.into())
             }
             MaskedAmount::V2(masked_amount) => {
-                external::TxOut_oneof_masked_amount::v2(masked_amount.into())
+                external::TxOut_oneof_masked_amount::masked_amount_v2(masked_amount.into())
             }
         }
     }
@@ -82,10 +82,10 @@ impl TryFrom<&external::TxOut_oneof_masked_amount> for MaskedAmount {
 
     fn try_from(source: &external::TxOut_oneof_masked_amount) -> Result<Self, Self::Error> {
         match source {
-            external::TxOut_oneof_masked_amount::v1(masked_amount) => {
+            external::TxOut_oneof_masked_amount::masked_amount_v1(masked_amount) => {
                 Ok(MaskedAmount::V1(masked_amount.try_into()?))
             }
-            external::TxOut_oneof_masked_amount::v2(masked_amount) => {
+            external::TxOut_oneof_masked_amount::masked_amount_v2(masked_amount) => {
                 Ok(MaskedAmount::V2(masked_amount.try_into()?))
             }
         }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -92,6 +92,7 @@ enum ProposeTxResult {
     InputRulesNotAllowed = 46;
     InputRuleMissingRequiredOutput = 47;
     InputRuleMaxTombstoneBlockExceeded = 48;
+    UnknownMaskedAmountVersion = 49;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -66,6 +66,7 @@ impl From<Error> for ProposeTxResult {
             Error::InputRule(InputRuleError::MaxTombstoneBlockExceeded) => {
                 Self::InputRuleMaxTombstoneBlockExceeded
             }
+            Error::UnknownMaskedAmountVersion => Self::UnknownMaskedAmountVersion,
         }
     }
 }
@@ -122,6 +123,7 @@ impl TryInto<Error> for ProposeTxResult {
             Self::InputRuleMaxTombstoneBlockExceeded => {
                 Ok(Error::InputRule(InputRuleError::MaxTombstoneBlockExceeded))
             }
+            Self::UnknownMaskedAmountVersion => Ok(Error::UnknownMaskedAmountVersion),
         }
     }
 }

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -267,5 +267,12 @@ message TxOutRecord {
     /// This is omitted for TxOut's from before the upgrade that introduced memos.
     bytes tx_out_e_memo_data = 9;
     /// The masked token id associated to the amount field in the TxOut that was recovered
-    bytes tx_out_amount_masked_token_id = 10;
+    oneof tx_out_masked_amount_token_id {
+        /// The masked token id associated to the v1 amount field in the TxOut that was recovered
+        /// The presence of this field indicates that a MaskedAmountV1 object was serialized.
+        bytes v1 = 10;
+        /// The masked token id associated to the v2 amount field in the TxOut that was recovered
+        /// The presence of this field indicates that a MaskedAmountV2 object was serialized.
+        bytes v2 = 11;
+    }
 }

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -267,12 +267,12 @@ message TxOutRecord {
     /// This is omitted for TxOut's from before the upgrade that introduced memos.
     bytes tx_out_e_memo_data = 9;
     /// The masked token id associated to the amount field in the TxOut that was recovered
-    oneof tx_out_masked_amount_token_id {
+    oneof tx_out_amount_masked_token_id {
         /// The masked token id associated to the v1 amount field in the TxOut that was recovered
         /// The presence of this field indicates that a MaskedAmountV1 object was serialized.
-        bytes tx_out_masked_amount_v1_token_id  = 10;
+        bytes tx_out_amount_masked_v1_token_id  = 10;
         /// The masked token id associated to the v2 amount field in the TxOut that was recovered
         /// The presence of this field indicates that a MaskedAmountV2 object was serialized.
-        bytes tx_out_masked_amount_v2_token_id = 11;
+        bytes tx_out_amount_masked_v2_token_id = 11;
     }
 }

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -270,9 +270,9 @@ message TxOutRecord {
     oneof tx_out_masked_amount_token_id {
         /// The masked token id associated to the v1 amount field in the TxOut that was recovered
         /// The presence of this field indicates that a MaskedAmountV1 object was serialized.
-        bytes v1 = 10;
+        bytes tx_out_masked_amount_v1_token_id  = 10;
         /// The masked token id associated to the v2 amount field in the TxOut that was recovered
         /// The presence of this field indicates that a MaskedAmountV2 object was serialized.
-        bytes v2 = 11;
+        bytes tx_out_masked_amount_v2_token_id = 11;
     }
 }

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -3,15 +3,14 @@
 // Test that mc_fog_types structs match the protos defined in .proto files,
 // by testing that they round-trip through the proto-generated rust types
 
-use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_keys::RistrettoPrivate;
 use mc_fog_api::kex_rng;
 use mc_fog_kex_rng::{KexRngPubkey, StoredRng};
 use mc_fog_report_api_test_utils::{round_trip_message, round_trip_protobuf_object};
 use mc_transaction_core::{
-    encrypted_fog_hint::EncryptedFogHint,
     membership_proofs::Range,
     tx::{TxOut, TxOutMembershipElement, TxOutMembershipHash, TxOutMembershipProof},
-    Amount, EncryptedMemo, MaskedAmount,
+    Amount, BlockVersion, EncryptedMemo, PublicAddress,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_test_helper::{run_with_several_seeds, CryptoRng, RngCore};
@@ -207,7 +206,7 @@ fn tx_out_record_round_trip() {
     }
 
     run_with_several_seeds(|mut rng| {
-        let fog_txout = mc_fog_types::view::FogTxOut::from(&TxOut::sample(&mut rng));
+        let fog_txout = mc_fog_types::view::FogTxOut::try_from(&TxOut::sample(&mut rng)).unwrap();
         let meta = mc_fog_types::view::FogTxOutMetadata {
             global_index: rng.next_u64(),
             block_index: rng.next_u64(),
@@ -438,25 +437,17 @@ impl Sample for mc_fog_types::view::TxOutSearchResult {
     }
 }
 
-impl Sample for MaskedAmount {
-    fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        let amount = Amount {
-            value: rng.next_u32() as u64,
-            token_id: rng.next_u64().into(),
-        };
-        MaskedAmount::new(amount, &RistrettoPublic::from_random(rng)).unwrap()
-    }
-}
-
 impl Sample for TxOut {
     fn sample<T: RngCore + CryptoRng>(rng: &mut T) -> Self {
-        TxOut {
-            masked_amount: MaskedAmount::sample(rng),
-            target_key: RistrettoPublic::from_random(rng).into(),
-            public_key: RistrettoPublic::from_random(rng).into(),
-            e_fog_hint: EncryptedFogHint::fake_onetime_hint(rng),
-            e_memo: Option::<EncryptedMemo>::sample(rng),
-        }
+        let amount = Amount::new(rng.next_u32() as u64, rng.next_u64().into());
+        TxOut::new(
+            BlockVersion::MAX,
+            amount,
+            &PublicAddress::from_random(rng),
+            &RistrettoPrivate::from_random(rng),
+            Default::default(),
+        )
+        .unwrap()
     }
 }
 

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -409,7 +409,8 @@ fn select_spendable_tx_outs(
                     get_tx_out_shared_secret(account.view_private_key(), &public_key);
 
                 let (amount, _blinding_factor) = tx_out
-                    .masked_amount
+                    .get_masked_amount()
+                    .unwrap_or_else(|err| panic!("TX missing masked value: {}", err))
                     .get_value(&shared_secret)
                     .unwrap_or_else(|err| {
                         panic!(

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -410,7 +410,7 @@ fn select_spendable_tx_outs(
 
                 let (amount, _blinding_factor) = tx_out
                     .get_masked_amount()
-                    .unwrap_or_else(|err| panic!("TX missing masked value: {}", err))
+                    .expect("TxOut missing masked value")
                     .get_value(&shared_secret)
                     .unwrap_or_else(|err| {
                         panic!(

--- a/fog/ingest/enclave/api/src/error.rs
+++ b/fog/ingest/enclave/api/src/error.rs
@@ -9,6 +9,7 @@ use mc_attest_core::{
 };
 use mc_attest_enclave_api::Error as AttestEnclaveError;
 use mc_crypto_keys::KeyError;
+use mc_fog_types::view::FogTxOutError;
 use mc_sgx_compat::sync::PoisonError;
 use mc_util_serial::{
     decode::Error as RmpDecodeError, encode::Error as RmpEncodeError,
@@ -18,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// An enumeration of errors which can occur when rotating keys in the ingest
 /// enclave
-#[derive(Clone, Debug, Deserialize, Display, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Display, PartialEq, Serialize)]
 pub enum RotateKeysError {
     /**
      * We tried to rotate keys when there was an existing rotated key that
@@ -31,7 +32,7 @@ pub enum RotateKeysError {
 }
 
 /// An enumeration of errors which can occur inside an ingest enclave.
-#[derive(Clone, Debug, Deserialize, Display, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Display, PartialEq, Serialize)]
 pub enum Error {
     /// Enclave not initialized
     NotInit,
@@ -87,6 +88,9 @@ pub enum Error {
      * row: capacity was {2}
      */
     ChunkTooBig(usize, usize, u64),
+
+    /// Invalid block data
+    InvalidBlockData(FogTxOutError),
 
     /// Error when rotating keys: {0}
     RotateKeys(RotateKeysError),

--- a/fog/ingest/enclave/api/src/lib.rs
+++ b/fog/ingest/enclave/api/src/lib.rs
@@ -89,7 +89,9 @@ pub trait IngestEnclave: ReportableEnclave {
     fn get_kex_rng_pubkey(&self) -> Result<KexRngPubkey>;
 
     /// Consume all the transactions and emit corresponding rows for the
-    /// recovery database
+    /// recovery database. If this caused our ORAM to fill up, then the egress
+    /// key will be rotated, resulting in a new KexRngPubkey. This will be
+    /// written to the database and the previous one should be retired.
     fn ingest_txs(&self, chunk: TxsForIngest) -> Result<(Vec<ETxOutRecord>, Option<KexRngPubkey>)>;
 
     /// Retrieve the public identity of the enclave, for peering

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -137,6 +137,7 @@ fn test_ingest_enclave(logger: Logger) {
                 let tx_out_record = bob_fog_credential
                     .decrypt_tx_out_result(tx_rows[idx].payload.clone())
                     .unwrap();
+
                 assert_eq!(tx_out_record.block_index, txs_for_ingest.block_index);
                 assert_eq!(
                     tx_out_record.tx_out_global_index,
@@ -144,7 +145,7 @@ fn test_ingest_enclave(logger: Logger) {
                 );
                 assert_eq!(
                     tx_out_record.get_fog_tx_out().unwrap(),
-                    FogTxOut::from(&tx_outs_for_bob[idx])
+                    FogTxOut::try_from(&tx_outs_for_bob[idx]).unwrap()
                 );
             }
 
@@ -305,7 +306,7 @@ fn test_ingest_enclave_malformed_txos(logger: Logger) {
                 );
                 assert_eq!(
                     tx_out_record.get_fog_tx_out().unwrap(),
-                    FogTxOut::from(&tx_outs[4 * index3])
+                    FogTxOut::try_from(&tx_outs[4 * index3]).unwrap()
                 );
 
                 assert!(
@@ -527,7 +528,7 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                         "{:?} {:?} alice:{} bob:{}",
                         tx_out_record, tx_row, alice_found, bob_found,
                     );
-                    let expected_fog_tx_out = FogTxOut::from(&all_tx_outs[idx]);
+                    let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,
@@ -567,7 +568,7 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                         "{:?} {:?} alice:{} bob:{}",
                         tx_out_record, tx_row, alice_found, bob_found,
                     );
-                    let expected_fog_tx_out = FogTxOut::from(&all_tx_outs[idx]);
+                    let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -229,15 +229,13 @@ mod test {
         logger::{test_with_logger, Logger},
         HashSet,
     };
-    use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
+    use mc_crypto_keys::RistrettoPrivate;
     use mc_fog_ledger_test_infra::{MockEnclave, MockLedger};
     use mc_transaction_core::{
-        encrypted_fog_hint::{EncryptedFogHint, ENCRYPTED_FOG_HINT_LEN},
         membership_proofs::Range,
-        onetime_keys::{create_shared_secret, create_tx_out_public_key, create_tx_out_target_key},
         tokens::Mob,
         tx::{TxOut, TxOutMembershipElement, TxOutMembershipProof},
-        Amount, MaskedAmount, Token,
+        Amount, BlockVersion, Token,
     };
     use mc_util_from_random::FromRandom;
     use mc_util_grpc::AnonymousAuthenticator;
@@ -250,33 +248,21 @@ mod test {
     fn get_tx_outs(num_tx_outs: u32) -> Vec<TxOut> {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let mut tx_outs: Vec<TxOut> = Vec::new();
-        let tx_secret_key = RistrettoPrivate::from_random(&mut rng);
         let recipient_account = AccountKey::random(&mut rng);
         let value: u64 = 100;
 
         for output_index in 0..num_tx_outs {
             let recipient_account_default_subaddress = recipient_account.default_subaddress();
-            let target_key =
-                create_tx_out_target_key(&tx_secret_key, &recipient_account_default_subaddress);
-            let public_key = create_tx_out_public_key(
+            let tx_secret_key = RistrettoPrivate::from_random(&mut rng);
+            let amount = Amount::new(value + output_index as u64, Mob::ID);
+            let tx_out = TxOut::new(
+                BlockVersion::ZERO,
+                amount,
+                &recipient_account_default_subaddress,
                 &tx_secret_key,
-                recipient_account_default_subaddress.spend_public_key(),
-            );
-            let shared_secret: RistrettoPublic = create_shared_secret(&target_key, &tx_secret_key);
-            // FIXME: Without a different value, the txouts are identical - that
-            // may be fine, or we may want a more robust mock ledger populator.
-            let amount = Amount {
-                value: value + output_index as u64,
-                token_id: Mob::ID,
-            };
-            let masked_amount = MaskedAmount::new(amount, &shared_secret).unwrap();
-            let tx_out = TxOut {
-                masked_amount,
-                target_key: target_key.into(),
-                public_key: public_key.into(),
-                e_fog_hint: EncryptedFogHint::new(&[7u8; ENCRYPTED_FOG_HINT_LEN]),
-                e_memo: None,
-            };
+                Default::default(),
+            )
+            .unwrap();
             tx_outs.push(tx_out);
         }
         tx_outs

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -619,7 +619,7 @@ impl CachedTxData {
                     }
                 };
 
-                let fog_tx_out_metadata: FogTxOutMetadata = FogTxOutMetadata {
+                let fog_tx_out_metadata = FogTxOutMetadata {
                     global_index: first_tx_out_global_index + i as u64,
                     block_index: block_data.index,
                     timestamp: block_data.timestamp,

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -1076,7 +1076,7 @@ mod test_build_transaction_helper {
                 let cached_inputs: Vec<(OwnedTxOut, TxOutMembershipProof)> = outputs
                     .into_iter()
                     .map(|tx_out| {
-                        let fog_tx_out = FogTxOut::from(&tx_out);
+                        let fog_tx_out = FogTxOut::try_from(&tx_out).unwrap();
                         let meta = FogTxOutMetadata::default();
                         let txo_record = TxOutRecord::new(fog_tx_out, meta);
 

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -13,7 +13,7 @@ use mc_fog_types::view::FogTxOutError;
 use mc_fog_view_protocol::TxOutPollingError;
 use mc_transaction_core::{
     validation::TransactionValidationError, AmountError, BlockVersionError,
-    SignedContingentInputError,
+    SignedContingentInputError, TxOutConversionError,
 };
 use mc_transaction_std::{SignedContingentInputBuilderError, TxBuilderError};
 use mc_util_uri::UriParseError;
@@ -32,6 +32,9 @@ pub enum TxOutMatchingError {
 
     /// Error parsing key: {0}
     Key(KeyError),
+
+    /// TxOut conversion error: {0}
+    TxOutConversion(TxOutConversionError),
 
     /// Error decompressing FogTxOut: {0}
     FogTxOut(FogTxOutError),
@@ -55,6 +58,12 @@ impl From<KeyError> for TxOutMatchingError {
 impl From<FogTxOutError> for TxOutMatchingError {
     fn from(src: FogTxOutError) -> Self {
         Self::FogTxOut(src)
+    }
+}
+
+impl From<TxOutConversionError> for TxOutMatchingError {
+    fn from(src: TxOutConversionError) -> Self {
+        Self::TxOutConversion(src)
     }
 }
 

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -11,7 +11,9 @@ use mc_fog_types::{
     BlockCount,
 };
 use mc_fog_view_protocol::{FogViewConnection, UserPrivate, UserRngSet};
-use mc_transaction_core::{fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, MaskedAmount, Token};
+use mc_transaction_core::{
+    fog_hint::FogHint, tokens::Mob, tx::TxOut, Amount, BlockVersion, MaskedAmount, Token,
+};
 use mc_util_from_random::FromRandom;
 use rand_core::{CryptoRng, RngCore};
 use std::collections::{HashMap, HashSet};
@@ -75,7 +77,7 @@ pub fn test_block_to_inputs_and_expected_outputs(
             .entry(upriv.clone())
             .or_insert_with(HashSet::default);
 
-        let fog_tx_out = FogTxOut::from(txo);
+        let fog_tx_out = FogTxOut::try_from(txo).unwrap();
         let meta = FogTxOutMetadata {
             global_index: global_tx_out_index as u64,
             block_index,
@@ -103,6 +105,7 @@ pub fn test_block_to_pairs(test_block: &TestBlock) -> Vec<(UserPrivate, TxOut)> 
 }
 
 /// Make a random transaction targeted at a specific user via fog
+// FIXME: This should use TxOut::new instead
 pub fn make_random_tx<T: RngCore + CryptoRng>(
     rng: &mut T,
     acct_server_pubkey: &RistrettoPublic,
@@ -115,7 +118,10 @@ pub fn make_random_tx<T: RngCore + CryptoRng>(
         token_id: Mob::ID,
     };
     TxOut {
-        masked_amount: MaskedAmount::new(amount, &public_key).expect("amount failed unexpectedly"),
+        masked_amount: Some(
+            MaskedAmount::new(BlockVersion::ZERO, amount, &public_key)
+                .expect("amount failed unexpectedly"),
+        ),
         target_key: target_key.into(),
         public_key: public_key.into(),
         e_fog_hint: recipient.encrypt(acct_server_pubkey, rng),

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -210,10 +210,14 @@ impl From<&MaskedAmount> for TxOutAmountMaskedTokenId {
     fn from(src: &MaskedAmount) -> Self {
         match src {
             MaskedAmount::V1(masked_amount) => {
-                TxOutAmountMaskedTokenId::TxOutAmountMaskedTokenIdV1(masked_amount.masked_token_id.clone())
+                TxOutAmountMaskedTokenId::TxOutAmountMaskedTokenIdV1(
+                    masked_amount.masked_token_id.clone(),
+                )
             }
             MaskedAmount::V2(masked_amount) => {
-                TxOutAmountMaskedTokenId::TxOutAmountMaskedTokenIdV2(masked_amount.masked_token_id.clone())
+                TxOutAmountMaskedTokenId::TxOutAmountMaskedTokenIdV2(
+                    masked_amount.masked_token_id.clone(),
+                )
             }
         }
     }

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -10,7 +10,7 @@ use mc_transaction_core::{
     tx::TxOut,
     AmountError, EncryptedMemo, MaskedAmount, MemoError,
 };
-use prost::Message;
+use prost::{Message, Oneof};
 use serde::{Deserialize, Serialize};
 
 pub use mc_fog_kex_rng::KexRngPubkey;
@@ -182,6 +182,43 @@ pub struct TxOutSearchResult {
     pub ciphertext: Vec<u8>,
 }
 
+/// An enum capturing the Oneof in the proto file around masked token id bytes
+/// This is an enum because the options are used to capture which version of
+/// masked amount was serialized.
+#[derive(Clone, Eq, Hash, Oneof, PartialEq)]
+pub enum MaskedTokenId {
+    /// A v1 masked amount's token id bytes.
+    /// This is used when the masked amount in the original TxOut has version 1
+    /// Note: This tag must match the historical tag used for masked token id
+    /// bytes
+    #[prost(bytes, tag = "10")]
+    V1(Vec<u8>),
+
+    /// A v2 masked amount's token id bytes
+    /// This is used when the masked amount in the original TxOut has version 2
+    #[prost(bytes, tag = "11")]
+    V2(Vec<u8>),
+}
+
+impl Default for MaskedTokenId {
+    fn default() -> Self {
+        Self::V2(Default::default())
+    }
+}
+
+impl From<&MaskedAmount> for MaskedTokenId {
+    fn from(src: &MaskedAmount) -> Self {
+        match src {
+            MaskedAmount::V1(masked_amount) => {
+                MaskedTokenId::V1(masked_amount.masked_token_id.clone())
+            }
+            MaskedAmount::V2(masked_amount) => {
+                MaskedTokenId::V2(masked_amount.masked_token_id.clone())
+            }
+        }
+    }
+}
+
 /// TxOutRecord is what information the fog service preserves for a user about
 /// their TxOut. These are created by the ingest server and then encrypted. The
 /// encrypted blobs are eventually returned to the user, who must deserialize
@@ -189,7 +226,7 @@ pub struct TxOutSearchResult {
 ///
 /// Note: There are conformance tests in fog-api that check that this matches
 /// the proto
-#[derive(Clone, Eq, Hash, PartialEq, Message)]
+#[derive(Clone, Eq, Hash, Message, PartialEq)]
 pub struct TxOutRecord {
     /// The (compressed ristretto) bytes of commitment associated to amount
     /// field in the TxOut that was recovered.
@@ -197,18 +234,22 @@ pub struct TxOutRecord {
     /// crc32 checksum of these bytes is stored.
     #[prost(bytes, tag = "1")]
     pub tx_out_amount_commitment_data: Vec<u8>,
+
     /// The masked value associated to amount field in the TxOut that was
     /// recovered
     #[prost(fixed64, required, tag = "2")]
     pub tx_out_amount_masked_value: u64,
+
     /// The (compressed ristretto) bytes of the target key associated to the
     /// TxOut that was recovered
     #[prost(bytes, required, tag = "3")]
     pub tx_out_target_key_data: Vec<u8>,
+
     /// The (compressed ristretto) bytes of the public key associated to the
     /// TxOut that was recovered
     #[prost(bytes, required, tag = "4")]
     pub tx_out_public_key_data: Vec<u8>,
+
     /// Global index within the set of all TxOuts
     #[prost(fixed64, required, tag = "5")]
     pub tx_out_global_index: u64,
@@ -236,8 +277,8 @@ pub struct TxOutRecord {
 
     /// The masked token id associated to the amount field in the TxOut that
     /// was recovered
-    #[prost(bytes, tag = "10")]
-    pub tx_out_amount_masked_token_id: Vec<u8>,
+    #[prost(oneof = "MaskedTokenId", tags = "10, 11")]
+    pub tx_out_amount_masked_token_id: Option<MaskedTokenId>,
 }
 
 impl TxOutRecord {
@@ -253,7 +294,7 @@ impl TxOutRecord {
             tx_out_amount_commitment_data: Default::default(),
             tx_out_amount_commitment_data_crc32: fog_tx_out.amount_commitment_data_crc32,
             tx_out_amount_masked_value: fog_tx_out.amount_masked_value,
-            tx_out_amount_masked_token_id: fog_tx_out.amount_masked_token_id,
+            tx_out_amount_masked_token_id: Some(fog_tx_out.amount_masked_token_id),
             tx_out_target_key_data: fog_tx_out.target_key.as_bytes().to_vec(),
             tx_out_public_key_data: fog_tx_out.public_key.as_bytes().to_vec(),
             tx_out_e_memo_data: fog_tx_out
@@ -270,11 +311,15 @@ impl TxOutRecord {
     /// Note that this discards some metadata (timestamp, block_index,
     /// global_index).
     pub fn get_fog_tx_out(&self) -> Result<FogTxOut, FogTxOutError> {
+        let amount_masked_token_id = self
+            .tx_out_amount_masked_token_id
+            .clone()
+            .ok_or(FogTxOutError::Amount(AmountError::MissingMaskedAmount))?;
         Ok(FogTxOut {
             target_key: CompressedRistrettoPublic::try_from(&self.tx_out_target_key_data[..])?,
             public_key: CompressedRistrettoPublic::try_from(&self.tx_out_public_key_data[..])?,
             amount_masked_value: self.tx_out_amount_masked_value,
-            amount_masked_token_id: self.tx_out_amount_masked_token_id.clone(),
+            amount_masked_token_id,
             amount_commitment_data_crc32: self.get_amount_data_crc32()?,
             e_memo: self.get_e_memo()?,
         })
@@ -331,7 +376,7 @@ pub struct FogTxOut {
     pub amount_masked_value: u64,
 
     /// The tx out masked token id
-    pub amount_masked_token_id: Vec<u8>,
+    pub amount_masked_token_id: MaskedTokenId,
 
     /// The crc32 of the tx out amount commitment bytes
     pub amount_commitment_data_crc32: u32,
@@ -342,18 +387,25 @@ pub struct FogTxOut {
 
 // Convert a TxOut to a FogTxOut in the efficient way (omitting compressed
 // commitment)
-impl From<&TxOut> for FogTxOut {
+impl TryFrom<&TxOut> for FogTxOut {
+    type Error = FogTxOutError;
+
     #[inline]
-    fn from(src: &TxOut) -> Self {
-        Self {
+    fn try_from(src: &TxOut) -> Result<Self, Self::Error> {
+        let masked_amount = src
+            .get_masked_amount()
+            .map_err(|_| FogTxOutError::Amount(AmountError::MissingMaskedAmount))?;
+        let amount_masked_value = *masked_amount.get_masked_value();
+        let amount_commitment_data_crc32 = masked_amount.commitment_crc32();
+        let amount_masked_token_id = MaskedTokenId::from(masked_amount);
+        Ok(Self {
             target_key: src.target_key,
             public_key: src.public_key,
-            amount_masked_value: src.masked_amount.masked_value,
-            amount_masked_token_id: src.masked_amount.masked_token_id.clone(),
-            amount_commitment_data_crc32: Crc::<u32>::new(&crc::CRC_32_ISO_HDLC)
-                .checksum(src.masked_amount.commitment.point.as_bytes()),
+            amount_masked_value,
+            amount_masked_token_id,
+            amount_commitment_data_crc32,
             e_memo: src.e_memo,
-        }
+        })
     }
 }
 
@@ -380,19 +432,35 @@ impl FogTxOut {
         let tx_out_shared_secret =
             mc_transaction_core::get_tx_out_shared_secret(view_key, &public_key);
 
-        let (masked_amount, _) = MaskedAmount::reconstruct(
-            self.amount_masked_value,
-            &self.amount_masked_token_id,
-            &tx_out_shared_secret,
-        )
-        .map_err(|_| FogTxOutError::ChecksumMismatch)?;
+        // Reconstruct the correct masked amount version, based on which of the oneof
+        // proto field was present
+        let masked_amount = match &self.amount_masked_token_id {
+            MaskedTokenId::V1(bytes) => {
+                let (masked_amount, _) = MaskedAmount::reconstruct_v1(
+                    self.amount_masked_value,
+                    bytes,
+                    &tx_out_shared_secret,
+                )
+                .map_err(FogTxOutError::Amount)?;
+                masked_amount
+            }
+            MaskedTokenId::V2(bytes) => {
+                let (masked_amount, _) = MaskedAmount::reconstruct_v2(
+                    self.amount_masked_value,
+                    bytes,
+                    &tx_out_shared_secret,
+                )
+                .map_err(FogTxOutError::Amount)?;
+                masked_amount
+            }
+        };
 
         if masked_amount.commitment_crc32() != self.amount_commitment_data_crc32 {
             return Err(FogTxOutError::ChecksumMismatch);
         }
 
         Ok(TxOut {
-            masked_amount,
+            masked_amount: Some(masked_amount),
             target_key: self.target_key,
             public_key: self.public_key,
             e_fog_hint: EncryptedFogHint::from(&[0u8; ENCRYPTED_FOG_HINT_LEN]),
@@ -402,7 +470,7 @@ impl FogTxOut {
 }
 
 /// An error that occurs when trying to convert a FogTxOut to a TxOut
-#[derive(Display, Debug)]
+#[derive(Clone, Deserialize, Display, Debug, Eq, PartialEq, Serialize)]
 pub enum FogTxOutError {
     /// CompressedCommitment crc32 mismatch
     ChecksumMismatch,

--- a/fog/view/protocol/src/user_private.rs
+++ b/fog/view/protocol/src/user_private.rs
@@ -164,7 +164,7 @@ mod testing {
         assert!(bool::from(success));
 
         // Prep for DB record
-        let fog_txout = FogTxOut::from(&txo);
+        let fog_txout = FogTxOut::try_from(&txo).unwrap();
         let meta = FogTxOutMetadata {
             global_index: 1,
             block_index: 1,

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -87,6 +87,9 @@ pub enum Error {
 
     /// Block metadata is required at this block version
     BlockMetadataRequired,
+
+    /// Missing masked amonut
+    MissingMaskedAmount,
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/ledger_db.rs
+++ b/ledger/db/src/ledger_db.rs
@@ -728,6 +728,16 @@ impl LedgerDB {
             return Err(Error::InvalidBlockContents);
         }
 
+        // Check that none of the outputs are missing masked amount (or, have a masked
+        // amount we don't understand)
+        if block_contents
+            .outputs
+            .iter()
+            .any(|output| output.get_masked_amount().is_err())
+        {
+            return Err(Error::MissingMaskedAmount);
+        }
+
         // Check that none of the key images were previously spent.
         for key_image in &block_contents.key_images {
             if self

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -60,7 +60,11 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     // Get the output value.
     let tx_out_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
     let shared_secret = get_tx_out_shared_secret(sender.view_private_key(), &tx_out_public_key);
-    let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
+    let (amount, _blinding) = tx_out
+        .get_masked_amount()
+        .unwrap()
+        .get_value(&shared_secret)
+        .unwrap();
 
     assert!(amount.value >= Mob::MINIMUM_FEE);
     create_transaction_with_amount(

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -497,13 +497,13 @@ pub struct JsonMaskedAmount {
 impl From<&mc_api::external::TxOut_oneof_masked_amount> for JsonMaskedAmount {
     fn from(src: &mc_api::external::TxOut_oneof_masked_amount) -> Self {
         match src {
-            mc_api::external::TxOut_oneof_masked_amount::v1(src) => Self {
+            mc_api::external::TxOut_oneof_masked_amount::masked_amount_v1(src) => Self {
                 commitment: hex::encode(src.get_commitment().get_data()),
                 masked_value: JsonU64(src.get_masked_value()),
                 masked_token_id: hex::encode(src.get_masked_token_id()),
                 version: None,
             },
-            mc_api::external::TxOut_oneof_masked_amount::v2(src) => Self {
+            mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(src) => Self {
                 commitment: hex::encode(src.get_commitment().get_data()),
                 masked_value: JsonU64(src.get_masked_value()),
                 masked_token_id: hex::encode(src.get_masked_token_id()),
@@ -534,10 +534,10 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
         );
 
         match src.version {
-            None | Some(1) => Ok(mc_api::external::TxOut_oneof_masked_amount::v1(
+            None | Some(1) => Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v1(
                 masked_amount,
             )),
-            Some(2) => Ok(mc_api::external::TxOut_oneof_masked_amount::v2(
+            Some(2) => Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(
                 masked_amount,
             )),
             Some(other) => Err(format!("Unknown masked amount version: {}", other)),

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -534,12 +534,12 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
         );
 
         match src.version {
-            None | Some(1) => Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v1(
-                masked_amount,
-            )),
-            Some(2) => Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(
-                masked_amount,
-            )),
+            None | Some(1) => {
+                Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v1(masked_amount))
+            }
+            Some(2) => {
+                Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(masked_amount))
+            }
             Some(other) => Err(format!("Unknown masked amount version: {}", other)),
         }
     }

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -174,15 +174,12 @@ impl TryFrom<&api::TxProposal> for TxProposal {
 mod test {
     use super::*;
     use mc_account_keys::AccountKey;
-    use mc_crypto_keys::RistrettoPublic;
+    use mc_crypto_keys::RistrettoPrivate;
     use mc_ledger_db::{
         test_utils::{create_ledger, create_transaction, initialize_ledger},
         Ledger,
     };
-    use mc_transaction_core::{
-        encrypted_fog_hint::ENCRYPTED_FOG_HINT_LEN, tokens::Mob, Amount, BlockVersion,
-        MaskedAmount, Token,
-    };
+    use mc_transaction_core::{tokens::Mob, Amount, BlockVersion, Token};
     use mc_util_from_random::FromRandom;
     use rand::{rngs::StdRng, SeedableRng};
 
@@ -195,14 +192,14 @@ mod test {
             value: 1u64 << 13,
             token_id: Mob::ID,
         };
-        let tx_out = TxOut {
-            masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
-                .unwrap(),
-            target_key: RistrettoPublic::from_random(&mut rng).into(),
-            public_key: RistrettoPublic::from_random(&mut rng).into(),
-            e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
-            e_memo: Some(Default::default()),
-        };
+        let tx_out = TxOut::new(
+            BlockVersion::MAX,
+            amount,
+            &PublicAddress::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+            Default::default(),
+        )
+        .unwrap();
 
         let subaddress_index = 123;
         let key_image = KeyImage::from(456);
@@ -287,14 +284,14 @@ mod test {
                 value: 1u64 << 13,
                 token_id: Mob::ID,
             };
-            let tx_out = TxOut {
-                masked_amount: MaskedAmount::new(amount, &RistrettoPublic::from_random(&mut rng))
-                    .unwrap(),
-                target_key: RistrettoPublic::from_random(&mut rng).into(),
-                public_key: RistrettoPublic::from_random(&mut rng).into(),
-                e_fog_hint: (&[0u8; ENCRYPTED_FOG_HINT_LEN]).into(),
-                e_memo: Some(Default::default()),
-            };
+            let tx_out = TxOut::new(
+                BlockVersion::MAX,
+                amount,
+                &PublicAddress::from_random(&mut rng),
+                &RistrettoPrivate::from_random(&mut rng),
+                Default::default(),
+            )
+            .unwrap();
 
             let subaddress_index = 123;
             let key_image = KeyImage::from(456);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -592,7 +592,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
 
         let (amount, _blinding) = tx_out
-            .masked_amount
+            .get_masked_amount()
+            .map_err(|err| rpc_internal_error("tx_out.get_masked_amount", err, &self.logger))?
             .get_value(&shared_secret)
             .map_err(|err| rpc_internal_error("amount.get_value", err, &self.logger))?;
 
@@ -3725,7 +3726,11 @@ mod test {
                             account_key.view_private_key(),
                             &output_public_key,
                         );
-                        tx_out.masked_amount.get_value(&shared_secret).ok()
+                        tx_out
+                            .get_masked_amount()
+                            .unwrap()
+                            .get_value(&shared_secret)
+                            .ok()
                     })
                     .expect("There should be an output belonging to the account key.");
 
@@ -3810,7 +3815,11 @@ mod test {
                             account_key.view_private_key(),
                             &output_public_key,
                         );
-                        tx_out.masked_amount.get_value(&shared_secret).ok()
+                        tx_out
+                            .get_masked_amount()
+                            .unwrap()
+                            .get_value(&shared_secret)
+                            .ok()
                     })
                     .expect("There should be an output belonging to the account key.");
 
@@ -4261,7 +4270,11 @@ mod test {
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret =
             get_tx_out_shared_secret(data.account_key.view_private_key(), &tx_public_key);
-        let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
+        let (amount, _blinding) = tx_out
+            .get_masked_amount()
+            .unwrap()
+            .get_value(&shared_secret)
+            .unwrap();
         assert_eq!(amount.value, tx_proposal.outlays[0].value);
         assert_eq!(amount.token_id, Mob::ID);
 
@@ -4338,7 +4351,11 @@ mod test {
         let tx_out = &tx_proposal.tx.prefix.outputs[0];
         let tx_public_key = RistrettoPublic::try_from(&tx_out.public_key).unwrap();
         let shared_secret = get_tx_out_shared_secret(receiver.view_private_key(), &tx_public_key);
-        let (amount, _blinding) = tx_out.masked_amount.get_value(&shared_secret).unwrap();
+        let (amount, _blinding) = tx_out
+            .get_masked_amount()
+            .unwrap()
+            .get_value(&shared_secret)
+            .unwrap();
         assert_eq!(amount.value, expected_value);
         assert_eq!(amount.token_id, Mob::ID);
     }
@@ -5286,7 +5303,8 @@ mod test {
                             get_tx_out_shared_secret(sender.view_private_key(), &tx_public_key);
 
                         let (amount, _blinding) = tx_out
-                            .masked_amount
+                            .get_masked_amount()
+                            .unwrap()
                             .get_value(&shared_secret)
                             .expect("Malformed amount");
 

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -383,7 +383,8 @@ fn match_tx_outs_into_utxos(
             get_tx_out_shared_secret(account_key.view_private_key(), &tx_public_key);
 
         let (amount, _blinding) = tx_out
-            .masked_amount
+            .get_masked_amount()
+            .expect("missing masked amount")
             .get_value(&shared_secret)
             .expect("Malformed amount"); // TODO
 

--- a/test-vectors/tx-out-records/build.rs
+++ b/test-vectors/tx-out-records/build.rs
@@ -151,7 +151,7 @@ fn generate_tx_out_record_data() -> TxOutRecordData {
         );
         assert_eq!(
             tx_out_record.get_fog_tx_out().unwrap(),
-            FogTxOut::from(&tx_outs_for_recipient[idx])
+            FogTxOut::try_from(&tx_outs_for_recipient[idx]).unwrap()
         );
         tx_out_records.push(tx_out_record);
     }

--- a/transaction/core/src/amount/error.rs
+++ b/transaction/core/src/amount/error.rs
@@ -1,17 +1,29 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 //! Errors that can occur when handling an amount commitment.
 
 use displaydoc::Display;
+use serde::{Deserialize, Serialize};
 
 /// An error which can occur when handling an amount commitment.
-#[derive(Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, Serialize)]
 pub enum AmountError {
     /**
      * The masked value, token id, or shared secret are not consistent with
      * the commitment.
      */
     InconsistentCommitment,
+
     /**
      * The masked token id has an invalid number of bytes
      */
     InvalidMaskedTokenId,
+
+    /**
+     * The masked amount is missing
+     */
+    MissingMaskedAmount,
+
+    /// Token Id is not supported at this block version
+    TokenIdNotSupportedAtBlockVersion,
 }

--- a/transaction/core/src/amount/v1.rs
+++ b/transaction/core/src/amount/v1.rs
@@ -1,0 +1,350 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A commitment to an output's amount, denominated in picoMOB.
+//!
+//! Amounts are implemented as Pedersen commitments. The associated private keys
+//! are "masked" using a shared secret.
+
+use crate::{
+    domain_separators::{
+        AMOUNT_BLINDING_DOMAIN_TAG, AMOUNT_TOKEN_ID_DOMAIN_TAG, AMOUNT_VALUE_DOMAIN_TAG,
+    },
+    Amount, AmountError, TokenId,
+};
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use crc::Crc;
+use mc_crypto_digestible::Digestible;
+use mc_crypto_hashes::{Blake2b512, Digest};
+use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_ring_signature::{generators, CompressedCommitment, Scalar};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+/// A commitment to an amount of MobileCoin or a related token, as it appears on
+/// the blockchain. This is a "blinded" commitment, and only the sender and
+/// receiver know the value and token id.
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
+#[digestible(name = "Amount")]
+pub struct MaskedAmountV1 {
+    /// A Pedersen commitment `v*H + b*G` to a quantity `v` of MobileCoin or a
+    /// related token, with blinding `b`,
+    #[prost(message, required, tag = "1")]
+    pub commitment: CompressedCommitment,
+
+    /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
+    #[prost(fixed64, required, tag = "2")]
+    pub masked_value: u64,
+
+    /// `masked_token_id = token_id XOR_8 Blake2B(token_id_mask |
+    /// shared_secret)` 8 bytes long when used, 0 bytes for older amounts
+    /// that don't have this.
+    #[prost(bytes, tag = "3")]
+    pub masked_token_id: Vec<u8>,
+}
+
+impl MaskedAmountV1 {
+    /// Creates a commitment `value*H + blinding*G`, and "masks" the commitment
+    /// secrets so that they can be recovered by the recipient.
+    ///
+    /// # Arguments
+    /// * `amount` - The amount information to be masked
+    /// * `tx_out_shared_secret` - The shared secret, e.g. `rB` for transaction
+    ///   private key `r` and recipient public key `B`.
+    #[inline]
+    pub fn new(
+        amount: Amount,
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<Self, AmountError> {
+        // The blinding is `Blake2B("blinding" | shared_secret)`
+        let blinding: Scalar = get_blinding(tx_out_shared_secret);
+
+        // Pedersen generators
+        let generator = generators(*amount.token_id);
+
+        // Pedersen commitment `v*H_i + b*G`.
+        let commitment = CompressedCommitment::new(amount.value, blinding, &generator);
+
+        // The value is XORed with the first 8 bytes of the mask.
+        // `v XOR_8 Scalar::from_hash(Blake2B(value_mask | shared_secret))`
+        let masked_value: u64 = amount.value ^ get_value_mask(tx_out_shared_secret);
+
+        // The token_id is XORed with the first 8 bytes of the mask.
+        // `v XOR_4 Blake2B(token_id_mask | shared_secret)`
+        let masked_token_id_val: u64 = *amount.token_id ^ get_token_id_mask(tx_out_shared_secret);
+        let masked_token_id = masked_token_id_val.to_le_bytes().to_vec();
+
+        Ok(MaskedAmountV1 {
+            commitment,
+            masked_value,
+            masked_token_id,
+        })
+    }
+
+    /// Returns the amount underlying the masked amount, given the TxOut shared
+    /// secret.
+    ///
+    /// Value is denominated in picoMOB.
+    ///
+    /// # Arguments
+    /// * `tx_out_shared_secret` - The shared secret, e.g. `rB`.
+    pub fn get_value(
+        &self,
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<(Amount, Scalar), AmountError> {
+        let (expected_commitment, amount, blinding) = Self::compute_commitment(
+            self.masked_value,
+            &self.masked_token_id,
+            tx_out_shared_secret,
+        )?;
+        if self.commitment != expected_commitment {
+            // The commitment does not agree with the provided value and blinding.
+            // This either means that the commitment does not correspond to the shared
+            // secret, or that the amount is malformed (and is probably not
+            // spendable).
+            return Err(AmountError::InconsistentCommitment);
+        }
+
+        Ok((amount, blinding))
+    }
+
+    /// Compute the crc32 of the compressed commitment
+    pub fn commitment_crc32(&self) -> u32 {
+        Self::compute_commitment_crc32(&self.commitment)
+    }
+
+    /// Recovers an Amount from only the masked value and masked_token_id, and
+    /// shared secret.
+    ///
+    /// Note: This fails and produces gibberish if the shared secret is wrong.
+    ///
+    /// * You should confirm by checking against the real commitment, or the the
+    ///   crc32 of commitment.
+    ///
+    /// Arguments:
+    /// * masked_value: u64
+    /// * masked_token_id: &[u8], either 0 or 4 bytes
+    /// * shared_secret: The shared secret curve point
+    ///
+    /// Returns:
+    /// * MaskedAmount
+    /// * Amount (token id and value)
+    /// or
+    /// * An amount error
+    pub fn reconstruct(
+        masked_value: u64,
+        masked_token_id: &[u8],
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<(Self, Amount), AmountError> {
+        let (expected_commitment, amount, _) =
+            Self::compute_commitment(masked_value, masked_token_id, tx_out_shared_secret)?;
+
+        let result = Self {
+            commitment: expected_commitment,
+            masked_value,
+            masked_token_id: masked_token_id.to_vec(),
+        };
+
+        Ok((result, amount))
+    }
+
+    /// Compute the expected commitment corresponding to a masked value, masked
+    /// token id, and shared secret, returning errors if the masked token id
+    /// is malformed.
+    fn compute_commitment(
+        masked_value: u64,
+        masked_token_id: &[u8],
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<(CompressedCommitment, Amount, Scalar), AmountError> {
+        let token_id = TokenId::from(Self::unmask_token_id(
+            masked_token_id,
+            tx_out_shared_secret,
+        )?);
+        let value: u64 = Self::unmask_value(masked_value, tx_out_shared_secret);
+        let blinding = get_blinding(tx_out_shared_secret);
+
+        // Pedersen generators
+        let generator = generators(*token_id);
+
+        let expected_commitment = CompressedCommitment::new(value, blinding, &generator);
+
+        Ok((expected_commitment, Amount { value, token_id }, blinding))
+    }
+
+    fn compute_commitment_crc32(commitment: &CompressedCommitment) -> u32 {
+        Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(commitment.point.as_bytes())
+    }
+
+    /// Reveals `masked_value`.
+    fn unmask_value(masked_value: u64, tx_out_shared_secret: &RistrettoPublic) -> u64 {
+        masked_value ^ get_value_mask(tx_out_shared_secret)
+    }
+
+    /// Reveals `masked_token_id`, with backwards compat
+    fn unmask_token_id(
+        masked_token_id: &[u8],
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<u64, AmountError> {
+        match masked_token_id.len() {
+            0 => Ok(0),
+            TokenId::NUM_BYTES => {
+                // Safety: We just checked masked_token_id.len() == TokenId::NUM_BYTES
+                let masked_token_id_val = u64::from_le_bytes(masked_token_id.try_into().unwrap());
+                Ok(masked_token_id_val ^ get_token_id_mask(tx_out_shared_secret))
+            }
+            _ => Err(AmountError::InvalidMaskedTokenId),
+        }
+    }
+}
+
+/// Computes `Blake2B(value_mask | shared_secret)`, hashed to a Ristretto
+/// scalar, then interprets the first 8 canonical bytes as a u64 number in
+/// little-endian representation.
+///
+/// # Arguments
+/// * `shared_secret` - The shared secret, e.g. `rB`.
+fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
+    let mut hasher = Blake2b512::new();
+    hasher.update(&AMOUNT_VALUE_DOMAIN_TAG);
+    hasher.update(&shared_secret.to_bytes());
+    let scalar = Scalar::from_hash(hasher);
+    let mut temp = [0u8; 8];
+    temp.copy_from_slice(&scalar.as_bytes()[0..8]);
+    u64::from_le_bytes(temp)
+}
+
+/// Computes `Blake2B(token_id_mask | shared_secret)`,
+/// then interprets the first 8 canonical bytes as a u64 number in
+/// little-endian representation.
+///
+/// # Arguments
+/// * `shared_secret` - The shared secret, e.g. `rB`.
+fn get_token_id_mask(shared_secret: &RistrettoPublic) -> u64 {
+    let mut hasher = Blake2b512::new();
+    hasher.update(&AMOUNT_TOKEN_ID_DOMAIN_TAG);
+    hasher.update(&shared_secret.to_bytes());
+    u64::from_le_bytes(hasher.finalize()[0..8].try_into().unwrap())
+}
+
+/// Computes `Blake2B("blinding" | shared_secret)`.
+///
+/// # Arguments
+/// * `shared_secret` - The shared secret, e.g. `rB`.
+fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
+    let mut hasher = Blake2b512::new();
+    hasher.update(&AMOUNT_BLINDING_DOMAIN_TAG);
+    hasher.update(&shared_secret.to_bytes());
+    Scalar::from_hash(hasher)
+}
+
+#[cfg(test)]
+mod amount_tests {
+    #![allow(clippy::unnecessary_operation)]
+
+    use super::*;
+    use crate::{proptest_fixtures::*, ring_signature::generators, CompressedCommitment};
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        /// MaskedAmount::new() should return Ok for valid values and blindings.
+        fn test_new_ok(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public()) {
+                let amount = Amount { value, token_id: token_id.into() };
+            assert!(MaskedAmountV1::new(amount, &shared_secret).is_ok());
+        }
+
+        #[test]
+        #[allow(non_snake_case)]
+        /// amount.commitment should agree with the value and blinding.
+        fn test_commitment(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public()) {
+                let amount = Amount { value, token_id: token_id.into() };
+                let amount = MaskedAmountV1::new(amount, &shared_secret).unwrap();
+                let blinding = get_blinding(&shared_secret);
+                let expected_commitment = CompressedCommitment::new(value, blinding, &generators(token_id));
+                assert_eq!(amount.commitment, expected_commitment);
+        }
+
+        #[test]
+        /// amount.unmask_value should return the value used to construct the amount.
+        fn test_unmask_value(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public())
+        {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV1::new(amount, &shared_secret).unwrap();
+            assert_eq!(
+                value,
+                MaskedAmountV1::unmask_value(masked_amount.masked_value, &shared_secret)
+            );
+        }
+
+        #[test]
+        /// get_value should return the correct value and blinding.
+        fn test_get_value_ok(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public()) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV1::new(amount, &shared_secret).unwrap();
+            let result = masked_amount.get_value(&shared_secret);
+            let blinding = get_blinding(&shared_secret);
+            let expected = Ok((amount, blinding));
+            assert_eq!(result, expected);
+        }
+
+
+        #[test]
+        /// get_value should return InconsistentCommitment if the masked value is incorrect.
+        fn test_get_value_incorrect_masked_value(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            other_masked_value in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public())
+        {
+            // Mutate amount to use a different masked value.
+            // With high probability, amount.masked_value won't equal other_masked_value.
+            let amount = Amount { value, token_id: token_id.into() };
+            let mut masked_amount = MaskedAmountV1::new(amount, &shared_secret).unwrap();
+            masked_amount.masked_value = other_masked_value;
+            let result = masked_amount.get_value(&shared_secret);
+            let expected = Err(AmountError::InconsistentCommitment);
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        /// get_value should return an Error if shared_secret is incorrect.
+        fn test_get_value_invalid_shared_secret(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public(),
+            other_shared_secret in arbitrary_ristretto_public(),
+        ) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV1::new(amount,  &shared_secret).unwrap();
+            let result = masked_amount.get_value(&other_shared_secret);
+            let expected = Err(AmountError::InconsistentCommitment);
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        /// test the length when this Amount is serialized
+        fn test_serialization_length(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public()
+        ) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV1::new(amount, &shared_secret).unwrap();
+            let buf = masked_amount.encode_to_vec();
+            assert_eq!(buf.len(), 55);
+        }
+    }
+}

--- a/transaction/core/src/amount/v2.rs
+++ b/transaction/core/src/amount/v2.rs
@@ -1,0 +1,357 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A commitment to an output's amount, denominated in picoMOB.
+//!
+//! Amounts are implemented as Pedersen commitments. The associated private keys
+//! are "masked" using a shared secret.
+
+use crate::{
+    domain_separators::{
+        AMOUNT_BLINDING_DOMAIN_TAG, AMOUNT_BLINDING_FACTORS_DOMAIN_TAG,
+        AMOUNT_SHARED_SECRET_DOMAIN_TAG, AMOUNT_TOKEN_ID_DOMAIN_TAG, AMOUNT_VALUE_DOMAIN_TAG,
+    },
+    Amount, AmountError, TokenId,
+};
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use crc::Crc;
+use hkdf::Hkdf;
+use mc_crypto_digestible::Digestible;
+use mc_crypto_hashes::Digest;
+use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_ring_signature::{generators, CompressedCommitment, Scalar};
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use sha2::Sha512;
+use zeroize::Zeroize;
+
+/// A commitment to an amount of MobileCoin or a related token, as it appears on
+/// the blockchain. This is a "blinded" commitment, and only the sender and
+/// receiver know the value and token id.
+///
+/// This differs from MaskedAmountV1 in that there is an "amount shared secret"
+/// which is computed by hashing from "tx out shared secret". The purpose of
+/// this is to make it possible to selectively reveal the amount and token id of
+/// a TxOut, without revealing the memo and other things. (See also MCIP #42).
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
+pub struct MaskedAmountV2 {
+    /// A Pedersen commitment `v*H + b*G` to a quantity `v` of MobileCoin or a
+    /// related token, with blinding `b`,
+    #[prost(message, required, tag = "1")]
+    pub commitment: CompressedCommitment,
+
+    /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
+    #[prost(fixed64, required, tag = "2")]
+    pub masked_value: u64,
+
+    /// `masked_token_id = token_id XOR_8 Blake2B(token_id_mask |
+    /// shared_secret)` 8 bytes long when used, 0 bytes for older amounts
+    /// that don't have this.
+    #[prost(bytes, tag = "3")]
+    pub masked_token_id: Vec<u8>,
+}
+
+impl MaskedAmountV2 {
+    /// Creates a commitment `value*H + blinding*G`, and "masks" the commitment
+    /// secrets so that they can be recovered by the recipient.
+    ///
+    /// # Arguments
+    /// * `amount` - The amount information to be masked
+    /// * `shared_secret` - The shared secret, e.g. `rB` for transaction private
+    ///   key `r` and recipient public key `B`.
+    #[inline]
+    pub fn new(
+        amount: Amount,
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<Self, AmountError> {
+        let amount_shared_secret = get_amount_shared_secret(tx_out_shared_secret);
+        let (value_mask, token_id_mask, blinding) = get_blinding_factors(&amount_shared_secret);
+
+        // Pedersen generators
+        let generator = generators(*amount.token_id);
+
+        // Pedersen commitment `v*H_i + b*G`.
+        let commitment = CompressedCommitment::new(amount.value, blinding, &generator);
+
+        // The value is XORed with the 8 bytes of the mask.
+        let masked_value: u64 = amount.value ^ value_mask;
+
+        // The token_id is XORed with the 8 bytes of the mask.
+        let masked_token_id_val: u64 = *amount.token_id ^ token_id_mask;
+        let masked_token_id = masked_token_id_val.to_le_bytes().to_vec();
+
+        Ok(Self {
+            commitment,
+            masked_value,
+            masked_token_id,
+        })
+    }
+
+    /// Returns the amount underlying the masked amount, given the shared
+    /// secret.
+    ///
+    /// Value is denominated in smallest representable units (e.g. "picoMOB").
+    ///
+    /// # Arguments
+    /// * `tx_out_shared_secret` - The shared secret, e.g. `rB`.
+    pub fn get_value(
+        &self,
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<(Amount, Scalar), AmountError> {
+        let amount_shared_secret = get_amount_shared_secret(tx_out_shared_secret);
+        self.get_value_from_amount_shared_secret(&amount_shared_secret)
+    }
+
+    /// Returns the amount underlying the masked amount, given the amount shared
+    /// secret.
+    ///
+    /// Generally, the recipient knows the TxOut shared secret, and it's more
+    /// convenient to use [get_value()]. This function allows that the sender or
+    /// recipient could selectively disclose the `amount_shared_secret` to a
+    /// third party who can then use this function to audit the value of
+    /// a TxOut without having permissions to do other things that require the
+    /// TxOut shared secret.
+    ///
+    /// # Arguments
+    /// * `amount_shared_secret` - The shared secret, derived by hashing TxOut
+    ///   shared secret
+    pub fn get_value_from_amount_shared_secret(
+        &self,
+        amount_shared_secret: &[u8; 32],
+    ) -> Result<(Amount, Scalar), AmountError> {
+        let (expected_commitment, amount, blinding) = Self::compute_commitment(
+            self.masked_value,
+            &self.masked_token_id,
+            amount_shared_secret,
+        )?;
+        if self.commitment != expected_commitment {
+            // The commitment does not agree with the provided value and blinding.
+            // This either means that the commitment does not correspond to the shared
+            // secret, or that the amount is malformed (and is probably not
+            // spendable).
+            return Err(AmountError::InconsistentCommitment);
+        }
+
+        Ok((amount, blinding))
+    }
+
+    /// Compute the crc32 of the compressed commitment
+    pub fn commitment_crc32(&self) -> u32 {
+        Self::compute_commitment_crc32(&self.commitment)
+    }
+
+    /// Recovers an Amount from only the masked value and masked_token_id, and
+    /// shared secret.
+    ///
+    /// Note: This fails and produces gibberish if the shared secret is wrong.
+    ///
+    /// * You should confirm by checking against the real commitment, or the the
+    ///   crc32 of commitment.
+    ///
+    /// Arguments:
+    /// * masked_value: u64
+    /// * masked_token_id: &[u8], either 0 or 4 bytes
+    /// * shared_secret: The shared secret curve point
+    ///
+    /// Returns:
+    /// * MaskedAmount
+    /// * Amount (token id and value)
+    /// or
+    /// * An amount error
+    pub fn reconstruct(
+        masked_value: u64,
+        masked_token_id: &[u8],
+        tx_out_shared_secret: &RistrettoPublic,
+    ) -> Result<(Self, Amount), AmountError> {
+        let amount_shared_secret = get_amount_shared_secret(tx_out_shared_secret);
+
+        let (expected_commitment, amount, _) =
+            Self::compute_commitment(masked_value, masked_token_id, &amount_shared_secret)?;
+
+        let result = Self {
+            commitment: expected_commitment,
+            masked_value,
+            masked_token_id: masked_token_id.to_vec(),
+        };
+
+        Ok((result, amount))
+    }
+
+    /// Compute the expected commitment corresponding to a masked value, masked
+    /// token id, and shared secret, returning errors if the masked token id
+    /// is malformed.
+    fn compute_commitment(
+        masked_value: u64,
+        masked_token_id: &[u8],
+        amount_shared_secret: &[u8; 32],
+    ) -> Result<(CompressedCommitment, Amount, Scalar), AmountError> {
+        let (value_mask, token_id_mask, blinding) = get_blinding_factors(amount_shared_secret);
+
+        // Note: Empty masked_token_id defaults to zero only in v1, not in v2, since v2
+        // masked amounts were never created without masked token id.
+        let token_id = TokenId::from(match masked_token_id.len() {
+            TokenId::NUM_BYTES => {
+                // Safety: We just checked masked_token_id.len() == TokenId::NUM_BYTES
+                u64::from_le_bytes(masked_token_id.try_into().unwrap()) ^ token_id_mask
+            }
+            _ => return Err(AmountError::InvalidMaskedTokenId),
+        });
+
+        let value = masked_value ^ value_mask;
+
+        // Pedersen generators
+        let generator = generators(*token_id);
+
+        let expected_commitment = CompressedCommitment::new(value, blinding, &generator);
+
+        Ok((expected_commitment, Amount { value, token_id }, blinding))
+    }
+
+    fn compute_commitment_crc32(commitment: &CompressedCommitment) -> u32 {
+        Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(commitment.point.as_bytes())
+    }
+}
+
+/// Computes the amount shared secret from the tx_out shared secret
+fn get_amount_shared_secret(tx_out_shared_secret: &RistrettoPublic) -> [u8; 32] {
+    let mut hasher = Sha512::new();
+    hasher.update(&AMOUNT_SHARED_SECRET_DOMAIN_TAG);
+    hasher.update(&tx_out_shared_secret.to_bytes());
+    // Safety: Sha512 is a 512-bit (64-byte) hash.
+    hasher.finalize()[0..32].try_into().unwrap()
+}
+
+/// Computes the value mask, token id mask, and blinding factor for the
+/// commitment, in a masked amount.
+///
+/// # Arguments
+/// * `amount_shared_secret` - The amount shared secret, derived as a hash of
+///   `rB`.
+fn get_blinding_factors(amount_shared_secret: &[u8; 32]) -> (u64, u64, Scalar) {
+    // Use HKDF-SHA512 to produce blinding factors for value, token id, and
+    // commitment
+    let kdf = Hkdf::<Sha512>::new(
+        Some(AMOUNT_BLINDING_FACTORS_DOMAIN_TAG),
+        amount_shared_secret,
+    );
+
+    let mut value_mask = [0u8; 8];
+    kdf.expand(AMOUNT_VALUE_DOMAIN_TAG.as_bytes(), &mut value_mask)
+        .expect("Digest output size is insufficient");
+
+    let mut token_id_mask = [0u8; 8];
+    kdf.expand(AMOUNT_TOKEN_ID_DOMAIN_TAG.as_bytes(), &mut token_id_mask)
+        .expect("Digest output size is insufficient");
+
+    let mut scalar_blinding_bytes = [0u8; 64];
+    kdf.expand(
+        AMOUNT_BLINDING_DOMAIN_TAG.as_bytes(),
+        &mut scalar_blinding_bytes,
+    )
+    .expect("Digest output size is insufficient");
+
+    (
+        u64::from_le_bytes(value_mask),
+        u64::from_le_bytes(token_id_mask),
+        Scalar::from_bytes_mod_order_wide(&scalar_blinding_bytes),
+    )
+}
+
+#[cfg(test)]
+mod amount_tests {
+    #![allow(clippy::unnecessary_operation)]
+
+    use super::*;
+    use crate::{proptest_fixtures::*, ring_signature::generators, CompressedCommitment};
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        /// MaskedAmount::new() should return Ok for valid values and blindings.
+        fn test_new_ok(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            tx_out_shared_secret in arbitrary_ristretto_public()) {
+                let amount = Amount { value, token_id: token_id.into() };
+             assert!(MaskedAmountV2::new(amount, &tx_out_shared_secret).is_ok());
+        }
+
+        #[test]
+        #[allow(non_snake_case)]
+        /// amount.commitment should agree with the value and blinding.
+        fn test_commitment(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            tx_out_shared_secret in arbitrary_ristretto_public()) {
+                let amount = Amount { value, token_id: token_id.into() };
+                let amount = MaskedAmountV2::new(amount, &tx_out_shared_secret).unwrap();
+
+                let amount_shared_secret = get_amount_shared_secret(&tx_out_shared_secret);
+                let (_, _, blinding) = get_blinding_factors(&amount_shared_secret);
+                let expected_commitment = CompressedCommitment::new(value, blinding, &generators(token_id));
+                assert_eq!(amount.commitment, expected_commitment);
+        }
+
+        #[test]
+        /// get_value should return the correct value and blinding.
+        fn test_get_value_ok(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            tx_out_shared_secret in arbitrary_ristretto_public()) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV2::new(amount, &tx_out_shared_secret).unwrap();
+            let result = masked_amount.get_value(&tx_out_shared_secret);
+
+                let amount_shared_secret = get_amount_shared_secret(&tx_out_shared_secret);
+                let (_, _, blinding) = get_blinding_factors(&amount_shared_secret);
+            let expected = Ok((amount, blinding));
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        /// get_value should return InconsistentCommitment if the masked value is incorrect.
+        fn test_get_value_incorrect_masked_value(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            other_masked_value in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public())
+        {
+            // Mutate amount to use a different masked value.
+            // With high probability, amount.masked_value won't equal other_masked_value.
+            let amount = Amount { value, token_id: token_id.into() };
+            let mut masked_amount = MaskedAmountV2::new(amount, &shared_secret).unwrap();
+            masked_amount.masked_value = other_masked_value;
+            let result = masked_amount.get_value(&shared_secret);
+            let expected = Err(AmountError::InconsistentCommitment);
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        /// get_value should return an Error if shared_secret is incorrect.
+        fn test_get_value_invalid_shared_secret(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public(),
+            other_shared_secret in arbitrary_ristretto_public(),
+        ) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV2::new(amount,  &shared_secret).unwrap();
+            let result = masked_amount.get_value(&other_shared_secret);
+            let expected = Err(AmountError::InconsistentCommitment);
+            assert_eq!(result, expected);
+        }
+
+        #[test]
+        /// test the length when this Amount is serialized
+        fn test_serialization_length(
+            value in any::<u64>(),
+            token_id in any::<u64>(),
+            shared_secret in arbitrary_ristretto_public()
+        ) {
+            let amount = Amount { value, token_id: token_id.into() };
+            let masked_amount = MaskedAmountV2::new(amount, &shared_secret).unwrap();
+            let buf = masked_amount.encode_to_vec();
+            assert_eq!(buf.len(), 55);
+        }
+    }
+}

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -23,6 +23,12 @@ pub const AMOUNT_TOKEN_ID_DOMAIN_TAG: &str = "mc_amount_token_id";
 /// Domain separator for Amount's blinding mask hash function.
 pub const AMOUNT_BLINDING_DOMAIN_TAG: &str = "mc_amount_blinding";
 
+/// Domain separator for Amount's shared-secret hash function.
+pub const AMOUNT_SHARED_SECRET_DOMAIN_TAG: &str = "mc_amount_shared_secret";
+
+/// Domain separator for Amount's blinding factors hkdf SALT
+pub const AMOUNT_BLINDING_FACTORS_DOMAIN_TAG: &[u8] = b"mc_amount_blinding_factors";
+
 /// Domain separator for Bulletproof transcript.
 pub const BULLETPROOF_DOMAIN_TAG: &str = "mc_bulletproof_transcript";
 

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -37,7 +37,7 @@ pub mod validation;
 #[cfg(test)]
 pub mod proptest_fixtures;
 
-pub use amount::{AmountError, MaskedAmount};
+pub use amount::{AmountError, MaskedAmount, MaskedAmountV1, MaskedAmountV2};
 pub use input_rules::{InputRuleError, InputRules};
 pub use memo::{EncryptedMemo, MemoError, MemoPayload};
 pub use signed_contingent_input::{
@@ -45,7 +45,7 @@ pub use signed_contingent_input::{
 };
 pub use token::{tokens, Token};
 pub use tx::MemoContext;
-pub use tx_error::{NewMemoError, NewTxError, ViewKeyMatchError};
+pub use tx_error::{NewMemoError, NewTxError, TxOutConversionError, ViewKeyMatchError};
 pub use tx_out_gift_code::TxOutGiftCode;
 
 // Re-export from transaction-types, and some from RingSignature crate.
@@ -60,8 +60,9 @@ pub mod ring_signature {
 // Re-export the one-time keys module which historically lived in this crate
 pub use mc_crypto_ring_signature::onetime_keys;
 
-use core::convert::TryFrom;
-use mc_account_keys::AccountKey;
+// Re-export some dependent types from mc-account-keys
+pub use mc_account_keys::{AccountKey, PublicAddress};
+
 use mc_crypto_keys::{KeyError, RistrettoPrivate, RistrettoPublic};
 use onetime_keys::{create_shared_secret, recover_public_subaddress_spend_key};
 use tx::TxOut;

--- a/transaction/core/src/memo.rs
+++ b/transaction/core/src/memo.rs
@@ -52,6 +52,7 @@ use mc_util_repr_bytes::{
     derive_prost_message_from_repr_bytes, derive_repr_bytes_from_as_ref_and_try_from,
     derive_serde_from_repr_bytes,
 };
+use serde::{Deserialize, Serialize};
 use sha2::Sha512;
 use zeroize::Zeroize;
 
@@ -224,7 +225,7 @@ derive_prost_message_from_repr_bytes!(MemoPayload);
 derive_debug_and_display_hex_from_as_ref!(MemoPayload);
 
 /// An error which can occur when handling memos
-#[derive(Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, Serialize)]
 pub enum MemoError {
     /// Wrong length for memo payload: {0}
     BadLength(usize),

--- a/transaction/core/src/proptest_fixtures.rs
+++ b/transaction/core/src/proptest_fixtures.rs
@@ -3,7 +3,7 @@
 pub use mc_crypto_ring_signature::{proptest_fixtures::*, CurveScalar, Scalar};
 pub use mc_transaction_types::Amount;
 
-use crate::{tokens::Mob, MaskedAmount, Token};
+use crate::{tokens::Mob, MaskedAmountV1, Token};
 use mc_crypto_keys::RistrettoPublic;
 use proptest::prelude::*;
 
@@ -11,11 +11,11 @@ prop_compose! {
     /// Generates an arbitrary masked_amount with value in [0,max_value].
     /// Of token_id = 0
     pub fn arbitrary_masked_amount(max_value: u64, shared_secret: RistrettoPublic)
-                (value in 0..=max_value) -> MaskedAmount {
+                (value in 0..=max_value) -> MaskedAmountV1 {
             let amount = Amount {
                 value,
                 token_id: Mob::ID,
             };
-            MaskedAmount::new(amount, &shared_secret).unwrap()
+            MaskedAmountV1::new(amount, &shared_secret).unwrap()
     }
 }

--- a/transaction/core/src/signed_contingent_input.rs
+++ b/transaction/core/src/signed_contingent_input.rs
@@ -5,7 +5,7 @@
 use crate::{
     ring_ct::{GeneratorCache, OutputSecret, PresignedInputRing, SignedInputRing},
     tx::TxIn,
-    Amount, TokenId,
+    Amount, TokenId, TxOutConversionError,
 };
 use alloc::vec::Vec;
 use displaydoc::Display;
@@ -98,7 +98,7 @@ impl SignedContingentInput {
             .signed_digest()
             .ok_or(SignedContingentInputError::MissingRules)?;
 
-        let signed_input_ring = SignedInputRing::from(&self.tx_in);
+        let signed_input_ring = SignedInputRing::try_from(&self.tx_in)?;
 
         self.mlsag
             .verify(&rules_digest, &signed_input_ring.members, &pseudo_output)?;
@@ -120,7 +120,7 @@ impl SignedContingentInput {
                     amount.blinding.into(),
                     generator,
                 ));
-                if expected_commitment != output.masked_amount.commitment {
+                if &expected_commitment != output.get_masked_amount()?.commitment() {
                     return Err(SignedContingentInputError::RequiredOutputMismatch);
                 }
             }
@@ -182,10 +182,18 @@ pub enum SignedContingentInputError {
     MissingProofs,
     /// Invalid Ring signature: {0}
     RingSignature(RingSignatureError),
+    /// TxOut conversion: {0}
+    TxOutConversion(TxOutConversionError),
 }
 
 impl From<RingSignatureError> for SignedContingentInputError {
     fn from(src: RingSignatureError) -> Self {
         Self::RingSignature(src)
+    }
+}
+
+impl From<TxOutConversionError> for SignedContingentInputError {
+    fn from(src: TxOutConversionError) -> Self {
+        Self::TxOutConversion(src)
     }
 }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -729,7 +729,6 @@ mod tests {
 
             // TxOut = decode(encode(TxOut))
             assert_eq!(tx_out, TxOut::decode(&tx_out.encode_to_vec()[..]).unwrap());
-            assert_eq!(tx_out.encode_to_vec().len(), 207);
 
             let tx_in = TxIn {
                 ring: vec![tx_out.clone()],

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -2,21 +2,19 @@
 
 //! Errors that can occur when creating a new TxOut
 
-use crate::{AmountError, BlockVersion, MemoError};
+use crate::{AmountError, MemoError};
 use alloc::{format, string::String};
 use core::str::Utf8Error;
 use displaydoc::Display;
 use mc_crypto_keys::KeyError;
 
 /// An error that occurs when creating a new TxOut
-#[derive(Debug, Display)]
+#[derive(Clone, Debug, Display)]
 pub enum NewTxError {
     /// Amount: {0}
     Amount(AmountError),
     /// Memo: {0}
     Memo(NewMemoError),
-    /// Token Id not allowed at block version: {0}
-    TokenIdNotAllowedAtBlockVersion(BlockVersion),
 }
 
 impl From<AmountError> for NewTxError {
@@ -31,13 +29,22 @@ impl From<NewMemoError> for NewTxError {
     }
 }
 
+/// An error that occurs when handling a TxOut
+#[derive(Clone, Debug, Display)]
+pub enum TxOutConversionError {
+    /// Unknown Masked Amount Version
+    UnknownMaskedAmountVersion,
+}
+
 /// An error that occurs when view key matching a TxOut
-#[derive(Debug, Display)]
+#[derive(Clone, Debug, Display)]
 pub enum ViewKeyMatchError {
     /// Key: {0}
     Key(KeyError),
     /// Amount: {0}
     Amount(AmountError),
+    /// Unknown Masked Amount Version
+    UnknownMaskedAmountVersion,
 }
 
 impl From<KeyError> for ViewKeyMatchError {
@@ -58,7 +65,7 @@ impl From<AmountError> for ViewKeyMatchError {
 /// We have included error codes for some known useful error conditions.
 /// For a custom MemoBuilder, you can try to reuse those, or use the Other
 /// error code.
-#[derive(Debug, Display, Eq, PartialEq)]
+#[derive(Clone, Debug, Display, Eq, PartialEq)]
 pub enum NewMemoError {
     /// Limits for '{0}' value exceeded
     LimitsExceeded(&'static str),

--- a/transaction/core/src/tx_out_gift_code.rs
+++ b/transaction/core/src/tx_out_gift_code.rs
@@ -40,20 +40,10 @@ impl TxOutGiftCode {
     }
 
     /// Un-blind amount given a MaskedAmount object
-    pub fn unblind_amount(&self, masked_amount: MaskedAmount) -> Result<Amount, AmountError> {
+    pub fn unblind_amount(&self, masked_amount: &MaskedAmount) -> Result<Amount, AmountError> {
         masked_amount
             .get_value(&self.shared_secret)
             .map(|(amount, _)| amount)
-    }
-
-    /// Un-blind amount given a masked value and token id
-    pub fn unblind_amount_with_masked_token_id(
-        &self,
-        masked_value: u64,
-        masked_token_id: &[u8],
-    ) -> Result<Amount, AmountError> {
-        MaskedAmount::reconstruct(masked_value, masked_token_id, &self.shared_secret)
-            .map(|(_, amount)| amount)
     }
 }
 

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use crate::InputRuleError;
+use crate::{InputRuleError, TxOutConversionError};
 use alloc::string::String;
 use displaydoc::Display;
 use mc_crypto_keys::KeyError;
@@ -147,6 +147,9 @@ pub enum TransactionValidationError {
 
     /// Input rule: {0}
     InputRule(InputRuleError),
+
+    /// Unknown Masked Amount version
+    UnknownMaskedAmountVersion,
 }
 
 impl From<mc_crypto_keys::KeyError> for TransactionValidationError {
@@ -158,5 +161,13 @@ impl From<mc_crypto_keys::KeyError> for TransactionValidationError {
 impl From<InputRuleError> for TransactionValidationError {
     fn from(src: InputRuleError) -> Self {
         Self::InputRule(src)
+    }
+}
+
+impl From<TxOutConversionError> for TransactionValidationError {
+    fn from(src: TxOutConversionError) -> Self {
+        match src {
+            TxOutConversionError::UnknownMaskedAmountVersion => Self::UnknownMaskedAmountVersion,
+        }
     }
 }

--- a/transaction/core/tests/input_rules.rs
+++ b/transaction/core/tests/input_rules.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 mod util;
 
 use mc_transaction_core::{tx::Tx, BlockVersion, InputRules};
@@ -44,9 +46,10 @@ fn test_input_rules_verify_required_outputs() {
     get_first_rules(&tx).verify(block_version, &tx).unwrap();
 
     // Modify the input rules to refer to a non-existent tx out
-    get_first_rules_mut(&mut tx).required_outputs[0]
-        .masked_amount
-        .masked_value += 1;
+    *get_first_rules_mut(&mut tx).required_outputs[0]
+        .get_masked_amount_mut()
+        .unwrap()
+        .get_masked_value_mut() += 1;
 
     assert!(get_first_rules(&tx).verify(block_version, &tx).is_err());
 }

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -73,7 +73,11 @@ fn test_validate_masked_token_id_exists() {
     let (tx, _) = create_test_tx(BlockVersion::ONE);
     let tx_out = tx.prefix.outputs.first().unwrap();
 
-    assert!(tx_out.masked_amount.masked_token_id.is_empty());
+    assert!(tx_out
+        .get_masked_amount()
+        .unwrap()
+        .masked_token_id()
+        .is_empty());
     assert_eq!(
         validate_masked_token_id_exists(tx_out),
         Err(TransactionValidationError::MissingMaskedTokenId)
@@ -82,7 +86,11 @@ fn test_validate_masked_token_id_exists() {
     let (tx, _) = create_test_tx(BlockVersion::TWO);
     let tx_out = tx.prefix.outputs.first().unwrap();
 
-    assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+    assert!(!tx_out
+        .get_masked_amount()
+        .unwrap()
+        .masked_token_id()
+        .is_empty());
     assert_eq!(validate_memo_exists(tx_out), Ok(()));
 }
 
@@ -92,13 +100,21 @@ fn test_validate_no_masked_token_id_exists() {
     let (tx, _) = create_test_tx(BlockVersion::ONE);
     let tx_out = tx.prefix.outputs.first().unwrap();
 
-    assert!(tx_out.masked_amount.masked_token_id.is_empty());
+    assert!(tx_out
+        .get_masked_amount()
+        .unwrap()
+        .masked_token_id()
+        .is_empty());
     assert_eq!(validate_that_no_masked_token_id_exists(tx_out), Ok(()));
 
     let (tx, _) = create_test_tx(BlockVersion::TWO);
     let tx_out = tx.prefix.outputs.first().unwrap();
 
-    assert!(!tx_out.masked_amount.masked_token_id.is_empty());
+    assert!(!tx_out
+        .get_masked_amount()
+        .unwrap()
+        .masked_token_id()
+        .is_empty());
     assert_eq!(
         validate_that_no_masked_token_id_exists(tx_out),
         Err(TransactionValidationError::MaskedTokenIdNotAllowed)
@@ -828,13 +844,19 @@ fn test_input_rules_validation() {
 
     // Modify the input rules to refer to a non-existent tx out
     let rules = tx.prefix.inputs[0].input_rules.as_mut().unwrap();
-    rules.required_outputs[0].masked_amount.masked_value += 1;
+    *rules.required_outputs[0]
+        .get_masked_amount_mut()
+        .unwrap()
+        .get_masked_value_mut() += 1;
 
     assert!(validate_all_input_rules(block_version, &tx).is_err());
 
     // Set masked value back, now modify tombstone block
     let rules = tx.prefix.inputs[0].input_rules.as_mut().unwrap();
-    rules.required_outputs[0].masked_amount.masked_value -= 1;
+    *rules.required_outputs[0]
+        .get_masked_amount_mut()
+        .unwrap()
+        .get_masked_value_mut() -= 1;
     rules.max_tombstone_block = tx.prefix.tombstone_block - 1;
 
     assert!(validate_all_input_rules(block_version, &tx).is_err());

--- a/transaction/std/src/error.rs
+++ b/transaction/std/src/error.rs
@@ -5,6 +5,7 @@ use mc_crypto_ring_signature_signer::Error as SignerError;
 use mc_fog_report_validation::FogPubkeyError;
 use mc_transaction_core::{
     ring_ct::Error as RingCtError, AmountError, NewMemoError, NewTxError, TokenId,
+    TxOutConversionError,
 };
 
 /// An error that can occur when using the TransactionBuilder
@@ -66,6 +67,9 @@ pub enum TxBuilderError {
 
     /// Signer: {0}
     Signer(SignerError),
+
+    /// TxOut Conversion: {0}
+    TxOutConversion(TxOutConversionError),
 }
 
 impl From<mc_util_serial::encode::Error> for TxBuilderError {
@@ -119,6 +123,12 @@ impl From<FogPubkeyError> for TxBuilderError {
 impl From<NewMemoError> for TxBuilderError {
     fn from(src: NewMemoError) -> Self {
         TxBuilderError::Memo(src)
+    }
+}
+
+impl From<TxOutConversionError> for TxBuilderError {
+    fn from(src: TxOutConversionError) -> Self {
+        TxBuilderError::TxOutConversion(src)
     }
 }
 

--- a/transaction/std/src/input_materials.rs
+++ b/transaction/std/src/input_materials.rs
@@ -11,7 +11,9 @@
 
 use crate::InputCredentials;
 use mc_crypto_keys::CompressedRistrettoPublic;
-use mc_transaction_core::{ring_ct::InputRing, tx::TxIn, Amount, SignedContingentInput};
+use mc_transaction_core::{
+    ring_ct::InputRing, tx::TxIn, Amount, SignedContingentInput, TxOutConversionError,
+};
 
 /// Material that can be used by the transaction builder to create an input to
 /// a transaction.
@@ -63,12 +65,13 @@ impl InputMaterials {
 
 // Helper which converts from InputMaterials (TransactionBuilder type) to
 // InputRing (rct_bulletproofs type)
-impl From<InputMaterials> for InputRing {
-    fn from(src: InputMaterials) -> InputRing {
-        match src {
-            InputMaterials::Signable(creds) => InputRing::Signable(creds.into()),
+impl TryFrom<InputMaterials> for InputRing {
+    type Error = TxOutConversionError;
+    fn try_from(src: InputMaterials) -> Result<InputRing, Self::Error> {
+        Ok(match src {
+            InputMaterials::Signable(creds) => InputRing::Signable(creds.try_into()?),
             InputMaterials::Presigned(input) => InputRing::Presigned(input.into()),
-        }
+        })
     }
 }
 

--- a/transaction/std/src/signed_contingent_input_builder.rs
+++ b/transaction/std/src/signed_contingent_input_builder.rs
@@ -248,9 +248,10 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
         )?;
 
         let (amount, blinding) = tx_out
-            .masked_amount
+            .get_masked_amount()
+            .expect("SignedContingentInputBuilder created an invalid MaskedAmount")
             .get_value(&shared_secret)
-            .expect("TransactionBuilder created an invalid Amount");
+            .expect("SignedContingentInputBuilder created an invalid Amount");
         let output_secret = OutputSecret { amount, blinding };
 
         self.impose_tombstone_block_limit(pubkey_expiry);
@@ -333,7 +334,7 @@ impl<FPR: FogPubkeyResolver> SignedContingentInputBuilder<FPR> {
         // Clear the merkle proofs, because this makes the SCI smaller,
         // and the recipient needs to regenerate them later most likely anyways.
         tx_in.proofs.clear();
-        let ring = SignableInputRing::from(self.input_credentials);
+        let ring = SignableInputRing::try_from(self.input_credentials)?;
 
         let pseudo_output_blinding = Scalar::random(rng);
 
@@ -784,7 +785,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_output.public_key).unwrap(),
                 );
-                let (amount, _) = bob_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(value - Mob::MINIMUM_FEE, Mob::ID));
 
                 let memo = bob_output.e_memo.unwrap().decrypt(&ss);
@@ -801,7 +806,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_change.public_key).unwrap(),
                 );
-                let (amount, _) = bob_change.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_change
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(200_000, token2));
 
                 let memo = bob_change.e_memo.unwrap().decrypt(&ss);
@@ -818,7 +827,11 @@ pub mod tests {
                     alice.view_private_key(),
                     &RistrettoPublic::try_from(&alice_output.public_key).unwrap(),
                 );
-                let (amount, _) = alice_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = alice_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, amount2);
 
                 let memo = alice_output.e_memo.unwrap().decrypt(&ss);
@@ -1032,7 +1045,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_output.public_key).unwrap(),
                 );
-                let (amount, _) = bob_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(value - Mob::MINIMUM_FEE, Mob::ID));
 
                 let memo = bob_output.e_memo.unwrap().decrypt(&ss);
@@ -1049,7 +1066,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_change.public_key).unwrap(),
                 );
-                let (amount, _) = bob_change.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_change
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(200_000, token2));
 
                 let memo = bob_change.e_memo.unwrap().decrypt(&ss);
@@ -1066,7 +1087,11 @@ pub mod tests {
                     alice.view_private_key(),
                     &RistrettoPublic::try_from(&alice_output.public_key).unwrap(),
                 );
-                let (amount, _) = alice_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = alice_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, amount2);
 
                 let memo = alice_output.e_memo.unwrap().decrypt(&ss);
@@ -1316,7 +1341,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_output.public_key).unwrap(),
                 );
-                let (amount, _) = bob_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(666, token3));
 
                 let memo = bob_output.e_memo.unwrap().decrypt(&ss);
@@ -1333,7 +1362,11 @@ pub mod tests {
                     bob.view_private_key(),
                     &RistrettoPublic::try_from(&bob_change.public_key).unwrap(),
                 );
-                let (amount, _) = bob_change.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = bob_change
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(200_000, token2));
 
                 let memo = bob_change.e_memo.unwrap().decrypt(&ss);
@@ -1350,7 +1383,11 @@ pub mod tests {
                     charlie.view_private_key(),
                     &RistrettoPublic::try_from(&charlie_output.public_key).unwrap(),
                 );
-                let (amount, _) = charlie_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = charlie_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(value - Mob::MINIMUM_FEE, Mob::ID));
 
                 let memo = charlie_output.e_memo.unwrap().decrypt(&ss);
@@ -1367,7 +1404,11 @@ pub mod tests {
                     charlie.view_private_key(),
                     &RistrettoPublic::try_from(&charlie_change.public_key).unwrap(),
                 );
-                let (amount, _) = charlie_change.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = charlie_change
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(333, token3));
 
                 let memo = charlie_change.e_memo.unwrap().decrypt(&ss);
@@ -1384,7 +1425,11 @@ pub mod tests {
                     alice.view_private_key(),
                     &RistrettoPublic::try_from(&alice_output.public_key).unwrap(),
                 );
-                let (amount, _) = alice_output.masked_amount.get_value(&ss).unwrap();
+                let (amount, _) = alice_output
+                    .get_masked_amount()
+                    .unwrap()
+                    .get_value(&ss)
+                    .unwrap();
                 assert_eq!(amount, Amount::new(100_000, token2));
 
                 let memo = alice_output.e_memo.unwrap().decrypt(&ss);

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -427,7 +427,8 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             create_output_with_fog_hint(self.block_version, amount, recipient, hint, memo_fn, rng)?;
 
         let (amount, blinding) = tx_out
-            .masked_amount
+            .get_masked_amount()
+            .expect("TransactionBuilder created an invalid MaskedAmount")
             .get_value(&shared_secret)
             .expect("TransactionBuilder created an invalid Amount");
         let output_secret = OutputSecret { amount, blinding };
@@ -616,8 +617,8 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         let input_rings = self
             .input_materials
             .into_iter()
-            .map(Into::into)
-            .collect::<Vec<InputRing>>();
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<InputRing>, _>>()?;
 
         let message = tx_prefix.hash().0;
         let signature = SignatureRctBulletproofs::sign(
@@ -1205,7 +1206,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1236,7 +1237,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1388,7 +1389,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1427,7 +1428,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1552,7 +1553,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE * 4);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1591,7 +1592,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1716,7 +1717,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1756,7 +1757,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1880,7 +1881,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -1920,7 +1921,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2032,7 +2033,7 @@ pub mod transaction_builder_tests {
                         recipient.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2054,7 +2055,7 @@ pub mod transaction_builder_tests {
                         sender.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2210,7 +2211,7 @@ pub mod transaction_builder_tests {
                         bob.view_private_key(),
                         &RistrettoPublic::try_from(&output.public_key).unwrap(),
                     );
-                    let (amount, _) = output.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
                     assert_eq!(amount.token_id, token_id);
 
@@ -2246,7 +2247,7 @@ pub mod transaction_builder_tests {
                         alice.view_private_key(),
                         &RistrettoPublic::try_from(&change.public_key).unwrap(),
                     );
-                    let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
                     assert_eq!(amount.value, change_value);
                     assert_eq!(amount.token_id, token_id);
 
@@ -3339,7 +3340,8 @@ pub mod transaction_builder_tests {
             );
 
             let (funding_amount, _) = funding_output
-                .masked_amount
+                .get_masked_amount()
+                .unwrap()
                 .get_value(&funding_output_ss)
                 .unwrap();
             assert_eq!(funding_amount.value, funding_output_amount.value);
@@ -3390,7 +3392,7 @@ pub mod transaction_builder_tests {
             };
 
             // Values we pretend we get from locating the TxOut using the global index
-            let masked_amount = funding_output.masked_amount.clone();
+            let masked_amount = funding_output.get_masked_amount().unwrap().clone();
 
             // Construct the sender Tx from the combo of "located" and "sent" information
             let (sending_input_amount, blinding) = masked_amount
@@ -3481,7 +3483,7 @@ pub mod transaction_builder_tests {
                 receiver.view_private_key(),
                 &RistrettoPublic::try_from(&change.public_key).unwrap(),
             );
-            let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+            let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
             assert_eq!(amount.value, sending_output_amount.value);
             assert_eq!(amount.token_id, token_id);
 
@@ -3556,7 +3558,7 @@ pub mod transaction_builder_tests {
                 sender.view_private_key(),
                 &RistrettoPublic::try_from(&change.public_key).unwrap(),
             );
-            let (amount, _) = change.masked_amount.get_value(&ss).unwrap();
+            let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
             assert_eq!(amount.value, cancellation_output_amount.value);
             assert_eq!(amount.token_id, token_id);
 

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -120,6 +120,12 @@ impl BlockVersion {
         self.0 >= 3
     }
 
+    /// Masked amount V2 derivation introduced with block version 3.
+    /// [MCIP #42](https://github.com/mobilecoinfoundation/mcips/pull/42)
+    pub fn masked_amount_v2_is_supported(&self) -> bool {
+        self.0 >= 3
+    }
+
     /// `BlockData.metadata` is required starting from v3.
     /// [MCIP #43](https://github.com/mobilecoinfoundation/mcips/pull/43)
     pub fn require_block_metadata(&self) -> bool {


### PR DESCRIPTION
This is an experiment to see if making `MaskedAmount` into an enum called `MaskedAmount` and then deriving `::prost::Oneof` is a tenable direction for introducing masked amount v2

edit: This experiment seems to have been successful, and looks like the way to go

The purpose of masked amount v2 is to update the derivation pathway that determines blinding factors that appear in masked amount, in connection to:
* the Pedersen commitment
* the masked_value
* the masked_token_id

The old derivation pathway derived all of these blinding factors from Blake2b hashes of the TxOut shared secret using different domain separators.

The new derivation pathway has an intermediate key called Amount shared secret, derived by a sha512 hash from TxOut shared secret. The blinding factors are then derived using HKDF sha512 from that.

This allows someone who owns a TxOut to selectively reveal the amount and token id in a way that a counterparty can verify, without also revealing the TxOut shared secret, the encrypted memo, etc.

This can then be used to implement partial fill atomic swaps, because the enclave can require that the amount shared secret is disclosed when necessary to verify partial fill rules.