### PR TITLE
Add a new "cmd" argument to mob prompt

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -26,6 +26,39 @@ If you have SGX-enabled hardware (activated in BIOS, and with SGX kernel module 
 you can use `./mob prompt --hw` to get SGX in the container. Then you can both build and
 run the tests in `SGX_MODE=HW`. (See below for an explanation.)
 
+##### IDE Support using the docker environment
+
+You can use `./mob prompt --cmd <command>` to run `<command>` from within
+the docker environment. For IDE support, this can be used to run `cargo check`.
+
+An example workspace configuration for Rust Analyzer is provided below
+
+```json
+"rust-analyzer.checkOnSave.overrideCommand": [
+    "./mob",
+    "prompt",
+    "--cmd",
+    "cargo",
+    "check",
+    "--workspace",
+    "--message-format=json",
+    "--all-targets"
+],
+"rust-analyzer.cargo.buildScripts.overrideCommand": [
+    "./mob",
+    "prompt",
+    "--cmd",
+    "cargo",
+    "check",
+    "--workspace",
+    "--message-format=json",
+    "--all-targets"
+],
+"rust-analyzer.cargo.buildScripts.useRustcWrapper": false,
+"rust-analyzer.cargo.buildScripts.enable": false,
+"rust-analyzer.procMacro.enable": false,
+```
+
 #### No-docker build
 
 A docker-less build also works fine for development:

--- a/BUILD.md
+++ b/BUILD.md
@@ -31,7 +31,7 @@ run the tests in `SGX_MODE=HW`. (See below for an explanation.)
 You can use `./mob prompt --cmd <command>` to run `<command>` from within
 the docker environment. For IDE support, this can be used to run `cargo check`.
 
-An example workspace configuration for Rust Analyzer is provided below
+An example workspace configuration for Rust Analyzer is provided below:
 
 ```json
 "rust-analyzer.checkOnSave.overrideCommand": [

--- a/mob
+++ b/mob
@@ -103,6 +103,7 @@ parser.add_argument("--ssh-dir", action='store_true', help='Mount $HOME/.ssh dir
 parser.add_argument("--ssh-agent", action='store_true', help='Use ssh-agent on host machine for ssh authentication. Also controlled by SSH_AUTH_SOCK env variable')
 parser.add_argument("--expose", nargs='+', default=None, help="Any additional ports to expose")
 parser.add_argument("--publish", nargs='+', default=None, help="Any additional ports to publish, e.g. if running wallet locally.")
+parser.add_argument("--cmd", nargs=argparse.REMAINDER, default=None, help="Run this command inside the bash shell instead of an interactive prompt")
 
 args = parser.parse_args()
 
@@ -440,12 +441,19 @@ docker_run.extend([tag])
 
 docker_run.extend(["/bin/bash"])
 
+if args.cmd is not None:
+    docker_run.extend(["-c"])
+    docker_run.extend([" ".join(args.cmd)])
+
 try:
     maybe_run(docker_run)
 except subprocess.CalledProcessError as exception:
     if args.action == 'prompt' and exception.returncode == 130:
         # This is normal exit of prompt
         sys.exit(0)
+    if args.action == 'prompt' and args.cmd is not None:
+        # Make sure custom commands have their expected return codes
+        sys.exit(exception.returncode)
     raise  # rethrow
 finally:
     # cleanup named container on exit

--- a/mob
+++ b/mob
@@ -448,12 +448,12 @@ if args.cmd is not None:
 try:
     maybe_run(docker_run)
 except subprocess.CalledProcessError as exception:
-    if args.action == 'prompt' and exception.returncode == 130:
-        # This is normal exit of prompt
-        sys.exit(0)
     if args.action == 'prompt' and args.cmd is not None:
         # Make sure custom commands have their expected return codes
         sys.exit(exception.returncode)
+    if args.action == 'prompt' and exception.returncode == 130:
+        # This is a normal exit of prompt
+        sys.exit(0)
     raise  # rethrow
 finally:
     # cleanup named container on exit

--- a/mob
+++ b/mob
@@ -30,7 +30,7 @@ the image and doesn't run it or give you a prompt. `--dry-run` just
 shows you the shell commands without executing them. `--no-pull` means you don't
 pull a docker image at all.
 
-`mob` tool attemps to mount the `/dev/isgx` device correctly if it is available
+`mob` tool attempts to mount the `/dev/isgx` device correctly if it is available
 and you selected `--hw` mode, so that you can run tests in hardware mode.
 
 usage notes (ssh)
@@ -74,7 +74,7 @@ it is an error if it can't find one.
 
 [image]
 dockerfile = path to dockerfile. build context is the dir of dockerfile
-target = layer in dockerfile that is targetted
+target = layer in dockerfile that is targeted
 repository = storage for remote images from farm e.g. gcr.io/mobilenode-211420 (optional)
 """
 


### PR DESCRIPTION
### Motivation

Like #2027, this change allows external tools, such as rust-analyzer, to run `cargo check` inside the docker environment, improving the development experience for people who can't install the SGX SDK locally.

This approach is more flexible than that in #2027, and no longer hard-codes any specific command.

I believe this approach is reliable under argparse's non-standard argument parsing, but if that proves to not be the case another option could be to take the command line as a single string, potentially requiring the user to escape it.