### PR TITLE
Add a `MetadataValidator` for validating block metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-blockchain-validators"
+version = "1.3.0-pre0"
+dependencies = [
+ "displaydoc",
+ "hex",
+ "mc-blockchain-test-utils",
+ "mc-blockchain-types",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "mc-util-test-helper",
+ "pem",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "mc-common"
 version = "1.3.0-pre0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "attest/verifier",
     "attest/verifier/types",
     "blockchain/types",
+    "blockchain/validators",
     "common",
     "connection",
     "connection/test-utils",

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mc-blockchain-validators"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2021"
+
+[dependencies]
+# MobileCoin dependencies
+mc-blockchain-types = { path = "../types" }
+mc-crypto-keys = { path = "../../crypto/keys" }
+
+# External dependencies
+displaydoc = "0.2"
+hex = "0.4"
+pem = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+toml = "0.5"
+
+[dev-dependencies]
+mc-blockchain-test-utils = { path = "../test-utils" }
+mc-util-from-random = { path = "../../util/from-random" }
+mc-util-test-helper = { path = "../../util/test-helper" }
+
+tempfile = "3.3"

--- a/blockchain/validators/src/error.rs
+++ b/blockchain/validators/src/error.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Validator errors.
+
+use displaydoc::Display;
+use hex::FromHexError;
+use mc_crypto_keys::{KeyError, SignatureError};
+use pem::PemError;
+use serde_json::Error as JsonError;
+use std::{io::Error as IoError, path::PathBuf};
+use toml::de::Error as FromTomlError;
+
+/// Validator errors.
+#[derive(Debug, Display, Eq, PartialEq)]
+pub enum ValidationError {
+    /// Unrecognized public key.
+    UnknownPubKey,
+
+    /// Expired/Invalid public key.
+    InvalidPubKey,
+
+    /// Signature error: {0}
+    Signature(String),
+}
+
+impl From<SignatureError> for ValidationError {
+    fn from(src: SignatureError) -> Self {
+        Self::Signature(src.to_string())
+    }
+}
+
+/// Parsing errors
+#[derive(Debug, Display, PartialEq)]
+pub enum ParseError {
+    /// Unrecognized extension in '{0}'
+    UnrecognizedExtension(PathBuf),
+
+    /// Invalid pub_key value: {0}
+    InvalidPubKeyValue(String),
+
+    /// Failed to parse key: {0}
+    Key(KeyError),
+
+    /// I/O error: {0}
+    Io(String),
+
+    /// Failed to parse hexadecimal string: {0}
+    Hex(FromHexError),
+
+    /// Failed to parse PEM: {0}
+    Pem(PemError),
+
+    /// Invalid PEM tag: {0}
+    InvalidPemTag(String),
+
+    /// Failed to parse TOML: {0}
+    Toml(String),
+
+    /// Failed to parse JSON: {0}
+    Json(String),
+}
+
+impl From<KeyError> for ParseError {
+    fn from(src: KeyError) -> Self {
+        Self::Key(src)
+    }
+}
+
+impl From<IoError> for ParseError {
+    fn from(src: IoError) -> Self {
+        Self::Io(src.to_string())
+    }
+}
+
+impl From<FromHexError> for ParseError {
+    fn from(src: FromHexError) -> Self {
+        Self::Hex(src)
+    }
+}
+
+impl From<PemError> for ParseError {
+    fn from(src: PemError) -> Self {
+        Self::Pem(src)
+    }
+}
+
+impl From<FromTomlError> for ParseError {
+    fn from(src: FromTomlError) -> Self {
+        Self::Toml(src.to_string())
+    }
+}
+
+impl From<JsonError> for ParseError {
+    fn from(src: JsonError) -> Self {
+        Self::Json(src.to_string())
+    }
+}

--- a/blockchain/validators/src/lib.rs
+++ b/blockchain/validators/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Blockchain validators.
+
+#![deny(missing_docs)]
+
+pub mod error;
+pub mod metadata;
+#[cfg(test)]
+pub mod test_utils;
+
+pub use crate::{
+    error::{ParseError, ValidationError},
+    metadata::MetadataValidator,
+};

--- a/blockchain/validators/src/metadata/key_range/config.rs
+++ b/blockchain/validators/src/metadata/key_range/config.rs
@@ -1,0 +1,442 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Configuration for the key range validator.
+
+use crate::ParseError;
+use hex::ToHex;
+use mc_blockchain_types::BlockIndex;
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    fs,
+    ops::RangeInclusive,
+    path::{Path, PathBuf},
+};
+
+/// Container for keys with a range of block indexes that are valid per key.
+pub type KeyValidityMap = BTreeMap<Ed25519Public, Vec<RangeInclusive<BlockIndex>>>;
+
+const PUBLIC_KEY_TAG: &str = "PUBLIC KEY";
+
+/// Container for key validity configs.
+/// Supports parsing a `metadata-signers.toml` as specified in [MCIP #43](https://github.com/mobilecoinfoundation/mcips/pull/43).
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Config {
+    /// The key validity ranges.
+    #[serde(alias = "node")] // alias for parsing
+    pub configs: Vec<KeyValidity>,
+
+    /// Optional base path for parsing relative PEM file paths.
+    #[serde(skip)]
+    pub base_path: Option<PathBuf>,
+}
+
+impl Config {
+    /// Load the config as TOML or JSON from the given file path.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ParseError> {
+        let path = path.as_ref();
+        let bytes = fs::read(path)?;
+        let mut config: Config = match path.extension().and_then(OsStr::to_str) {
+            Some("toml") => Ok(toml::from_slice(&bytes)?),
+            Some("json") => Ok(serde_json::from_slice(&bytes)?),
+            _ => Err(ParseError::UnrecognizedExtension(path.into())),
+        }?;
+        config.base_path = path.parent().map(Into::into);
+        Ok(config)
+    }
+
+    /// Get a [KeyValidityMap] from this config.
+    pub fn to_validity_map(&self) -> Result<KeyValidityMap, ParseError> {
+        let mut map = KeyValidityMap::new();
+        for config in &self.configs {
+            let key = parse_pem_or_hex(&config.pub_key, self.base_path.clone())?;
+            map.entry(key).or_default().push(config.to_range());
+        }
+        Ok(map)
+    }
+}
+
+/// A declaration that a public key is valid for a specified range of block
+/// indexes.
+#[derive(Clone, Debug, Deserialize, Ord, PartialOrd, Serialize)]
+pub struct KeyValidity {
+    /// The pub key, as a PEM file path or 64 hexadecimal characters.
+    /// File paths are parsed relative to the config file.
+    #[serde(alias = "message_signing_pub_key")] // alias for parsing
+    pub pub_key: String,
+    /// The first block index that used this key.
+    pub first_block_index: BlockIndex,
+    /// The last block index that used this key. Can be `None` for active keys.
+    pub last_block_index: Option<BlockIndex>,
+}
+
+impl KeyValidity {
+    /// Instantiate an instance with the given serialized value and index range.
+    pub fn new(
+        pub_key: String,
+        first_block_index: BlockIndex,
+        // Allows passing `N`, `Some(N)` or `None`
+        last_block_index: impl Into<Option<BlockIndex>>,
+    ) -> Self {
+        Self {
+            pub_key,
+            first_block_index,
+            last_block_index: last_block_index.into(),
+        }
+    }
+
+    /// Instantiate an instance with the given pub key and index range.
+    pub fn with_key(
+        key: Ed25519Public,
+        first_block_index: BlockIndex,
+        // Allows passing `N`, `Some(N)` or `None`
+        last_block_index: impl Into<Option<BlockIndex>>,
+    ) -> Self {
+        Self::new(key.encode_hex(), first_block_index, last_block_index)
+    }
+
+    /// Get a range of indexes from this config.
+    pub fn to_range(&self) -> RangeInclusive<BlockIndex> {
+        self.first_block_index..=self.last_block_index.unwrap_or(BlockIndex::MAX)
+    }
+}
+
+impl PartialEq for KeyValidity {
+    fn eq(&self, other: &Self) -> bool {
+        self.first_block_index == other.first_block_index
+            && self.last_block_index == other.last_block_index
+            && self.pub_key.trim() == other.pub_key.trim()
+    }
+}
+impl Eq for KeyValidity {}
+
+/// A helper method for deserializing an Ed25519Public from a PEM string, PEM
+/// file path, or hexadecimal string.
+fn parse_pem_or_hex(
+    value: &str,
+    base_path: impl Into<Option<PathBuf>>,
+) -> Result<Ed25519Public, ParseError> {
+    let value = value.trim();
+
+    let base_path = base_path.into().or_else(|| std::env::current_dir().ok());
+    let path = if let Some(base) = base_path {
+        base.join(&value)
+    } else {
+        value.into()
+    };
+
+    Ok(if path.exists() {
+        let pem = pem::parse(fs::read(path)?)?;
+        if pem.tag == PUBLIC_KEY_TAG {
+            Ed25519Public::try_from_der(&pem.contents)?
+        } else {
+            Err(ParseError::InvalidPemTag(pem.tag))?
+        }
+    } else if let Ok(pem) = pem::parse(value) {
+        if pem.tag == PUBLIC_KEY_TAG {
+            Ed25519Public::try_from_der(&pem.contents)?
+        } else {
+            Err(ParseError::InvalidPemTag(pem.tag))?
+        }
+    } else if value.len() == 64 {
+        Ed25519Public::try_from(hex::decode(value)?)?
+    } else {
+        Err(ParseError::InvalidPubKeyValue(value.to_owned()))?
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    static INPUT_TOML: &str = r#"
+        # Key A is always valid.
+        [[node]]
+        pub_key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        first_block_index = 0
+
+        # Key B is only valid for the first 10 blocks.
+        [[node]]
+        pub_key = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        first_block_index = 0
+        last_block_index = 10
+
+        # Key C is valid for all blocks except 11..=19
+        [[node]]
+        pub_key = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        first_block_index = 0
+        last_block_index = 10
+
+        [[node]]
+        # Can also use `message_signing_pub_key`
+        message_signing_pub_key = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        first_block_index = 20
+    "#;
+
+    static INPUT_JSON: &str = r#"
+    {
+        "node": [
+            {
+                "pub_key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "first_block_index": 0
+            },
+            {
+                "pub_key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "first_block_index": 0,
+                "last_block_index": 10
+            },
+            {
+                "pub_key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "first_block_index": 0,
+                "last_block_index": 10
+            },
+            {
+                "message_signing_pub_key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "first_block_index": 20
+            }
+        ]
+    }
+    "#;
+
+    /// PEM encoding of the Ed25519Public key:
+    ///     0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    const KEY_A_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqo=\n-----END PUBLIC KEY-----";
+
+    /// PEM encoding of the Ed25519Public key:
+    ///     0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    const KEY_B_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAu7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7u7s=\n-----END PUBLIC KEY-----";
+
+    /// PEM encoding of the Ed25519Public key:
+    ///     0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+    const KEY_C_PEM: &str = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMw=\n-----END PUBLIC KEY-----";
+
+    fn make_pub_key(val: u8) -> Ed25519Public {
+        Ed25519Public::try_from(vec![val; 32]).unwrap()
+    }
+
+    #[test]
+    fn load_toml_from_path() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("metadata-signers.toml");
+        fs::write(&path, INPUT_TOML).unwrap();
+
+        let key_a = make_pub_key(0xAA);
+        let key_b = make_pub_key(0xBB);
+        let key_c = make_pub_key(0xCC);
+
+        // Parse the TOML.
+        let cfg = Config::load(&path).unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                configs: vec![
+                    KeyValidity::with_key(key_a, 0, None),
+                    KeyValidity::with_key(key_b, 0, 10),
+                    KeyValidity::with_key(key_c, 0, 10),
+                    KeyValidity::with_key(key_c, 20, None),
+                ],
+                base_path: path.parent().map(Into::into),
+            }
+        );
+
+        // Verify the validity map.
+        assert_eq!(
+            cfg.to_validity_map().unwrap(),
+            [
+                (key_a, vec![0..=BlockIndex::MAX]),
+                (key_b, vec![0..=10]),
+                (key_c, vec![0..=10, 20..=BlockIndex::MAX]),
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn load_json_from_path() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("metadata-signers.json");
+        fs::write(&path, INPUT_JSON).unwrap();
+
+        let key_a = make_pub_key(0xAA);
+        let key_b = make_pub_key(0xBB);
+        let key_c = make_pub_key(0xCC);
+
+        // Parse the JSON.
+        let cfg = Config::load(&path).unwrap();
+        assert_eq!(
+            cfg,
+            Config {
+                configs: vec![
+                    KeyValidity::with_key(key_a, 0, None),
+                    KeyValidity::with_key(key_b, 0, 10),
+                    KeyValidity::with_key(key_c, 0, 10),
+                    KeyValidity::with_key(key_c, 20, None),
+                ],
+                base_path: path.parent().map(Into::into),
+            }
+        );
+
+        // Verify the validity map.
+        assert_eq!(
+            cfg.to_validity_map().unwrap(),
+            [
+                (key_a, vec![0..=BlockIndex::MAX]),
+                (key_b, vec![0..=10]),
+                (key_c, vec![0..=10, 20..=BlockIndex::MAX]),
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn toml_with_pems() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let subdir = TempDir::new_in(dir).unwrap();
+
+        let config_path = dir.join("metadata-signers.toml");
+        let abs_path = subdir.path().join("test_abs.pem");
+        let rel_path = "test_rel.pem";
+
+        // Write key A in the child directory.
+        fs::write(&abs_path, KEY_A_PEM).unwrap();
+
+        // Write key B at rel_path next to the TOML file.
+        fs::write(dir.join(rel_path), KEY_B_PEM).unwrap();
+
+        // Write the TOML, with key C as inline PEM.
+        let toml = format!(
+            r#"
+            [[node]]
+            pub_key = "{}"
+            first_block_index = 0
+
+            [[node]]
+            pub_key = "{}"
+            first_block_index = 0
+            last_block_index = 10
+
+            [[node]]
+            message_signing_pub_key = """{}"""
+            first_block_index = 20
+        "#,
+            abs_path.display(),
+            rel_path,
+            KEY_C_PEM,
+        );
+        fs::write(&config_path, toml).unwrap();
+
+        // Parse the TOML.
+        let config = Config::load(&config_path).unwrap();
+
+        assert_eq!(
+            config,
+            Config {
+                configs: vec![
+                    KeyValidity::new(abs_path.display().to_string(), 0, None),
+                    KeyValidity::new(rel_path.to_string(), 0, 10),
+                    KeyValidity::new(KEY_C_PEM.to_string(), 20, None),
+                ],
+                base_path: config_path.parent().map(Into::into),
+            }
+        );
+
+        // Verify the validity map.
+        assert_eq!(
+            config.to_validity_map().unwrap(),
+            [
+                (make_pub_key(0xAA), vec![0..=BlockIndex::MAX]),
+                (make_pub_key(0xBB), vec![0..=10]),
+                (make_pub_key(0xCC), vec![20..=BlockIndex::MAX])
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn json_with_pems() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let subdir = TempDir::new_in(dir).unwrap();
+
+        let config_path = dir.join("metadata-signers.json");
+        let abs_path = subdir.path().join("test_abs.pem");
+        let rel_path = "test_rel.pem";
+
+        // Write key A in the child directory.
+        fs::write(&abs_path, KEY_A_PEM).unwrap();
+
+        // Write key B at rel_path next to the JSON file.
+        fs::write(dir.join(rel_path), KEY_B_PEM).unwrap();
+
+        // Write the JSON, with key C as inline PEM.
+        let json = serde_json::json!({
+            "node": [
+                {
+                    "pub_key": abs_path.to_str(),
+                    "first_block_index": 0,
+                },
+                {
+                    "pub_key": rel_path,
+                    "first_block_index": 0,
+                    "last_block_index": 10,
+                },
+                {
+                    "message_signing_pub_key": KEY_C_PEM,
+                    "first_block_index": 20,
+                },
+            ]
+        })
+        .to_string();
+        fs::write(&config_path, json).unwrap();
+
+        // Parse the JSON.
+        let config = Config::load(&config_path).unwrap();
+
+        assert_eq!(
+            config,
+            Config {
+                configs: vec![
+                    KeyValidity::new(abs_path.display().to_string(), 0, None),
+                    KeyValidity::new(rel_path.to_string(), 0, 10),
+                    KeyValidity::new(KEY_C_PEM.to_string(), 20, None),
+                ],
+                base_path: config_path.parent().map(Into::into),
+            }
+        );
+
+        // Verify the validity map.
+        assert_eq!(
+            config.to_validity_map().unwrap(),
+            [
+                (make_pub_key(0xAA), vec![0..=BlockIndex::MAX]),
+                (make_pub_key(0xBB), vec![0..=10]),
+                (make_pub_key(0xCC), vec![20..=BlockIndex::MAX])
+            ]
+            .into()
+        );
+    }
+
+    #[test]
+    fn unsupported_extension() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("metadata-signers.poml");
+        fs::write(&file, INPUT_TOML).unwrap();
+
+        let result = Config::load(&file);
+        assert_eq!(result, Err(ParseError::UnrecognizedExtension(file)));
+    }
+
+    #[test]
+    fn no_extension() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("metadata-signers");
+        fs::write(&file, INPUT_TOML).unwrap();
+
+        let result = Config::load(&file);
+        assert_eq!(result, Err(ParseError::UnrecognizedExtension(file)));
+    }
+}

--- a/blockchain/validators/src/metadata/key_range/config.rs
+++ b/blockchain/validators/src/metadata/key_range/config.rs
@@ -8,7 +8,7 @@ use mc_blockchain_types::BlockIndex;
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     ffi::OsStr,
     fs,
     ops::RangeInclusive,
@@ -16,7 +16,7 @@ use std::{
 };
 
 /// Container for keys with a range of block indexes that are valid per key.
-pub type KeyValidityMap = BTreeMap<Ed25519Public, Vec<RangeInclusive<BlockIndex>>>;
+pub type KeyValidityMap = HashMap<Ed25519Public, Vec<RangeInclusive<BlockIndex>>>;
 
 const PUBLIC_KEY_TAG: &str = "PUBLIC KEY";
 

--- a/blockchain/validators/src/metadata/key_range/mod.rs
+++ b/blockchain/validators/src/metadata/key_range/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! See [validator].
+
+pub mod config;
+pub mod validator;
+
+pub use self::{
+    config::{Config, KeyValidity, KeyValidityMap},
+    validator::KeyRangeValidator,
+};

--- a/blockchain/validators/src/metadata/key_range/validator.rs
+++ b/blockchain/validators/src/metadata/key_range/validator.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A validator that checks that a given key is used within a configured range
+//! of indexes.
+
+use super::{Config, KeyValidityMap};
+use crate::{ParseError, ValidationError};
+use mc_blockchain_types::BlockIndex;
+use mc_crypto_keys::Ed25519Public;
+use std::path::Path;
+
+/// A validator that checks that a given key is used within a configured range
+/// of indexes.
+#[derive(Clone, Debug)]
+pub struct KeyRangeValidator {
+    config: KeyValidityMap,
+}
+
+impl KeyRangeValidator {
+    /// Instantiate a validator with the given key validity ranges.
+    pub fn new(config: KeyValidityMap) -> Self {
+        Self { config }
+    }
+
+    /// Load the config from the given TOML file path.
+    /// Parses a `metadata-signers.toml` as specified in [MCIP #43](https://github.com/mobilecoinfoundation/mcips/pull/43).
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ParseError> {
+        let config = Config::load(path)?.to_validity_map()?;
+        Ok(Self { config })
+    }
+
+    /// Verifies that the given signing key is allowed at the given block index.
+    pub fn validate(
+        &self,
+        key: &Ed25519Public,
+        block_index: BlockIndex,
+    ) -> Result<(), ValidationError> {
+        let ranges = self.config.get(key).ok_or(ValidationError::UnknownPubKey)?;
+
+        for range in ranges {
+            if range.contains(&block_index) {
+                return Ok(());
+            }
+        }
+
+        Err(ValidationError::InvalidPubKey)
+    }
+}

--- a/blockchain/validators/src/metadata/key_range/validator.rs
+++ b/blockchain/validators/src/metadata/key_range/validator.rs
@@ -37,12 +37,10 @@ impl KeyRangeValidator {
     ) -> Result<(), ValidationError> {
         let ranges = self.config.get(key).ok_or(ValidationError::UnknownPubKey)?;
 
-        for range in ranges {
-            if range.contains(&block_index) {
-                return Ok(());
-            }
+        if ranges.iter().any(|range| range.contains(&block_index)) {
+            Ok(())
+        } else {
+            Err(ValidationError::InvalidPubKey)
         }
-
-        Err(ValidationError::InvalidPubKey)
     }
 }

--- a/blockchain/validators/src/metadata/mod.rs
+++ b/blockchain/validators/src/metadata/mod.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A [BlockMetadata] validator.
+
+pub mod key_range;
+
+use crate::{ParseError, ValidationError};
+use key_range::KeyRangeValidator;
+use mc_blockchain_types::{BlockIndex, BlockMetadata};
+use std::path::Path;
+
+/// A [BlockMetadata] validator that validates metadata signatures, signing
+/// keys, and AVRs.
+pub struct MetadataValidator {
+    key_range: KeyRangeValidator,
+}
+
+impl MetadataValidator {
+    /// Instantiate a validator.
+    ///
+    /// Args:
+    /// `signers_config`: Path to `metadata-signers.toml`
+    pub fn new(signers_config: impl AsRef<Path>) -> Result<Self, ParseError> {
+        let key_range = KeyRangeValidator::load(signers_config)?;
+
+        Ok(Self { key_range })
+    }
+
+    /// Validate that the given metadata is valid at the given block index.
+    pub fn validate(
+        &self,
+        metadata: &BlockMetadata,
+        block_index: BlockIndex,
+    ) -> Result<(), ValidationError> {
+        self.key_range.validate(metadata.node_key(), block_index)?;
+        // TODO: Validate AVR.
+        metadata.verify()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{make_key, make_metadata};
+    use mc_crypto_keys::Ed25519Signature;
+
+    fn make_validator() -> MetadataValidator {
+        let key_range = KeyRangeValidator::new(
+            [
+                // Key #1 is always valid.
+                (make_key(1), vec![0..=BlockIndex::MAX]),
+                // Key #2 is only valid for the first 11 blocks.
+                (make_key(2), vec![0..=10]),
+                // Key #3 is valid from block index 10 onward.
+                (make_key(3), vec![10..=BlockIndex::MAX]),
+            ]
+            .into(),
+        );
+
+        MetadataValidator { key_range }
+    }
+
+    #[test]
+    fn happy_path() {
+        let validator = make_validator();
+        let metadata = make_metadata(1);
+        assert_eq!(validator.validate(&metadata, 0), Ok(()));
+        assert_eq!(validator.validate(&metadata, 10), Ok(()));
+        assert_eq!(validator.validate(&metadata, 100), Ok(()));
+        assert_eq!(validator.validate(&metadata, 1000), Ok(()));
+    }
+
+    #[test]
+    fn unrecognized_key() {
+        let validator = make_validator();
+        let metadata = make_metadata(10);
+        assert_eq!(
+            validator.validate(&metadata, 0),
+            Err(ValidationError::UnknownPubKey)
+        );
+    }
+
+    #[test]
+    fn expired_key() {
+        let validator = make_validator();
+        let metadata = make_metadata(2);
+        assert_eq!(
+            validator.validate(&metadata, 11),
+            Err(ValidationError::InvalidPubKey)
+        );
+        assert_eq!(validator.validate(&metadata, 10), Ok(()));
+    }
+
+    #[test]
+    fn premature_key() {
+        let validator = make_validator();
+        let metadata = make_metadata(3);
+        assert_eq!(
+            validator.validate(&metadata, 1),
+            Err(ValidationError::InvalidPubKey)
+        );
+        assert_eq!(
+            validator.validate(&metadata, 9),
+            Err(ValidationError::InvalidPubKey)
+        );
+        assert_eq!(validator.validate(&metadata, 10), Ok(()));
+    }
+
+    #[test]
+    fn bad_metadata_signature() {
+        let validator = make_validator();
+        let ok_metadata = make_metadata(1);
+        assert_eq!(validator.validate(&ok_metadata, 0), Ok(()));
+
+        let mut signature_bytes = ok_metadata.signature().to_bytes();
+        signature_bytes[0] += 1;
+        let metadata = BlockMetadata::new(
+            ok_metadata.contents().clone(),
+            *ok_metadata.node_key(),
+            Ed25519Signature::new(signature_bytes),
+        );
+
+        assert!(matches!(
+            validator.validate(&metadata, 0),
+            Err(ValidationError::Signature(_))
+        ));
+    }
+}

--- a/blockchain/validators/src/test_utils.rs
+++ b/blockchain/validators/src/test_utils.rs
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Test helpers.
+
+use mc_blockchain_test_utils::{make_block_id, make_block_metadata_contents};
+use mc_blockchain_types::BlockMetadata;
+use mc_crypto_keys::{Ed25519Pair, Ed25519Public};
+use mc_util_from_random::FromRandom;
+use mc_util_test_helper::{RngType as FixedRng, SeedableRng};
+
+pub fn make_key(seed: u64) -> Ed25519Public {
+    *make_metadata(seed).node_key()
+}
+
+pub fn make_metadata(seed: u64) -> BlockMetadata {
+    let seed_bytes = seed.to_be_bytes();
+    let mut seed = [0u8; 32];
+    seed[0..seed_bytes.len()].copy_from_slice(&seed_bytes);
+    let mut rng = FixedRng::from_seed(seed);
+
+    let signer = Ed25519Pair::from_random(&mut rng);
+
+    BlockMetadata::from_contents_and_keypair(
+        make_block_metadata_contents(make_block_id(&mut rng), &mut rng),
+        &signer,
+    )
+    .expect("BlockMetadata::from_contents_and_keypair")
+}

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -106,6 +106,12 @@ impl AsRef<[u8]> for Ed25519Public {
     }
 }
 
+impl AsRef<[u8; PUBLIC_KEY_LENGTH]> for Ed25519Public {
+    fn as_ref(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
+        self.0.as_bytes()
+    }
+}
+
 impl TryFrom<&[u8]> for Ed25519Public {
     type Error = KeyError;
 
@@ -116,9 +122,11 @@ impl TryFrom<&[u8]> for Ed25519Public {
     }
 }
 
-impl AsRef<[u8; PUBLIC_KEY_LENGTH]> for Ed25519Public {
-    fn as_ref(&self) -> &[u8; PUBLIC_KEY_LENGTH] {
-        self.0.as_bytes()
+impl TryFrom<Vec<u8>> for Ed25519Public {
+    type Error = KeyError;
+
+    fn try_from(src: Vec<u8>) -> Result<Self, Self::Error> {
+        src.as_slice().try_into()
     }
 }
 
@@ -290,6 +298,14 @@ impl<'bytes> TryFrom<&'bytes [u8]> for Ed25519Private {
     }
 }
 
+impl TryFrom<Vec<u8>> for Ed25519Private {
+    type Error = SignatureError;
+
+    fn try_from(src: Vec<u8>) -> Result<Self, Self::Error> {
+        src.as_slice().try_into()
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Ed25519Pair(Keypair);
 
@@ -359,6 +375,14 @@ impl<'bytes> TryFrom<&'bytes [u8]> for Ed25519Pair {
     }
 }
 
+impl TryFrom<Vec<u8>> for Ed25519Pair {
+    type Error = SignatureError;
+
+    fn try_from(src: Vec<u8>) -> Result<Self, Self::Error> {
+        src.as_slice().try_into()
+    }
+}
+
 impl Verifier<Ed25519Signature> for Ed25519Pair {
     fn verify(&self, message: &[u8], signature: &Ed25519Signature) -> Result<(), SignatureError> {
         let sig =
@@ -423,6 +447,14 @@ impl<'a> TryFrom<&'a [u8]> for Ed25519Signature {
 
     fn try_from(bytes: &'a [u8]) -> Result<Self, SignatureError> {
         Ok(Self(Signature::try_from(bytes)?))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Ed25519Signature {
+    type Error = SignatureError;
+
+    fn try_from(src: Vec<u8>) -> Result<Self, Self::Error> {
+        src.as_slice().try_into()
     }
 }
 


### PR DESCRIPTION
This PR adds validation for metadata signing keys; #2136 adds AVR validation.

This config can be used to revoke metadata signing keys, when `LedgerDB` calls this as part of its validation before appending blocks.

See [MCIP 43](https://github.com/mobilecoinfoundation/mcips/blob/block-metadata/text/0043-block-metadata.md#signing-key-history) and #2104 for more details.