### PR TITLE
Update all crate versions to match the current version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "1.0.0"
+version = "1.3.0-pre0"
 dependencies = [
  "clap 3.1.18",
  "displaydoc",
@@ -5202,7 +5202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "0.1.0"
+version = "1.3.0-pre0"
 dependencies = [
  "clap 3.1.18",
  "mc-util-build-info",

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.0'
+version '1.3.0-pre0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -71,10 +71,5 @@ slog-stdlog = { version = "4.1.1", optional = true }
 slog-term = { version = "2.9", optional = true }
 
 [dev-dependencies]
+proptest = { version = "1.0", default-features = false, features = ["default-code-coverage"] }
 scoped_threadpool = "0.1.*"
-
-[dev-dependencies.proptest]
-version = "1.0" # Only works for 0.9.1 or newer
-default-features = false
-# Enable all default features not known to break code coverage builds
-features = ["default-code-coverage"]

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "1.0.0"
+version = "1.3.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "0.1.0"
+version = "1.3.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 


### PR DESCRIPTION
`mc-util-cli` and `go-grpc-gateway-testing` depend on `mc-*` crates, so use the same version.

Found via the following command: `find . -iname "*.toml" | xargs grep '^version *=' | grep -v 'version = "1.3.0-pre0"'`
With this change, this command no longer yields any results.