### PR TITLE
Use zerossl service for dev

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -106,7 +106,7 @@ jobs:
         VIEW_ENCLAVE_PRIVKEY: ${{ env.ENCLAVE_SIGNING_KEY_PATH }}
         INGEST_ENCLAVE_PRIVKEY: ${{ env.ENCLAVE_SIGNING_KEY_PATH }}
       run: |
-        ls -al "${ENCLAVE_SIGNING_KEY_PATH}"
+        git config --global --add safe.directory '*'
         cargo build --release \
           -p mc-admin-http-gateway \
           -p mc-consensus-mint-client \

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -265,6 +265,7 @@ jobs:
         chart_version: ${{ inputs.version }}
         chart_set: |
           --set=image.org=${{ inputs.docker_image_org }}
+          --set=global.certManagerClusterIssuer=zerossl-prod-http
         chart_wait_timeout: 10m
         release_name: ${{ matrix.release_name }}
         namespace: ${{ inputs.namespace }}
@@ -376,6 +377,7 @@ jobs:
         chart_wait_timeout: 10m
         chart_set: |
           --set=image.org=${{ inputs.docker_image_org }}
+          --set=global.certManagerClusterIssuer=zerossl-prod-http
         release_name: fog-services
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "consensusNode.fullname" . }}-client-grpc
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{- toYaml .Values.node.client.ingress.annotations | nindent 4 }}
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/templates/gateway-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/gateway-ingress.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "consensusNode.fullname" . }}-grpc-gateway
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{- toYaml .Values.grpcGateway.ingress | nindent 4}}
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/templates/node-certificate.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-certificate.yaml
@@ -1,5 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "consensusNode.fullname" . }}-internal-tls
@@ -10,9 +10,10 @@ spec:
   secretName: {{ include "consensusNode.fullname" . }}-internal-tls
   duration: 8760h # 365d
   renewBefore: 360h # 15d
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
   usages:
   - server auth
   - client auth

--- a/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
@@ -4,6 +4,9 @@ kind: Ingress
 metadata:
   name: {{ include "consensusNode.fullname" . }}-peer-grpc
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{- toYaml .Values.node.peer.ingress.annotations | nindent 4 }}
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -10,6 +10,8 @@ image:
 
 ### Shared values with child charts.
 global:
+  certManagerClusterIssuer: letsencrypt-production-http
+
   # Shared across all instances of consensusNodeConfig config.
   node:
     ledgerDistribution:
@@ -149,7 +151,6 @@ node:
   client:
     ingress:
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         # HAProxy Ingress
         haproxy.org/server-proto: 'h2'              # Force GRPC/H2 mode
         haproxy.org/server-ssl: 'false'             # The backend (server) is http
@@ -166,7 +167,6 @@ node:
   peer:
     ingress:
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         # HAProxy Ingress
         haproxy.org/server-proto: 'h2'              # Force GRPC/H2 mode
         haproxy.org/server-ssl: 'false'             # The backend (server) is http
@@ -187,7 +187,6 @@ grpcGateway:
     name: go-grpc-gateway
   nodeSelector: {}
   ingress:
-    cert-manager.io/cluster-issuer: letsencrypt-production-http
     #HAProxy Ingress
     haproxy.org/path-rewrite: /gw/(.*) /\1      # Strip the /gw prefix
     haproxy.org/server-ssl: 'false'             # The backend (server) is http

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
@@ -7,6 +7,9 @@ metadata:
     app: fog-ledger
     {{- include "fogServices.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{ toYaml (tpl .Values.fogLedger.ingress.grpc.annotations . | fromYaml)| nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
@@ -7,6 +7,9 @@ metadata:
     app: fog-ledger
     {{- include "fogServices.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{ toYaml (tpl .Values.fogLedger.ingress.http.annotations . | fromYaml)| nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     app: fog-report
     {{- include "fogServices.labels" $ | nindent 4 }}
   annotations:
+    {{- if $.Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{- toYaml $.Values.fogReport.ingress.grpc.annotations | nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     app: fog-report
     {{- include "fogServices.labels" $ | nindent 4 }}
   annotations:
+    {{- if $.Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{- toYaml $.Values.fogReport.ingress.http.annotations | nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
@@ -7,6 +7,9 @@ metadata:
     app: fog-view
     {{- include "fogServices.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{ toYaml (tpl .Values.fogView.ingress.grpc.annotations . | fromYaml)| nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
@@ -7,6 +7,9 @@ metadata:
     app: fog-view
     {{- include "fogServices.labels" . | nindent 4 }}
   annotations:
+    {{- if .Values.global.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
     {{ toYaml (tpl .Values.fogView.ingress.http.annotations . | fromYaml)| nindent 4 }}
 spec:
   tls:

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -21,6 +21,9 @@ image:
   org: mobilecoin
   tag: '' # Overrides the image tag whose default is the chart appVersion.
 
+global:
+  certManagerClusterIssuer: letsencrypt-production-http
+
 ### Fog Report Service
 fogReport:
   replicaCount: 2
@@ -42,7 +45,6 @@ fogReport:
   ingress:
     grpc:
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         haproxy.org/timeout-client: 239s            # 4 min timeout on azure
@@ -54,7 +56,6 @@ fogReport:
 
     http:
       annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         haproxy.org/timeout-client: 239s            # 4 min timeout on azure
         haproxy.org/timeout-server: 239s
@@ -100,7 +101,6 @@ fogView:
   ingress:
     grpc:
       annotations: |-
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         haproxy.org/timeout-client: 239s            # 4 min timeout on azure
@@ -113,7 +113,6 @@ fogView:
           cookie VIEW insert indirect nocache dynamic
     http:
       annotations: |-
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         haproxy.org/timeout-client: 239s            # 4 min timeout on azure
         haproxy.org/timeout-server: 239s
@@ -187,7 +186,6 @@ fogLedger:
   ingress:
     grpc:
       annotations: |-
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         # haproxy.org/cookie-persistence: "fog-ledger"
@@ -202,7 +200,6 @@ fogLedger:
 
     http:
       annotations: |-
-        cert-manager.io/cluster-issuer: letsencrypt-production-http
         haproxy.org/server-ssl: "false"             # The backend (server) is http
         haproxy.org/timeout-client: 239s            # 4 min timeout on azure
         haproxy.org/timeout-server: 239s


### PR DESCRIPTION
### Motivation

We started hitting rate limits for LetsEncrypt, switch to ZeroSSL with a paid account for no rate limits.

- Update helm charts and deploy process to use ZeroSSL service for CD deployments.
- Fix git commit detection on build 


