### PR TITLE
Improve `VerificationReport` rendering in logs

### DIFF
--- a/sgx/report-cache/untrusted/src/lib.rs
+++ b/sgx/report-cache/untrusted/src/lib.rs
@@ -176,7 +176,7 @@ impl<E: ReportableEnclave, R: RaClient> ReportCache<E, R> {
         let retval = self.ra_client.verify_quote(&quote, Some(ias_nonce))?;
         log::debug!(
             self.logger,
-            "Quote verified by remote attestation service {:?}...",
+            "Quote verified by remote attestation service: {}",
             retval,
         );
         let report_body = VerificationReportData::try_from(&retval)


### PR DESCRIPTION
The current output is unwieldy.

<details>
<summary>Sample output</summary>

Before: `2022-06-10 21:36:16.721963255 UTC DEBG Quote verified by remote attestation service VerificationReport { sig: VerificationSignature([8, 169, 184, 224, 61, 130, 40, 71, 160, 184, 190, 253, 183, 243, 44, 101, 161, 101, 134, 165, 136, 187, 103, 1, 160, 10, 10, 49, 35, 120, 209, 78, 38, 55, 244, 65, 175, 42, 18, 248, 34, 25, 44, 31, 55, 178, 74, 120, 215, 130, 123, 132, 136, 155, 112, 241, 184, 153, 41, 247, 253, 57, 122, 184, 161, 150, 15, 101, 20, 211, 112, 249, 243, 2, 117, 15, 169, 73, 59, 54, 193, 106, 148, 172, 123, 1, 180, 54, 70, 230, 66, 57, 121, 190, 243, 82, 49, 114, 81, 203, 7, 144, 99, 169, 53, 34, 48, 184, 221, 191, 204, 116, 47, 101, 181, 119, 87, 13, 129, 74, 53, 161, 77, 170, 35, 37, 25, 158, 234, 129, 91, 98, 28, 83, 0, 255, 133, 94, 228, 138, 213, 183, 247, 203, 76, 163, 142, 252, 164, 124, 45, 175, 149, 41, 96, 169, 96, 166, 50, 10, 213, 77, 37, 121, 120, 115, 147, 112, 200, 153, 88, 228, 11, 171, 209, 207, 44, 2, 149, 22, 231, 77, 25, 37, 18, 8, 106, 141, 61, 250, 179, 229, 32, 167, 13, 248, 200, 210, 16, 27, 96, 198, 83, 202, 121, 184, 205, 66, 81, 253, 59, 104, 217, 228, 23, 142, 151, 63, 213, 80, 141, 18, 45, 31, 169, 2, 162, 252, 176, 23, 185, 149, 251, 155, 89, 79, 36, 249, 170, 252, 184, 126, 112, 234, 30, 217, 165, 184, 117, 28, 117, 10, 162, 28, 186, 128]), chain: [[48, 130, 4, 181, 48, 130, 3, 29, 160, 3, 2, 1, 2, 2, 1, 1, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 11, 5, 0, 48, 129, 137, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 11, 48, 9, 6, 3, 85, 4, 8, 12, 2, 67, 65, 49, 20, 48, 18, 6, 3, 85, 4, 7, 12, 11, 83, 97, 110, 116, 97, 32, 67, 108, 97, 114, 97, 49, 26, 48, 24, 6, 3, 85, 4, 10, 12, 17, 73, 110, 116, 101, 108, 32, 67, 111, 114, 112, 111, 114, 97, 116, 105, 111, 110, 49, 59, 48, 57, 6, 3, 85, 4, 3, 12, 50, 83, 105, 109, 117, 108, 97, 116, 105, 111, 110, 32, 73, 110, 116, 101, 108, 32, 83, 71, 88, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 32, 82, 101, 112, 111, 114, 116, 32, 83, 105, 103, 110, 105, 110, 103, 32, 67, 65, 48, 30, 23, 13, 50, 50, 48, 54, 49, 48, 50, 48, 50, 54, 53, 49, 90, 23, 13, 50, 50, 48, 54, 49, 55, 50, 49, 50, 54, 53, 49, 90, 48, 129, 137, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 11, 48, 9, 6, 3, 85, 4, 8, 12, 2, 67, 65, 49, 20, 48, 18, 6, 3, 85, 4, 7, 12, 11, 83, 97, 110, 116, 97, 32, 67, 108, 97, 114, 97, 49, 26, 48, 24, 6, 3, 85, 4, 10, 12, 17, 73, 110, 116, 101, 108, 32, 67, 111, 114, 112, 111, 114, 97, 116, 105, 111, 110, 49, 59, 48, 57, 6, 3, 85, 4, 3, 12, 50, 83, 105, 109, 117, 108, 97, 116, 105, 111, 110, 32, 73, 110, 116, 101, 108, 32, 83, 71, 88, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 32, 82, 101, 112, 111, 114, 116, 32, 83, 105, 103, 110, 105, 110, 103, 32, 67, 65, 48, 130, 1, 162, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 1, 5, 0, 3, 130, 1, 143, 0, 48, 130, 1, 138, 2, 130, 1, 129, 0, 226, 160, 131, 168, 112, 166, 147, 51, 51, 47, 57, 79, 1, 159, 247, 234, 67, 26, 163, 110, 109, 22, 211, 153, 60, 200, 59, 98, 98, 46, 200, 178, 104, 17, 196, 6, 89, 199, 52, 167, 123, 44, 15, 25, 207, 120, 34, 144, 6, 58, 184, 92, 235, 221, 21, 211, 12, 130, 83, 239, 181, 239, 10, 14, 189, 52, 218, 62, 125, 116, 231, 203, 177, 103, 185, 12, 82, 28, 88, 164, 134, 10, 28, 220, 222, 67, 144, 244, 122, 119, 168, 180, 104, 93, 65, 65, 86, 144, 15, 88, 168, 155, 187, 160, 164, 218, 80, 90, 166, 3, 116, 244, 117, 46, 227, 249, 206, 151, 161, 104, 173, 76, 226, 100, 101, 121, 15, 155, 35, 255, 156, 243, 200, 226, 52, 88, 151, 143, 203, 240, 237, 24, 88, 115, 59, 224, 115, 161, 226, 24, 162, 204, 74, 227, 63, 214, 87, 95, 157, 164, 96, 196, 187, 245, 165, 27, 56, 254, 164, 30, 205, 204, 144, 133, 138, 105, 114, 119, 149, 19, 214, 187, 8, 55, 155, 140, 76, 239, 151, 113, 42, 100, 10, 26, 133, 160, 126, 202, 113, 74, 121, 18, 238, 217, 247, 234, 203, 69, 60, 41, 151, 194, 89, 138, 137, 34, 114, 233, 242, 196, 241, 48, 215, 116, 177, 152, 154, 75, 83, 132, 212, 125, 163, 141, 21, 85, 249, 28, 13, 59, 118, 74, 222, 239, 152, 120, 44, 79, 186, 79, 171, 39, 106, 161, 90, 87, 219, 130, 62, 161, 225, 242, 3, 49, 19, 214, 218, 75, 175, 100, 237, 116, 63, 82, 37, 180, 67, 189, 11, 42, 16, 203, 181, 61, 206, 211, 107, 174, 57, 147, 197, 255, 107, 112, 134, 229, 169, 170, 119, 70, 76, 61, 193, 223, 125, 163, 196, 13, 167, 126, 82, 27, 50, 9, 63, 233, 175, 62, 244, 225, 215, 239, 255, 160, 124, 130, 58, 33, 239, 203, 121, 151, 208, 252, 3, 207, 199, 236, 176, 7, 15, 13, 104, 40, 103, 35, 203, 93, 65, 124, 1, 227, 65, 64, 213, 99, 134, 96, 112, 188, 122, 108, 41, 33, 42, 65, 211, 30, 217, 36, 163, 217, 222, 125, 129, 65, 231, 72, 53, 151, 249, 217, 147, 55, 2, 3, 1, 0, 1, 163, 38, 48, 36, 48, 18, 6, 3, 85, 29, 19, 1, 1, 255, 4, 8, 48, 6, 1, 1, 255, 2, 1, 0, 48, 14, 6, 3, 85, 29, 15, 1, 1, 255, 4, 4, 3, 2, 1, 6, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 11, 5, 0, 3, 130, 1, 129, 0, 218, 218, 61, 150, 191, 67, 211, 111, 1, 107, 81, 96, 212, 82, 128, 172, 224, 167, 184, 80, 207, 103, 189, 171, 11, 49, 197, 239, 241, 178, 208, 117, 100, 204, 244, 189, 60, 153, 252, 16, 209, 137, 185, 4, 230, 27, 86, 223, 102, 12, 119, 252, 113, 89, 177, 55, 186, 92, 80, 63, 181, 248, 90, 131, 111, 113, 73, 207, 175, 227, 130, 150, 227, 204, 109, 68, 22, 72, 5, 243, 253, 102, 203, 214, 120, 173, 188, 177, 183, 5, 31, 8, 77, 177, 199, 11, 236, 93, 132, 251, 154, 113, 29, 163, 52, 122, 194, 130, 246, 123, 83, 26, 131, 244, 25, 142, 27, 169, 157, 241, 118, 94, 68, 116, 196, 187, 35, 240, 45, 105, 170, 204, 220, 249, 80, 192, 102, 16, 188, 192, 34, 210, 114, 4, 94, 98, 70, 246, 40, 217, 184, 6, 23, 24, 155, 16, 172, 135, 65, 41, 80, 74, 134, 229, 166, 92, 147, 154, 35, 191, 37, 6, 16, 83, 162, 33, 16, 248, 216, 159, 157, 163, 119, 27, 50, 8, 72, 161, 103, 190, 171, 226, 136, 52, 81, 27, 68, 103, 194, 54, 109, 23, 244, 207, 112, 152, 62, 46, 210, 123, 228, 145, 32, 192, 122, 231, 1, 197, 153, 135, 81, 215, 134, 233, 37, 23, 79, 93, 248, 155, 38, 53, 22, 194, 44, 12, 137, 138, 72, 213, 30, 91, 138, 4, 65, 98, 17, 178, 157, 193, 167, 99, 118, 60, 52, 215, 188, 128, 196, 42, 30, 45, 30, 124, 58, 129, 85, 158, 215, 110, 70, 251, 220, 225, 254, 40, 180, 130, 100, 33, 248, 61, 136, 81, 160, 166, 2, 53, 52, 204, 84, 173, 206, 75, 103, 84, 160, 191, 180, 206, 22, 116, 44, 107, 21, 251, 197, 48, 253, 132, 213, 51, 207, 98, 83, 159, 33, 81, 141, 99, 67, 63, 151, 108, 210, 166, 23, 108, 15, 88, 87, 128, 74, 120, 143, 124, 24, 185, 50, 99, 39, 224, 72, 26, 230, 55, 136, 212, 234, 18, 75, 48, 232, 133, 148, 86, 90, 101, 130, 33, 155, 218, 215, 88, 235, 250, 48, 53, 254, 145, 155, 98, 231, 104, 140, 174, 222, 231, 249, 179, 137, 80, 200, 204], [48, 130, 4, 40, 48, 130, 2, 144, 160, 3, 2, 1, 2, 2, 1, 2, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 11, 5, 0, 48, 129, 137, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 11, 48, 9, 6, 3, 85, 4, 8, 12, 2, 67, 65, 49, 20, 48, 18, 6, 3, 85, 4, 7, 12, 11, 83, 97, 110, 116, 97, 32, 67, 108, 97, 114, 97, 49, 26, 48, 24, 6, 3, 85, 4, 10, 12, 17, 73, 110, 116, 101, 108, 32, 67, 111, 114, 112, 111, 114, 97, 116, 105, 111, 110, 49, 59, 48, 57, 6, 3, 85, 4, 3, 12, 50, 83, 105, 109, 117, 108, 97, 116, 105, 111, 110, 32, 73, 110, 116, 101, 108, 32, 83, 71, 88, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 32, 82, 101, 112, 111, 114, 116, 32, 83, 105, 103, 110, 105, 110, 103, 32, 67, 65, 48, 30, 23, 13, 50, 50, 48, 54, 49, 48, 50, 48, 50, 54, 53, 49, 90, 23, 13, 50, 50, 48, 54, 49, 55, 50, 49, 50, 54, 53, 49, 90, 48, 129, 133, 49, 11, 48, 9, 6, 3, 85, 4, 6, 19, 2, 85, 83, 49, 11, 48, 9, 6, 3, 85, 4, 8, 12, 2, 67, 65, 49, 20, 48, 18, 6, 3, 85, 4, 7, 12, 11, 83, 97, 110, 116, 97, 32, 67, 108, 97, 114, 97, 49, 26, 48, 24, 6, 3, 85, 4, 10, 12, 17, 73, 110, 116, 101, 108, 32, 67, 111, 114, 112, 111, 114, 97, 116, 105, 111, 110, 49, 55, 48, 53, 6, 3, 85, 4, 3, 12, 46, 83, 105, 109, 117, 108, 97, 116, 105, 111, 110, 32, 73, 110, 116, 101, 108, 32, 83, 71, 88, 32, 65, 116, 116, 101, 115, 116, 97, 116, 105, 111, 110, 32, 82, 101, 112, 111, 114, 116, 32, 83, 105, 103, 110, 101, 114, 48, 130, 1, 34, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 1, 5, 0, 3, 130, 1, 15, 0, 48, 130, 1, 10, 2, 130, 1, 1, 0, 205, 218, 252, 23, 76, 239, 120, 224, 230, 208, 181, 47, 78, 58, 159, 183, 115, 182, 107, 43, 169, 202, 198, 84, 141, 10, 132, 8, 58, 176, 202, 187, 194, 140, 29, 84, 93, 40, 112, 8, 137, 244, 255, 143, 166, 181, 42, 145, 156, 40, 93, 176, 230, 254, 163, 123, 130, 212, 49, 142, 102, 27, 205, 110, 185, 41, 121, 26, 38, 238, 90, 8, 175, 82, 94, 155, 235, 35, 175, 249, 4, 135, 88, 241, 94, 25, 209, 67, 26, 242, 51, 234, 6, 13, 56, 170, 186, 111, 228, 125, 60, 73, 57, 237, 122, 221, 141, 248, 149, 11, 133, 243, 197, 143, 231, 66, 67, 189, 204, 236, 36, 166, 76, 19, 4, 149, 188, 188, 154, 223, 57, 200, 192, 166, 36, 72, 166, 67, 61, 121, 120, 153, 134, 177, 171, 132, 39, 52, 190, 3, 139, 212, 46, 74, 190, 85, 44, 193, 143, 28, 7, 185, 5, 127, 246, 84, 85, 183, 34, 222, 164, 73, 100, 115, 232, 243, 27, 116, 118, 144, 2, 200, 154, 227, 10, 159, 244, 92, 140, 111, 228, 227, 18, 42, 252, 160, 83, 231, 244, 143, 121, 110, 53, 214, 88, 231, 9, 44, 120, 226, 78, 43, 165, 19, 245, 247, 45, 44, 219, 129, 230, 18, 121, 222, 115, 202, 1, 139, 4, 82, 97, 206, 38, 141, 25, 5, 40, 1, 157, 67, 75, 239, 67, 189, 164, 63, 42, 27, 48, 170, 239, 82, 215, 112, 34, 247, 2, 3, 1, 0, 1, 163, 29, 48, 27, 48, 9, 6, 3, 85, 29, 19, 4, 2, 48, 0, 48, 14, 6, 3, 85, 29, 15, 1, 1, 255, 4, 4, 3, 2, 6, 192, 48, 13, 6, 9, 42, 134, 72, 134, 247, 13, 1, 1, 11, 5, 0, 3, 130, 1, 129, 0, 168, 96, 154, 211, 190, 75, 50, 191, 98, 59, 72, 107, 162, 9, 216, 180, 252, 95, 247, 34, 83, 235, 72, 223, 87, 152, 36, 239, 151, 138, 220, 41, 151, 64, 6, 75, 168, 114, 148, 65, 42, 117, 137, 44, 203, 38, 92, 208, 246, 90, 84, 100, 131, 151, 200, 241, 35, 1, 214, 186, 41, 254, 255, 240, 48, 50, 170, 149, 187, 23, 103, 41, 250, 53, 0, 76, 215, 249, 130, 72, 191, 220, 106, 229, 92, 91, 160, 64, 1, 66, 78, 20, 49, 207, 223, 227, 139, 221, 135, 75, 180, 103, 121, 81, 195, 149, 70, 129, 25, 108, 11, 50, 141, 95, 140, 90, 179, 128, 253, 4, 222, 116, 123, 153, 244, 32, 21, 146, 205, 187, 111, 208, 140, 49, 29, 209, 214, 248, 224, 24, 115, 208, 153, 131, 135, 69, 171, 126, 77, 166, 119, 151, 156, 111, 177, 221, 80, 216, 41, 189, 73, 27, 196, 247, 7, 200, 230, 5, 161, 84, 210, 165, 62, 35, 2, 132, 123, 82, 68, 13, 156, 165, 79, 221, 81, 220, 13, 88, 64, 211, 24, 197, 13, 173, 204, 52, 83, 200, 161, 3, 35, 61, 211, 6, 102, 214, 69, 108, 39, 153, 15, 205, 98, 217, 187, 239, 130, 8, 220, 4, 217, 162, 160, 226, 41, 243, 203, 85, 32, 53, 200, 132, 145, 175, 82, 174, 255, 247, 254, 121, 107, 35, 249, 119, 215, 201, 206, 225, 221, 213, 143, 62, 134, 254, 202, 230, 172, 230, 206, 210, 112, 135, 89, 120, 22, 16, 72, 86, 69, 35, 168, 30, 238, 107, 216, 59, 146, 68, 196, 92, 87, 243, 174, 45, 79, 58, 166, 16, 129, 197, 94, 195, 211, 237, 16, 26, 235, 102, 205, 165, 218, 92, 191, 140, 181, 212, 247, 162, 128, 189, 236, 244, 96, 222, 216, 16, 244, 149, 71, 176, 155, 232, 210, 75, 182, 201, 238, 5, 179, 96, 195, 236, 202, 76, 148, 250, 67, 73, 26, 44, 193, 100, 101, 230, 1, 1, 76, 144, 173, 129, 57, 143, 170, 10, 178, 55, 161, 175, 151, 74, 162, 214, 65, 159, 38, 181, 216, 84, 209, 84, 29, 177, 230, 165, 191, 159, 9, 247, 79, 100, 199, 74, 58, 17]], http_body: "{\"epidPseudonym\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"id\":\"0\",\"isvEnclaveQuoteBody\":\"AgABAAsAAADvAO8A7+/v7wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASCDzN2rmsvIDTTt6S0ineAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAADnAAAAAAAAALvYOm8ASLCrlvtM8L2gv+zPhSF6+63ZBrQ8h+qTzfIXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOkkUC6Zg3R85BGn4kvFwK64EOA6eBTLvMrWnLX94VwQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdwTZpu6Do1P1I+jhLMKRAq6GWJkjO2xZJ0Y9rFmdrTFIQVJ5kWH8k+2vwYxqsG4jv9IE3jZ7fN6qIoP9uhPLYqAIAAO7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7mCvDkiT/Mu6YAhcM2gBAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u6vcGxtdE8m+w8qm6bCgT4K\",\"isvEnclaveQuoteStatus\":\"OK\",\"nonce\":\"0c2ce2f86adfb6a7d6eb040e74293feb\",\"timestamp\":\"2020-06-30T22:16:41.409742\",\"version\":4}" }..., mc.enclave_type: mc_consensus_enclave::ConsensusServiceSgxEnclave, mc.local_node_id: localhost:3300, mc.app: consensus-service, mc.module: mc_sgx_report_cache_untrusted, mc.src: sgx/report-cache/untrusted/src/lib.rs:177`

After: `2022-06-10 22:04:49.419087984 UTC DEBG Quote verified by remote attestation service: VerificationReport { sig: 8aedc3a843a2947c940dbcdb26b1e76ede687ffb5e3a74428a7d514308a3d6c8e7818df6116002a9a77c7b296a8f61a6c2cd00a8b7f0be66ea62a7a5ae54e49e411838921d7eeb2761f352d497cd177917c12e88c80e9054cb332c4a6b16ba18e56fef0009a2640ff0ed5f22bbab57966ea56140adf735e02302e80cf1ffaca9ba19db4954c5a7698a73543618e3556f62f61fc4b953bd658e72c58b94f6744694593e71899439a898a648bcbb0a18cc8204189a886e756fd1b9f6193ea268820fd1a9391b0290207af43a93c805684e61b584f5979764ea0b458e22951bb247ae61fde1968860ebac3a2066e1eb9b2247779835bd6de525927fa5860a3a5ef0, chain: [308204b53082031da003020102020101300d06092a864886f70d01010b0500308189310b3009060355040613025553310b300906035504080c0243413114301206035504070c0b53616e746120436c617261311a3018060355040a0c11496e74656c20436f72706f726174696f6e313b303906035504030c3253696d756c6174696f6e20496e74656c20534758204174746573746174696f6e205265706f7274205369676e696e67204341301e170d3232303631303230353933375a170d3232303631373231353933375a308189310b3009060355040613025553310b300906035504080c0243413114301206035504070c0b53616e746120436c617261311a3018060355040a0c11496e74656c20436f72706f726174696f6e313b303906035504030c3253696d756c6174696f6e20496e74656c20534758204174746573746174696f6e205265706f7274205369676e696e67204341308201a2300d06092a864886f70d01010105000382018f003082018a0282018100a660f56254d60c16d27cc583c10ff4a1910fbaabac4aae7849f3caec63f632aa89af7523db5aba61b71e2225210aad01967493cf29e4960fab47d528d6aee728d9b375cacad96dcaf9a69da31c9bc5de7be2141f451f5f55b585c679f248cb69f05cf781f812589da6cc063986dde7694ff8d7eaa392cbff8435f869855c78a8c72e2cd92efe9a51165d54dd99a054f249a865396774b2b209a04e01d26920877c10620fdae262311bccb862687c73fa8b051ac19854e7dd567b89efe1367951b4b00775514d69be0e9cb66e940871c624a428e659a04251277a8ce21e4836ad7b8b0580d615f880d6c47be055cb90f86b1963b8c105d4b30c892128f41b5734b4a45431fe523542919d6adda5c7feee5efb9e3ddc08492a93a85509e1883496d55b8142d87615a0101632c9cf9c0119438d42a8b239a6b924eb8c58e1b092fdc9d2d19b011f9808dc7caadeae1776497194554f4d5c438dffb06d2cd5d562aa6a2a6738901edc7a4236933660bb1442159a588dd3bf481c21cbe75c5ef7e0390203010001a326302430120603551d130101ff040830060101ff020100300e0603551d0f0101ff040403020106300d06092a864886f70d01010b050003820181007ad7b3dd1c2fc1722b0b69f75b882e37d9d271c5f4fd724bb396af12f3dfb960c4df88a43b3106236f6a9918d80e7d61e3664ed756423ca96857d8b6c8e8df3ea68ad9a8fe9bd80a4d1064ffd316d7df0d27787d3c592dd2c12750c04f79f70570d82e12031a5875df9d3ebb85ab41f71128eba97108c4c34da4e222622d39a174ffdc1110bb45788963fcf038e4f1abde1fd29418e24d2b4ac1d9568bd0af372741f18ded91496a01e7719d78566dc81ab1e94078c8efecf7f9b9a00a2346206ee084549d1d0cba8dce05c62008367d93ebe282e97a2c49fc8eecceb9bb2c7d7c19c634c7764aed1be055c5b805b4594da4680677b41d717460c3a5cd500d73cc348a75c0dea3029b685368a029b0768ce45ae1f302e2f44ffd4618a74588b95b38919fbdae731d80464badf6ec44843356ceafba3ceb69e8f6dd37e870a403e7b37dcc19ea39e5731c5d5c1be98274d0c56f20b1ffee0049c7f7bba42238dd749fb2885e75777ea541d897e924dc5c03714c628aaf37cc4cd295aba5f7f471, 3082042830820290a003020102020102300d06092a864886f70d01010b0500308189310b3009060355040613025553310b300906035504080c0243413114301206035504070c0b53616e746120436c617261311a3018060355040a0c11496e74656c20436f72706f726174696f6e313b303906035504030c3253696d756c6174696f6e20496e74656c20534758204174746573746174696f6e205265706f7274205369676e696e67204341301e170d3232303631303230353933375a170d3232303631373231353933375a308185310b3009060355040613025553310b300906035504080c0243413114301206035504070c0b53616e746120436c617261311a3018060355040a0c11496e74656c20436f72706f726174696f6e3137303506035504030c2e53696d756c6174696f6e20496e74656c20534758204174746573746174696f6e205265706f7274205369676e657230820122300d06092a864886f70d01010105000382010f003082010a0282010100ba7f881b4ce4e324e22dbeaf3a720988fc0055648b36322091405236ee875827287d518b003c69c64b6080cdb4eeea9941c582124cd94bd4432735c77d959f2f0cf5745131cb19662f33165461ef2e43b6e459cbab60ac29b4d8543f2581eb04b202fa25294c9cfe4f56f3e000ade0f831778fc9c2d427f199cc490da565ab76e36097b7e1dd7637de32325e033de3f42adb3b5eeafeefd362f65b2dd132d6cf09d23a1015a23380946ad98415e73ac602a5e9e2fa82c3bf62451e51db325838b1accbef5016c2c8512c9829f7a2a5079ddee56654a4108c53439309ad704a8ccd6167983d280bf5844d7ede4532b8fd5104bc0308cb59e269516e30951a128d0203010001a31d301b30090603551d1304023000300e0603551d0f0101ff0404030206c0300d06092a864886f70d01010b0500038201810040aa9a33e762aaf6a07ba494726596f6893fd27581375145b783fbba4ced0216e08d681939745885be6c717e9897dbe71f66d54b624b6b00afd1b273e0c86c5384fad8389df0982ba44ec5271214f024da98a27ae40818e38987b6cb78f2c2396055cbde98ad542e988943cd5065ad79083ebdcebf8abe9072fd65c880ca51ad8a4fb89fc80b01ba57aec5f41dd769d8e358b283d82f491361afdf23b13b75075fb05e0c2827bab223b944a4709076edb38de47f185dc665922305cb441b6b8588f8160bbf45a733684558a3d61a65dad393485c35a4b79c08e3c0f7ee5f39a030edf92b9b5b9df2fa7be13d526ae87c3acc826be7c31b5d2b36c48b52a9c1eb58ed7593d5ca7a975f0aaa87ea0f1c77b71e2e72896e67efcc128c401db0a4bc588656119655da2b8a3cbc14b1d4708f3da3283c8024b91e7702ce801d6fb45fb7a6f6bd499fa6e11d5e100b3e0b6718d67f3beca25891253535cf3cecf97af8908f04b775cc9732e9adc8a4bcef084604f63c02feefbe9f959c7f998ad2e9ed], http_body: "{\"epidPseudonym\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\",\"id\":\"0\",\"isvEnclaveQuoteBody\":\"AgABAAsAAADvAO8A7+/v7wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASCDzN2rmsvIDTTt6S0ineAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAADnAAAAAAAAAPRdP878gy18RhqC7WkFhQjN49IN0vnbudbZ728peg4zAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADjguPwlEGdVsIZB1/CSLtHFMxFpRoTGRG2rE+XrXA/XgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABKQAiEbrYNlioE5FPVjJe0iqMN09WW+46bYDKvbLJHJjvd71yw9mWQB0b7AvPDa4+SmpwKI6t8itdSkbmFkbIEqAIAAO7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7vUhUSNp0Wv78U30/2gBAADu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u53QUCDy2l6Fx6GTS4G0p7R\",\"isvEnclaveQuoteStatus\":\"OK\",\"nonce\":\"e29384bd0112d53516a5f30daa73526a\",\"timestamp\":\"2020-06-30T22:16:41.409742\",\"version\":4}" }, mc.enclave_type: mc_consensus_enclave::ConsensusServiceSgxEnclave, mc.local_node_id: localhost:3300, mc.app: consensus-service, mc.module: mc_sgx_report_cache_untrusted, mc.src: sgx/report-cache/untrusted/src/lib.rs:177`
</details>