### PR TITLE
Mark some attestation errors as not retriable

### DIFF
--- a/connection/src/error.rs
+++ b/connection/src/error.rs
@@ -40,7 +40,11 @@ pub enum Error {
 impl Error {
     /// Policy decision, whether the call should be retried.
     pub fn should_retry(&self) -> bool {
-        matches!(self, Error::Grpc(_) | Error::Attestation(_))
+        match self {
+            Error::Grpc(_) => true,
+            Error::Attestation(err) => err.should_retry(),
+            _ => false,
+        }
     }
 }
 

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -125,7 +125,7 @@ impl AttestationError for ThickClientAttestationError {
             Self::Grpc(_) | Self::Cipher(_) | Self::CredentialsProvider(_) => true,
             Self::Ake(AkeError::ReportVerification(_)) => false,
             Self::Ake(_) => true,
-            _ => false,
+            Self::InvalidResponderID(_, _) | Self::UriConversionError(_) => false,
         }
     }
 }

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -119,6 +119,15 @@ impl AttestationError for ThickClientAttestationError {
     fn should_reattest(&self) -> bool {
         matches!(self, Self::Grpc(_) | Self::Ake(_) | Self::Cipher(_))
     }
+
+    fn should_retry(&self) -> bool {
+        match self {
+            Self::Grpc(_) | Self::Cipher(_) | Self::CredentialsProvider(_) => true,
+            Self::Ake(AkeError::ReportVerification(_)) => false,
+            Self::Ake(_) => true,
+            _ => false,
+        }
+    }
 }
 
 /// A connection from a client to a consensus enclave.

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -32,6 +32,12 @@ pub trait Connection: Display + Eq + Hash + Ord + PartialEq + PartialOrd + Send 
 pub trait AttestationError: Debug + Display + Send + Sync {
     /// Should the error result in re-attestation?
     fn should_reattest(&self) -> bool;
+
+    /// Should the error be retried?
+    /// Some errors like, failing to verify IAS report, are not retriable, since
+    /// report verification is deterministic and the report will probably not be
+    /// different the next time.
+    fn should_retry(self) -> bool;
 }
 
 pub trait AttestedConnection: Connection {

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -37,7 +37,7 @@ pub trait AttestationError: Debug + Display + Send + Sync {
     /// Some errors like, failing to verify IAS report, are not retriable, since
     /// report verification is deterministic and the report will probably not be
     /// different the next time.
-    fn should_retry(self) -> bool;
+    fn should_retry(&self) -> bool;
 }
 
 pub trait AttestedConnection: Connection {

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -30,10 +30,10 @@ impl AttestationError for Error {
 
     fn should_retry(&self) -> bool {
         match self {
-            Rpc(_) | Cipher(_) | ProtoDecode(_) => true,
-            Ake(AkeError::ReportVerification) => false,
-            Ake(_) => true,
-            InvalidUri(_) => false,
+            Error::Rpc(_) | Error::Cipher(_) | Error::ProtoDecode(_) => true,
+            Error::Ake(AkeError::ReportVerification(_)) => false,
+            Error::Ake(_) => true,
+            Error::InvalidUri(_) => false,
         }
     }
 }

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -23,15 +23,18 @@ pub enum Error {
     ProtoDecode(DecodeError),
 }
 
-impl Error {
-    pub fn should_retry(&self) -> bool {
-        matches!(self, Error::Rpc(_) | Error::Ake(_))
-    }
-}
-
 impl AttestationError for Error {
     fn should_reattest(&self) -> bool {
         matches!(self, Self::Rpc(_) | Self::Ake(_) | Self::Cipher(_))
+    }
+
+    fn should_retry(&self) -> bool {
+        match self {
+            Rpc(_) | Cipher(_) | ProtoDecode(_) => true,
+            Ake(AkeError::ReportVerification) => false,
+            Ake(_) => true,
+            InvalidUri(_) => false,
+        }
     }
 }
 

--- a/fog/enclave_connection/src/lib.rs
+++ b/fog/enclave_connection/src/lib.rs
@@ -16,7 +16,7 @@ use mc_common::{
     logger::{log, Logger},
     trace_time,
 };
-use mc_connection::{AttestedConnection, Connection};
+use mc_connection::{AttestationError, AttestedConnection, Connection};
 use mc_crypto_keys::X25519;
 use mc_crypto_rand::McRng;
 use mc_util_grpc::{BasicCredentials, GrpcCookieStore};

--- a/fog/ingest/server/src/connection_error.rs
+++ b/fog/ingest/server/src/connection_error.rs
@@ -118,4 +118,8 @@ impl AttestationError for PeerAttestationError {
     fn should_reattest(&self) -> bool {
         true
     }
+
+    fn should_retry(&self) -> bool {
+        true
+    }
 }

--- a/peers/src/error.rs
+++ b/peers/src/error.rs
@@ -156,4 +156,8 @@ impl AttestationError for PeerAttestationError {
     fn should_reattest(&self) -> bool {
         true
     }
+
+    fn should_retry(&self) -> bool {
+        true
+    }
 }


### PR DESCRIPTION
I noticed in testing that fog-distro retries infinitely on report
verification failures, which occur if you are using a slam with bad
sigstruct for the network.

This is partly because slam ignores whether errors are retriable.
But even thick client will retry on all attestation errors, because
the `should_retry` function considers all attestation errors retriable

This commit makes the `should_retry` logic more nuanced. Attestation errors
now also expose `should_retry`. The following errors are now
considered non-retriable, and all others are still retriable.

* Any attestation verification failure (because,
the verifier will be the same next time and the report will be too,
so it has no chance to succeed on retry)
* The responder id construction / uri parsing errors, because, the
uri will not be different next time so it has no chance to succeed on
retry.

If this is merged, then I will use the "should_retry" function to help
in a subsequent PR.