### PR TITLE
Implement bare bones FogViewRouterAPI server + client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,7 +4186,9 @@ dependencies = [
 name = "mc-fog-view-connection"
 version = "1.3.0-pre0"
 dependencies = [
+ "futures",
  "grpcio",
+ "mc-attest-api",
  "mc-attest-core",
  "mc-attest-verifier",
  "mc-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4202,6 +4202,7 @@ dependencies = [
  "mc-util-serial",
  "mc-util-telemetry",
  "retry",
+ "tokio",
 ]
 
 [[package]]
@@ -5537,24 +5538,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
 dependencies = [
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -5636,15 +5627,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "num-bigint"
@@ -7481,9 +7463,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -7772,9 +7754,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
 dependencies = [
  "bytes 1.1.0",
  "libc",
@@ -7784,6 +7766,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -8139,6 +8122,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,6 +7764,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -10,6 +10,32 @@ import "external.proto";
 import "kex_rng.proto";
 import "fog_common.proto";
 
+/// A single Duplex streaming API that allows clients to authorize with Fog View and
+/// query it for TxOuts.
+service FogViewRouterAPI {
+    rpc request(stream FogViewRouterRequest) returns (stream FogViewRouterResponse) {}
+}
+
+message FogViewRouterRequest {
+    oneof request_data {
+        /// This is called to perform IX key exchange
+        /// with the enclave before making a query call.
+        attest.AuthMessage auth = 1;
+        /// Input should be an encrypted QueryRequest
+        attest.Message query = 2;
+    }
+}
+
+message FogViewRouterResponse {
+    oneof response_data {
+        /// Returned for an auth request.
+        attest.AuthMessage auth = 1;
+        /// Returned for an auth request.
+        /// The data is an encrypted QueryResponse.
+        attest.Message query = 2;
+    }
+}
+
 service FogViewAPI {
     /// This is called to perform IX key exchange with the enclave before calling GetOutputs.
     rpc Auth(attest.AuthMessage) returns (attest.AuthMessage) {}

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -30,7 +30,7 @@ message FogViewRouterResponse {
     oneof response_data {
         /// Returned for an auth request.
         attest.AuthMessage auth = 1;
-        /// Returned for an auth request.
+        /// Returned for a query request.
         /// The data is an encrypted QueryResponse.
         attest.Message query = 2;
     }

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -161,8 +161,10 @@ mod tests {
         );
         assert!(!uri.use_tls());
 
-        let uri =
-            FogViewRouterUri::from_str("insecure-fog-view-router://node1.test.mobilecoin.com:3225/").unwrap();
+        let uri = FogViewRouterUri::from_str(
+            "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
+        )
+        .unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
         assert_eq!(
             uri.responder_id().unwrap(),
@@ -171,7 +173,8 @@ mod tests {
         assert!(!uri.use_tls());
 
         let uri =
-            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/").unwrap();
+            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
+                .unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
         assert_eq!(
             uri.responder_id().unwrap(),

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -162,20 +162,20 @@ mod tests {
         assert!(!uri.use_tls());
 
         let uri =
-            FogViewRouterUri::from_str("fog-view-router://node1.test.mobilecoin.com:443/").unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
+            FogViewRouterUri::from_str("insecure-fog-view-router://node1.test.mobilecoin.com:3225/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
         assert!(!uri.use_tls());
 
         let uri =
-            FogViewStoreUri::from_str("fog-view-store://node1.test.mobilecoin.com:443/").unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
+            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
         assert!(!uri.use_tls());
     }

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -97,16 +97,15 @@ pub type FogLedgerUri = Uri<FogLedgerScheme>;
 /// and scheme.
 pub type FogIngestUri = Uri<FogIngestScheme>;
 /// Usi used when talking to fog-ingest-peer service.
-pub type IngestPeerUri = Uri<IngestPeerScheme>;
 /// Uri used when talking to fog view router service.
 pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
 /// Uri used when talking to fog view store service.
 pub type FogViewStoreUri = Uri<FogViewStoreScheme>;
+pub type IngestPeerUri = Uri<IngestPeerScheme>;
 
 #[cfg(test)]
 mod tests {
-    use super::{FogLedgerUri, FogViewUri};
-    use crate::{ConnectionUri, FogViewRouterUri, FogViewStoreUri};
+    use super::*;
     use core::str::FromStr;
     use mc_common::ResponderId;
 

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -4,6 +4,34 @@ use mc_util_uri::{Uri, UriScheme};
 
 pub use mc_util_uri::{ConnectionUri, FogUri, UriParseError};
 
+/// Fog View Shard Scheme
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct FogViewRouterScheme {}
+
+impl UriScheme for FogViewRouterScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "fog-view-router";
+    const SCHEME_INSECURE: &'static str = "insecure-fog-view-router";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3225;
+}
+
+/// Fog View Store Scheme
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct FogViewStoreScheme {}
+
+impl UriScheme for FogViewStoreScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "fog-view-store";
+    const SCHEME_INSECURE: &'static str = "insecure-fog-view-store";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3225;
+}
+
 /// Fog View Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct FogViewScheme {}
@@ -70,11 +98,15 @@ pub type FogLedgerUri = Uri<FogLedgerScheme>;
 pub type FogIngestUri = Uri<FogIngestScheme>;
 /// Usi used when talking to fog-ingest-peer service.
 pub type IngestPeerUri = Uri<IngestPeerScheme>;
+/// Uri used when talking to fog view router service.
+pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
+/// Uri used when talking to fog view store service.
+pub type FogViewStoreUri = Uri<FogViewStoreScheme>;
 
 #[cfg(test)]
 mod tests {
     use super::{FogLedgerUri, FogViewUri};
-    use crate::ConnectionUri;
+    use crate::{ConnectionUri, FogViewRouterUri, FogViewStoreUri};
     use core::str::FromStr;
     use mc_common::ResponderId;
 
@@ -127,6 +159,24 @@ mod tests {
         assert_eq!(
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri =
+            FogViewRouterUri::from_str("fog-view-router://node1.test.mobilecoin.com:443/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri =
+            FogViewStoreUri::from_str("fog-view-store://node1.test.mobilecoin.com:443/").unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:443");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:443").unwrap()
         );
         assert!(!uri.use_tls());
     }

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -5,7 +5,7 @@ use mc_util_uri::{Uri, UriScheme};
 pub use mc_util_uri::{ConnectionUri, FogUri, UriParseError};
 
 /// Fog View Shard Scheme
-#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FogViewRouterScheme {}
 
 impl UriScheme for FogViewRouterScheme {
@@ -87,20 +87,20 @@ impl UriScheme for IngestPeerScheme {
     const DEFAULT_INSECURE_PORT: u16 = 8090;
 }
 
-/// Uri used when talking to fog-view service, with the right default ports and
-/// scheme.
-pub type FogViewUri = Uri<FogViewScheme>;
-/// Uri used when talking to fog-ledger service, with the right default ports
-/// and scheme.
-pub type FogLedgerUri = Uri<FogLedgerScheme>;
 /// Uri used when talking to fog-ingest service, with the right default ports
 /// and scheme.
 pub type FogIngestUri = Uri<FogIngestScheme>;
-/// Usi used when talking to fog-ingest-peer service.
+/// Uri used when talking to fog-ledger service, with the right default ports
+/// and scheme.
+pub type FogLedgerUri = Uri<FogLedgerScheme>;
 /// Uri used when talking to fog view router service.
 pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
 /// Uri used when talking to fog view store service.
 pub type FogViewStoreUri = Uri<FogViewStoreScheme>;
+/// Uri used when talking to fog-view service, with the right default ports and
+/// scheme.
+pub type FogViewUri = Uri<FogViewScheme>;
+/// Uri used when talking to fog-ingest-peer service.
 pub type IngestPeerUri = Uri<IngestPeerScheme>;
 
 #[cfg(test)]

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 # mobilecoin
+mc-attest-api = { path = "../../../attest/api" }
 mc-attest-core = { path = "../../../attest/core" }
 mc-attest-verifier = { path = "../../../attest/verifier" }
 mc-common = { path = "../../../common", features = ["log"] }
@@ -23,5 +24,6 @@ mc-fog-uri = { path = "../../uri" }
 mc-fog-view-protocol = { path = "../protocol" }
 
 # third-party
+futures = "0.3"
 grpcio = "0.10.2"
 retry = "1.3"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -27,4 +27,4 @@ mc-fog-view-protocol = { path = "../protocol" }
 futures = "0.3"
 grpcio = "0.10.2"
 retry = "1.3"
-tokio = "1.19.2"
+tokio = { version = "1.19.2", features = ["full"] }

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -27,3 +27,4 @@ mc-fog-view-protocol = { path = "../protocol" }
 futures = "0.3"
 grpcio = "0.10.2"
 retry = "1.3"
+tokio = "1.19.2"

--- a/fog/view/connection/src/bin/router_client.rs
+++ b/fog/view/connection/src/bin/router_client.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A simple binary that creates a Fog View Router Client and sends off
+//! requests to the Fog View Router server.
+
+use mc_fog_uri::FogViewRouterUri;
+use mc_fog_view_connection::fog_view_router_client::FogViewRouterGrpcClient;
+use std::{str::FromStr, sync::Arc};
+
+fn main() {
+    futures::executor::block_on(async_main()).unwrap();
+}
+
+async fn async_main() -> Result<(), grpcio::Error> {
+    let fog_view_router_uri = FogViewRouterUri::from_str("insecure-fog-view-router://127.0.0.1/")
+        .expect("wrong fog view router uri");
+    let env = Arc::new(
+        grpcio::EnvBuilder::new()
+            .name_prefix("Main-RPC".to_string())
+            .build(),
+    );
+    let (logger, _global_logger_guard) =
+        mc_common::logger::create_app_logger(mc_common::logger::o!());
+
+    let fog_view_router_client =
+        FogViewRouterGrpcClient::new(fog_view_router_uri.clone(), env.clone(), logger.clone());
+
+    fog_view_router_client.request().await
+}

--- a/fog/view/connection/src/bin/router_client.rs
+++ b/fog/view/connection/src/bin/router_client.rs
@@ -7,13 +7,10 @@ use mc_fog_uri::FogViewRouterUri;
 use mc_fog_view_connection::fog_view_router_client::FogViewRouterGrpcClient;
 use std::{str::FromStr, sync::Arc};
 
-fn main() {
-    futures::executor::block_on(async_main()).unwrap();
-}
-
-async fn async_main() -> Result<(), grpcio::Error> {
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), grpcio::Error> {
     let fog_view_router_uri = FogViewRouterUri::from_str("insecure-fog-view-router://127.0.0.1/")
-        .expect("wrong fog view router uri");
+        .expect("failed to connect to fog view router uri");
     let env = Arc::new(
         grpcio::EnvBuilder::new()
             .name_prefix("Main-RPC".to_string())

--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -57,7 +57,7 @@ impl FogViewRouterGrpcClient {
 
         let receive = async move {
             let mut counter = 0;
-            while let Some(_) = receiver.try_next().await? {
+            while (receiver.try_next().await?).is_some() {
                 counter += 1;
                 log::info!(self.logger, "Got message {} ", counter);
             }

--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Makes dummy requests to the fog view router service
+
+use futures::{SinkExt, TryStreamExt};
+use grpcio::{ChannelBuilder, Environment};
+use mc_attest_api::attest::Message;
+use mc_common::logger::{log, o, Logger};
+use mc_fog_api::{view::FogViewRouterRequest, view_grpc::FogViewRouterApiClient};
+use mc_fog_uri::FogViewRouterUri;
+use mc_util_grpc::ConnectionUriGrpcioChannel;
+use std::sync::Arc;
+
+/// A high-level object mediating requests to the fog view router service
+pub struct FogViewRouterGrpcClient {
+    /// The fog view router grpc client
+    fog_view_router_client: FogViewRouterApiClient,
+    /// A logger object
+    logger: Logger,
+}
+
+impl FogViewRouterGrpcClient {
+    /// Creates a new fog view router grpc client
+    ///
+    /// Arguments:
+    /// * uri: The Uri to connect to
+    /// * env: A grpc environment (thread pool) to use for this connection
+    /// * logger: For logging
+    pub fn new(uri: FogViewRouterUri, env: Arc<Environment>, logger: Logger) -> Self {
+        let logger = logger.new(o!("mc.fog.view.router.cxn" => uri.to_string()));
+
+        let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&uri, &logger);
+
+        let fog_view_router_client = FogViewRouterApiClient::new(ch);
+
+        Self {
+            fog_view_router_client,
+            logger,
+        }
+    }
+
+    /// Makes streaming requests to the fog view router service.
+    pub async fn request(&self) -> Result<(), grpcio::Error> {
+        let (mut sink, mut receiver) = self.fog_view_router_client.request()?;
+        let attested_message = Message::new();
+        let mut request = FogViewRouterRequest::new();
+        request.set_query(attested_message);
+        let send = async move {
+            for i in 0..5 {
+                log::info!(self.logger, "Sending message {}", i);
+                sink.send((request.clone(), grpcio::WriteFlags::default()))
+                    .await?;
+            }
+            sink.close().await?;
+            Ok(()) as Result<(), grpcio::Error>
+        };
+
+        let receive = async move {
+            let mut counter = 0;
+            while let Some(_) = receiver.try_next().await? {
+                counter += 1;
+                log::info!(self.logger, "Got message {} ", counter);
+            }
+            Ok(())
+        };
+        let (sr, rr) = futures::join!(send, receive);
+        sr.and(rr)?;
+        Ok(())
+    }
+}

--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -27,7 +27,7 @@ impl FogViewRouterGrpcClient {
     /// * env: A grpc environment (thread pool) to use for this connection
     /// * logger: For logging
     pub fn new(uri: FogViewRouterUri, env: Arc<Environment>, logger: Logger) -> Self {
-        let logger = logger.new(o!("mc.fog.view.router.cxn" => uri.to_string()));
+        let logger = logger.new(o!("mc.fog.view.router.uri" => uri.to_string()));
 
         let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&uri, &logger);
 
@@ -64,7 +64,6 @@ impl FogViewRouterGrpcClient {
             Ok(())
         };
         let (sr, rr) = futures::join!(send, receive);
-        sr.and(rr)?;
-        Ok(())
+        sr.and(rr)
     }
 }

--- a/fog/view/connection/src/lib.rs
+++ b/fog/view/connection/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![deny(missing_docs)]
 
+pub mod fog_view_router_client;
+
 use grpcio::{ChannelBuilder, Environment};
 use mc_attest_verifier::Verifier;
 use mc_common::{

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+#![deny(missing_docs)]
+
+//! MobileCoin Fog View Router target
+use mc_common::logger::log;
+use mc_fog_uri::FogViewStoreUri;
+use mc_fog_view_enclave::{SgxViewEnclave, ENCLAVE_FILE};
+use mc_fog_view_server::{
+    config::FogViewRouterConfig, fog_view_router_server::FogViewRouterServer,
+};
+use mc_util_cli::ParserWithBuildInfo;
+use std::{env, str::FromStr};
+
+fn main() {
+    mc_common::setup_panic_handler();
+    let config = FogViewRouterConfig::parse();
+    let (logger, _global_logger_guard) =
+        mc_common::logger::create_app_logger(mc_common::logger::o!());
+
+    let enclave_path = env::current_exe()
+        .expect("Could not get the path of our executable")
+        .with_file_name(ENCLAVE_FILE);
+    log::info!(
+        logger,
+        "enclave path {}, responder ID {}",
+        enclave_path.to_str().unwrap(),
+        &config.client_responder_id
+    );
+    let sgx_enclave = SgxViewEnclave::new(
+        enclave_path,
+        config.client_responder_id.clone(),
+        config.omap_capacity,
+        logger.clone(),
+    );
+
+    // TODO: Remove and get from a config.
+    let mut shard_uris: Vec<FogViewStoreUri> = Vec::new();
+    for i in 0..50 {
+        let shard_uri_string = format!(
+            "insecure-fog-view-store://node{}.test.mobilecoin.com:3225",
+            i
+        );
+        let shard_uri = FogViewStoreUri::from_str(&shard_uri_string).unwrap();
+        shard_uris.push(shard_uri);
+    }
+
+    let mut router_server = FogViewRouterServer::new(
+        config.clone(),
+        sgx_enclave.clone(),
+        shard_uris.clone(),
+        logger.clone(),
+    );
+    router_server.start();
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
+}

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -44,12 +44,7 @@ fn main() {
         shard_uris.push(shard_uri);
     }
 
-    let mut router_server = FogViewRouterServer::new(
-        config.clone(),
-        sgx_enclave.clone(),
-        shard_uris.clone(),
-        logger.clone(),
-    );
+    let mut router_server = FogViewRouterServer::new(config, sgx_enclave, shard_uris, logger);
     router_server.start();
 
     loop {

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
 use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
-use mc_fog_uri::FogViewUri;
+use mc_fog_uri::{FogViewRouterUri, FogViewUri};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
 use serde::Serialize;
@@ -67,4 +67,34 @@ pub struct MobileAcctViewConfig {
     /// Postgres config
     #[clap(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+}
+
+/// Configuration parameters for the Fog View Router.
+#[derive(Clone, Parser, Serialize)]
+#[clap(version)]
+pub struct FogViewRouterConfig {
+    /// The ID with which to respond to client attestation requests.
+    ///
+    /// This ID needs to match the host:port clients use in their URI when
+    /// referencing this node.
+    #[clap(long, env = "MC_CLIENT_RESPONDER_ID")]
+    pub client_responder_id: ResponderId,
+
+    /// gRPC listening URI for client requests.
+    #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
+    pub client_listen_uri: FogViewRouterUri,
+
+    // TODO: Add shard uris which are of type Vec<FogViewStoreUri>.
+    /// The capacity to build the OMAP (ORAM hash table) with.
+    /// About 75% of this capacity can be used.
+    /// The hash table will overflow when there are more TxOut's than this,
+    /// and the server will have to be restarted with a larger number.
+    ///
+    /// Note: At time of writing, the hash table will be allocated to use all
+    /// available SGX EPC memory, and then beyond that it will be allocated on
+    /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
+    /// you will either get killed by OOM killer, or it will start being swapped
+    /// to disk by linux kernel.
+    #[clap(long, default_value = "1048576", env = "MC_OMAP_CAPACITY")]
+    pub omap_capacity: u64,
 }

--- a/fog/view/server/src/fog_view_router_server.rs
+++ b/fog/view/server/src/fog_view_router_server.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Server object containing a view node
+//! Constructible from config (for testability) and with a mechanism for
+//! stopping it
+
+use crate::{config::FogViewRouterConfig, fog_view_router_service::FogViewRouterService};
+use futures::executor::block_on;
+use mc_common::logger::{log, Logger};
+use mc_fog_api::view_grpc;
+use mc_fog_uri::{ConnectionUri, FogViewStoreUri};
+use mc_fog_view_enclave::ViewEnclaveProxy;
+use mc_util_grpc::{ConnectionUriGrpcioServer, ReadinessIndicator};
+use std::sync::Arc;
+
+pub struct FogViewRouterServer<E>
+where
+    E: ViewEnclaveProxy,
+{
+    server: grpcio::Server,
+    _enclave: E,
+    logger: Logger,
+}
+
+impl<E> FogViewRouterServer<E>
+where
+    E: ViewEnclaveProxy,
+{
+    /// Creates a new view router server instance
+    pub fn new(
+        config: FogViewRouterConfig,
+        enclave: E,
+        shards: Vec<FogViewStoreUri>,
+        logger: Logger,
+    ) -> FogViewRouterServer<E> {
+        let readiness_indicator = ReadinessIndicator::default();
+
+        let env = Arc::new(
+            grpcio::EnvBuilder::new()
+                .name_prefix("Main-RPC".to_string())
+                .build(),
+        );
+
+        let fog_view_router_service = view_grpc::create_fog_view_router_api(
+            FogViewRouterService::new(enclave.clone(), shards.clone(), logger.clone()),
+        );
+        log::debug!(logger, "Constructed Fog View Router GRPC Service");
+
+        // Health check service
+        let health_service =
+            mc_util_grpc::HealthService::new(Some(readiness_indicator.into()), logger.clone())
+                .into_service();
+
+        // Package service into grpc server
+        log::info!(
+            logger,
+            "Starting Fog View Router server on {}",
+            config.client_listen_uri.addr(),
+        );
+        let server_builder = grpcio::ServerBuilder::new(env)
+            .register_service(fog_view_router_service)
+            .register_service(health_service)
+            .bind_using_uri(&config.client_listen_uri, logger.clone());
+
+        let server = server_builder.build().unwrap();
+
+        Self {
+            server,
+            _enclave: enclave,
+            logger,
+        }
+    }
+
+    /// Starts the server
+    pub fn start(&mut self) {
+        self.server.start();
+        for (host, port) in self.server.bind_addrs() {
+            log::info!(self.logger, "API listening on {}:{}", host, port);
+        }
+    }
+
+    /// Stops the server
+    pub fn stop(&mut self) {
+        block_on(self.server.shutdown()).expect("Could not stop grpc server");
+    }
+}
+
+impl<E> Drop for FogViewRouterServer<E>
+where
+    E: ViewEnclaveProxy,
+{
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/fog/view/server/src/fog_view_router_server.rs
+++ b/fog/view/server/src/fog_view_router_server.rs
@@ -42,7 +42,7 @@ where
         );
 
         let fog_view_router_service = view_grpc::create_fog_view_router_api(
-            FogViewRouterService::new(enclave.clone(), shards.clone(), logger.clone()),
+            FogViewRouterService::new(enclave.clone(), shards, logger.clone()),
         );
         log::debug!(logger, "Constructed Fog View Router GRPC Service");
 

--- a/fog/view/server/src/fog_view_router_service.rs
+++ b/fog/view/server/src/fog_view_router_service.rs
@@ -1,0 +1,151 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use futures::{future::try_join_all, FutureExt, SinkExt, TryFutureExt, TryStreamExt};
+use grpcio::{DuplexSink, RequestStream, RpcContext, WriteFlags};
+use mc_attest_api::attest;
+use mc_common::logger::{log, Logger};
+use mc_fog_api::{
+    view::{FogViewRouterRequest, FogViewRouterResponse},
+    view_grpc::FogViewRouterApi,
+};
+use mc_fog_uri::FogViewStoreUri;
+use mc_fog_view_enclave_api::ViewEnclaveProxy;
+use mc_util_grpc::{rpc_logger, rpc_permissions_error};
+use mc_util_metrics::SVC_COUNTERS;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct FogViewRouterService<E: ViewEnclaveProxy> {
+    enclave: E,
+    shards: Vec<Arc<FogViewStoreUri>>,
+    logger: Logger,
+}
+
+impl<E: ViewEnclaveProxy> FogViewRouterService<E> {
+    /// Creates a new FogViewRouterService that can be used by a gRPC server to
+    /// fulfill gRPC requests.
+    pub fn new(enclave: E, shards: Vec<FogViewStoreUri>, logger: Logger) -> Self {
+        let mut shard_arcs: Vec<Arc<FogViewStoreUri>> = Vec::new();
+        for shard in shards {
+            let shard_arc = Arc::new(shard);
+            shard_arcs.push(shard_arc);
+        }
+        Self {
+            enclave,
+            shards: shard_arcs,
+            logger,
+        }
+    }
+}
+
+impl<E: ViewEnclaveProxy> FogViewRouterApi for FogViewRouterService<E> {
+    fn request(
+        &mut self,
+        ctx: RpcContext,
+        requests: RequestStream<FogViewRouterRequest>,
+        responses: DuplexSink<FogViewRouterResponse>,
+    ) {
+        log::info!(self.logger, "Request received in request fn");
+        let _timer = SVC_COUNTERS.req(&ctx);
+        mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
+            let logger = logger.clone();
+            // TODO: Confirm that we don't need to perform the authenticator logic. I think
+            // we don't  because of streaming...
+            let future = handle_request(
+                self.shards.clone(),
+                self.enclave.clone(),
+                requests,
+                responses,
+                logger.clone(),
+            )
+            .map_err(move |err: grpcio::Error| log::error!(&logger, "failed to reply: {}", err))
+            // TODO: Do stuff with the error
+            .map(|_| ());
+
+            ctx.spawn(future)
+        });
+    }
+}
+
+/// Receives a client's request and performs either authentication or a query.
+async fn handle_request<E: ViewEnclaveProxy>(
+    shards: Vec<Arc<FogViewStoreUri>>,
+    enclave: E,
+    mut requests: RequestStream<FogViewRouterRequest>,
+    mut responses: DuplexSink<FogViewRouterResponse>,
+    logger: Logger,
+) -> Result<(), grpcio::Error> {
+    while let Some(mut request) = requests.try_next().await? {
+        if request.has_auth() {
+            match enclave.client_accept(request.take_auth().into()) {
+                Ok((enclave_response, _)) => {
+                    let mut auth_message = attest::AuthMessage::new();
+                    auth_message.set_data(enclave_response.into());
+
+                    let mut response = FogViewRouterResponse::new();
+                    response.set_auth(auth_message);
+                    responses
+                        .send((response.clone(), WriteFlags::default()))
+                        .await?;
+                }
+                Err(client_error) => {
+                    log::debug!(
+                        &logger,
+                        "ViewEnclaveApi::client_accept failed: {}",
+                        client_error
+                    );
+                    let rpc_permissions_error = rpc_permissions_error(
+                        "client_auth",
+                        format!("Permission denied: {:?}", client_error),
+                        &logger,
+                    );
+                    return responses.fail(rpc_permissions_error).await;
+                }
+            }
+        } else if request.has_query() {
+            log::info!(logger, "Request has query");
+            let _result = route_query(shards.clone(), logger.clone()).await;
+
+            let response = FogViewRouterResponse::new();
+            responses
+                .send((response.clone(), WriteFlags::default()))
+                .await?;
+        } else {
+            // TODO: Throw some sort of error though not sure
+            //  that's necessary.
+        }
+    }
+
+    responses.close().await?;
+    Ok(())
+}
+
+// TODO: This method will be responsible for contacting each shard, passing
+// along a  MultiViewStoreQuery message. It will eventually return a Vec of
+// encrypted QueryResponses that  the caller of this method will transform into
+// one FogViewRouterResponse to return to the client.
+async fn route_query(
+    shards: Vec<Arc<FogViewStoreUri>>,
+    logger: Logger,
+) -> Result<Vec<i32>, String> {
+    let mut futures = Vec::new();
+    for (i, shard) in shards.iter().enumerate() {
+        let future = contact_shard(i, shard.clone(), logger.clone());
+        futures.push(future);
+    }
+
+    try_join_all(futures).await
+}
+
+// TODO: Pass along the MultiViewStoreQuery to the individual shard.
+//  This method will eventually return an encrypted QueryResponse that the
+//  router will decrypt and collate with all of the other shards' responses.
+async fn contact_shard(
+    index: usize,
+    shard: Arc<FogViewStoreUri>,
+    logger: Logger,
+) -> Result<i32, String> {
+    log::info!(logger, "Contacting shard {} at index {}", shard, index);
+
+    Ok(0)
+}

--- a/fog/view/server/src/lib.rs
+++ b/fog/view/server/src/lib.rs
@@ -4,6 +4,8 @@
 
 pub mod config;
 pub mod error;
+pub mod fog_view_router_server;
+pub mod fog_view_router_service;
 pub mod fog_view_service;
 pub mod server;
 


### PR DESCRIPTION
### Motivation

This is the first PR in a series of PRs that implement the Fog View Router service as described in the design [doc](https://docs.google.com/document/d/1-ju5efGK6vvuYjxj1pKhfFcpgGlornuxZYvOC-nsbjs/edit?usp=sharing). 

This PR implements the "bare bones" structure of the Fog View Router service, meaning that it defines the gRPC API in a proto file, sets up the canonical MobileCoin server + service gRPC structure, and implements the general shape of the async / future paradigm that will be used by the service when the actual logic is implemented

### Future Work
- This PR address the first item in the #2028 ticket. Future PRs will address each additional item. 