### PR TITLE
Clean up `pub use *`

### DIFF
--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -22,8 +22,7 @@ pub mod log {
 }
 
 /// Expose slog and select useful primitives.
-pub use slog;
-pub use slog::{o, FnValue, Level, Logger, PushFnValue};
+pub use slog::{self, o, FnValue, Level, Logger, PushFnValue};
 
 /// Create a logger that discards everything.
 pub fn create_null_logger() -> Logger {

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -678,4 +678,4 @@ cfg_if! {
 // [1]: https://github.com/serde-rs/serde/blob/v1.0.89/serde/src/lib.rs#L245-L256
 #[cfg(feature = "derive")]
 #[doc(hidden)]
-pub use mc_crypto_digestible_derive::*;
+pub use mc_crypto_digestible_derive::Digestible;

--- a/crypto/digestible/test-utils/src/lib.rs
+++ b/crypto/digestible/test-utils/src/lib.rs
@@ -1,10 +1,15 @@
-use mc_crypto_digestible::{DigestTranscript, Digestible};
-
-mod mock_merlin;
-pub use mock_merlin::MockMerlin;
-
 mod inspect_ast;
-pub use inspect_ast::*;
+mod mock_merlin;
+
+pub use crate::{
+    inspect_ast::{
+        calculate_digest_ast, ASTAggregate, ASTNode, ASTNone, ASTPrimitive, ASTSequence,
+        ASTVariant, InspectAST,
+    },
+    mock_merlin::MockMerlin,
+};
+
+use mc_crypto_digestible::{DigestTranscript, Digestible};
 
 pub fn digestible_test_case<D: Digestible>(
     context: &'static str,

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -3,22 +3,21 @@
 //! This module implements the common keys traits for the Ed25519 digital
 //! signature scheme.
 
-pub use ed25519::signature::Error as SignatureError;
-
-use alloc::vec;
-
-use crate::traits::*;
-use alloc::vec::Vec;
+use crate::{
+    DigestSigner, DigestVerifier, DistinguishedEncoding, KeyError, PrivateKey, PublicKey,
+    Signature as SignatureTrait, SignatureError, Signer, Verifier,
+};
+use alloc::{vec, vec::Vec};
 use core::{
     cmp::Ordering,
     convert::TryFrom,
     hash::{Hash, Hasher},
 };
-use digest::generic_array::typenum::{U32, U64};
-use ed25519::{
-    signature::{DigestSigner, DigestVerifier, Signature as SignatureTrait, Signer, Verifier},
-    Signature,
+use digest::{
+    generic_array::typenum::{U32, U64},
+    Digest,
 };
+use ed25519::Signature;
 use ed25519_dalek::{
     Keypair, PublicKey as DalekPublicKey, SecretKey, Signature as DalekSignature,
     PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH,
@@ -455,7 +454,7 @@ derive_prost_message_from_repr_bytes!(Ed25519Signature);
 #[cfg(test)]
 mod ed25519_tests {
     use super::*;
-    use digest::generic_array::typenum::Unsigned;
+    use crate::{ReprBytes, Unsigned};
     use mc_crypto_digestible::Digestible;
     use mc_crypto_hashes::PseudoMerlin;
     use rand_core::SeedableRng;

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -56,11 +56,25 @@ mod traits;
 mod x25519;
 
 pub use crate::{
-    ed25519::{Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, SignatureError},
-    ristretto::*,
-    traits::*,
-    x25519::*,
+    ed25519::{Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature},
+    ristretto::{
+        CompressedRistrettoPublic, Ristretto, RistrettoEphemeralPrivate, RistrettoPrivate,
+        RistrettoPublic, RistrettoSecret, RistrettoSignature,
+    },
+    traits::{
+        DistinguishedEncoding, Fingerprintable, Kex, KexEphemeralPrivate, KexPrivate, KexPublic,
+        KexReusablePrivate, KexSecret, KeyError, PrivateKey, PublicKey,
+    },
+    x25519::{
+        X25519EphemeralPrivate, X25519Private, X25519Public, X25519Secret, X25519, X25519_LEN,
+    },
 };
 
 // Expected format for base64 strings
 pub(crate) const B64_CONFIG: base64::Config = base64::STANDARD;
+
+pub use digest::Digest;
+pub use mc_util_repr_bytes::{typenum::Unsigned, GenericArray, LengthMismatch, ReprBytes};
+pub use signature::{
+    DigestSigner, DigestVerifier, Error as SignatureError, Signature, Signer, Verifier,
+};

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -2,7 +2,10 @@
 
 #![allow(non_snake_case)]
 
-use crate::traits::*;
+use crate::{
+    GenericArray, Kex, KexEphemeralPrivate, KexPrivate, KexPublic, KexReusablePrivate, KexSecret,
+    KeyError, PrivateKey, PublicKey, Signature,
+};
 use alloc::vec::Vec;
 use core::{
     cmp::Ordering,

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -2,10 +2,7 @@
 
 //! Abstract traits used by Structs which implement key management
 
-pub use digest::Digest;
-pub use ed25519::signature::{DigestSigner, DigestVerifier, Signature, Signer, Verifier};
-pub use mc_util_repr_bytes::{typenum::Unsigned, GenericArray, LengthMismatch, ReprBytes};
-
+use crate::{Digest, LengthMismatch, ReprBytes, Unsigned};
 use alloc::{string::String, vec::Vec};
 use core::{convert::TryFrom, fmt::Debug, hash::Hash};
 use displaydoc::Display;

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -2,12 +2,11 @@
 
 //! dalek-cryptography based keys implementations
 
-// Badly-named Macros
-use alloc::vec;
-
-// Dependencies
-use crate::{traits::*, B64_CONFIG};
-use alloc::{string::ToString, vec::Vec};
+use crate::{
+    Digest, DistinguishedEncoding, Fingerprintable, Kex, KexEphemeralPrivate, KexPrivate,
+    KexPublic, KexReusablePrivate, KexSecret, KeyError, PrivateKey, PublicKey, B64_CONFIG,
+};
+use alloc::{string::ToString, vec, vec::Vec};
 use core::{
     convert::{AsRef, TryFrom},
     fmt::{Debug, Error as FmtError, Formatter, Result as FmtResult},
@@ -569,6 +568,7 @@ impl Kex for X25519 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{ReprBytes, Unsigned};
     use mc_util_serial::{deserialize, serialize};
 
     #[test]

--- a/crypto/message-cipher/src/lib.rs
+++ b/crypto/message-cipher/src/lib.rs
@@ -6,8 +6,10 @@ extern crate alloc;
 mod aes_impl;
 mod traits;
 
-pub use aes_impl::*;
-pub use traits::*;
+pub use crate::{
+    aes_impl::AeadMessageCipher,
+    traits::{CipherError, MessageCipher, ProstCipherError},
+};
 
 /// AesMessageCipher is the one we expect to use
 use aes_gcm::Aes256Gcm;

--- a/crypto/ring-signature/src/ring_signature/mod.rs
+++ b/crypto/ring-signature/src/ring_signature/mod.rs
@@ -4,13 +4,7 @@
 
 #![allow(non_snake_case)]
 
-use curve25519_dalek::traits::MultiscalarMul;
 pub use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
-
-use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT};
-use mc_crypto_hashes::{Blake2b512, Digest};
-use mc_crypto_keys::RistrettoPublic;
 
 mod curve_scalar;
 mod error;
@@ -18,11 +12,21 @@ mod generator_cache;
 mod key_image;
 mod mlsag;
 
-pub use curve_scalar::*;
-pub use error::Error;
-pub use generator_cache::*;
-pub use key_image::*;
-pub use mlsag::*;
+pub use self::{
+    curve_scalar::CurveScalar,
+    error::Error,
+    generator_cache::GeneratorCache,
+    key_image::KeyImage,
+    mlsag::{CryptoRngCore, ReducedTxOut, RingMLSAG},
+};
+
+use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
+use curve25519_dalek::{
+    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
+    traits::MultiscalarMul,
+};
+use mc_crypto_hashes::{Blake2b512, Digest};
+use mc_crypto_keys::RistrettoPublic;
 
 /// The base point for blinding factors used with all amount commitments
 pub const B_BLINDING: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;

--- a/crypto/sig/src/lib.rs
+++ b/crypto/sig/src/lib.rs
@@ -63,7 +63,7 @@ mod tests {
     use mc_util_test_helper::run_with_several_seeds;
 
     mod compat_20210122 {
-        use crate::*;
+        use super::*;
         use core::convert::TryFrom;
 
         // These example files were created by hacking the unit tests in

--- a/libmobilecoin/src/common/mod.rs
+++ b/libmobilecoin/src/common/mod.rs
@@ -37,15 +37,6 @@
 
 pub(crate) mod macros;
 
-pub use buffer::*;
-pub use data::*;
-pub use error::*;
-pub use rng::*;
-pub use string::*;
-
-pub(crate) use boundary::*;
-pub(crate) use into_ffi::*;
-
 mod boundary;
 mod buffer;
 mod data;
@@ -53,3 +44,16 @@ mod error;
 mod into_ffi;
 mod rng;
 mod string;
+
+pub use self::{
+    buffer::{McBuffer, McMutableBuffer},
+    data::{mc_data_free, mc_data_get_bytes, McData},
+    error::{mc_error_free, McError},
+    rng::{CallbackRng, FfiCallbackRng, McRngCallback, SdkRng},
+    string::mc_string_free,
+};
+
+pub(crate) use self::{
+    boundary::{ffi_boundary, ffi_boundary_with_error},
+    into_ffi::{FfiTryFrom, FfiTryInto, FromFfi, IntoFfi, TryFromFfi},
+};

--- a/libmobilecoin/src/lib.rs
+++ b/libmobilecoin/src/lib.rs
@@ -14,4 +14,4 @@ pub mod transaction;
 
 mod error;
 
-pub use error::*;
+pub use error::LibMcError;

--- a/transaction/core/src/amount/mod.rs
+++ b/transaction/core/src/amount/mod.rs
@@ -7,6 +7,9 @@
 
 #![cfg_attr(test, allow(clippy::unnecessary_operation))]
 
+mod error;
+pub use error::AmountError;
+
 use crate::{
     domain_separators::{
         AMOUNT_BLINDING_DOMAIN_TAG, AMOUNT_TOKEN_ID_DOMAIN_TAG, AMOUNT_VALUE_DOMAIN_TAG,
@@ -23,9 +26,6 @@ use mc_crypto_ring_signature::{generators, CompressedCommitment, Scalar};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
-
-mod error;
-pub use error::AmountError;
 
 /// A commitment to an amount of MobileCoin or a related token, as it appears on
 /// the blockchain. This is a "blinded" commitment, and only the sender and

--- a/transaction/core/src/ring_ct/mod.rs
+++ b/transaction/core/src/ring_ct/mod.rs
@@ -5,5 +5,9 @@
 mod error;
 mod rct_bulletproofs;
 
-pub use error::Error;
-pub use rct_bulletproofs::*;
+pub use self::{
+    error::Error,
+    rct_bulletproofs::{
+        InputRing, OutputSecret, PresignedInputRing, SignatureRctBulletproofs, SignedInputRing,
+    },
+};

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -4,8 +4,6 @@
 
 extern crate alloc;
 
-use alloc::{format, vec::Vec};
-
 use super::error::{TransactionValidationError, TransactionValidationResult};
 use crate::{
     constants::*,
@@ -13,6 +11,7 @@ use crate::{
     tx::{Tx, TxOut, TxOutMembershipProof, TxPrefix},
     Amount, BlockVersion, TokenId,
 };
+use alloc::{format, vec::Vec};
 use mc_common::HashSet;
 use rand_core::{CryptoRng, RngCore};
 

--- a/util/ffi/src/lib.rs
+++ b/util/ffi/src/lib.rs
@@ -67,10 +67,12 @@
 //!  * `extern "C" fn ffi_func_name(param: FfiRefPtr<'_, ForeignType>)`
 //!  * `extern "C" fn ffi_func_name<'a>(param: FfiRefPtr<'a, ForeignType>)`
 
-pub use ffi_owned_ptr::*;
-pub use ffi_ref_ptr::*;
-pub use ffi_str::*;
-
 mod ffi_owned_ptr;
 mod ffi_ref_ptr;
 mod ffi_str;
+
+pub use crate::{
+    ffi_owned_ptr::{FfiOptOwnedPtr, FfiOwnedPtr},
+    ffi_ref_ptr::{FfiMutPtr, FfiOptMutPtr, FfiOptRefPtr, FfiRefPtr},
+    ffi_str::{FfiOptOwnedStr, FfiOptStr, FfiOwnedStr, FfiStr},
+};


### PR DESCRIPTION
Per [Rust style guide](https://doc.rust-lang.org/1.0.0/style/style/imports.html#avoid-use-*,-except-in-tests.): "Avoid `use *`, except  in tests." (i.e. `use super::*`)