### PR TITLE
Android ffi bindings for gift codes

### DIFF
--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -1465,7 +1465,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSenderMemo_get_1fee(
         || Ok(0),
         &env,
         |env| {
-            let memo: MutexGuard<GiftCodeFundingMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let memo: MutexGuard<GiftCodeSenderMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
 
             Ok(memo.get_fee() as jlong)
         },
@@ -1774,7 +1774,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemoBuiler_init(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSendingMemoBuiler_init(
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSenderMemoBuiler_init(
     env: JNIEnv,
     obj: JObject,
     note: JString,

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -53,8 +53,10 @@ use mc_transaction_core::{
 };
 use mc_transaction_std::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, DestinationMemo,
-    InputCredentials, MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedSubaddresses,
-    SenderMemoCredential, TransactionBuilder,
+    GiftCodeCancellationMemo, GiftCodeCancellationMemoBuilder, GiftCodeFundingMemo,
+    GiftCodeFundingMemoBuilder, GiftCodeSenderMemo, GiftCodeSenderMemoBuilder, InputCredentials,
+    MemoBuilder, MemoPayload, RTHMemoBuilder, ReservedSubaddresses, SenderMemoCredential,
+    TransactionBuilder,
 };
 
 use mc_util_from_random::FromRandom;
@@ -1350,6 +1352,178 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_DestinationMemo_get_1total_1out
 }
 
 /********************************************************************
+ * GiftCodeFundingMemo
+ */
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemo_init_1jni_1from_1memo_1data(
+    env: JNIEnv,
+    obj: JObject,
+    memo_data: jbyteArray,
+) {
+    jni_ffi_call(&env, |env| {
+        let memo_data = <[u8; 64]>::try_from(&env.convert_byte_array(memo_data)?[..])?;
+        let memo: GiftCodeFundingMemo = GiftCodeFundingMemo::from(&memo_data);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemo_validate_1gift_1code_1funding_1tx_1out(
+    env: JNIEnv,
+    obj: JObject,
+    tx_out_public_key: JObject,
+) -> jboolean {
+    jni_ffi_call_or(
+        || Ok(JNI_FALSE),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeFundingMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let key: MutexGuard<RistrettoPublic> =
+                env.get_rust_field(tx_out_public_key, RUST_OBJ_FIELD)?;
+
+            let key_matches = memo.public_key_matches(&key);
+
+            Ok(key_matches as u8)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemo_get_1note(
+    env: JNIEnv,
+    obj: JObject,
+) -> jstring {
+    jni_ffi_call_or(
+        || Ok(env.new_string("")?.into_inner()),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeFundingMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let funding_note = memo.funding_note()?;
+
+            Ok(env.new_string(funding_note)?.into_inner())
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemo_get_1fee(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeFundingMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+
+            Ok(memo.get_fee() as jlong)
+        },
+    )
+}
+
+/********************************************************************
+ * GiftCodeSenderMemo
+ */
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSenderMemo_init_1jni_1from_1memo_1data(
+    env: JNIEnv,
+    obj: JObject,
+    memo_data: jbyteArray,
+) {
+    jni_ffi_call(&env, |env| {
+        let memo_data = <[u8; 64]>::try_from(&env.convert_byte_array(memo_data)?[..])?;
+        let memo: GiftCodeSenderMemo = GiftCodeSenderMemo::from(&memo_data);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSenderMemo_get_1note(
+    env: JNIEnv,
+    obj: JObject,
+) -> jstring {
+    jni_ffi_call_or(
+        || Ok(env.new_string("")?.into_inner()),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeSenderMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let sender_note = memo.sender_note()?;
+
+            Ok(env.new_string(sender_note)?.into_inner())
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSenderMemo_get_1fee(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeFundingMemo> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+
+            Ok(memo.get_fee() as jlong)
+        },
+    )
+}
+
+/********************************************************************
+ * GiftCodeCancellationMemo
+ */
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeCancellationMemo_init_1jni_1from_1memo_1data(
+    env: JNIEnv,
+    obj: JObject,
+    memo_data: jbyteArray,
+) {
+    jni_ffi_call(&env, |env| {
+        let memo_data = <[u8; 64]>::try_from(&env.convert_byte_array(memo_data)?[..])?;
+        let memo: GiftCodeCancellationMemo = GiftCodeCancellationMemo::from(&memo_data);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeCancellationMemo_get_1global_1index(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeCancellationMemo> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+
+            Ok(memo.cancelled_gift_code_index() as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeCancellationMemo_get_1fee(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let memo: MutexGuard<GiftCodeCancellationMemo> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+
+            Ok(memo.get_fee() as jlong)
+        },
+    )
+}
+
+/********************************************************************
  * TxOut
  */
 
@@ -1580,6 +1754,58 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TxOutMemoBuilder_init_1jni_1wit
 }
 
 /********************************************************************
+ * GiftCodeMemoBuilders
+ */
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeFundingMemoBuiler_init(
+    env: JNIEnv,
+    obj: JObject,
+    note: JString,
+) {
+    jni_ffi_call(&env, |env| {
+        let note: String = env.get_string(note)?.into();
+        let memo_builder = GiftCodeFundingMemoBuilder::new(note.as_str())?;
+
+        let memo_builder_box: Box<dyn MemoBuilder + Sync + Send> = Box::new(memo_builder);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo_builder_box)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeSendingMemoBuiler_init(
+    env: JNIEnv,
+    obj: JObject,
+    note: JString,
+) {
+    jni_ffi_call(&env, |env| {
+        let note: String = env.get_string(note)?.into();
+        let memo_builder = GiftCodeSenderMemoBuilder::new(note.as_str())?;
+
+        let memo_builder_box: Box<dyn MemoBuilder + Sync + Send> = Box::new(memo_builder);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo_builder_box)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_GiftCodeCancellationMemoBuiler_init(
+    env: JNIEnv,
+    obj: JObject,
+    global_index: JObject,
+) {
+    jni_ffi_call(&env, |env| {
+        let index = jni_big_int_to_u64(env, global_index)?;
+        let memo_builder = GiftCodeCancellationMemoBuilder::new(index);
+
+        let memo_builder_box: Box<dyn MemoBuilder + Sync + Send> = Box::new(memo_builder);
+
+        Ok(env.set_rust_field(obj, RUST_OBJ_FIELD, memo_builder_box)?)
+    })
+}
+
+/********************************************************************
  * TransactionBuilder
  */
 
@@ -1759,6 +1985,59 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
 
             let (tx_out, confirmation_number) =
                 tx_builder.add_change_output(amount, &change_destination, &mut rng)?;
+            if !confirmation_number_out.is_null() {
+                let len = env.get_array_length(confirmation_number_out)?;
+                if len as usize >= confirmation_number.to_vec().len() {
+                    env.set_byte_array_region(
+                        confirmation_number_out,
+                        0,
+                        confirmation_number
+                            .to_vec()
+                            .into_iter()
+                            .map(|u| u as i8)
+                            .collect::<Vec<_>>()
+                            .as_slice(),
+                    )?;
+                }
+            }
+
+            let mbox = Box::new(Mutex::new(tx_out));
+            let ptr: *mut Mutex<TxOut> = Box::into_raw(mbox);
+            Ok(ptr as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1gift_1code_1output(
+    env: JNIEnv,
+    obj: JObject,
+    value: JObject,
+    source_account_key: JObject,
+    confirmation_number_out: jbyteArray,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let mut tx_builder: MutexGuard<TransactionBuilder<FogResolver>> =
+                env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let source_account_key: MutexGuard<AccountKey> =
+                env.get_rust_field(source_account_key, RUST_OBJ_FIELD)?;
+
+            let value = jni_big_int_to_u64(env, value)?;
+            let reserved_subaddresses = ReservedSubaddresses::from(&*source_account_key);
+            let mut rng = McRng::default();
+
+            // TODO (GH #1867): If you want to do mixed transactions, use something other
+            // than fee_token_id here.
+            let amount = Amount {
+                value: value as u64,
+                token_id: tx_builder.get_fee_token_id(),
+            };
+
+            let (tx_out, confirmation_number) =
+                tx_builder.add_gift_code_output(amount, &reserved_subaddresses, &mut rng)?;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
                 if len as usize >= confirmation_number.to_vec().len() {

--- a/android-bindings/src/error.rs
+++ b/android-bindings/src/error.rs
@@ -8,7 +8,9 @@ use mc_crypto_box::Error as CryptoBoxError;
 use mc_crypto_keys::KeyError;
 use mc_crypto_noise::CipherError;
 use mc_fog_kex_rng::Error as KexRngError;
-use mc_transaction_core::{ring_signature::Error as RingSignatureError, AmountError};
+use mc_transaction_core::{
+    ring_signature::Error as RingSignatureError, AmountError, MemoError, NewMemoError,
+};
 use mc_transaction_std::TxBuilderError;
 use mc_util_encodings::Error as EncodingsError;
 use mc_util_serial::{
@@ -90,6 +92,12 @@ pub enum McError {
 
     /// Downcast from Anyhow Error failed: {0}
     DowncastAnyFailed(anyhow::Error),
+
+    /// MemoBuilder initialization failed: {0}
+    MemoBuilder(NewMemoError),
+
+    /// Retrieving memo data failed: {0}
+    MemoData(MemoError),
 }
 
 impl From<FromUtf8Error> for McError {
@@ -218,6 +226,18 @@ impl From<anyhow::Error> for McError {
             Ok(error_kind) => error_kind.into(),
             Err(e) => Self::DowncastAnyFailed(e),
         }
+    }
+}
+
+impl From<NewMemoError> for McError {
+    fn from(src: NewMemoError) -> Self {
+        Self::MemoBuilder(src)
+    }
+}
+
+impl From<MemoError> for McError {
+    fn from(src: MemoError) -> Self {
+        Self::MemoData(src)
     }
 }
 


### PR DESCRIPTION
### Changelog

* Added FFI methods for making gift code outputs, memo builders, and retrieving gift code memo data
* Added a few error conversions to error enum

### Motivation

Provide Android SDK with the ability to make gift code transactions, and read/write gift code memos.

### Future Work
* Add mobilecoind support for gift codes
* Support end to end testing
* Support SDK & full service teams in full implementation of TxOut gift codes