### PR TITLE
Implement create_multi_view_query_data API for Fog View Router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "mc-attest-enclave-api",
  "mc-common",
  "mc-crypto-keys",
+ "mc-crypto-noise",
  "mc-fog-recovery-db-iface",
  "mc-fog-types",
  "mc-sgx-compat",
@@ -4272,7 +4273,9 @@ dependencies = [
 name = "mc-fog-view-enclave-impl"
 version = "1.3.0-pre0"
 dependencies = [
+ "aes-gcm",
  "aligned-cmov",
+ "mc-attest-ake",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -4,7 +4,7 @@ use mc_util_uri::{Uri, UriScheme};
 
 pub use mc_util_uri::{ConnectionUri, FogUri, UriParseError};
 
-/// Fog View Shard Scheme
+/// Fog View Router Scheme
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FogViewRouterScheme {}
 

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -11,6 +11,7 @@ mc-attest-core = { path = "../../../../attest/core", default-features = false }
 mc-attest-enclave-api = { path = "../../../../attest/enclave-api", default-features = false }
 mc-common = { path = "../../../../common", default-features = false }
 mc-crypto-keys = { path = "../../../../crypto/keys", default-features = false }
+mc-crypto-noise = { path = "../../../../crypto/noise", default-features = false }
 mc-sgx-compat = { path = "../../../../sgx/compat", default-features = false }
 mc-sgx-report-cache-api = { path = "../../../../sgx/report-cache/api" }
 mc-sgx-types = { path = "../../../../sgx/types", default-features = false }

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -18,6 +18,7 @@ use mc_attest_enclave_api::{
 };
 use mc_common::ResponderId;
 use mc_crypto_keys::X25519Public;
+use mc_crypto_noise::CipherError;
 use mc_fog_recovery_db_iface::FogUserEvent;
 use mc_fog_types::ETxOutRecord;
 use mc_sgx_compat::sync::PoisonError;
@@ -199,8 +200,8 @@ pub enum Error {
     Poison,
     /// Enclave not initialized
     EnclaveNotInitialized,
-    /// Cipher encryption failed
-    Cipher,
+    /// Cipher encryption failed: {0}
+    Cipher(CipherError),
 }
 
 impl From<SgxError> for Error {
@@ -257,8 +258,8 @@ impl From<AddRecordsError> for Error {
     }
 }
 
-impl From<mc_crypto_noise::CipherError> for Error {
-    fn from(_: mc_crypto_noise::CipherError) -> Self {
-        Error::Cipher
+impl From<CipherError> for Error {
+    fn from(src: CipherError) -> Self {
+        Error::Cipher(src)
     }
 }

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -7,6 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 # mobilecoin
+mc-attest-ake = { path = "../../../../attest/ake", default-features = false }
 mc-attest-core = { path = "../../../../attest/core", default-features = false }
 mc-attest-enclave-api = { path = "../../../../attest/enclave-api", default-features = false }
 mc-common = { path = "../../../../common", default-features = false }
@@ -27,6 +28,9 @@ mc-oblivious-traits = "2.2"
 mc-fog-recovery-db-iface = { path = "../../../recovery_db_iface" }
 mc-fog-types = { path = "../../../types" }
 mc-fog-view-enclave-api = { path = "../api" }
+
+# third-party
+aes-gcm = "0.9.4"
 
 [dev-dependencies]
 mc-common = { path = "../../../../common", features = ["loggers"] }

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -206,12 +206,14 @@ where
         let client_query_bytes = self.ake.client_decrypt(client_query.clone())?;
 
         let mut encryptors = self.store_encryptors.lock()?;
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(encryptors.len());
         for store_encryptor in encryptors.deref_mut() {
-            let data = store_encryptor.encrypt(&client_query.aad, &client_query_bytes)?;
+            let aad = client_query.aad.clone();
+            let data = store_encryptor.encrypt(&aad, &client_query_bytes)?;
+            let channel_id = client_query.channel_id.clone();
             results.push(EnclaveMessage {
-                aad: client_query.clone().aad,
-                channel_id: client_query.clone().channel_id,
+                aad,
+                channel_id,
                 data,
             });
         }

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -9,7 +9,10 @@ extern crate alloc;
 mod e_tx_out_store;
 use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
 
+use aes_gcm::Aes256Gcm;
 use alloc::vec::Vec;
+use core::ops::DerefMut;
+use mc_attest_ake::Ready;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage};
 use mc_common::logger::{log, Logger};
@@ -39,6 +42,13 @@ where
 
     /// Logger object
     logger: Logger,
+
+    /// Encrypts a QueryRequest for each individual Fog View Store.
+    /// TODO: Use a BTreeMap<FogViewShardLoadBalancerID,
+    /// BTreeMap<FogViewStoreId, Ready<...>>>  when implement the cursoring
+    /// optimization. For right now, it's fine to leave as a Vec because a
+    /// follow up PR will implement cursoring.
+    store_encryptors: Mutex<Vec<Ready<Aes256Gcm>>>,
 }
 
 impl<OSC> ViewEnclave<OSC>
@@ -48,6 +58,7 @@ where
     pub fn new(logger: Logger) -> Self {
         Self {
             e_tx_out_store: Mutex::new(None),
+            store_encryptors: Mutex::new(Vec::new()),
             ake: Default::default(),
             logger,
         }
@@ -182,6 +193,29 @@ where
         for rec in records {
             store.add_record(&rec.search_key, &rec.payload)?;
         }
+
         Ok(())
+    }
+
+    /// Takes in a client's query request and returns a list of query requests
+    /// to be sent off to each Fog View Store shard.
+    fn create_multi_view_store_query_data(
+        &self,
+        client_query: EnclaveMessage<ClientSession>,
+    ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
+        let client_query_bytes = self.ake.client_decrypt(client_query.clone())?;
+
+        let mut encryptors = self.store_encryptors.lock()?;
+        let mut results = Vec::new();
+        for store_encryptor in encryptors.deref_mut() {
+            let data = store_encryptor.encrypt(&client_query.aad, &client_query_bytes)?;
+            results.push(EnclaveMessage {
+                aad: client_query.clone().aad,
+                channel_id: client_query.clone().channel_id,
+                data,
+            });
+        }
+
+        Ok(results)
     }
 }

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -179,4 +179,15 @@ impl ViewEnclaveApi for SgxViewEnclave {
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
+
+    fn create_multi_view_store_query_data(
+        &self,
+        client_query: EnclaveMessage<ClientSession>,
+    ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::CreateMultiViewStoreQuery(
+            client_query,
+        ))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
 }

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "mc-attest-enclave-api",
  "mc-common",
  "mc-crypto-keys",
+ "mc-crypto-noise",
  "mc-fog-recovery-db-iface",
  "mc-fog-types",
  "mc-sgx-compat",
@@ -1104,7 +1105,9 @@ dependencies = [
 name = "mc-fog-view-enclave-impl"
 version = "1.3.0-pre0"
 dependencies = [
+ "aes-gcm",
  "aligned-cmov",
+ "mc-attest-ake",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-common",

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -120,6 +120,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }
         ViewEnclaveRequest::AddRecords(records) => serialize(&ENCLAVE.add_records(records)),
+        ViewEnclaveRequest::CreateMultiViewStoreQuery(client_query) => {
+            serialize(&ENCLAVE.create_multi_view_store_query_data(client_query))
+        }
     }
     .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }

--- a/fog/view/server/src/fog_view_router_service.rs
+++ b/fog/view/server/src/fog_view_router_service.rs
@@ -2,6 +2,7 @@
 
 use futures::{future::try_join_all, FutureExt, SinkExt, TryFutureExt, TryStreamExt};
 use grpcio::{DuplexSink, RequestStream, RpcContext, WriteFlags};
+use mc_attest_api::attest;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse},
@@ -95,7 +96,12 @@ async fn handle_request<E: ViewEnclaveProxy>(
                 }
             }
         } else if request.has_query() {
-            log::info!(logger, "Request has query");
+            let query: attest::Message = request.take_query();
+            // TODO: In the next PR, use this _shard_query_data to construct a
+            //  MultiViewStoreQuery and send it off to the Fog View Load
+            //  Balancers.
+            let _multi_view_store_query_data =
+                enclave.create_multi_view_store_query_data(query.into());
             let _result = route_query(shards.clone(), logger.clone()).await;
 
             let response = FogViewRouterResponse::new();


### PR DESCRIPTION
### Motivation

This is the second PR for the Fog View Router project. As described in the design [doc](https://docs.google.com/document/d/1-ju5efGK6vvuYjxj1pKhfFcpgGlornuxZYvOC-nsbjs/edit), the router receives a client query request, decrypts it, and then re-encrypts it for each Fog View Store that it knows about. This PR implements the view enclave API that performs this decryption and re-encryption step. In the next PR, I'll implement the logic that takes the output of this API and creates a MultiViewStoreQuery (see the design doc for the definition of this message)

Addresses the second item in #2028 

### Future Work
- Use the output of the API to create the MultiViewStoreQuery and send it to the Fog View Load Balancers