### PR TITLE
Cleanup: DRY up references to `mc_mobilecoind_api` with an alias

### DIFF
--- a/mobilecoind-dev-faucet/src/data_types.rs
+++ b/mobilecoind-dev-faucet/src/data_types.rs
@@ -3,6 +3,7 @@
 //! Serializeable data types that wrap the mobilecoind API.
 
 use mc_api::external::PublicAddress;
+use mc_mobilecoind_api as api;
 use mc_transaction_core::TokenId;
 use mc_util_serial::JsonU64;
 use serde_derive::{Deserialize, Serialize};
@@ -103,8 +104,8 @@ pub struct JsonReceiverTxReceipt {
     pub confirmation_number: String,
 }
 
-impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
-    fn from(src: &mc_mobilecoind_api::ReceiverTxReceipt) -> Self {
+impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
+    fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
             tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
@@ -167,8 +168,8 @@ pub struct JsonSubmitTxResponse {
     pub receiver_tx_receipt_list: Vec<JsonReceiverTxReceipt>,
 }
 
-impl From<Result<mc_mobilecoind_api::SubmitTxResponse, String>> for JsonSubmitTxResponse {
-    fn from(src: Result<mc_mobilecoind_api::SubmitTxResponse, String>) -> Self {
+impl From<Result<api::SubmitTxResponse, String>> for JsonSubmitTxResponse {
+    fn from(src: Result<api::SubmitTxResponse, String>) -> Self {
         match src {
             Ok(mut resp) => Self {
                 success: true,

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use grpcio::ChannelBuilder;
 use mc_api::external::{CompressedRistretto, PublicAddress, RistrettoPrivate};
 use mc_common::logger::{create_app_logger, log, o};
-use mc_mobilecoind_api::{mobilecoind_api_grpc::MobilecoindApiClient, MobilecoindUri};
+use mc_mobilecoind_api::{self as api, mobilecoind_api_grpc::MobilecoindApiClient, MobilecoindUri};
 use mc_mobilecoind_json::data_types::*;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use protobuf::RepeatedField;
@@ -49,7 +49,7 @@ fn set_password(
     state: &rocket::State<State>,
     password: Json<JsonPasswordRequest>,
 ) -> Result<Json<JsonPasswordResponse>, String> {
-    let mut req = mc_mobilecoind_api::SetDbPasswordRequest::new();
+    let mut req = api::SetDbPasswordRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
             .map_err(|err| format!("Failed decoding password hex: {}", err))?,
@@ -67,7 +67,7 @@ fn unlock_db(
     state: &rocket::State<State>,
     password: Json<JsonUnlockDbRequest>,
 ) -> Result<Json<JsonUnlockDbResponse>, String> {
-    let mut req = mc_mobilecoind_api::UnlockDbRequest::new();
+    let mut req = api::UnlockDbRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
             .map_err(|err| format!("Failed decoding password hex: {}", err))?,
@@ -84,7 +84,7 @@ fn unlock_db(
 fn version(state: &rocket::State<State>) -> Result<Json<JsonMobilecoindVersionResponse>, String> {
     let resp = state
         .mobilecoind_api_client
-        .get_version(&mc_mobilecoind_api::Empty::new())
+        .get_version(&api::Empty::new())
         .map_err(|err| format!("Failed getting version: {}", err))?;
     Ok(Json(JsonMobilecoindVersionResponse::from(&resp)))
 }
@@ -94,7 +94,7 @@ fn version(state: &rocket::State<State>) -> Result<Json<JsonMobilecoindVersionRe
 fn entropy(state: &rocket::State<State>) -> Result<Json<JsonRootEntropyResponse>, String> {
     let resp = state
         .mobilecoind_api_client
-        .generate_root_entropy(&mc_mobilecoind_api::Empty::new())
+        .generate_root_entropy(&api::Empty::new())
         .map_err(|err| format!("Failed getting entropy: {}", err))?;
     Ok(Json(JsonRootEntropyResponse::from(&resp)))
 }
@@ -107,7 +107,7 @@ fn account_key_from_root_entropy(
     let entropy =
         hex::decode(root_entropy).map_err(|err| format!("Failed to decode hex key: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest::new();
+    let mut req = api::GetAccountKeyFromRootEntropyRequest::new();
     req.set_root_entropy(entropy.to_vec());
 
     let resp = state
@@ -123,7 +123,7 @@ fn account_key_from_root_entropy(
 fn mnemonic(state: &rocket::State<State>) -> Result<Json<JsonMnemonicResponse>, String> {
     let resp = state
         .mobilecoind_api_client
-        .generate_mnemonic(&mc_mobilecoind_api::Empty::new())
+        .generate_mnemonic(&api::Empty::new())
         .map_err(|err| format!("Failed getting entropy: {}", err))?;
     Ok(Json(JsonMnemonicResponse::from(&resp)))
 }
@@ -133,7 +133,7 @@ fn account_key_from_mnemonic(
     state: &rocket::State<State>,
     mnemonic: Json<JsonMnemonicResponse>,
 ) -> Result<Json<JsonAccountKeyResponse>, String> {
-    let mut req = mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest::new();
+    let mut req = api::GetAccountKeyFromMnemonicRequest::new();
     req.set_mnemonic(mnemonic.mnemonic.clone());
 
     let resp = state
@@ -151,7 +151,7 @@ fn add_monitor(
     state: &rocket::State<State>,
     monitor: Json<JsonMonitorRequest>,
 ) -> Result<Json<JsonMonitorResponse>, String> {
-    let mut account_key = mc_mobilecoind_api::external::AccountKey::new();
+    let mut account_key = api::external::AccountKey::new();
     let mut view_private_key = RistrettoPrivate::new();
     view_private_key.set_data(
         hex::decode(&monitor.account_key.view_private_key)
@@ -165,7 +165,7 @@ fn add_monitor(
     account_key.set_view_private_key(view_private_key);
     account_key.set_spend_private_key(spend_private_key);
 
-    let mut req = mc_mobilecoind_api::AddMonitorRequest::new();
+    let mut req = api::AddMonitorRequest::new();
     req.set_account_key(account_key);
     req.set_first_subaddress(monitor.first_subaddress);
     req.set_num_subaddresses(monitor.num_subaddresses);
@@ -185,7 +185,7 @@ fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::RemoveMonitorRequest::new();
+    let mut req = api::RemoveMonitorRequest::new();
     req.set_monitor_id(monitor_id);
 
     let _resp = state
@@ -201,7 +201,7 @@ fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(
 fn monitors(state: &rocket::State<State>) -> Result<Json<JsonMonitorListResponse>, String> {
     let resp = state
         .mobilecoind_api_client
-        .get_monitor_list(&mc_mobilecoind_api::Empty::new())
+        .get_monitor_list(&api::Empty::new())
         .map_err(|err| format!("Failed getting monitor list: {}", err))?;
     Ok(Json(JsonMonitorListResponse::from(&resp)))
 }
@@ -215,7 +215,7 @@ fn monitor_status(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::GetMonitorStatusRequest::new();
+    let mut req = api::GetMonitorStatusRequest::new();
     req.set_monitor_id(monitor_id);
 
     let resp = state
@@ -236,7 +236,7 @@ fn balance(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::GetBalanceRequest::new();
+    let mut req = api::GetBalanceRequest::new();
     req.set_monitor_id(monitor_id);
     req.set_subaddress_index(subaddress_index);
 
@@ -257,7 +257,7 @@ fn utxos(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::GetUnspentTxOutListRequest::new();
+    let mut req = api::GetUnspentTxOutListRequest::new();
     req.set_monitor_id(monitor_id);
     req.set_subaddress_index(subaddress_index);
 
@@ -280,7 +280,7 @@ fn public_address(
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
     // Get our public address.
-    let mut req = mc_mobilecoind_api::GetPublicAddressRequest::new();
+    let mut req = api::GetPublicAddressRequest::new();
     req.set_monitor_id(monitor_id);
     req.set_subaddress_index(subaddress_index);
 
@@ -298,11 +298,11 @@ fn create_request_code(
     state: &rocket::State<State>,
     request: Json<JsonCreateRequestCodeRequest>,
 ) -> Result<Json<JsonCreateRequestCodeResponse>, String> {
-    let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
+    let receiver = api::external::PublicAddress::try_from(&request.receiver)
         .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
-    let mut req = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+    let mut req = api::CreateRequestCodeRequest::new();
     req.set_receiver(receiver);
     if let Some(value) = request.value {
         req.set_value(u64::from(value));
@@ -325,7 +325,7 @@ fn parse_request_code(
     state: &rocket::State<State>,
     b58_code: String,
 ) -> Result<Json<JsonParseRequestCodeResponse>, String> {
-    let mut req = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+    let mut req = api::ParseRequestCodeRequest::new();
     req.set_b58_code(b58_code);
     let resp = state
         .mobilecoind_api_client
@@ -344,11 +344,11 @@ fn create_address_code(
     state: &rocket::State<State>,
     request: Json<JsonCreateAddressCodeRequest>,
 ) -> Result<Json<JsonCreateAddressCodeResponse>, String> {
-    let receiver = mc_mobilecoind_api::external::PublicAddress::try_from(&request.receiver)
+    let receiver = api::external::PublicAddress::try_from(&request.receiver)
         .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
 
     // Generate b58 code
-    let mut req = mc_mobilecoind_api::CreateAddressCodeRequest::new();
+    let mut req = api::CreateAddressCodeRequest::new();
     req.set_receiver(receiver);
 
     let resp = state
@@ -365,7 +365,7 @@ fn parse_address_code(
     state: &rocket::State<State>,
     b58_code: String,
 ) -> Result<Json<JsonParseAddressCodeResponse>, String> {
-    let mut req = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+    let mut req = api::ParseAddressCodeRequest::new();
     req.set_b58_code(b58_code);
     let resp = state
         .mobilecoind_api_client
@@ -395,7 +395,7 @@ fn build_and_submit(
     let public_address = PublicAddress::try_from(&transfer.request_data.receiver)?;
 
     // Generate an outlay
-    let mut outlay = mc_mobilecoind_api::Outlay::new();
+    let mut outlay = api::Outlay::new();
     outlay.set_receiver(public_address);
     outlay.set_value(transfer.request_data.value.into());
 
@@ -407,7 +407,7 @@ fn build_and_submit(
         .unwrap_or(0);
 
     // Send the payment request
-    let mut req = mc_mobilecoind_api::SendPaymentRequest::new();
+    let mut req = api::SendPaymentRequest::new();
     req.set_sender_monitor_id(monitor_id);
     req.set_sender_subaddress(subaddress_index);
     req.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
@@ -453,7 +453,7 @@ fn pay_address_code(
         .unwrap_or(0);
 
     // Send the pay address code request
-    let mut req = mc_mobilecoind_api::PayAddressCodeRequest::new();
+    let mut req = api::PayAddressCodeRequest::new();
     req.set_sender_monitor_id(monitor_id);
     req.set_sender_subaddress(subaddress_index);
     req.set_receiver_b58_code(transfer.receiver_b58_address_code.clone());
@@ -493,21 +493,21 @@ fn generate_request_code_transaction(
     let public_address = PublicAddress::try_from(&request.transfer.receiver)?;
 
     // Generate an outlay
-    let mut outlay = mc_mobilecoind_api::Outlay::new();
+    let mut outlay = api::Outlay::new();
     outlay.set_receiver(public_address);
     outlay.set_value(request.transfer.value.into());
 
-    let inputs: Vec<mc_mobilecoind_api::UnspentTxOut> = request
+    let inputs: Vec<api::UnspentTxOut> = request
         .input_list
         .iter()
         .map(|input| {
-            mc_mobilecoind_api::UnspentTxOut::try_from(input)
+            api::UnspentTxOut::try_from(input)
                 .map_err(|err| format!("Failed to convert input: {}", err))
         })
         .collect::<Result<_, String>>()?;
 
     // Get a tx proposal
-    let mut req = mc_mobilecoind_api::GenerateTxRequest::new();
+    let mut req = api::GenerateTxRequest::new();
     req.set_sender_monitor_id(monitor_id);
     req.set_change_subaddress(subaddress_index);
     req.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
@@ -528,9 +528,9 @@ fn submit_tx(
     proposal: Json<JsonTxProposalRequest>,
 ) -> Result<Json<JsonSubmitTxResponse>, String> {
     // Send the payment request
-    let mut req = mc_mobilecoind_api::SubmitTxRequest::new();
+    let mut req = api::SubmitTxRequest::new();
     req.set_tx_proposal(
-        mc_mobilecoind_api::TxProposal::try_from(&proposal.tx_proposal)
+        api::TxProposal::try_from(&proposal.tx_proposal)
             .map_err(|err| format!("Failed to convert tx proposal: {}", err))?,
     );
 
@@ -552,7 +552,7 @@ fn check_transfer_status(
     let resp = state
         .mobilecoind_api_client
         .get_tx_status_as_sender(
-            &mc_mobilecoind_api::SubmitTxResponse::try_from(&submit_response.0)
+            &api::SubmitTxResponse::try_from(&submit_response.0)
                 .map_err(|err| format!("Could not convert JsonSubmitTxResponse: {}", err))?,
         )
         .map_err(|err| format!("Failed getting status: {}", err))?;
@@ -580,7 +580,7 @@ fn check_receiver_transfer_status(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut receiver_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+    let mut receiver_receipt = api::ReceiverTxReceipt::new();
     let mut tx_public_key = CompressedRistretto::new();
     tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{}", err))?);
     receiver_receipt.set_tx_public_key(tx_public_key);
@@ -591,7 +591,7 @@ fn check_receiver_transfer_status(
         hex::decode(&receipt.confirmation_number).map_err(|err| format!("{}", err))?,
     );
 
-    let mut req = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+    let mut req = api::GetTxStatusAsReceiverRequest::new();
     req.set_receipt(receiver_receipt);
     req.set_monitor_id(monitor_id);
 
@@ -608,7 +608,7 @@ fn check_receiver_transfer_status(
 fn ledger_info(state: &rocket::State<State>) -> Result<Json<JsonLedgerInfoResponse>, String> {
     let resp = state
         .mobilecoind_api_client
-        .get_ledger_info(&mc_mobilecoind_api::Empty::new())
+        .get_ledger_info(&api::Empty::new())
         .map_err(|err| format!("Failed getting ledger info: {}", err))?;
 
     Ok(Json(JsonLedgerInfoResponse::from(&resp)))
@@ -620,7 +620,7 @@ fn block_info(
     state: &rocket::State<State>,
     block_num: u64,
 ) -> Result<Json<JsonBlockInfoResponse>, String> {
-    let mut req = mc_mobilecoind_api::GetBlockInfoRequest::new();
+    let mut req = api::GetBlockInfoRequest::new();
     req.set_block(block_num);
 
     let resp = state
@@ -637,7 +637,7 @@ fn block_details(
     state: &rocket::State<State>,
     block_num: u64,
 ) -> Result<Json<JsonBlockDetailsResponse>, String> {
-    let mut req = mc_mobilecoind_api::GetBlockRequest::new();
+    let mut req = api::GetBlockRequest::new();
     req.set_block(block_num);
 
     let resp = state
@@ -657,7 +657,7 @@ fn processed_block(
     let monitor_id =
         hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
 
-    let mut req = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+    let mut req = api::GetProcessedBlockRequest::new();
     req.set_monitor_id(monitor_id);
     req.set_block(block_num);
 
@@ -681,7 +681,7 @@ fn tx_out_get_block_index_by_public_key(
     let mut tx_out_public_key_proto = CompressedRistretto::new();
     tx_out_public_key_proto.set_data(tx_out_public_key);
 
-    let mut req = mc_mobilecoind_api::GetBlockIndexByTxPubKeyRequest::new();
+    let mut req = api::GetBlockIndexByTxPubKeyRequest::new();
     req.set_tx_public_key(tx_out_public_key_proto);
 
     let resp = state
@@ -706,7 +706,7 @@ fn get_proof_of_membership(
         .collect::<Result<Vec<_>, _>>()?;
 
     // Make gRPC request.
-    let mut get_membership_proofs_request = mc_mobilecoind_api::GetMembershipProofsRequest::new();
+    let mut get_membership_proofs_request = api::GetMembershipProofsRequest::new();
     get_membership_proofs_request.set_outputs(RepeatedField::from_vec(outputs));
 
     let get_membership_proofs_response = state
@@ -748,7 +748,7 @@ fn get_mixins(
         .collect::<Result<Vec<_>, _>>()?;
 
     // Make gRPC request
-    let mut get_mixins_request = mc_mobilecoind_api::GetMixinsRequest::new();
+    let mut get_mixins_request = api::GetMixinsRequest::new();
     get_mixins_request.set_num_mixins(num_mixins);
     get_mixins_request.set_excluded(RepeatedField::from_vec(excluded));
 

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -7,6 +7,7 @@ use mc_api::external::{
     PublicAddress, RingMLSAG, SignatureRctBulletproofs, Tx, TxIn, TxOutMembershipElement,
     TxOutMembershipHash, TxOutMembershipProof, TxPrefix,
 };
+use mc_mobilecoind_api as api;
 use mc_util_serial::JsonU64;
 use protobuf::RepeatedField;
 use serde_derive::{Deserialize, Serialize};
@@ -37,8 +38,8 @@ pub struct JsonRootEntropyResponse {
     pub entropy: String,
 }
 
-impl From<&mc_mobilecoind_api::GenerateRootEntropyResponse> for JsonRootEntropyResponse {
-    fn from(src: &mc_mobilecoind_api::GenerateRootEntropyResponse) -> Self {
+impl From<&api::GenerateRootEntropyResponse> for JsonRootEntropyResponse {
+    fn from(src: &api::GenerateRootEntropyResponse) -> Self {
         Self {
             entropy: hex::encode(&src.root_entropy),
         }
@@ -50,8 +51,8 @@ pub struct JsonMnemonicResponse {
     pub mnemonic: String,
 }
 
-impl From<&mc_mobilecoind_api::GenerateMnemonicResponse> for JsonMnemonicResponse {
-    fn from(src: &mc_mobilecoind_api::GenerateMnemonicResponse) -> Self {
+impl From<&api::GenerateMnemonicResponse> for JsonMnemonicResponse {
+    fn from(src: &api::GenerateMnemonicResponse) -> Self {
         Self {
             mnemonic: src.mnemonic.clone(),
         }
@@ -64,8 +65,8 @@ pub struct JsonAccountKeyResponse {
     pub spend_private_key: String,
 }
 
-impl From<&mc_mobilecoind_api::GetAccountKeyResponse> for JsonAccountKeyResponse {
-    fn from(src: &mc_mobilecoind_api::GetAccountKeyResponse) -> Self {
+impl From<&api::GetAccountKeyResponse> for JsonAccountKeyResponse {
+    fn from(src: &api::GetAccountKeyResponse) -> Self {
         Self {
             view_private_key: hex::encode(&src.get_account_key().get_view_private_key().get_data()),
             spend_private_key: hex::encode(
@@ -88,8 +89,8 @@ pub struct JsonMonitorResponse {
     pub is_new: bool,
 }
 
-impl From<&mc_mobilecoind_api::AddMonitorResponse> for JsonMonitorResponse {
-    fn from(src: &mc_mobilecoind_api::AddMonitorResponse) -> Self {
+impl From<&api::AddMonitorResponse> for JsonMonitorResponse {
+    fn from(src: &api::AddMonitorResponse) -> Self {
         Self {
             monitor_id: hex::encode(&src.monitor_id),
             is_new: src.is_new,
@@ -102,8 +103,8 @@ pub struct JsonMonitorListResponse {
     pub monitor_ids: Vec<String>,
 }
 
-impl From<&mc_mobilecoind_api::GetMonitorListResponse> for JsonMonitorListResponse {
-    fn from(src: &mc_mobilecoind_api::GetMonitorListResponse) -> Self {
+impl From<&api::GetMonitorListResponse> for JsonMonitorListResponse {
+    fn from(src: &api::GetMonitorListResponse) -> Self {
         Self {
             monitor_ids: src.get_monitor_id_list().iter().map(hex::encode).collect(),
         }
@@ -118,8 +119,8 @@ pub struct JsonMonitorStatusResponse {
     pub next_block: u64,
 }
 
-impl From<&mc_mobilecoind_api::GetMonitorStatusResponse> for JsonMonitorStatusResponse {
-    fn from(src: &mc_mobilecoind_api::GetMonitorStatusResponse) -> Self {
+impl From<&api::GetMonitorStatusResponse> for JsonMonitorStatusResponse {
+    fn from(src: &api::GetMonitorStatusResponse) -> Self {
         let status = src.get_status();
 
         Self {
@@ -136,8 +137,8 @@ pub struct JsonBalanceResponse {
     pub balance: String,
 }
 
-impl From<&mc_mobilecoind_api::GetBalanceResponse> for JsonBalanceResponse {
-    fn from(src: &mc_mobilecoind_api::GetBalanceResponse) -> Self {
+impl From<&api::GetBalanceResponse> for JsonBalanceResponse {
+    fn from(src: &api::GetBalanceResponse) -> Self {
         Self {
             balance: src.balance.to_string(),
         }
@@ -155,8 +156,8 @@ pub struct JsonUnspentTxOut {
     pub monitor_id: String,
 }
 
-impl From<&mc_mobilecoind_api::UnspentTxOut> for JsonUnspentTxOut {
-    fn from(src: &mc_mobilecoind_api::UnspentTxOut) -> Self {
+impl From<&api::UnspentTxOut> for JsonUnspentTxOut {
+    fn from(src: &api::UnspentTxOut) -> Self {
         Self {
             tx_out: src.get_tx_out().into(),
             subaddress_index: src.get_subaddress_index(),
@@ -170,10 +171,10 @@ impl From<&mc_mobilecoind_api::UnspentTxOut> for JsonUnspentTxOut {
 }
 
 // Helper conversion between json and protobuf
-impl TryFrom<&JsonUnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
+impl TryFrom<&JsonUnspentTxOut> for api::UnspentTxOut {
     type Error = String;
 
-    fn try_from(src: &JsonUnspentTxOut) -> Result<mc_mobilecoind_api::UnspentTxOut, String> {
+    fn try_from(src: &JsonUnspentTxOut) -> Result<api::UnspentTxOut, String> {
         let mut key_image = KeyImage::new();
         key_image.set_data(
             hex::decode(&src.key_image)
@@ -181,7 +182,7 @@ impl TryFrom<&JsonUnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
         );
 
         // Reconstruct the public address as a protobuf
-        let mut utxo = mc_mobilecoind_api::UnspentTxOut::new();
+        let mut utxo = api::UnspentTxOut::new();
         utxo.set_tx_out(
             mc_api::external::TxOut::try_from(&src.tx_out)
                 .map_err(|err| format!("Failed to get TxOut: {}", err))?,
@@ -205,8 +206,8 @@ pub struct JsonUtxosResponse {
     pub output_list: Vec<JsonUnspentTxOut>,
 }
 
-impl From<&mc_mobilecoind_api::GetUnspentTxOutListResponse> for JsonUtxosResponse {
-    fn from(src: &mc_mobilecoind_api::GetUnspentTxOutListResponse) -> Self {
+impl From<&api::GetUnspentTxOutListResponse> for JsonUtxosResponse {
+    fn from(src: &api::GetUnspentTxOutListResponse) -> Self {
         Self {
             output_list: src
                 .get_output_list()
@@ -229,8 +230,8 @@ pub struct JsonCreateRequestCodeResponse {
     pub b58_request_code: String,
 }
 
-impl From<&mc_mobilecoind_api::CreateRequestCodeResponse> for JsonCreateRequestCodeResponse {
-    fn from(src: &mc_mobilecoind_api::CreateRequestCodeResponse) -> Self {
+impl From<&api::CreateRequestCodeResponse> for JsonCreateRequestCodeResponse {
+    fn from(src: &api::CreateRequestCodeResponse) -> Self {
         Self {
             b58_request_code: String::from(src.get_b58_code()),
         }
@@ -288,8 +289,8 @@ pub struct JsonPublicAddressResponse {
     pub b58_address_code: String,
 }
 
-impl From<&mc_mobilecoind_api::GetPublicAddressResponse> for JsonPublicAddressResponse {
-    fn from(src: &mc_mobilecoind_api::GetPublicAddressResponse) -> Self {
+impl From<&api::GetPublicAddressResponse> for JsonPublicAddressResponse {
+    fn from(src: &api::GetPublicAddressResponse) -> Self {
         let public_address = src.get_public_address();
         Self {
             view_public_key: hex::encode(&public_address.get_view_public_key().get_data()),
@@ -341,8 +342,8 @@ pub struct JsonParseRequestCodeResponse {
     pub memo: String,
 }
 
-impl From<&mc_mobilecoind_api::ParseRequestCodeResponse> for JsonParseRequestCodeResponse {
-    fn from(src: &mc_mobilecoind_api::ParseRequestCodeResponse) -> Self {
+impl From<&api::ParseRequestCodeResponse> for JsonParseRequestCodeResponse {
+    fn from(src: &api::ParseRequestCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
             value: JsonU64(src.get_value()),
@@ -361,8 +362,8 @@ pub struct JsonCreateAddressCodeResponse {
     pub b58_code: String,
 }
 
-impl From<&mc_mobilecoind_api::CreateAddressCodeResponse> for JsonCreateAddressCodeResponse {
-    fn from(src: &mc_mobilecoind_api::CreateAddressCodeResponse) -> Self {
+impl From<&api::CreateAddressCodeResponse> for JsonCreateAddressCodeResponse {
+    fn from(src: &api::CreateAddressCodeResponse) -> Self {
         Self {
             b58_code: String::from(src.get_b58_code()),
         }
@@ -374,8 +375,8 @@ pub struct JsonParseAddressCodeResponse {
     pub receiver: JsonPublicAddress,
 }
 
-impl From<&mc_mobilecoind_api::ParseAddressCodeResponse> for JsonParseAddressCodeResponse {
-    fn from(src: &mc_mobilecoind_api::ParseAddressCodeResponse) -> Self {
+impl From<&api::ParseAddressCodeResponse> for JsonParseAddressCodeResponse {
+    fn from(src: &api::ParseAddressCodeResponse) -> Self {
         Self {
             receiver: JsonPublicAddress::from(src.get_receiver()),
         }
@@ -388,8 +389,8 @@ pub struct JsonSenderTxReceipt {
     pub tombstone: u64,
 }
 
-impl From<&mc_mobilecoind_api::SenderTxReceipt> for JsonSenderTxReceipt {
-    fn from(src: &mc_mobilecoind_api::SenderTxReceipt) -> Self {
+impl From<&api::SenderTxReceipt> for JsonSenderTxReceipt {
+    fn from(src: &api::SenderTxReceipt) -> Self {
         Self {
             key_images: src
                 .get_key_image_list()
@@ -410,8 +411,8 @@ pub struct JsonReceiverTxReceipt {
     pub confirmation_number: String,
 }
 
-impl From<&mc_mobilecoind_api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
-    fn from(src: &mc_mobilecoind_api::ReceiverTxReceipt) -> Self {
+impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
+    fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
             tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
@@ -435,8 +436,8 @@ pub struct JsonSendPaymentResponse {
     pub receiver_tx_receipt_list: Vec<JsonReceiverTxReceipt>,
 }
 
-impl From<&mc_mobilecoind_api::SendPaymentResponse> for JsonSendPaymentResponse {
-    fn from(src: &mc_mobilecoind_api::SendPaymentResponse) -> Self {
+impl From<&api::SendPaymentResponse> for JsonSendPaymentResponse {
+    fn from(src: &api::SendPaymentResponse) -> Self {
         Self {
             sender_tx_receipt: JsonSenderTxReceipt::from(src.get_sender_tx_receipt()),
             receiver_tx_receipt_list: src
@@ -462,8 +463,8 @@ pub struct JsonOutlay {
     pub receiver: JsonPublicAddress,
 }
 
-impl From<&mc_mobilecoind_api::Outlay> for JsonOutlay {
-    fn from(src: &mc_mobilecoind_api::Outlay) -> Self {
+impl From<&api::Outlay> for JsonOutlay {
+    fn from(src: &api::Outlay) -> Self {
         Self {
             value: JsonU64(src.get_value()),
             receiver: src.get_receiver().into(),
@@ -471,11 +472,11 @@ impl From<&mc_mobilecoind_api::Outlay> for JsonOutlay {
     }
 }
 
-impl TryFrom<&JsonOutlay> for mc_mobilecoind_api::Outlay {
+impl TryFrom<&JsonOutlay> for api::Outlay {
     type Error = String;
 
-    fn try_from(src: &JsonOutlay) -> Result<mc_mobilecoind_api::Outlay, String> {
-        let mut outlay = mc_mobilecoind_api::Outlay::new();
+    fn try_from(src: &JsonOutlay) -> Result<api::Outlay, String> {
+        let mut outlay = api::Outlay::new();
         outlay.set_value(src.value.into());
         outlay.set_receiver(
             PublicAddress::try_from(&src.receiver)
@@ -999,8 +1000,8 @@ pub struct JsonTxProposal {
     pub outlay_confirmation_numbers: Vec<Vec<u8>>,
 }
 
-impl From<&mc_mobilecoind_api::TxProposal> for JsonTxProposal {
-    fn from(src: &mc_mobilecoind_api::TxProposal) -> Self {
+impl From<&api::TxProposal> for JsonTxProposal {
+    fn from(src: &api::TxProposal) -> Self {
         let outlay_map: Vec<(usize, usize)> = src
             .get_outlay_index_to_tx_out_index()
             .iter()
@@ -1022,26 +1023,26 @@ impl From<&mc_mobilecoind_api::TxProposal> for JsonTxProposal {
 }
 
 // Helper conversion between json and protobuf
-impl TryFrom<&JsonTxProposal> for mc_mobilecoind_api::TxProposal {
+impl TryFrom<&JsonTxProposal> for api::TxProposal {
     type Error = String;
 
-    fn try_from(src: &JsonTxProposal) -> Result<mc_mobilecoind_api::TxProposal, String> {
-        let mut inputs: Vec<mc_mobilecoind_api::UnspentTxOut> = Vec::new();
+    fn try_from(src: &JsonTxProposal) -> Result<api::TxProposal, String> {
+        let mut inputs: Vec<api::UnspentTxOut> = Vec::new();
         for input in src.input_list.iter() {
-            let utxo = mc_mobilecoind_api::UnspentTxOut::try_from(input)
+            let utxo = api::UnspentTxOut::try_from(input)
                 .map_err(|err| format!("Failed to convert input: {}", err))?;
             inputs.push(utxo);
         }
 
-        let mut outlays: Vec<mc_mobilecoind_api::Outlay> = Vec::new();
+        let mut outlays: Vec<api::Outlay> = Vec::new();
         for outlay in src.outlay_list.iter() {
-            let out = mc_mobilecoind_api::Outlay::try_from(outlay)
+            let out = api::Outlay::try_from(outlay)
                 .map_err(|err| format!("Failed to convert outlay: {}", err))?;
             outlays.push(out);
         }
 
         // Reconstruct the public address as a protobuf
-        let mut proposal = mc_mobilecoind_api::TxProposal::new();
+        let mut proposal = api::TxProposal::new();
         proposal.set_input_list(RepeatedField::from_vec(inputs));
         proposal.set_outlay_list(RepeatedField::from_vec(outlays));
         proposal
@@ -1072,8 +1073,8 @@ pub struct JsonCreateTxProposalResponse {
     pub tx_proposal: JsonTxProposal,
 }
 
-impl From<&mc_mobilecoind_api::GenerateTxResponse> for JsonCreateTxProposalResponse {
-    fn from(src: &mc_mobilecoind_api::GenerateTxResponse) -> Self {
+impl From<&api::GenerateTxResponse> for JsonCreateTxProposalResponse {
+    fn from(src: &api::GenerateTxResponse) -> Self {
         Self {
             tx_proposal: src.get_tx_proposal().into(),
         }
@@ -1091,8 +1092,8 @@ pub struct JsonSubmitTxResponse {
     pub receiver_tx_receipt_list: Vec<JsonReceiverTxReceipt>,
 }
 
-impl From<&mc_mobilecoind_api::SubmitTxResponse> for JsonSubmitTxResponse {
-    fn from(src: &mc_mobilecoind_api::SubmitTxResponse) -> Self {
+impl From<&api::SubmitTxResponse> for JsonSubmitTxResponse {
+    fn from(src: &api::SubmitTxResponse) -> Self {
         Self {
             sender_tx_receipt: src.get_sender_tx_receipt().into(),
             receiver_tx_receipt_list: src
@@ -1104,11 +1105,11 @@ impl From<&mc_mobilecoind_api::SubmitTxResponse> for JsonSubmitTxResponse {
     }
 }
 
-impl TryFrom<&JsonSubmitTxResponse> for mc_mobilecoind_api::SubmitTxResponse {
+impl TryFrom<&JsonSubmitTxResponse> for api::SubmitTxResponse {
     type Error = String;
 
     fn try_from(src: &JsonSubmitTxResponse) -> Result<Self, String> {
-        let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+        let mut sender_receipt = api::SenderTxReceipt::new();
 
         let key_images: Vec<KeyImage> = src
             .sender_tx_receipt
@@ -1129,7 +1130,7 @@ impl TryFrom<&JsonSubmitTxResponse> for mc_mobilecoind_api::SubmitTxResponse {
 
         let mut receiver_receipts = Vec::new();
         for r in src.receiver_tx_receipt_list.iter() {
-            let mut receiver_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+            let mut receiver_receipt = api::ReceiverTxReceipt::new();
             receiver_receipt.set_recipient(
                 PublicAddress::try_from(&r.recipient)
                     .map_err(|err| format!("Failed to convert recipient: {}", err))?,
@@ -1153,7 +1154,7 @@ impl TryFrom<&JsonSubmitTxResponse> for mc_mobilecoind_api::SubmitTxResponse {
             receiver_receipts.push(receiver_receipt);
         }
 
-        let mut resp = mc_mobilecoind_api::SubmitTxResponse::new();
+        let mut resp = api::SubmitTxResponse::new();
         resp.set_sender_tx_receipt(sender_receipt);
         resp.set_receiver_tx_receipt_list(RepeatedField::from_vec(receiver_receipts));
 
@@ -1166,20 +1167,18 @@ pub struct JsonStatusResponse {
     pub status: String,
 }
 
-impl From<&mc_mobilecoind_api::GetTxStatusAsSenderResponse> for JsonStatusResponse {
-    fn from(src: &mc_mobilecoind_api::GetTxStatusAsSenderResponse) -> Self {
+impl From<&api::GetTxStatusAsSenderResponse> for JsonStatusResponse {
+    fn from(src: &api::GetTxStatusAsSenderResponse) -> Self {
         let status_str = match src.get_status() {
-            mc_mobilecoind_api::TxStatus::Unknown => "unknown",
-            mc_mobilecoind_api::TxStatus::Verified => "verified",
-            mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded => "failed",
-            mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber => "invalid_confirmation",
-            mc_mobilecoind_api::TxStatus::PublicKeysInDifferentBlocks => {
-                "public_keys_in_different_blocks"
-            }
-            mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageBlockMismatch => {
+            api::TxStatus::Unknown => "unknown",
+            api::TxStatus::Verified => "verified",
+            api::TxStatus::TombstoneBlockExceeded => "failed",
+            api::TxStatus::InvalidConfirmationNumber => "invalid_confirmation",
+            api::TxStatus::PublicKeysInDifferentBlocks => "public_keys_in_different_blocks",
+            api::TxStatus::TransactionFailureKeyImageBlockMismatch => {
                 "transaction_failure_key_image_block_mismatch"
             }
-            mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageAlreadySpent => {
+            api::TxStatus::TransactionFailureKeyImageAlreadySpent => {
                 "transaction_failure_key_image_already_spent"
             }
         };
@@ -1190,20 +1189,18 @@ impl From<&mc_mobilecoind_api::GetTxStatusAsSenderResponse> for JsonStatusRespon
     }
 }
 
-impl From<&mc_mobilecoind_api::GetTxStatusAsReceiverResponse> for JsonStatusResponse {
-    fn from(src: &mc_mobilecoind_api::GetTxStatusAsReceiverResponse) -> Self {
+impl From<&api::GetTxStatusAsReceiverResponse> for JsonStatusResponse {
+    fn from(src: &api::GetTxStatusAsReceiverResponse) -> Self {
         let status_str = match src.get_status() {
-            mc_mobilecoind_api::TxStatus::Unknown => "unknown",
-            mc_mobilecoind_api::TxStatus::Verified => "verified",
-            mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded => "failed",
-            mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber => "invalid_confirmation",
-            mc_mobilecoind_api::TxStatus::PublicKeysInDifferentBlocks => {
-                "public_keys_in_different_blocks"
-            }
-            mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageBlockMismatch => {
+            api::TxStatus::Unknown => "unknown",
+            api::TxStatus::Verified => "verified",
+            api::TxStatus::TombstoneBlockExceeded => "failed",
+            api::TxStatus::InvalidConfirmationNumber => "invalid_confirmation",
+            api::TxStatus::PublicKeysInDifferentBlocks => "public_keys_in_different_blocks",
+            api::TxStatus::TransactionFailureKeyImageBlockMismatch => {
                 "transaction_failure_key_image_block_mismatch"
             }
-            mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageAlreadySpent => {
+            api::TxStatus::TransactionFailureKeyImageAlreadySpent => {
                 "transaction_failure_key_image_already_spent"
             }
         };
@@ -1220,8 +1217,8 @@ pub struct JsonLedgerInfoResponse {
     pub txo_count: JsonU64,
 }
 
-impl From<&mc_mobilecoind_api::GetLedgerInfoResponse> for JsonLedgerInfoResponse {
-    fn from(src: &mc_mobilecoind_api::GetLedgerInfoResponse) -> Self {
+impl From<&api::GetLedgerInfoResponse> for JsonLedgerInfoResponse {
+    fn from(src: &api::GetLedgerInfoResponse) -> Self {
         Self {
             block_count: JsonU64(src.block_count),
             txo_count: JsonU64(src.txo_count),
@@ -1235,8 +1232,8 @@ pub struct JsonBlockInfoResponse {
     pub txo_count: JsonU64,
 }
 
-impl From<&mc_mobilecoind_api::GetBlockInfoResponse> for JsonBlockInfoResponse {
-    fn from(src: &mc_mobilecoind_api::GetBlockInfoResponse) -> Self {
+impl From<&api::GetBlockInfoResponse> for JsonBlockInfoResponse {
+    fn from(src: &api::GetBlockInfoResponse) -> Self {
         Self {
             key_image_count: JsonU64(src.key_image_count),
             txo_count: JsonU64(src.txo_count),
@@ -1256,8 +1253,8 @@ pub struct JsonBlockDetailsResponse {
     pub txos: Vec<JsonTxOut>,
 }
 
-impl From<&mc_mobilecoind_api::GetBlockResponse> for JsonBlockDetailsResponse {
-    fn from(src: &mc_mobilecoind_api::GetBlockResponse) -> Self {
+impl From<&api::GetBlockResponse> for JsonBlockDetailsResponse {
+    fn from(src: &api::GetBlockResponse) -> Self {
         let block = src.get_block();
 
         Self {
@@ -1287,12 +1284,12 @@ pub struct JsonProcessedTxOut {
     pub direction: String,
 }
 
-impl From<&mc_mobilecoind_api::ProcessedTxOut> for JsonProcessedTxOut {
-    fn from(src: &mc_mobilecoind_api::ProcessedTxOut) -> Self {
+impl From<&api::ProcessedTxOut> for JsonProcessedTxOut {
+    fn from(src: &api::ProcessedTxOut) -> Self {
         let direction_str = match src.direction {
-            mc_mobilecoind_api::ProcessedTxOutDirection::Invalid => "invalid",
-            mc_mobilecoind_api::ProcessedTxOutDirection::Received => "received",
-            mc_mobilecoind_api::ProcessedTxOutDirection::Spent => "spent",
+            api::ProcessedTxOutDirection::Invalid => "invalid",
+            api::ProcessedTxOutDirection::Received => "received",
+            api::ProcessedTxOutDirection::Spent => "spent",
         };
 
         Self {
@@ -1311,8 +1308,8 @@ pub struct JsonProcessedBlockResponse {
     pub tx_outs: Vec<JsonProcessedTxOut>,
 }
 
-impl From<&mc_mobilecoind_api::GetProcessedBlockResponse> for JsonProcessedBlockResponse {
-    fn from(src: &mc_mobilecoind_api::GetProcessedBlockResponse) -> Self {
+impl From<&api::GetProcessedBlockResponse> for JsonProcessedBlockResponse {
+    fn from(src: &api::GetProcessedBlockResponse) -> Self {
         Self {
             tx_outs: src
                 .get_tx_outs()
@@ -1328,10 +1325,8 @@ pub struct JsonBlockIndexByTxPubKeyResponse {
     pub block_index: String,
 }
 
-impl From<&mc_mobilecoind_api::GetBlockIndexByTxPubKeyResponse>
-    for JsonBlockIndexByTxPubKeyResponse
-{
-    fn from(src: &mc_mobilecoind_api::GetBlockIndexByTxPubKeyResponse) -> Self {
+impl From<&api::GetBlockIndexByTxPubKeyResponse> for JsonBlockIndexByTxPubKeyResponse {
+    fn from(src: &api::GetBlockIndexByTxPubKeyResponse) -> Self {
         Self {
             block_index: src.block.to_string(),
         }
@@ -1343,8 +1338,8 @@ pub struct JsonMobilecoindVersionResponse {
     pub version: String,
 }
 
-impl From<&mc_mobilecoind_api::MobilecoindVersionResponse> for JsonMobilecoindVersionResponse {
-    fn from(src: &mc_mobilecoind_api::MobilecoindVersionResponse) -> Self {
+impl From<&api::MobilecoindVersionResponse> for JsonMobilecoindVersionResponse {
+    fn from(src: &api::MobilecoindVersionResponse) -> Self {
         Self {
             version: src.get_version().to_string(),
         }
@@ -1414,7 +1409,7 @@ mod test {
             let attempted_spend_tombstone = 1234;
 
             // make proto UnspentTxOut
-            let mut unspent = mc_mobilecoind_api::UnspentTxOut::new();
+            let mut unspent = api::UnspentTxOut::new();
             unspent.set_tx_out(mc_api::external::TxOut::from(&tx_out));
             unspent.set_subaddress_index(subaddress_index);
             unspent.set_key_image(mc_api::external::KeyImage::from(&key_image));
@@ -1425,7 +1420,7 @@ mod test {
         };
 
         // Make proto outlay
-        let mut outlay = mc_mobilecoind_api::Outlay::new();
+        let mut outlay = api::Outlay::new();
         let public_addr = AccountKey::random(&mut rng).default_subaddress();
         outlay.set_receiver(mc_api::external::PublicAddress::from(&public_addr));
         outlay.set_value(1234);
@@ -1437,7 +1432,7 @@ mod test {
             )];
 
         // Make proto TxProposal
-        let mut proto_proposal = mc_mobilecoind_api::TxProposal::new();
+        let mut proto_proposal = api::TxProposal::new();
         proto_proposal.set_input_list(RepeatedField::from_vec(vec![utxo]));
         proto_proposal.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
         proto_proposal.set_tx(mc_api::external::Tx::from(&tx));
@@ -1453,7 +1448,7 @@ mod test {
         let json_proposal = JsonTxProposal::from(&proto_proposal);
 
         // Json -> Proto
-        let proto2 = mc_mobilecoind_api::TxProposal::try_from(&json_proposal).unwrap();
+        let proto2 = api::TxProposal::try_from(&json_proposal).unwrap();
 
         // Assert each field, then the whole thing
         assert_eq!(proto_proposal.input_list, proto2.input_list);

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -10,7 +10,7 @@ use crate::{
 use mc_account_keys::PublicAddress;
 use mc_api::ConversionError;
 use mc_common::HashMap;
-use mc_mobilecoind_api::{self};
+use mc_mobilecoind_api as api;
 use mc_transaction_core::{
     ring_signature::KeyImage,
     tx::{Tx, TxOut, TxOutConfirmationNumber},
@@ -18,7 +18,7 @@ use mc_transaction_core::{
 use protobuf::RepeatedField;
 use std::convert::TryFrom;
 
-impl From<&UnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
+impl From<&UnspentTxOut> for api::UnspentTxOut {
     fn from(src: &UnspentTxOut) -> Self {
         let mut dst = Self::new();
 
@@ -34,10 +34,10 @@ impl From<&UnspentTxOut> for mc_mobilecoind_api::UnspentTxOut {
     }
 }
 
-impl TryFrom<&mc_mobilecoind_api::UnspentTxOut> for UnspentTxOut {
+impl TryFrom<&api::UnspentTxOut> for UnspentTxOut {
     type Error = ConversionError;
 
-    fn try_from(src: &mc_mobilecoind_api::UnspentTxOut) -> Result<Self, Self::Error> {
+    fn try_from(src: &api::UnspentTxOut) -> Result<Self, Self::Error> {
         let tx_out = TxOut::try_from(src.get_tx_out())?;
         let subaddress_index = src.subaddress_index;
         let key_image = KeyImage::try_from(src.get_key_image())?;
@@ -58,7 +58,7 @@ impl TryFrom<&mc_mobilecoind_api::UnspentTxOut> for UnspentTxOut {
     }
 }
 
-impl From<&Outlay> for mc_mobilecoind_api::Outlay {
+impl From<&Outlay> for api::Outlay {
     fn from(src: &Outlay) -> Self {
         let mut dst = Self::new();
 
@@ -69,10 +69,10 @@ impl From<&Outlay> for mc_mobilecoind_api::Outlay {
     }
 }
 
-impl TryFrom<&mc_mobilecoind_api::Outlay> for Outlay {
+impl TryFrom<&api::Outlay> for Outlay {
     type Error = ConversionError;
 
-    fn try_from(src: &mc_mobilecoind_api::Outlay) -> Result<Self, Self::Error> {
+    fn try_from(src: &api::Outlay) -> Result<Self, Self::Error> {
         let value = src.value;
         let receiver = PublicAddress::try_from(src.get_receiver())?;
 
@@ -80,9 +80,9 @@ impl TryFrom<&mc_mobilecoind_api::Outlay> for Outlay {
     }
 }
 
-impl From<&TxProposal> for mc_mobilecoind_api::TxProposal {
-    fn from(src: &TxProposal) -> mc_mobilecoind_api::TxProposal {
-        let mut dst = mc_mobilecoind_api::TxProposal::new();
+impl From<&TxProposal> for api::TxProposal {
+    fn from(src: &TxProposal) -> api::TxProposal {
+        let mut dst = api::TxProposal::new();
 
         dst.set_input_list(RepeatedField::from_vec(
             src.utxos.iter().map(|utxo| utxo.into()).collect(),
@@ -109,10 +109,10 @@ impl From<&TxProposal> for mc_mobilecoind_api::TxProposal {
     }
 }
 
-impl TryFrom<&mc_mobilecoind_api::TxProposal> for TxProposal {
+impl TryFrom<&api::TxProposal> for TxProposal {
     type Error = ConversionError;
 
-    fn try_from(src: &mc_mobilecoind_api::TxProposal) -> Result<Self, Self::Error> {
+    fn try_from(src: &api::TxProposal) -> Result<Self, Self::Error> {
         if src.fee != src.get_tx().get_prefix().fee {
             return Err(ConversionError::FeeMismatch);
         }
@@ -220,7 +220,7 @@ mod test {
             token_id: *Mob::ID,
         };
 
-        let proto = mc_mobilecoind_api::UnspentTxOut::from(&rust);
+        let proto = api::UnspentTxOut::from(&rust);
 
         assert_eq!(tx_out, TxOut::try_from(proto.get_tx_out()).unwrap());
         assert_eq!(subaddress_index, proto.subaddress_index);
@@ -246,7 +246,7 @@ mod test {
             receiver: public_addr.clone(),
             value: 1234,
         };
-        let proto = mc_mobilecoind_api::Outlay::from(&rust);
+        let proto = api::Outlay::from(&rust);
 
         assert_eq!(proto.value, rust.value);
         assert_eq!(
@@ -333,7 +333,7 @@ mod test {
             outlay_confirmation_numbers,
         };
 
-        let proto = mc_mobilecoind_api::TxProposal::from(&rust);
+        let proto = api::TxProposal::from(&rust);
 
         assert_eq!(
             rust.utxos,

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -30,6 +30,7 @@ use mc_fog_report_validation::FogPubkeyResolver;
 use mc_ledger_db::{Error as LedgerError, Ledger, LedgerDB};
 use mc_ledger_sync::{NetworkState, PollingNetworkState};
 use mc_mobilecoind_api::{
+    self as api,
     mobilecoind_api_grpc::{create_mobilecoind_api, MobilecoindApi},
     MobilecoindUri,
 };
@@ -226,17 +227,17 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_version_impl(
         &self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::MobilecoindVersionResponse, RpcStatus> {
-        let mut response = mc_mobilecoind_api::MobilecoindVersionResponse::new();
+        _request: api::Empty,
+    ) -> Result<api::MobilecoindVersionResponse, RpcStatus> {
+        let mut response = api::MobilecoindVersionResponse::new();
         response.set_version(env!("CARGO_PKG_VERSION").to_string());
         Ok(response)
     }
 
     fn add_monitor_impl(
         &mut self,
-        request: mc_mobilecoind_api::AddMonitorRequest,
-    ) -> Result<mc_mobilecoind_api::AddMonitorResponse, RpcStatus> {
+        request: api::AddMonitorRequest,
+    ) -> Result<api::AddMonitorResponse, RpcStatus> {
         // Get the AccountKey from the GRPC request.
         let proto_account_key = request.account_key.as_ref().ok_or_else(|| {
             RpcStatus::with_message(RpcStatusCode::INVALID_ARGUMENT, "account_key".into())
@@ -263,7 +264,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         .map_err(|err| rpc_internal_error("mobilecoind_db.add_monitor", err, &self.logger))?;
 
         // Return success response.
-        let mut response = mc_mobilecoind_api::AddMonitorResponse::new();
+        let mut response = api::AddMonitorResponse::new();
         response.set_monitor_id(id.to_vec());
         response.set_is_new(is_new);
         Ok(response)
@@ -271,8 +272,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn remove_monitor_impl(
         &mut self,
-        request: mc_mobilecoind_api::RemoveMonitorRequest,
-    ) -> Result<mc_mobilecoind_api::Empty, RpcStatus> {
+        request: api::RemoveMonitorRequest,
+    ) -> Result<api::Empty, RpcStatus> {
         // Get MonitorId from from the GRPC request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -285,20 +286,20 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?;
 
         // Return success response.
-        let response = mc_mobilecoind_api::Empty::new();
+        let response = api::Empty::new();
         Ok(response)
     }
 
     fn get_monitor_list_impl(
         &mut self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GetMonitorListResponse, RpcStatus> {
+        _request: api::Empty,
+    ) -> Result<api::GetMonitorListResponse, RpcStatus> {
         let monitor_map: HashMap<MonitorId, MonitorData> =
             self.mobilecoind_db.get_monitor_map().map_err(|err| {
                 rpc_internal_error("mobilecoind_db.get_monitor_store_map", err, &self.logger)
             })?;
 
-        let mut response = mc_mobilecoind_api::GetMonitorListResponse::new();
+        let mut response = api::GetMonitorListResponse::new();
         for id in monitor_map.keys() {
             response.mut_monitor_id_list().push(id.to_vec());
         }
@@ -307,8 +308,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_monitor_status_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetMonitorStatusRequest,
-    ) -> Result<mc_mobilecoind_api::GetMonitorStatusResponse, RpcStatus> {
+        request: api::GetMonitorStatusRequest,
+    ) -> Result<api::GetMonitorStatusResponse, RpcStatus> {
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
 
@@ -319,22 +320,22 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 rpc_internal_error("mobilecoind_db.get_monitor_data", err, &self.logger)
             })?;
 
-        let mut status = mc_mobilecoind_api::MonitorStatus::new();
+        let mut status = api::MonitorStatus::new();
         status.set_account_key(mc_api::external::AccountKey::from(&data.account_key));
         status.set_first_subaddress(data.first_subaddress);
         status.set_num_subaddresses(data.num_subaddresses);
         status.set_first_block(data.first_block);
         status.set_next_block(data.next_block);
 
-        let mut response = mc_mobilecoind_api::GetMonitorStatusResponse::new();
+        let mut response = api::GetMonitorStatusResponse::new();
         response.set_status(status);
         Ok(response)
     }
 
     fn get_unspent_tx_out_list_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetUnspentTxOutListRequest,
-    ) -> Result<mc_mobilecoind_api::GetUnspentTxOutListResponse, RpcStatus> {
+        request: api::GetUnspentTxOutListRequest,
+    ) -> Result<api::GetUnspentTxOutListResponse, RpcStatus> {
         // Get MonitorId from from the GRPC request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -354,33 +355,32 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .collect();
 
         // Convert to protos.
-        let proto_utxos: Vec<mc_mobilecoind_api::UnspentTxOut> =
-            utxos.iter().map(|utxo| utxo.into()).collect();
+        let proto_utxos: Vec<api::UnspentTxOut> = utxos.iter().map(|utxo| utxo.into()).collect();
 
         // Returrn response.
-        let mut response = mc_mobilecoind_api::GetUnspentTxOutListResponse::new();
+        let mut response = api::GetUnspentTxOutListResponse::new();
         response.set_output_list(RepeatedField::from_vec(proto_utxos));
         Ok(response)
     }
 
     fn generate_root_entropy_impl(
         &mut self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GenerateRootEntropyResponse, RpcStatus> {
+        _request: api::Empty,
+    ) -> Result<api::GenerateRootEntropyResponse, RpcStatus> {
         let mut rng = rand::thread_rng();
         let root_id = RootIdentity::from_random(&mut rng);
-        let mut response = mc_mobilecoind_api::GenerateRootEntropyResponse::new();
+        let mut response = api::GenerateRootEntropyResponse::new();
         response.set_root_entropy(root_id.root_entropy.as_ref().to_vec());
         Ok(response)
     }
 
     fn generate_mnemonic_impl(
         &mut self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GenerateMnemonicResponse, RpcStatus> {
+        _request: api::Empty,
+    ) -> Result<api::GenerateMnemonicResponse, RpcStatus> {
         let mnemonic = Mnemonic::new(MnemonicType::Words24, Language::English);
 
-        let mut response = mc_mobilecoind_api::GenerateMnemonicResponse::new();
+        let mut response = api::GenerateMnemonicResponse::new();
         response.set_mnemonic(mnemonic.phrase().to_string());
         response.set_bip39_entropy(mnemonic.entropy().to_vec());
         Ok(response)
@@ -388,8 +388,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_account_key_from_root_entropy_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest,
-    ) -> Result<mc_mobilecoind_api::GetAccountKeyResponse, RpcStatus> {
+        request: api::GetAccountKeyFromRootEntropyRequest,
+    ) -> Result<api::GetAccountKeyResponse, RpcStatus> {
         // Get the entropy.
         if request.get_root_entropy().len() != 32 {
             return Err(RpcStatus::with_message(
@@ -405,30 +405,30 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let account_key = AccountKey::from(&root_id);
 
         // Return response.
-        let mut response = mc_mobilecoind_api::GetAccountKeyResponse::new();
+        let mut response = api::GetAccountKeyResponse::new();
         response.set_account_key((&account_key).into());
         Ok(response)
     }
 
     fn get_account_key_from_mnemonic_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest,
-    ) -> Result<mc_mobilecoind_api::GetAccountKeyResponse, RpcStatus> {
+        request: api::GetAccountKeyFromMnemonicRequest,
+    ) -> Result<api::GetAccountKeyResponse, RpcStatus> {
         let mnemonic = Mnemonic::from_phrase(request.get_mnemonic(), Language::English)
             .map_err(|err| rpc_invalid_arg_error("mnemonic", err, &self.logger))?;
         let key = mnemonic.derive_slip10_key(request.account_index);
         let account_key = AccountKey::from(key);
 
         // Return response.
-        let mut response = mc_mobilecoind_api::GetAccountKeyResponse::new();
+        let mut response = api::GetAccountKeyResponse::new();
         response.set_account_key((&account_key).into());
         Ok(response)
     }
 
     fn get_public_address_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetPublicAddressRequest,
-    ) -> Result<mc_mobilecoind_api::GetPublicAddressResponse, RpcStatus> {
+        request: api::GetPublicAddressRequest,
+    ) -> Result<api::GetPublicAddressResponse, RpcStatus> {
         // Get MonitorId from from the GRPC request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -456,11 +456,11 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let subaddress = data.account_key.subaddress(request.subaddress_index);
 
         // Also build the b58 wrapper
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&subaddress).into());
 
         // Return response.
-        let mut response = mc_mobilecoind_api::GetPublicAddressResponse::new();
+        let mut response = api::GetPublicAddressResponse::new();
         response.set_public_address((&subaddress).into());
         response.set_b58_code(
             wrapper
@@ -473,17 +473,18 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn parse_request_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ParseRequestCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ParseRequestCodeResponse, RpcStatus> {
-        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
-            request.get_b58_code().to_string(),
-        )
-        .map_err(|err| rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger))?;
+        request: api::ParseRequestCodeRequest,
+    ) -> Result<api::ParseRequestCodeResponse, RpcStatus> {
+        let wrapper =
+            api::printable::PrintableWrapper::b58_decode(request.get_b58_code().to_string())
+                .map_err(|err| {
+                    rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger)
+                })?;
 
         // A request code could be a public address or a payment request
         if wrapper.has_payment_request() {
             let payment_request = wrapper.get_payment_request();
-            let mut response = mc_mobilecoind_api::ParseRequestCodeResponse::new();
+            let mut response = api::ParseRequestCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             response.set_value(payment_request.get_value());
             response.set_memo(payment_request.get_memo().to_string());
@@ -491,7 +492,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             Ok(response)
         } else if wrapper.has_public_address() {
             let public_address = wrapper.get_public_address();
-            let mut response = mc_mobilecoind_api::ParseRequestCodeResponse::new();
+            let mut response = api::ParseRequestCodeResponse::new();
             response.set_receiver(public_address.clone());
             response.set_value(0);
             response.set_memo(String::new());
@@ -506,37 +507,38 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn create_request_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::CreateRequestCodeRequest,
-    ) -> Result<mc_mobilecoind_api::CreateRequestCodeResponse, RpcStatus> {
+        request: api::CreateRequestCodeRequest,
+    ) -> Result<api::CreateRequestCodeResponse, RpcStatus> {
         let receiver = PublicAddress::try_from(request.get_receiver())
             .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
 
-        let mut payment_request = mc_mobilecoind_api::printable::PaymentRequest::new();
+        let mut payment_request = api::printable::PaymentRequest::new();
         payment_request.set_public_address((&receiver).into());
         payment_request.set_value(request.get_value());
         payment_request.set_memo(request.get_memo().to_string());
         payment_request.set_token_id(request.get_token_id());
 
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_payment_request(payment_request);
 
         let encoded = wrapper
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::CreateRequestCodeResponse::new();
+        let mut response = api::CreateRequestCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
 
     fn parse_transfer_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ParseTransferCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ParseTransferCodeResponse, RpcStatus> {
-        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
-            request.get_b58_code().to_string(),
-        )
-        .map_err(|err| rpc_internal_error("PrintableWrapper.b58_decode", err, &self.logger))?;
+        request: api::ParseTransferCodeRequest,
+    ) -> Result<api::ParseTransferCodeResponse, RpcStatus> {
+        let wrapper =
+            api::printable::PrintableWrapper::b58_decode(request.get_b58_code().to_string())
+                .map_err(|err| {
+                    rpc_internal_error("PrintableWrapper.b58_decode", err, &self.logger)
+                })?;
 
         if !wrapper.has_transfer_payload() {
             return Err(RpcStatus::with_message(
@@ -615,7 +617,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             attempted_spend_tombstone: 0,
         };
 
-        let mut response = mc_mobilecoind_api::ParseTransferCodeResponse::new();
+        let mut response = api::ParseTransferCodeResponse::new();
         response.set_root_entropy(transfer_payload.get_root_entropy().to_vec());
         response.set_bip39_entropy(transfer_payload.get_bip39_entropy().to_vec());
         response.set_tx_public_key((&tx_public_key).into());
@@ -627,8 +629,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn create_transfer_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::CreateTransferCodeRequest,
-    ) -> Result<mc_mobilecoind_api::CreateTransferCodeResponse, RpcStatus> {
+        request: api::CreateTransferCodeRequest,
+    ) -> Result<api::CreateTransferCodeResponse, RpcStatus> {
         // Must have entropy.
         if request.bip39_entropy.is_empty() && request.root_entropy.is_empty() {
             return Err(RpcStatus::with_message(
@@ -672,42 +674,43 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             ));
         }
 
-        let mut transfer_payload = mc_mobilecoind_api::printable::TransferPayload::new();
+        let mut transfer_payload = api::printable::TransferPayload::new();
         transfer_payload.set_root_entropy(request.get_root_entropy().to_vec());
         transfer_payload.set_bip39_entropy(request.get_bip39_entropy().to_vec());
         transfer_payload.set_tx_out_public_key(request.get_tx_public_key().clone());
         transfer_payload.set_memo(request.get_memo().to_string());
 
-        let mut transfer_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut transfer_wrapper = api::printable::PrintableWrapper::new();
         transfer_wrapper.set_transfer_payload(transfer_payload);
 
         let encoded = transfer_wrapper
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::CreateTransferCodeResponse::new();
+        let mut response = api::CreateTransferCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
 
     fn parse_address_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::ParseAddressCodeRequest,
-    ) -> Result<mc_mobilecoind_api::ParseAddressCodeResponse, RpcStatus> {
-        let wrapper = mc_mobilecoind_api::printable::PrintableWrapper::b58_decode(
-            request.get_b58_code().to_string(),
-        )
-        .map_err(|err| rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger))?;
+        request: api::ParseAddressCodeRequest,
+    ) -> Result<api::ParseAddressCodeResponse, RpcStatus> {
+        let wrapper =
+            api::printable::PrintableWrapper::b58_decode(request.get_b58_code().to_string())
+                .map_err(|err| {
+                    rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger)
+                })?;
 
         // An address code could be a public address or a payment request
         if wrapper.has_payment_request() {
             let payment_request = wrapper.get_payment_request();
-            let mut response = mc_mobilecoind_api::ParseAddressCodeResponse::new();
+            let mut response = api::ParseAddressCodeResponse::new();
             response.set_receiver(payment_request.get_public_address().clone());
             Ok(response)
         } else if wrapper.has_public_address() {
             let public_address = wrapper.get_public_address();
-            let mut response = mc_mobilecoind_api::ParseAddressCodeResponse::new();
+            let mut response = api::ParseAddressCodeResponse::new();
             response.set_receiver(public_address.clone());
             Ok(response)
         } else {
@@ -720,19 +723,19 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn create_address_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::CreateAddressCodeRequest,
-    ) -> Result<mc_mobilecoind_api::CreateAddressCodeResponse, RpcStatus> {
+        request: api::CreateAddressCodeRequest,
+    ) -> Result<api::CreateAddressCodeResponse, RpcStatus> {
         let receiver = PublicAddress::try_from(request.get_receiver())
             .map_err(|err| rpc_internal_error("PublicAddress.try_from", err, &self.logger))?;
 
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&receiver).into());
 
         let encoded = wrapper
             .b58_encode()
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::CreateAddressCodeResponse::new();
+        let mut response = api::CreateAddressCodeResponse::new();
         response.set_b58_code(encoded);
         Ok(response)
     }
@@ -740,8 +743,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
     /// Get mixins
     fn get_mixins_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetMixinsRequest,
-    ) -> Result<mc_mobilecoind_api::GetMixinsResponse, RpcStatus> {
+        request: api::GetMixinsRequest,
+    ) -> Result<api::GetMixinsResponse, RpcStatus> {
         let num_mixins: usize = request.get_num_mixins() as usize;
         let excluded: Vec<TxOut> = request
             .get_excluded()
@@ -765,12 +768,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map(|nested| nested.into_iter().flatten().collect())
             .map_err(|e| rpc_internal_error("get_rings_error", e, &self.logger))?; // TODO better error handling
 
-        let mut response = mc_mobilecoind_api::GetMixinsResponse::new();
+        let mut response = api::GetMixinsResponse::new();
 
-        let tx_outs_with_proofs: Vec<mc_mobilecoind_api::TxOutWithProof> = mixins_with_proofs
+        let tx_outs_with_proofs: Vec<api::TxOutWithProof> = mixins_with_proofs
             .iter()
             .map(|(tx_out, proof)| {
-                let mut tx_out_with_proof = mc_mobilecoind_api::TxOutWithProof::new();
+                let mut tx_out_with_proof = api::TxOutWithProof::new();
                 tx_out_with_proof.set_output(tx_out.into());
                 tx_out_with_proof.set_proof(proof.into());
                 tx_out_with_proof
@@ -784,8 +787,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
     /// Get a proof of membership for each requested TxOut.
     fn get_membership_proofs_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetMembershipProofsRequest,
-    ) -> Result<mc_mobilecoind_api::GetMembershipProofsResponse, RpcStatus> {
+        request: api::GetMembershipProofsRequest,
+    ) -> Result<api::GetMembershipProofsResponse, RpcStatus> {
         let outputs: Vec<TxOut> = request
             .get_outputs()
             .iter()
@@ -801,10 +804,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .get_membership_proofs(&outputs)
             .map_err(|err| rpc_internal_error("get_membership_proofs", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::GetMembershipProofsResponse::new();
+        let mut response = api::GetMembershipProofsResponse::new();
 
         for (tx_out, proof) in outputs.iter().zip(proofs.iter()) {
-            let mut tx_out_with_proof = mc_mobilecoind_api::TxOutWithProof::new();
+            let mut tx_out_with_proof = api::TxOutWithProof::new();
             tx_out_with_proof.set_output(tx_out.into());
             tx_out_with_proof.set_proof(proof.into());
             response.mut_output_list().push(tx_out_with_proof);
@@ -815,8 +818,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn generate_tx_impl(
         &mut self,
-        request: mc_mobilecoind_api::GenerateTxRequest,
-    ) -> Result<mc_mobilecoind_api::GenerateTxResponse, RpcStatus> {
+        request: api::GenerateTxRequest,
+    ) -> Result<api::GenerateTxResponse, RpcStatus> {
         // Get sender monitor id from request.
         let sender_monitor_id = MonitorId::try_from(&request.sender_monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -912,15 +915,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?;
 
         // Success.
-        let mut response = mc_mobilecoind_api::GenerateTxResponse::new();
+        let mut response = api::GenerateTxResponse::new();
         response.set_tx_proposal((&tx_proposal).into());
         Ok(response)
     }
 
     fn generate_optimization_tx_impl(
         &mut self,
-        request: mc_mobilecoind_api::GenerateOptimizationTxRequest,
-    ) -> Result<mc_mobilecoind_api::GenerateOptimizationTxResponse, RpcStatus> {
+        request: api::GenerateOptimizationTxRequest,
+    ) -> Result<api::GenerateOptimizationTxResponse, RpcStatus> {
         // Get monitor id from request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -944,15 +947,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?;
 
         // Success.
-        let mut response = mc_mobilecoind_api::GenerateOptimizationTxResponse::new();
+        let mut response = api::GenerateOptimizationTxResponse::new();
         response.set_tx_proposal((&tx_proposal).into());
         Ok(response)
     }
 
     fn generate_tx_from_tx_out_list_impl(
         &mut self,
-        request: mc_mobilecoind_api::GenerateTxFromTxOutListRequest,
-    ) -> Result<mc_mobilecoind_api::GenerateTxFromTxOutListResponse, RpcStatus> {
+        request: api::GenerateTxFromTxOutListRequest,
+    ) -> Result<api::GenerateTxFromTxOutListResponse, RpcStatus> {
         let proto_account_key = request.account_key.as_ref().ok_or_else(|| {
             RpcStatus::with_message(RpcStatusCode::INVALID_ARGUMENT, "account_key".into())
         })?;
@@ -1005,15 +1008,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 )
             })?;
 
-        let mut response = mc_mobilecoind_api::GenerateTxFromTxOutListResponse::new();
+        let mut response = api::GenerateTxFromTxOutListResponse::new();
         response.set_tx_proposal((&tx_proposal).into());
         Ok(response)
     }
 
     fn generate_burn_redemption_tx_impl(
         &mut self,
-        request: mc_mobilecoind_api::GenerateBurnRedemptionTxRequest,
-    ) -> Result<mc_mobilecoind_api::GenerateBurnRedemptionTxResponse, RpcStatus> {
+        request: api::GenerateBurnRedemptionTxRequest,
+    ) -> Result<api::GenerateBurnRedemptionTxResponse, RpcStatus> {
         // Get sender monitor id from request.
         let sender_monitor_id = MonitorId::try_from(&request.sender_monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -1119,22 +1122,22 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?;
 
         // Success.
-        let mut response = mc_mobilecoind_api::GenerateBurnRedemptionTxResponse::new();
+        let mut response = api::GenerateBurnRedemptionTxResponse::new();
         response.set_tx_proposal((&tx_proposal).into());
         Ok(response)
     }
 
     fn generate_transfer_code_tx_impl(
         &mut self,
-        request: mc_mobilecoind_api::GenerateTransferCodeTxRequest,
-    ) -> Result<mc_mobilecoind_api::GenerateTransferCodeTxResponse, RpcStatus> {
+        request: api::GenerateTransferCodeTxRequest,
+    ) -> Result<api::GenerateTransferCodeTxResponse, RpcStatus> {
         // Generate entropy.
-        let mnemonic_response = self.generate_mnemonic_impl(mc_mobilecoind_api::Empty::new())?;
+        let mnemonic_response = self.generate_mnemonic_impl(api::Empty::new())?;
         let mnemonic_str = mnemonic_response.get_mnemonic().to_string();
         let bip39_entropy = mnemonic_response.get_bip39_entropy();
 
         // Generate a new account using this mnemonic.
-        let mut account_key_request = mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest::new();
+        let mut account_key_request = api::GetAccountKeyFromMnemonicRequest::new();
         account_key_request.set_mnemonic(mnemonic_str);
 
         let account_key_response = self.get_account_key_from_mnemonic_impl(account_key_request)?;
@@ -1148,7 +1151,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         };
 
         // Generate transaction.
-        let mut generate_tx_request = mc_mobilecoind_api::GenerateTxRequest::new();
+        let mut generate_tx_request = api::GenerateTxRequest::new();
         generate_tx_request.set_sender_monitor_id(request.get_sender_monitor_id().to_vec());
         generate_tx_request.set_change_subaddress(request.change_subaddress);
         generate_tx_request.set_input_list(RepeatedField::from_vec(request.input_list.to_vec()));
@@ -1204,12 +1207,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let tx_public_key = RistrettoPublic::try_from(&proto_tx_public_key)
             .map_err(|err| rpc_internal_error("ristretto_public.try_from", err, &self.logger))?;
 
-        let mut transfer_payload = mc_mobilecoind_api::printable::TransferPayload::new();
+        let mut transfer_payload = api::printable::TransferPayload::new();
         transfer_payload.set_bip39_entropy(bip39_entropy.to_vec());
         transfer_payload.set_tx_out_public_key((&tx_public_key).into());
         transfer_payload.set_memo(request.get_memo().to_string());
 
-        let mut transfer_wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut transfer_wrapper = api::printable::PrintableWrapper::new();
         transfer_wrapper.set_transfer_payload(transfer_payload);
 
         let b58_code = transfer_wrapper
@@ -1217,7 +1220,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
 
         // Construct response.
-        let mut response = mc_mobilecoind_api::GenerateTransferCodeTxResponse::new();
+        let mut response = api::GenerateTransferCodeTxResponse::new();
         response.set_tx_proposal(tx_proposal);
         response.set_bip39_entropy(bip39_entropy.to_vec());
         response.set_tx_public_key(proto_tx_public_key);
@@ -1228,8 +1231,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn submit_tx_impl(
         &mut self,
-        request: mc_mobilecoind_api::SubmitTxRequest,
-    ) -> Result<mc_mobilecoind_api::SubmitTxResponse, RpcStatus> {
+        request: api::SubmitTxRequest,
+    ) -> Result<api::SubmitTxResponse, RpcStatus> {
         // Get TxProposal from request.
         let tx_proposal = TxProposal::try_from(request.get_tx_proposal())
             .map_err(|err| rpc_internal_error("tx_proposal.try_from", err, &self.logger))?;
@@ -1262,7 +1265,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
 
         // Construct sender receipt.
-        let mut sender_tx_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+        let mut sender_tx_receipt = api::SenderTxReceipt::new();
         sender_tx_receipt.set_key_image_list(RepeatedField::from_vec(
             tx_proposal
                 .utxos
@@ -1300,7 +1303,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                         )
                     })?;
 
-                let mut receiver_tx_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+                let mut receiver_tx_receipt = api::ReceiverTxReceipt::new();
                 receiver_tx_receipt.set_recipient((&outlay.receiver).into());
                 receiver_tx_receipt.set_tx_public_key((&tx_out.public_key).into());
                 receiver_tx_receipt.set_tx_out_hash(tx_out.hash().to_vec());
@@ -1314,10 +1317,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
                 Ok(receiver_tx_receipt)
             })
-            .collect::<Result<Vec<mc_mobilecoind_api::ReceiverTxReceipt>, RpcStatus>>()?;
+            .collect::<Result<Vec<api::ReceiverTxReceipt>, RpcStatus>>()?;
 
         // Return response.
-        let mut response = mc_mobilecoind_api::SubmitTxResponse::new();
+        let mut response = api::SubmitTxResponse::new();
         response.set_sender_tx_receipt(sender_tx_receipt);
         response.set_receiver_tx_receipt_list(RepeatedField::from_vec(receiver_tx_receipts));
         Ok(response)
@@ -1325,8 +1328,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_ledger_info_impl(
         &mut self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GetLedgerInfoResponse, RpcStatus> {
+        _request: api::Empty,
+    ) -> Result<api::GetLedgerInfoResponse, RpcStatus> {
         let num_blocks = self
             .ledger_db
             .num_blocks()
@@ -1337,7 +1340,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .num_txos()
             .map_err(|err| rpc_internal_error("ledger_db.num_txos", err, &self.logger))?;
 
-        let mut response = mc_mobilecoind_api::GetLedgerInfoResponse::new();
+        let mut response = api::GetLedgerInfoResponse::new();
         response.set_block_count(num_blocks);
         response.set_txo_count(num_txos);
         Ok(response)
@@ -1345,8 +1348,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_block_info_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetBlockInfoRequest,
-    ) -> Result<mc_mobilecoind_api::GetBlockInfoResponse, RpcStatus> {
+        request: api::GetBlockInfoRequest,
+    ) -> Result<api::GetBlockInfoResponse, RpcStatus> {
         let block_contents = self
             .ledger_db
             .get_block_contents(request.block)
@@ -1356,7 +1359,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let num_key_images = block_contents.key_images.len();
 
         // Return response.
-        let mut response = mc_mobilecoind_api::GetBlockInfoResponse::new();
+        let mut response = api::GetBlockInfoResponse::new();
         response.set_key_image_count(num_key_images as u64);
         response.set_txo_count(num_tx_outs as u64);
         Ok(response)
@@ -1364,9 +1367,9 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_block_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetBlockRequest,
-    ) -> Result<mc_mobilecoind_api::GetBlockResponse, RpcStatus> {
-        let mut response = mc_mobilecoind_api::GetBlockResponse::new();
+        request: api::GetBlockRequest,
+    ) -> Result<api::GetBlockResponse, RpcStatus> {
+        let mut response = api::GetBlockResponse::new();
 
         let block_data = self
             .ledger_db
@@ -1395,7 +1398,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                     rpc_internal_error("watcher_db.get_block_signatures", err, &self.logger)
                 })?;
             for signature_data in signatures.iter() {
-                let mut signature_message = mc_mobilecoind_api::ArchiveBlockSignatureData::new();
+                let mut signature_message = api::ArchiveBlockSignatureData::new();
                 signature_message.set_src_url(signature_data.src_url.clone());
                 signature_message.set_filename(signature_data.archive_filename.clone());
                 signature_message.set_signature(
@@ -1411,8 +1414,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_tx_status_as_sender_impl(
         &mut self,
-        request: mc_mobilecoind_api::SubmitTxResponse,
-    ) -> Result<mc_mobilecoind_api::GetTxStatusAsSenderResponse, RpcStatus> {
+        request: api::SubmitTxResponse,
+    ) -> Result<api::GetTxStatusAsSenderResponse, RpcStatus> {
         // Sanity-test the request.
         if request
             .get_sender_tx_receipt()
@@ -1494,16 +1497,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .iter()
                 .any(|key_image_in_ledger| *key_image_in_ledger)
             {
-                let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-                response.set_status(
-                    mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageAlreadySpent,
-                );
+                let mut response = api::GetTxStatusAsSenderResponse::new();
+                response.set_status(api::TxStatus::TransactionFailureKeyImageAlreadySpent);
                 return Ok(response);
             }
 
             // Otherwise, the transaction is still pending or otherwise status unknown.
-            let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-            response.set_status(mc_mobilecoind_api::TxStatus::Unknown);
+            let mut response = api::GetTxStatusAsSenderResponse::new();
+            response.set_status(api::TxStatus::Unknown);
             return Ok(response);
         }
 
@@ -1512,8 +1513,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // transaction containing output public keys that somehow end up landing
         // in different blocks.
         if found_pubkey_indices.iter().min() != found_pubkey_indices.iter().max() {
-            let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-            response.set_status(mc_mobilecoind_api::TxStatus::PublicKeysInDifferentBlocks);
+            let mut response = api::GetTxStatusAsSenderResponse::new();
+            response.set_status(api::TxStatus::PublicKeysInDifferentBlocks);
             return Ok(response);
         }
 
@@ -1537,8 +1538,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .iter()
             .all(|key_image_found| *key_image_found)
         {
-            let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-            response.set_status(mc_mobilecoind_api::TxStatus::Verified);
+            let mut response = api::GetTxStatusAsSenderResponse::new();
+            response.set_status(api::TxStatus::Verified);
             return Ok(response);
         }
 
@@ -1548,9 +1549,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .iter()
             .any(|key_image_found| *key_image_found)
         {
-            let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-            response
-                .set_status(mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageBlockMismatch);
+            let mut response = api::GetTxStatusAsSenderResponse::new();
+            response.set_status(api::TxStatus::TransactionFailureKeyImageBlockMismatch);
             return Ok(response);
         }
 
@@ -1561,21 +1561,21 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map_err(|err| rpc_internal_error("ledger_db.num_blocks", err, &self.logger))?;
 
         if num_blocks >= request.get_sender_tx_receipt().tombstone {
-            let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-            response.set_status(mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded);
+            let mut response = api::GetTxStatusAsSenderResponse::new();
+            response.set_status(api::TxStatus::TombstoneBlockExceeded);
             return Ok(response);
         }
 
         // No key images in ledger, tombstone block not yet exceeded.
-        let mut response = mc_mobilecoind_api::GetTxStatusAsSenderResponse::new();
-        response.set_status(mc_mobilecoind_api::TxStatus::Unknown);
+        let mut response = api::GetTxStatusAsSenderResponse::new();
+        response.set_status(api::TxStatus::Unknown);
         Ok(response)
     }
 
     fn get_tx_status_as_receiver_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetTxStatusAsReceiverRequest,
-    ) -> Result<mc_mobilecoind_api::GetTxStatusAsReceiverResponse, RpcStatus> {
+        request: api::GetTxStatusAsReceiverRequest,
+    ) -> Result<api::GetTxStatusAsReceiverResponse, RpcStatus> {
         // Sanity-test the request.
         if request.get_receipt().get_tx_out_hash().len() != 32 {
             return Err(RpcStatus::with_message(
@@ -1650,11 +1650,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                             // to prove that they created it. This prevents a third-party observer
                             // from taking credit for someone elses
                             // payment.
-                            let mut response =
-                                mc_mobilecoind_api::GetTxStatusAsReceiverResponse::new();
-                            response.set_status(
-                                mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber,
-                            );
+                            let mut response = api::GetTxStatusAsReceiverResponse::new();
+                            response.set_status(api::TxStatus::InvalidConfirmationNumber);
                             return Ok(response);
                         }
                     }
@@ -1667,8 +1664,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 }
 
                 // The hash found its way into the ledger, so the transaction succeeded.
-                let mut response = mc_mobilecoind_api::GetTxStatusAsReceiverResponse::new();
-                response.set_status(mc_mobilecoind_api::TxStatus::Verified);
+                let mut response = api::GetTxStatusAsReceiverResponse::new();
+                response.set_status(api::TxStatus::Verified);
                 return Ok(response);
             }
             Err(mc_ledger_db::Error::NotFound) => {}
@@ -1688,21 +1685,21 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map_err(|err| rpc_internal_error("ledger_db.num_blocks", err, &self.logger))?;
 
         if num_blocks >= request.get_receipt().tombstone {
-            let mut response = mc_mobilecoind_api::GetTxStatusAsReceiverResponse::new();
-            response.set_status(mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded);
+            let mut response = api::GetTxStatusAsReceiverResponse::new();
+            response.set_status(api::TxStatus::TombstoneBlockExceeded);
             return Ok(response);
         }
 
         // Tx out not in ledger, tombstone block not yet exceeded.
-        let mut response = mc_mobilecoind_api::GetTxStatusAsReceiverResponse::new();
-        response.set_status(mc_mobilecoind_api::TxStatus::Unknown);
+        let mut response = api::GetTxStatusAsReceiverResponse::new();
+        response.set_status(api::TxStatus::Unknown);
         Ok(response)
     }
 
     fn get_processed_block_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetProcessedBlockRequest,
-    ) -> Result<mc_mobilecoind_api::GetProcessedBlockResponse, RpcStatus> {
+        request: api::GetProcessedBlockRequest,
+    ) -> Result<api::GetProcessedBlockResponse, RpcStatus> {
         // Get MonitorId from from the GRPC request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -1725,19 +1722,19 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             })?
             .iter()
             .map(|src| {
-                let mut dst = mc_mobilecoind_api::ProcessedTxOut::new();
+                let mut dst = api::ProcessedTxOut::new();
                 dst.set_monitor_id(monitor_id.to_vec());
                 dst.set_subaddress_index(src.subaddress_index);
                 dst.set_public_key((&src.public_key).into());
                 dst.set_key_image((&src.key_image).into());
                 dst.set_value(src.value);
                 dst.set_direction(
-                    mc_mobilecoind_api::ProcessedTxOutDirection::from_i32(src.direction)
-                        .unwrap_or(mc_mobilecoind_api::ProcessedTxOutDirection::Invalid),
+                    api::ProcessedTxOutDirection::from_i32(src.direction)
+                        .unwrap_or(api::ProcessedTxOutDirection::Invalid),
                 );
 
                 let subaddress = account_key.subaddress(src.subaddress_index);
-                let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+                let mut wrapper = api::printable::PrintableWrapper::new();
                 wrapper.set_public_address((&subaddress).into());
                 let encoded = wrapper
                     .b58_encode()
@@ -1749,15 +1746,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .collect::<Result<Vec<_>, _>>()?;
 
         // Return response
-        let mut response = mc_mobilecoind_api::GetProcessedBlockResponse::new();
+        let mut response = api::GetProcessedBlockResponse::new();
         response.set_tx_outs(RepeatedField::from_vec(processed_tx_outs));
         Ok(response)
     }
 
     fn get_block_index_by_tx_pub_key_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetBlockIndexByTxPubKeyRequest,
-    ) -> Result<mc_mobilecoind_api::GetBlockIndexByTxPubKeyResponse, RpcStatus> {
+        request: api::GetBlockIndexByTxPubKeyRequest,
+    ) -> Result<api::GetBlockIndexByTxPubKeyResponse, RpcStatus> {
         let tx_public_key = RistrettoPublic::try_from(request.get_tx_public_key())
             .map_err(|err| rpc_internal_error("RistrettoPublic.try_from", err, &self.logger))?;
 
@@ -1785,15 +1782,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 )
             })?;
 
-        let mut response = mc_mobilecoind_api::GetBlockIndexByTxPubKeyResponse::new();
+        let mut response = api::GetBlockIndexByTxPubKeyResponse::new();
         response.set_block(block_index);
         Ok(response)
     }
 
     fn get_balance_impl(
         &mut self,
-        request: mc_mobilecoind_api::GetBalanceRequest,
-    ) -> Result<mc_mobilecoind_api::GetBalanceResponse, RpcStatus> {
+        request: api::GetBalanceRequest,
+    ) -> Result<api::GetBalanceResponse, RpcStatus> {
         // Get MonitorId from from the GRPC request.
         let monitor_id = MonitorId::try_from(&request.monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -1826,15 +1823,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
 
         // Return response.
-        let mut response = mc_mobilecoind_api::GetBalanceResponse::new();
+        let mut response = api::GetBalanceResponse::new();
         response.set_balance(balance as u64);
         Ok(response)
     }
 
     fn send_payment_impl(
         &mut self,
-        request: mc_mobilecoind_api::SendPaymentRequest,
-    ) -> Result<mc_mobilecoind_api::SendPaymentResponse, RpcStatus> {
+        request: api::SendPaymentRequest,
+    ) -> Result<api::SendPaymentResponse, RpcStatus> {
         // Get sender monitor id from request.
         let sender_monitor_id = MonitorId::try_from(&request.sender_monitor_id)
             .map_err(|err| rpc_internal_error("monitor_id.try_from.bytes", err, &self.logger))?;
@@ -1890,15 +1887,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
             })?;
 
-        let proto_tx_proposal = mc_mobilecoind_api::TxProposal::from(&tx_proposal);
+        let proto_tx_proposal = api::TxProposal::from(&tx_proposal);
 
         // Submit transaction.
-        let mut submit_tx_request = mc_mobilecoind_api::SubmitTxRequest::new();
+        let mut submit_tx_request = api::SubmitTxRequest::new();
         submit_tx_request.set_tx_proposal(proto_tx_proposal.clone());
         let mut submit_tx_response = self.submit_tx_impl(submit_tx_request)?;
 
         // Return response.
-        let mut response = mc_mobilecoind_api::SendPaymentResponse::new();
+        let mut response = api::SendPaymentResponse::new();
         response.set_sender_tx_receipt(submit_tx_response.take_sender_tx_receipt());
         response.set_receiver_tx_receipt_list(submit_tx_response.take_receiver_tx_receipt_list());
         response.set_tx_proposal(proto_tx_proposal);
@@ -1907,8 +1904,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn pay_address_code_impl(
         &mut self,
-        request: mc_mobilecoind_api::PayAddressCodeRequest,
-    ) -> Result<mc_mobilecoind_api::SendPaymentResponse, RpcStatus> {
+        request: api::PayAddressCodeRequest,
+    ) -> Result<api::SendPaymentResponse, RpcStatus> {
         // Sanity check.
         if request.get_amount() == 0 {
             return Err(RpcStatus::with_message(
@@ -1918,17 +1915,17 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
 
         // Try and decode the address code.
-        let mut parse_address_code_request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+        let mut parse_address_code_request = api::ParseAddressCodeRequest::new();
         parse_address_code_request.set_b58_code(request.get_receiver_b58_code().to_owned());
         let parse_address_code_response =
             self.parse_address_code_impl(parse_address_code_request)?;
 
         // Forward to SendPayment
-        let mut outlay = mc_mobilecoind_api::Outlay::new();
+        let mut outlay = api::Outlay::new();
         outlay.set_value(request.get_amount());
         outlay.set_receiver(parse_address_code_response.get_receiver().clone());
 
-        let mut send_payment_request = mc_mobilecoind_api::SendPaymentRequest::new();
+        let mut send_payment_request = api::SendPaymentRequest::new();
         send_payment_request.set_sender_monitor_id(request.get_sender_monitor_id().to_vec());
         send_payment_request.set_sender_subaddress(request.get_sender_subaddress());
         send_payment_request.set_outlay_list(RepeatedField::from_vec(vec![outlay]));
@@ -1944,8 +1941,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn get_network_status_impl(
         &mut self,
-        _request: mc_mobilecoind_api::Empty,
-    ) -> Result<mc_mobilecoind_api::GetNetworkStatusResponse, RpcStatus> {
+        _request: api::Empty,
+    ) -> Result<api::GetNetworkStatusResponse, RpcStatus> {
         let network_state = self.network_state.read().expect("lock poisoned");
         let num_blocks = self
             .ledger_db
@@ -1970,7 +1967,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 RpcStatus::with_message(RpcStatusCode::INTERNAL, "no peers reachable".to_owned())
             })?;
 
-        let mut response = mc_mobilecoind_api::GetNetworkStatusResponse::new();
+        let mut response = api::GetNetworkStatusResponse::new();
 
         response.set_network_highest_block_index(
             network_state.highest_block_index_on_network().unwrap_or(0),
@@ -1991,8 +1988,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
     fn set_db_password_impl(
         &mut self,
-        request: mc_mobilecoind_api::SetDbPasswordRequest,
-    ) -> Result<mc_mobilecoind_api::Empty, RpcStatus> {
+        request: api::SetDbPasswordRequest,
+    ) -> Result<api::Empty, RpcStatus> {
         // Check if the database is unlocked and allowing this operation.
         if !self.mobilecoind_db.is_unlocked() {
             return Err(RpcStatus::with_message(
@@ -2008,13 +2005,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         log::info!(self.logger, "DB encryption password updated successfully.");
 
-        Ok(mc_mobilecoind_api::Empty::default())
+        Ok(api::Empty::default())
     }
 
-    fn unlock_db_impl(
-        &mut self,
-        request: mc_mobilecoind_api::UnlockDbRequest,
-    ) -> Result<mc_mobilecoind_api::Empty, RpcStatus> {
+    fn unlock_db_impl(&mut self, request: api::UnlockDbRequest) -> Result<api::Empty, RpcStatus> {
         if self.mobilecoind_db.is_unlocked() {
             return Err(RpcStatus::with_message(
                 RpcStatusCode::INTERNAL,
@@ -2031,7 +2025,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         log::info!(self.logger, "Successfully unlocked, starting sync thread.");
         (self.start_sync_thread)();
 
-        Ok(mc_mobilecoind_api::Empty::default())
+        Ok(api::Empty::default())
     }
 }
 
@@ -2044,8 +2038,8 @@ macro_rules! build_api {
                 fn $service_function_name(
                     &mut self,
                     ctx: RpcContext,
-                    request: mc_mobilecoind_api::$service_request_type,
-                    sink: UnarySink<mc_mobilecoind_api::$service_response_type>,
+                    request: api::$service_request_type,
+                    sink: UnarySink<api::$service_response_type>,
                 ) {
                     let logger = rpc_logger(&ctx, &self.logger);
                     send_result(
@@ -2181,7 +2175,7 @@ mod test {
         )
         .expect("failed to create data");
 
-        let mut request = mc_mobilecoind_api::AddMonitorRequest::new();
+        let mut request = api::AddMonitorRequest::new();
         request.set_account_key(mc_api::external::AccountKey::from(&data.account_key));
         request.set_first_subaddress(data.first_subaddress);
         request.set_num_subaddresses(data.num_subaddresses);
@@ -2248,7 +2242,7 @@ mod test {
 
         // Remove all the monitors we added.
         for id in monitor_ids {
-            let mut request = mc_mobilecoind_api::RemoveMonitorRequest::new();
+            let mut request = api::RemoveMonitorRequest::new();
             request.set_monitor_id(id.to_vec());
             client
                 .remove_monitor(&request)
@@ -2288,7 +2282,7 @@ mod test {
 
         // Ask the api for a list of all monitors.
         let response = client
-            .get_monitor_list(&mc_mobilecoind_api::Empty::new())
+            .get_monitor_list(&api::Empty::new())
             .expect("failed to get monitor list");
 
         let monitor_id_list: Vec<MonitorId> = response
@@ -2336,7 +2330,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Query monitor status.
-        let mut request = mc_mobilecoind_api::GetMonitorStatusRequest::new();
+        let mut request = api::GetMonitorStatusRequest::new();
         request.set_monitor_id(id.to_vec());
 
         let response = client
@@ -2358,14 +2352,14 @@ mod test {
         // return an error.
         mobilecoind_db.remove_monitor(&id).unwrap();
 
-        let mut request = mc_mobilecoind_api::GetMonitorStatusRequest::new();
+        let mut request = api::GetMonitorStatusRequest::new();
         request.set_monitor_id(id.to_vec());
         assert!(client.get_monitor_status(&request).is_err());
 
-        let request = mc_mobilecoind_api::GetMonitorStatusRequest::new();
+        let request = api::GetMonitorStatusRequest::new();
         assert!(client.get_monitor_status(&request).is_err());
 
-        let mut request = mc_mobilecoind_api::GetMonitorStatusRequest::new();
+        let mut request = api::GetMonitorStatusRequest::new();
         request.set_monitor_id(vec![3; 3]);
         assert!(client.get_monitor_status(&request).is_err());
     }
@@ -2420,7 +2414,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Query for unspent tx outs for a subaddress that did not receive any tx outs.
-        let mut request = mc_mobilecoind_api::GetUnspentTxOutListRequest::new();
+        let mut request = api::GetUnspentTxOutListRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(1);
 
@@ -2431,7 +2425,7 @@ mod test {
         assert_eq!(response.output_list.to_vec(), vec![]);
 
         // Query with the correct subaddress index.
-        let mut request = mc_mobilecoind_api::GetUnspentTxOutListRequest::new();
+        let mut request = api::GetUnspentTxOutListRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(0);
 
@@ -2532,7 +2526,7 @@ mod test {
 
         // call get entropy
         let response = client
-            .generate_root_entropy(&mc_mobilecoind_api::Empty::default())
+            .generate_root_entropy(&api::Empty::default())
             .unwrap();
         let entropy = response.get_root_entropy().to_vec();
         assert_eq!(entropy.len(), 32);
@@ -2548,9 +2542,7 @@ mod test {
             get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // call get entropy
-        let response = client
-            .generate_mnemonic(&mc_mobilecoind_api::Empty::default())
-            .unwrap();
+        let response = client.generate_mnemonic(&api::Empty::default()).unwrap();
         let mnemonic_str = response.get_mnemonic();
         assert_ne!(mnemonic_str, "");
 
@@ -2580,7 +2572,7 @@ mod test {
             AccountKey::from(key)
         };
 
-        let mut request = mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest::new();
+        let mut request = api::GetAccountKeyFromMnemonicRequest::new();
         request.set_mnemonic(mnemonic_str.to_string());
         request.set_account_index(666);
 
@@ -2592,10 +2584,10 @@ mod test {
         );
 
         // Calling with no mnemonic or invalid mnemonic should error.
-        let request = mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest::new();
+        let request = api::GetAccountKeyFromMnemonicRequest::new();
         assert!(client.get_account_key_from_mnemonic(&request).is_err());
 
-        let mut request = mc_mobilecoind_api::GetAccountKeyFromMnemonicRequest::new();
+        let mut request = api::GetAccountKeyFromMnemonicRequest::new();
         request.set_mnemonic("lol".to_string());
         assert!(client.get_account_key_from_mnemonic(&request).is_err());
     }
@@ -2613,7 +2605,7 @@ mod test {
         let root_id = RootIdentity::from(&root_entropy);
         let account_key = AccountKey::from(&root_id);
 
-        let mut request = mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest::new();
+        let mut request = api::GetAccountKeyFromRootEntropyRequest::new();
         request.set_root_entropy(root_entropy.to_vec());
 
         let response = client.get_account_key_from_root_entropy(&request).unwrap();
@@ -2624,11 +2616,11 @@ mod test {
         );
 
         // Calling with no root entropy or invalid root entropy should error.
-        let request = mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest::new();
+        let request = api::GetAccountKeyFromRootEntropyRequest::new();
         assert!(client.get_account_key_from_root_entropy(&request).is_err());
 
         let root_entropy = [123u8; 31];
-        let mut request = mc_mobilecoind_api::GetAccountKeyFromRootEntropyRequest::new();
+        let mut request = api::GetAccountKeyFromRootEntropyRequest::new();
         request.set_root_entropy(root_entropy.to_vec());
         assert!(client.get_account_key_from_root_entropy(&request).is_err());
     }
@@ -2654,7 +2646,7 @@ mod test {
         let id = mobilecoind_db.add_monitor(&data).unwrap();
 
         // Call get public address.
-        let mut request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+        let mut request = api::GetPublicAddressRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(10);
         let response = client.get_public_address(&request).unwrap();
@@ -2665,26 +2657,26 @@ mod test {
         );
 
         // Test that the b58 encoding is correct
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&account_key.subaddress(10)).into());
         let b58_code = wrapper.b58_encode().unwrap();
         assert_eq!(response.get_b58_code(), b58_code,);
 
         // Subaddress that is out of index or an invalid monitor id should error.
-        let request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+        let request = api::GetPublicAddressRequest::new();
         assert!(client.get_public_address(&request).is_err());
 
-        let mut request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+        let mut request = api::GetPublicAddressRequest::new();
         request.set_monitor_id(vec![3; 3]);
         request.set_subaddress_index(10);
         assert!(client.get_public_address(&request).is_err());
 
-        let mut request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+        let mut request = api::GetPublicAddressRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(0);
         assert!(client.get_public_address(&request).is_err());
 
-        let mut request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+        let mut request = api::GetPublicAddressRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(1000);
         assert!(client.get_public_address(&request).is_err());
@@ -2699,9 +2691,7 @@ mod test {
             get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get ledger info.
-        let response = client
-            .get_ledger_info(&mc_mobilecoind_api::Empty::new())
-            .unwrap();
+        let response = client.get_ledger_info(&api::Empty::new()).unwrap();
         assert_eq!(response.block_count, ledger_db.num_blocks().unwrap());
         assert_eq!(response.txo_count, ledger_db.num_txos().unwrap());
     }
@@ -2715,7 +2705,7 @@ mod test {
             get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get block info for a valid block.
-        let mut request = mc_mobilecoind_api::GetBlockInfoRequest::new();
+        let mut request = api::GetBlockInfoRequest::new();
         request.set_block(0);
 
         let response = client.get_block_info(&request).unwrap();
@@ -2723,7 +2713,7 @@ mod test {
         assert_eq!(response.txo_count, 3); // 3 recipients = 3 tx outs
 
         // Call with an invalid block number.
-        let mut request = mc_mobilecoind_api::GetBlockInfoRequest::new();
+        let mut request = api::GetBlockInfoRequest::new();
         request.set_block(ledger_db.num_blocks().unwrap());
 
         assert!(client.get_block_info(&request).is_err());
@@ -2738,7 +2728,7 @@ mod test {
             get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
         // Call get block info for a valid block.
-        let mut request = mc_mobilecoind_api::GetBlockRequest::new();
+        let mut request = api::GetBlockRequest::new();
         request.set_block(0);
 
         let response = client.get_block(&request).unwrap();
@@ -2781,20 +2771,17 @@ mod test {
             .unwrap();
         let output = block.outputs[0].clone();
 
-        let mut receiver_receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
-        receiver_receipt.set_recipient(mc_mobilecoind_api::external::PublicAddress::from(
-            &recipient,
-        ));
-        receiver_receipt.set_tx_public_key(
-            mc_mobilecoind_api::external::CompressedRistretto::from(&output.public_key),
-        );
+        let mut receiver_receipt = api::ReceiverTxReceipt::new();
+        receiver_receipt.set_recipient(api::external::PublicAddress::from(&recipient));
+        receiver_receipt
+            .set_tx_public_key(api::external::CompressedRistretto::from(&output.public_key));
         receiver_receipt.set_tx_out_hash(output.hash().into());
         receiver_receipt.set_tombstone(1);
         // For this test, confirmation number is irrelevant, so left blank
 
         // A receipt with all key images in the same block is verified.
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(1)).into(),
                 (&KeyImage::from(2)).into(),
@@ -2802,7 +2789,7 @@ mod test {
             ]));
             sender_receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone()
@@ -2810,16 +2797,13 @@ mod test {
 
             let response = client.get_tx_status_as_sender(&request).unwrap();
 
-            assert_eq!(
-                response.get_status(),
-                mc_mobilecoind_api::TxStatus::Verified
-            );
+            assert_eq!(response.get_status(), api::TxStatus::Verified);
         }
 
         // A receipt with an extra key image should be
         // TransactionFailureKeyImageBlockMismatch.
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(1)).into(),
                 (&KeyImage::from(2)).into(),
@@ -2828,7 +2812,7 @@ mod test {
             ]));
             sender_receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone()
@@ -2838,21 +2822,21 @@ mod test {
 
             assert_eq!(
                 response.get_status(),
-                mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageBlockMismatch
+                api::TxStatus::TransactionFailureKeyImageBlockMismatch
             );
         }
 
         // A receipt with key images that are not in the ledger is pending (unknown) if
         // its tombstone block has not been exceeded.
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
             sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone()
@@ -2860,20 +2844,20 @@ mod test {
 
             let response = client.get_tx_status_as_sender(&request).unwrap();
 
-            assert_eq!(response.get_status(), mc_mobilecoind_api::TxStatus::Unknown);
+            assert_eq!(response.get_status(), api::TxStatus::Unknown);
         }
 
         // A receipt with key images that are not in the ledger having its tombstone
         // block exceeded.
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
             sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone()
@@ -2881,10 +2865,7 @@ mod test {
 
             let response = client.get_tx_status_as_sender(&request).unwrap();
 
-            assert_eq!(
-                response.get_status(),
-                mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded
-            );
+            assert_eq!(response.get_status(), api::TxStatus::TombstoneBlockExceeded);
         }
 
         // Add another block to the ledger with different key images, to the same
@@ -2904,7 +2885,7 @@ mod test {
         // A receipt with all the key_images in the ledger, but in different blocks,
         // should fail.
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(1)).into(),
                 (&KeyImage::from(2)).into(),
@@ -2912,7 +2893,7 @@ mod test {
             ]));
             sender_receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone()
@@ -2922,7 +2903,7 @@ mod test {
 
             assert_eq!(
                 response.get_status(),
-                mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageBlockMismatch
+                api::TxStatus::TransactionFailureKeyImageBlockMismatch
             );
         }
 
@@ -2933,27 +2914,25 @@ mod test {
             .unwrap();
         let output2 = block2.outputs[0].clone();
 
-        let mut receiver_receipt2 = mc_mobilecoind_api::ReceiverTxReceipt::new();
-        receiver_receipt2.set_recipient(mc_mobilecoind_api::external::PublicAddress::from(
-            &recipient,
+        let mut receiver_receipt2 = api::ReceiverTxReceipt::new();
+        receiver_receipt2.set_recipient(api::external::PublicAddress::from(&recipient));
+        receiver_receipt2.set_tx_public_key(api::external::CompressedRistretto::from(
+            &output2.public_key,
         ));
-        receiver_receipt2.set_tx_public_key(
-            mc_mobilecoind_api::external::CompressedRistretto::from(&output2.public_key),
-        );
         receiver_receipt2.set_tx_out_hash(output2.hash().into());
         receiver_receipt2.set_tombstone(1);
         // For this test, confirmation number is irrelevant, so left blank
 
         // A receiver receipt with multiple public keys in different blocks should fail
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(1)).into(),
                 (&KeyImage::from(2)).into(),
             ]));
             sender_receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![
                 receiver_receipt.clone(),
@@ -2964,7 +2943,7 @@ mod test {
 
             assert_eq!(
                 response.get_status(),
-                mc_mobilecoind_api::TxStatus::PublicKeysInDifferentBlocks
+                api::TxStatus::PublicKeysInDifferentBlocks
             );
         }
 
@@ -2972,28 +2951,26 @@ mod test {
         // key_images which have should fail.
         // A receiver receipt with multiple public keys in different blocks should fail
         {
-            let mut sender_receipt = mc_mobilecoind_api::SenderTxReceipt::new();
+            let mut sender_receipt = api::SenderTxReceipt::new();
             sender_receipt.set_key_image_list(RepeatedField::from_vec(vec![
                 (&KeyImage::from(1)).into(),
                 (&KeyImage::from(4)).into(),
             ]));
             sender_receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::SubmitTxResponse::new();
+            let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
             // Modify the receiver_receipt to have a public key not in the ledger
-            receiver_receipt.set_tx_public_key(
-                mc_mobilecoind_api::external::CompressedRistretto::from(
-                    &CompressedRistrettoPublic::from(&RistrettoPublic::from_random(&mut rng)),
-                ),
-            );
+            receiver_receipt.set_tx_public_key(api::external::CompressedRistretto::from(
+                &CompressedRistrettoPublic::from(&RistrettoPublic::from_random(&mut rng)),
+            ));
             request.set_receiver_tx_receipt_list(RepeatedField::from_vec(vec![receiver_receipt]));
 
             let response = client.get_tx_status_as_sender(&request).unwrap();
 
             assert_eq!(
                 response.get_status(),
-                mc_mobilecoind_api::TxStatus::TransactionFailureKeyImageAlreadySpent
+                api::TxStatus::TransactionFailureKeyImageAlreadySpent
             );
         }
     }
@@ -3008,10 +2985,10 @@ mod test {
 
         // A call with an invalid hash should fail
         {
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+            let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
 
             assert!(client.get_tx_status_as_receiver(&request).is_err());
@@ -3022,18 +2999,15 @@ mod test {
             let tx_out = ledger_db.get_tx_out_by_index(1).unwrap();
             let hash = tx_out.hash();
 
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+            let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(1);
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
 
             let response = client.get_tx_status_as_receiver(&request).unwrap();
-            assert_eq!(
-                response.get_status(),
-                mc_mobilecoind_api::TxStatus::Verified
-            );
+            assert_eq!(response.get_status(), api::TxStatus::Verified);
         }
 
         // A call with a hash thats is not in the ledger and hasn't exceeded tombstone
@@ -3041,15 +3015,15 @@ mod test {
         {
             let hash = [0; 32];
 
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+            let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
 
             let response = client.get_tx_status_as_receiver(&request).unwrap();
-            assert_eq!(response.get_status(), mc_mobilecoind_api::TxStatus::Unknown);
+            assert_eq!(response.get_status(), api::TxStatus::Unknown);
         }
 
         // A call with a hash thats is not in the ledger and has exceeded tombstone
@@ -3057,18 +3031,15 @@ mod test {
         {
             let hash = [0; 32];
 
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
+            let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
 
             let response = client.get_tx_status_as_receiver(&request).unwrap();
-            assert_eq!(
-                response.get_status(),
-                mc_mobilecoind_api::TxStatus::TombstoneBlockExceeded
-            );
+            assert_eq!(response.get_status(), api::TxStatus::TombstoneBlockExceeded);
         }
 
         // Now create a monitor for the receiver to test confirmation numbers
@@ -3102,23 +3073,18 @@ mod test {
         {
             let hash = tx_out.hash();
 
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
-            receipt.set_tx_public_key(mc_mobilecoind_api::external::CompressedRistretto::from(
-                &tx_out.public_key,
-            ));
+            let mut receipt = api::ReceiverTxReceipt::new();
+            receipt.set_tx_public_key(api::external::CompressedRistretto::from(&tx_out.public_key));
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(10);
             receipt.set_confirmation_number(tx_confirmation.to_vec());
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
             request.set_monitor_id(monitor_id.to_vec());
 
             let response = client.get_tx_status_as_receiver(&request).unwrap();
-            assert_eq!(
-                response.get_status(),
-                mc_mobilecoind_api::TxStatus::Verified
-            );
+            assert_eq!(response.get_status(), api::TxStatus::Verified);
         }
 
         // A request with an a bad confirmation number and a monitor ID should return
@@ -3126,22 +3092,20 @@ mod test {
         {
             let hash = tx_out.hash();
 
-            let mut receipt = mc_mobilecoind_api::ReceiverTxReceipt::new();
-            receipt.set_tx_public_key(mc_mobilecoind_api::external::CompressedRistretto::from(
-                &tx_out.public_key,
-            ));
+            let mut receipt = api::ReceiverTxReceipt::new();
+            receipt.set_tx_public_key(api::external::CompressedRistretto::from(&tx_out.public_key));
             receipt.set_tx_out_hash(hash.to_vec());
             receipt.set_tombstone(10);
             receipt.set_confirmation_number(vec![0u8; 32]);
 
-            let mut request = mc_mobilecoind_api::GetTxStatusAsReceiverRequest::new();
+            let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
             request.set_monitor_id(monitor_id.to_vec());
 
             let response = client.get_tx_status_as_receiver(&request).unwrap();
             assert_eq!(
                 response.get_status(),
-                mc_mobilecoind_api::TxStatus::InvalidConfirmationNumber
+                api::TxStatus::InvalidConfirmationNumber
             );
         }
     }
@@ -3219,7 +3183,7 @@ mod test {
 
         // Query a bunch of blocks and verify the data.
         for block_index in 1..num_blocks {
-            let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+            let mut request = api::GetProcessedBlockRequest::new();
             request.set_monitor_id(monitor_id.to_vec());
             request.set_block(block_index);
 
@@ -3247,17 +3211,17 @@ mod test {
             assert_eq!(tx_out.value, expected_utxo.value);
             assert_eq!(
                 tx_out.get_direction(),
-                mc_mobilecoind_api::ProcessedTxOutDirection::Received,
+                api::ProcessedTxOutDirection::Received,
             );
 
             // test address code
-            let mut request = mc_mobilecoind_api::GetPublicAddressRequest::new();
+            let mut request = api::GetPublicAddressRequest::new();
             request.set_monitor_id(monitor_id.to_vec());
             request.set_subaddress_index(expected_utxo.subaddress_index);
             let response = client.get_public_address(&request).unwrap();
             let public_address = PublicAddress::try_from(response.get_public_address()).unwrap();
 
-            let mut request = mc_mobilecoind_api::CreateAddressCodeRequest::new();
+            let mut request = api::CreateAddressCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&public_address));
             let response = client.create_address_code(&request).unwrap();
             let b58_code = response.get_b58_code();
@@ -3288,7 +3252,7 @@ mod test {
 
             wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
-            let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+            let mut request = api::GetProcessedBlockRequest::new();
             request.set_monitor_id(monitor_id.to_vec());
             request.set_block(num_blocks);
 
@@ -3326,10 +3290,7 @@ mod test {
                 );
                 assert_eq!(tx_out.get_key_image(), &(&expected_utxo.key_image).into());
                 assert_eq!(tx_out.value, expected_utxo.value);
-                assert_eq!(
-                    tx_out.get_direction(),
-                    mc_mobilecoind_api::ProcessedTxOutDirection::Spent,
-                );
+                assert_eq!(tx_out.get_direction(), api::ProcessedTxOutDirection::Spent,);
             }
         }
 
@@ -3350,7 +3311,7 @@ mod test {
 
             wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
-            let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+            let mut request = api::GetProcessedBlockRequest::new();
             request.set_monitor_id(monitor_id.to_vec());
             request.set_block(num_blocks + 1);
 
@@ -3366,28 +3327,28 @@ mod test {
             assert_eq!(tx_out.get_value(), 102030);
             assert_eq!(
                 tx_out.get_direction(),
-                mc_mobilecoind_api::ProcessedTxOutDirection::Received
+                api::ProcessedTxOutDirection::Received
             );
             assert_eq!(tx_out.get_token_id(), 2);
         }
 
         // Query a block that will never get processed since its before the monitor's
         // first block.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_block(0);
 
         assert!(client.get_processed_block(&request).is_err());
 
         // Query a block that hasn't been processed yet.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_block(num_blocks + 2);
 
         assert!(client.get_processed_block(&request).is_err());
 
         // Query with an unknown monitor id.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(vec![1; 32]);
         request.set_block(1);
 
@@ -3417,11 +3378,10 @@ mod test {
 
         // Response should contain the requested number of distinct mixins.
         {
-            let mut request = mc_mobilecoind_api::GetMixinsRequest::new();
+            let mut request = api::GetMixinsRequest::new();
             request.set_num_mixins(13);
             let response = client.get_mixins(&request).unwrap();
-            let mixins_with_proofs: Vec<mc_mobilecoind_api::TxOutWithProof> =
-                response.get_mixins().to_vec();
+            let mixins_with_proofs: Vec<api::TxOutWithProof> = response.get_mixins().to_vec();
 
             assert_eq!(mixins_with_proofs.len(), 13);
 
@@ -3440,7 +3400,7 @@ mod test {
         // Requesting more mixins than exist in the ledger should return an error.
         // TODO: enforce a limit on the number of mixins that may be requested.
         {
-            let mut bad_request = mc_mobilecoind_api::GetMixinsRequest::new();
+            let mut bad_request = api::GetMixinsRequest::new();
             bad_request.set_num_mixins(10000);
             let response = client.get_mixins(&bad_request);
 
@@ -3497,19 +3457,15 @@ mod test {
 
         // The ledger contains 40 outputs. Requesting 30 and excluding 10 should return
         // exactly the remaining 30.
-        let mut request = mc_mobilecoind_api::GetMixinsRequest::new();
+        let mut request = api::GetMixinsRequest::new();
         request.set_num_mixins(30);
         request.set_excluded(RepeatedField::from_vec(
-            to_exclude
-                .iter()
-                .map(mc_mobilecoind_api::external::TxOut::from)
-                .collect(),
+            to_exclude.iter().map(api::external::TxOut::from).collect(),
         ));
 
         let response = client.get_mixins(&request).unwrap();
 
-        let mixins_with_proofs: Vec<mc_mobilecoind_api::TxOutWithProof> =
-            response.get_mixins().to_vec();
+        let mixins_with_proofs: Vec<api::TxOutWithProof> = response.get_mixins().to_vec();
 
         // Should contain 30 mixins
         assert_eq!(mixins_with_proofs.len(), 30);
@@ -3540,8 +3496,8 @@ mod test {
                 &mut rng,
             );
 
-        let mixins_with_proofs: Vec<mc_mobilecoind_api::TxOutWithProof> = {
-            let mut request = mc_mobilecoind_api::GetMixinsRequest::new();
+        let mixins_with_proofs: Vec<api::TxOutWithProof> = {
+            let mut request = api::GetMixinsRequest::new();
             request.set_num_mixins(13);
             let response = client.get_mixins(&request).unwrap();
             response.get_mixins().to_vec()
@@ -3558,7 +3514,7 @@ mod test {
                 let index = ledger_db.get_tx_out_index_by_hash(&mixin.hash()).unwrap();
                 let proofs = ledger_db.get_tx_out_proof_of_memberships(&[index]).unwrap();
                 assert_eq!(proofs.len(), 1);
-                mc_mobilecoind_api::external::TxOutMembershipProof::from(&proofs[0])
+                api::external::TxOutMembershipProof::from(&proofs[0])
             };
 
             assert_eq!(mixin_with_proof.get_proof(), &expected_proof);
@@ -3610,12 +3566,9 @@ mod test {
             ]
         };
 
-        let mut request = mc_mobilecoind_api::GetMembershipProofsRequest::new();
+        let mut request = api::GetMembershipProofsRequest::new();
         request.set_outputs(RepeatedField::from_vec(
-            outputs
-                .iter()
-                .map(mc_mobilecoind_api::external::TxOut::from)
-                .collect(),
+            outputs.iter().map(api::external::TxOut::from).collect(),
         ));
 
         let response = client.get_membership_proofs(&request).unwrap();
@@ -3627,7 +3580,7 @@ mod test {
             // The response should contain a TxOutWithProof for each requested TxOut.
             assert_eq!(
                 output_with_proof.get_output(),
-                &mc_mobilecoind_api::external::TxOut::from(tx_out)
+                &api::external::TxOut::from(tx_out)
             );
 
             // The returned proof should be correct.
@@ -3636,7 +3589,7 @@ mod test {
                 let proofs = ledger_db.get_tx_out_proof_of_memberships(&[index]).unwrap();
                 assert_eq!(proofs.len(), 1);
 
-                mc_mobilecoind_api::external::TxOutMembershipProof::from(&proofs[0])
+                api::external::TxOutMembershipProof::from(&proofs[0])
             };
 
             assert_eq!(output_with_proof.get_proof(), &expected_proof);
@@ -3714,21 +3667,18 @@ mod test {
         ];
 
         // Call generate tx.
-        let mut request = mc_mobilecoind_api::GenerateTxRequest::new();
+        let mut request = api::GenerateTxRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_change_subaddress(0);
         request.set_input_list(RepeatedField::from_vec(
             utxos
                 .iter()
                 .filter(|utxo| utxo.token_id == *Mob::ID)
-                .map(mc_mobilecoind_api::UnspentTxOut::from)
+                .map(api::UnspentTxOut::from)
                 .collect(),
         ));
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         // Test the happy flow for MOB.
@@ -3810,21 +3760,18 @@ mod test {
 
         // Test the happy flow for TokenId(2)
         {
-            let mut request = mc_mobilecoind_api::GenerateTxRequest::new();
+            let mut request = api::GenerateTxRequest::new();
             request.set_sender_monitor_id(monitor_id.to_vec());
             request.set_change_subaddress(0);
             request.set_input_list(RepeatedField::from_vec(
                 utxos
                     .iter()
                     .filter(|utxo| utxo.token_id == 2)
-                    .map(mc_mobilecoind_api::UnspentTxOut::from)
+                    .map(api::UnspentTxOut::from)
                     .collect(),
             ));
             request.set_outlay_list(RepeatedField::from_vec(
-                outlays
-                    .iter()
-                    .map(mc_mobilecoind_api::Outlay::from)
-                    .collect(),
+                outlays.iter().map(api::Outlay::from).collect(),
             ));
             request.set_token_id(2);
 
@@ -3930,9 +3877,7 @@ mod test {
         {
             // Junk input
             let mut request = request.clone();
-            request
-                .mut_input_list()
-                .push(mc_mobilecoind_api::UnspentTxOut::default());
+            request.mut_input_list().push(api::UnspentTxOut::default());
             assert!(client.generate_tx(&request).is_err());
         }
 
@@ -3940,31 +3885,23 @@ mod test {
             // Attempt to spend more than we have
             let num_blocks = ledger_db.num_blocks().unwrap();
             let mut request = request.clone();
-            request.set_outlay_list(RepeatedField::from_vec(vec![
-                mc_mobilecoind_api::Outlay::from(&Outlay {
-                    receiver: receiver1.default_subaddress(),
-                    value: test_utils::DEFAULT_PER_RECIPIENT_AMOUNT * num_blocks,
-                }),
-            ]));
+            request.set_outlay_list(RepeatedField::from_vec(vec![api::Outlay::from(&Outlay {
+                receiver: receiver1.default_subaddress(),
+                value: test_utils::DEFAULT_PER_RECIPIENT_AMOUNT * num_blocks,
+            })]));
             assert!(client.generate_tx(&request).is_err());
         }
 
         {
             // Mixing input tokens (utxos has both Mob and TokenId(2))
-            let mut request = mc_mobilecoind_api::GenerateTxRequest::new();
+            let mut request = api::GenerateTxRequest::new();
             request.set_sender_monitor_id(monitor_id.to_vec());
             request.set_change_subaddress(0);
             request.set_input_list(RepeatedField::from_vec(
-                utxos
-                    .iter()
-                    .map(mc_mobilecoind_api::UnspentTxOut::from)
-                    .collect(),
+                utxos.iter().map(api::UnspentTxOut::from).collect(),
             ));
             request.set_outlay_list(RepeatedField::from_vec(
-                outlays
-                    .iter()
-                    .map(mc_mobilecoind_api::Outlay::from)
-                    .collect(),
+                outlays.iter().map(api::Outlay::from).collect(),
             ));
             assert!(client.generate_tx(&request).is_err());
         }
@@ -4031,7 +3968,7 @@ mod test {
         assert!(!utxos.is_empty());
 
         // Prepare request
-        let mut request = mc_mobilecoind_api::GenerateBurnRedemptionTxRequest::new();
+        let mut request = api::GenerateBurnRedemptionTxRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_change_subaddress(0);
         request.set_input_list(utxos);
@@ -4141,11 +4078,10 @@ mod test {
         // Grab the first TxOut of each block in the database and verify its index.
         for block_index in 0..test_utils::GET_TESTING_ENVIRONMENT_NUM_BLOCKS as u64 {
             let block_contents = ledger_db.get_block_contents(block_index).unwrap();
-            let tx_out_pub_key = mc_mobilecoind_api::external::CompressedRistretto::from(
-                &block_contents.outputs[0].public_key,
-            );
+            let tx_out_pub_key =
+                api::external::CompressedRistretto::from(&block_contents.outputs[0].public_key);
 
-            let mut request = mc_mobilecoind_api::GetBlockIndexByTxPubKeyRequest::new();
+            let mut request = api::GetBlockIndexByTxPubKeyRequest::new();
             request.set_tx_public_key(tx_out_pub_key);
 
             let response = client.get_block_index_by_tx_pub_key(&request).unwrap();
@@ -4191,14 +4127,11 @@ mod test {
         assert!(!utxos.is_empty());
 
         // Call generate transfer code ctx.
-        let mut request = mc_mobilecoind_api::GenerateTransferCodeTxRequest::new();
+        let mut request = api::GenerateTransferCodeTxRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_change_subaddress(0);
         request.set_input_list(RepeatedField::from_vec(
-            utxos
-                .iter()
-                .map(mc_mobilecoind_api::UnspentTxOut::from)
-                .collect(),
+            utxos.iter().map(api::UnspentTxOut::from).collect(),
         ));
         request.set_value(1337);
 
@@ -4323,7 +4256,7 @@ mod test {
         assert!(!utxos.is_empty());
 
         // Call generate optimization tx.
-        let mut request = mc_mobilecoind_api::GenerateOptimizationTxRequest::new();
+        let mut request = api::GenerateOptimizationTxRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_subaddress(0);
 
@@ -4412,13 +4345,10 @@ mod test {
 
         // Build a request to transfer the first two TxOuts
         let tx_utxos = utxos[0..2].to_vec();
-        let mut request = mc_mobilecoind_api::GenerateTxFromTxOutListRequest::new();
+        let mut request = api::GenerateTxFromTxOutListRequest::new();
         request.set_account_key((&sender).into());
         request.set_input_list(RepeatedField::from_vec(
-            tx_utxos
-                .iter()
-                .map(mc_mobilecoind_api::UnspentTxOut::from)
-                .collect(),
+            tx_utxos.iter().map(api::UnspentTxOut::from).collect(),
         ));
         let receiver = AccountKey::random(&mut rng);
         request.set_receiver((&receiver.default_subaddress()).into());
@@ -4494,20 +4424,14 @@ mod test {
         ];
 
         // Call generate tx.
-        let mut request = mc_mobilecoind_api::GenerateTxRequest::new();
+        let mut request = api::GenerateTxRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_change_subaddress(0);
         request.set_input_list(RepeatedField::from_vec(
-            utxos
-                .iter()
-                .map(mc_mobilecoind_api::UnspentTxOut::from)
-                .collect(),
+            utxos.iter().map(api::UnspentTxOut::from).collect(),
         ));
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         // Get our propsal which we'll use for the test.
@@ -4518,8 +4442,8 @@ mod test {
 
         // Test the happy flow.
         {
-            let mut request = mc_mobilecoind_api::SubmitTxRequest::new();
-            request.set_tx_proposal(mc_mobilecoind_api::TxProposal::from(&tx_proposal));
+            let mut request = api::SubmitTxRequest::new();
+            request.set_tx_proposal(api::TxProposal::from(&tx_proposal));
 
             let response = client.submit_tx(&request).unwrap();
 
@@ -4663,7 +4587,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Get balance for a monitor_id/subaddress index that has a balance.
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(0);
 
@@ -4674,7 +4598,7 @@ mod test {
         );
 
         // Get balance for subaddress with no utxos should return 0.
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(id.to_vec());
         request.set_subaddress_index(1);
 
@@ -4685,14 +4609,14 @@ mod test {
         let mut id2 = id.clone().to_vec();
         id2[0] = !id2[0];
 
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(id2);
         request.set_subaddress_index(0);
 
         assert_eq!(response.balance, 0);
 
         // Invalid monitor id should error
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(vec![1; 2]);
         request.set_subaddress_index(0);
 
@@ -4752,14 +4676,11 @@ mod test {
         ];
 
         // Call send payment.
-        let mut request = mc_mobilecoind_api::SendPaymentRequest::new();
+        let mut request = api::SendPaymentRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         let response = client.send_payment(&request).unwrap();
@@ -4943,14 +4864,11 @@ mod test {
 
         // Call send payment without a limit on UTXOs - a single large UTXO should be
         // selected.
-        let mut request = mc_mobilecoind_api::SendPaymentRequest::new();
+        let mut request = api::SendPaymentRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         let response = client.send_payment(&request).unwrap();
@@ -5089,14 +5007,11 @@ mod test {
         ];
 
         // Call send payment.
-        let mut request = mc_mobilecoind_api::SendPaymentRequest::new();
+        let mut request = api::SendPaymentRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         let response = client.send_payment(&request).unwrap();
@@ -5216,14 +5131,11 @@ mod test {
         ];
 
         // Call send payment.
-        let mut request = mc_mobilecoind_api::SendPaymentRequest::new();
+        let mut request = api::SendPaymentRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_outlay_list(RepeatedField::from_vec(
-            outlays
-                .iter()
-                .map(mc_mobilecoind_api::Outlay::from)
-                .collect(),
+            outlays.iter().map(api::Outlay::from).collect(),
         ));
 
         let response = client.send_payment(&request);
@@ -5272,12 +5184,12 @@ mod test {
 
         // Generate b58 address code for this recipient.
         let receiver_public_address = receiver.default_subaddress();
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&receiver_public_address).into());
         let b58_code = wrapper.b58_encode().unwrap();
 
         // Call pay address code.
-        let mut request = mc_mobilecoind_api::PayAddressCodeRequest::new();
+        let mut request = api::PayAddressCodeRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_receiver_b58_code(b58_code);
@@ -5291,7 +5203,7 @@ mod test {
         let receipt = &response.get_receiver_tx_receipt_list()[0];
         assert_eq!(
             receipt.get_recipient(),
-            &mc_mobilecoind_api::external::PublicAddress::from(&receiver_public_address)
+            &api::external::PublicAddress::from(&receiver_public_address)
         );
     }
 
@@ -5337,13 +5249,13 @@ mod test {
 
         // Generate b58 address code for this recipient.
         let receiver_public_address = receiver.default_subaddress();
-        let mut wrapper = mc_mobilecoind_api::printable::PrintableWrapper::new();
+        let mut wrapper = api::printable::PrintableWrapper::new();
         wrapper.set_public_address((&receiver_public_address).into());
         let b58_code = wrapper.b58_encode().unwrap();
 
         let test_amount = 345;
 
-        let mut request = mc_mobilecoind_api::PayAddressCodeRequest::new();
+        let mut request = api::PayAddressCodeRequest::new();
         request.set_sender_monitor_id(monitor_id.to_vec());
         request.set_sender_subaddress(0);
         request.set_receiver_b58_code(b58_code);
@@ -5436,14 +5348,14 @@ mod test {
         // Try with just a receiver
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+            let mut request = api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
 
             let response = client.create_request_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode the b58.
-            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+            let mut request = api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_request_code(&request).unwrap();
@@ -5459,7 +5371,7 @@ mod test {
         // Try with receiver and value
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+            let mut request = api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
 
@@ -5467,7 +5379,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+            let mut request = api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_request_code(&request).unwrap();
@@ -5483,7 +5395,7 @@ mod test {
         // Try with receiver, value and memo
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+            let mut request = api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
             request.set_memo("hello there".to_owned());
@@ -5492,7 +5404,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+            let mut request = api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_request_code(&request).unwrap();
@@ -5509,7 +5421,7 @@ mod test {
         // Try with receiver, value and token id.
         {
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+            let mut request = api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
             request.set_token_id(123);
@@ -5518,7 +5430,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+            let mut request = api::ParseRequestCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_request_code(&request).unwrap();
@@ -5534,7 +5446,7 @@ mod test {
 
         // Attempting to decode junk data should fail
         {
-            let mut request = mc_mobilecoind_api::ParseRequestCodeRequest::new();
+            let mut request = api::ParseRequestCodeRequest::new();
             request.set_b58_code("junk".to_owned());
 
             assert!(client.parse_request_code(&request).is_err());
@@ -5579,19 +5491,19 @@ mod test {
 
         // An invalid request should fail to encode.
         {
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_root_entropy(vec![3u8; 8]); // key is wrong size
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.create_transfer_code(&request).is_err());
 
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_root_entropy(vec![4u8; 32]);
             request.set_memo("memo".to_owned()); // forgot to set tx_public_key
             assert!(client.create_transfer_code(&request).is_err());
 
             // no entropy is being set
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.create_transfer_code(&request).is_err());
@@ -5601,7 +5513,7 @@ mod test {
         // data.
         {
             // Encode
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_root_entropy(root_entropy.to_vec());
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("test memo".to_owned());
@@ -5610,7 +5522,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Decode
-            let mut request = mc_mobilecoind_api::ParseTransferCodeRequest::new();
+            let mut request = api::ParseTransferCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_transfer_code(&request).unwrap();
@@ -5648,7 +5560,7 @@ mod test {
             assert_eq!(utxos.len(), 1);
 
             // Convert to proto utxo.
-            let proto_utxo: mc_mobilecoind_api::UnspentTxOut = (&utxos[0]).into();
+            let proto_utxo: api::UnspentTxOut = (&utxos[0]).into();
 
             assert_eq!(&proto_utxo, response.get_utxo());
         }
@@ -5692,13 +5604,13 @@ mod test {
 
         // An invalid request should fail to encode.
         {
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_bip39_entropy(vec![3u8; 8]); // key is wrong size
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("memo".to_owned());
             assert!(client.create_transfer_code(&request).is_err());
 
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_bip39_entropy(vec![4u8; 32]);
             request.set_memo("memo".to_owned()); // forgot to set tx_public_key
             assert!(client.create_transfer_code(&request).is_err());
@@ -5708,7 +5620,7 @@ mod test {
         // data.
         {
             // Encode
-            let mut request = mc_mobilecoind_api::CreateTransferCodeRequest::new();
+            let mut request = api::CreateTransferCodeRequest::new();
             request.set_bip39_entropy(bip39_entropy.to_vec());
             request.set_tx_public_key((&tx_public_key).into());
             request.set_memo("test memo".to_owned());
@@ -5717,7 +5629,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Decode
-            let mut request = mc_mobilecoind_api::ParseTransferCodeRequest::new();
+            let mut request = api::ParseTransferCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_transfer_code(&request).unwrap();
@@ -5755,7 +5667,7 @@ mod test {
             assert_eq!(utxos.len(), 1);
 
             // Convert to proto utxo.
-            let proto_utxo: mc_mobilecoind_api::UnspentTxOut = (&utxos[0]).into();
+            let proto_utxo: api::UnspentTxOut = (&utxos[0]).into();
 
             assert_eq!(&proto_utxo, response.get_utxo());
         }
@@ -5774,14 +5686,14 @@ mod test {
             let receiver = AccountKey::random(&mut rng).default_subaddress();
 
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateAddressCodeRequest::new();
+            let mut request = api::CreateAddressCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
 
             let response = client.create_address_code(&request).unwrap();
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+            let mut request = api::ParseAddressCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_address_code(&request).unwrap();
@@ -5799,7 +5711,7 @@ mod test {
             let receiver = AccountKey::random(&mut rng).default_subaddress();
 
             // Generate a request code
-            let mut request = mc_mobilecoind_api::CreateRequestCodeRequest::new();
+            let mut request = api::CreateRequestCodeRequest::new();
             request.set_receiver(mc_api::external::PublicAddress::from(&receiver));
             request.set_value(1234567890);
             request.set_memo("hello there".to_owned());
@@ -5808,7 +5720,7 @@ mod test {
             let b58_code = response.get_b58_code();
 
             // Attempt to decode it.
-            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+            let mut request = api::ParseAddressCodeRequest::new();
             request.set_b58_code(b58_code.to_string());
 
             let response = client.parse_address_code(&request).unwrap();
@@ -5822,7 +5734,7 @@ mod test {
 
         // Attempting to decode junk data should fail
         {
-            let mut request = mc_mobilecoind_api::ParseAddressCodeRequest::new();
+            let mut request = api::ParseAddressCodeRequest::new();
             request.set_b58_code("junk".to_owned());
 
             assert!(client.parse_address_code(&request).is_err());
@@ -5836,9 +5748,7 @@ mod test {
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
             get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
 
-        let network_status = client
-            .get_network_status(&mc_mobilecoind_api::Empty::new())
-            .unwrap();
+        let network_status = client.get_network_status(&api::Empty::new()).unwrap();
 
         assert_eq!(
             network_status.network_highest_block_index,
@@ -5876,7 +5786,7 @@ mod test {
                 &mut rng,
             );
 
-        let mut request = mc_mobilecoind_api::AddMonitorRequest::new();
+        let mut request = api::AddMonitorRequest::new();
         request.set_account_key(mc_api::external::AccountKey::from(&data.account_key));
         request.set_first_subaddress(data.first_subaddress);
         request.set_num_subaddresses(data.num_subaddresses);
@@ -5890,7 +5800,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Verify we have the expected balance.
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_subaddress_index(0);
 
@@ -5903,7 +5813,7 @@ mod test {
 
         // Get our UTXOs and force one of them to be spent, since we want to test the
         // add-remove-add behavior with spent key images in the ledger.
-        let mut request = mc_mobilecoind_api::GetUnspentTxOutListRequest::new();
+        let mut request = api::GetUnspentTxOutListRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_subaddress_index(0);
 
@@ -5931,7 +5841,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Verify we have the expected balance.
-        let mut request = mc_mobilecoind_api::GetBalanceRequest::new();
+        let mut request = api::GetBalanceRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_subaddress_index(0);
 
@@ -5939,7 +5849,7 @@ mod test {
         assert_eq!(response.balance, orig_balance - first_utxo.value);
 
         // Verify we have processed block information for this monitor.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_block(0);
 
@@ -5949,7 +5859,7 @@ mod test {
         assert_eq!(response.get_tx_outs().len(), 1);
 
         // Remove the monitor.
-        let mut request = mc_mobilecoind_api::RemoveMonitorRequest::new();
+        let mut request = api::RemoveMonitorRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         client
             .remove_monitor(&request)
@@ -5960,14 +5870,14 @@ mod test {
         assert_eq!(0, monitors_map.len());
 
         // Verify we no longer have processed block information for this monitor.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_block(0);
 
         assert!(client.get_processed_block(&request).is_err());
 
         // Re-add the monitor.
-        let mut request = mc_mobilecoind_api::AddMonitorRequest::new();
+        let mut request = api::AddMonitorRequest::new();
         request.set_account_key(mc_api::external::AccountKey::from(&data.account_key));
         request.set_first_subaddress(data.first_subaddress);
         request.set_num_subaddresses(data.num_subaddresses);
@@ -5980,7 +5890,7 @@ mod test {
         wait_for_monitors(&mobilecoind_db, &ledger_db, &logger);
 
         // Verify we have processed block information for this monitor.
-        let mut request = mc_mobilecoind_api::GetProcessedBlockRequest::new();
+        let mut request = api::GetProcessedBlockRequest::new();
         request.set_monitor_id(monitor_id.to_vec());
         request.set_block(0);
 
@@ -6008,7 +5918,7 @@ mod test {
 
         // Send request.
         let response = client
-            .get_version(&mc_mobilecoind_api::Empty::new())
+            .get_version(&api::Empty::new())
             .expect("Failed to get version");
         assert!(!response.version.is_empty());
     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2030,7 +2030,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 }
 
 macro_rules! build_api {
-    ($( $service_function_name:ident $service_request_type:ident $service_response_type:ident $service_function_impl:ident ),+)
+    ($( $service_function_name:ident $service_request_type:ident $service_response_type:ident $service_function_impl:ident $(,)?)+)
     =>
     (
         impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolver> MobilecoindApi for ServiceApi<T, FPR> {
@@ -2108,7 +2108,7 @@ build_api! {
     set_db_password SetDbPasswordRequest Empty set_db_password_impl,
     unlock_db UnlockDbRequest Empty unlock_db_impl,
 
-    get_version Empty MobilecoindVersionResponse get_version_impl
+    get_version Empty MobilecoindVersionResponse get_version_impl,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Also support trailing comma in the `build_api` macro. This way future method additions do not need to modify the last line.