### PR TITLE
Add bindings for CRC computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,6 +2260,7 @@ version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "crc",
  "displaydoc",
  "generic-array",
  "jni",

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -11,6 +11,9 @@ name = "mobilecoin_android"
 crate-type = ["cdylib"]
 
 [dependencies]
+# External dependencies
+crc = "3.0.0"
+
 # fog
 mc-fog-kex-rng = { path = "../fog/kex_rng" }
 

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.1'
+version '1.2.2'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -13,6 +13,7 @@ use crate::{
 use aes_gcm::Aes256Gcm;
 use bip39::{Language, Mnemonic};
 use core::convert::TryFrom;
+use crc::Crc;
 use generic_array::{typenum::U66, GenericArray};
 use jni::{
     objects::{JObject, JString},
@@ -2044,6 +2045,23 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_get_1shared_1secret(
             let ptr: *mut Mutex<RistrettoPublic> = Box::into_raw(mbox);
 
             Ok(ptr as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_Util_compute_1commitment_1crc32(
+    env: JNIEnv,
+    _obj: JObject,
+    commitment_bytes: jbyteArray,
+) -> jint {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let commitment_bytes = env.convert_byte_array(commitment_bytes)?;
+            let crc32 = Crc::<u32>::new(&crc::CRC_32_ISO_HDLC).checksum(&commitment_bytes);
+            Ok(crc32 as jint)
         },
     )
 }


### PR DESCRIPTION
Added Android bindings for commitment CRC computation

### Motivation

This PR is needed in order to verify the reconstructed TxOutRecord commitment data
