### PR TITLE
Longer startup, topology and affinity rules 

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -16,6 +16,9 @@ on:
     - feature/*
     - develop
 
+# don't run more than one at a time for a branch/tag
+concurrency: mobilecoin-dev-cd-${{ github.ref }}
+
 jobs:
 ############################################
 # Generate environment information

--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -28,20 +28,28 @@ spec:
         client-load-balanced: 'true'
         {{- end }}
     spec:
-      nodeSelector:
-        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
+      # Try to balance pods across zones
+      topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        # Wait until we have nodes
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            # match app and helm chart version
+            app: consensus-node
+            helm.sh/chart: {{ include "consensusNode.chart" . }}
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app
-                  operator: In
-                  values:
-                  - consensus-node
-              topologyKey: 'kubernetes.io/hostname'
+          requireDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                # match all consensus-nodes deployed by the same chart version
+                app: consensus-node
+                helm.sh/chart: {{ include "consensusNode.chart" . }}
+      nodeSelector:
+        {{- toYaml .Values.node.nodeSelector | nindent 8 }}
       tolerations:
       {{- toYaml .Values.node.tolerations | nindent 6 }}
       imagePullSecrets:

--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -42,6 +42,7 @@ spec:
       affinity:
         podAntiAffinity:
           requireDuringSchedulingIgnoredDuringExecution:
+          # Require pods to be on separate nodes.
           - topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels:

--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             helm.sh/chart: {{ include "consensusNode.chart" . }}
       affinity:
         podAntiAffinity:
-          requireDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           # Require pods to be on separate nodes.
           - topologyKey: kubernetes.io/hostname
             labelSelector:

--- a/.internal-ci/helm/fog-ingest/templates/fog-ingest-statefulset.yaml
+++ b/.internal-ci/helm/fog-ingest/templates/fog-ingest-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
             # match on this helm chart install
             app: fog-ingest
             helm.sh/chart: {{ include "fogIngest.chart" . }}
-            {{- include "fogIngest.selectorLabels" . | nindent 6 }}
+            {{- include "fogIngest.selectorLabels" . | nindent 12 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,7 +42,7 @@ spec:
               # match on this helm chart install
               app: fog-ingest
               helm.sh/chart: {{ include "fogIngest.chart" . }}
-              {{- include "fogIngest.selectorLabels" . | nindent 6 }}
+              {{- include "fogIngest.selectorLabels" . | nindent 14 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       terminationGracePeriodSeconds: 30

--- a/.internal-ci/helm/fog-ingest/templates/fog-ingest-statefulset.yaml
+++ b/.internal-ci/helm/fog-ingest/templates/fog-ingest-statefulset.yaml
@@ -21,6 +21,28 @@ spec:
         app: fog-ingest
         {{- include "fogIngest.labels" . | nindent 8 }}
     spec:
+      # Try to balance pods across zones
+      topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        # Wait until we have nodes
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            # match on this helm chart install
+            app: fog-ingest
+            helm.sh/chart: {{ include "fogIngest.chart" . }}
+            {{- include "fogIngest.selectorLabels" . | nindent 6 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          # Require pods to be on separate nodes.
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              # match on this helm chart install
+              app: fog-ingest
+              helm.sh/chart: {{ include "fogIngest.chart" . }}
+              {{- include "fogIngest.selectorLabels" . | nindent 6 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       terminationGracePeriodSeconds: 30

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
@@ -31,8 +31,8 @@ spec:
           matchLabels:
             # match on this helm chart install
             app: fog-ledger
-            helm.sh/chart: {{ include "fogLedger.chart" . }}
-            {{- include "fogLedger.selectorLabels" . | nindent 12 }}
+            helm.sh/chart: {{ include "fogServices.chart" . }}
+            {{- include "fogServices.selectorLabels" . | nindent 12 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -41,8 +41,8 @@ spec:
             labelSelector:
               # match on this helm chart install
               app: fog-ledger
-              helm.sh/chart: {{ include "fogLedger.chart" . }}
-              {{- include "fogLedger.selectorLabels" . | nindent 14 }}
+              helm.sh/chart: {{ include "fogServices.chart" . }}
+              {{- include "fogServices.selectorLabels" . | nindent 14 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       terminationGracePeriodSeconds: 30

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
@@ -32,7 +32,7 @@ spec:
             # match on this helm chart install
             app: fog-ledger
             helm.sh/chart: {{ include "fogLedger.chart" . }}
-            {{- include "fogLedger.selectorLabels" . | nindent 6 }}
+            {{- include "fogLedger.selectorLabels" . | nindent 12 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -42,7 +42,7 @@ spec:
               # match on this helm chart install
               app: fog-ledger
               helm.sh/chart: {{ include "fogLedger.chart" . }}
-              {{- include "fogLedger.selectorLabels" . | nindent 6 }}
+              {{- include "fogLedger.selectorLabels" . | nindent 14 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       terminationGracePeriodSeconds: 30

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-statefulset.yaml
@@ -21,6 +21,28 @@ spec:
         app: fog-ledger
         {{- include "fogServices.labels" . | nindent 8 }}
     spec:
+      # Try to balance pods across zones
+      topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        # Wait until we have nodes
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            # match on this helm chart install
+            app: fog-ledger
+            helm.sh/chart: {{ include "fogLedger.chart" . }}
+            {{- include "fogLedger.selectorLabels" . | nindent 6 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          # Require pods to be on separate nodes.
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              # match on this helm chart install
+              app: fog-ledger
+              helm.sh/chart: {{ include "fogLedger.chart" . }}
+              {{- include "fogLedger.selectorLabels" . | nindent 6 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       terminationGracePeriodSeconds: 30

--- a/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
@@ -20,6 +20,18 @@ spec:
         app: fog-report
         {{- include "fogServices.labels" . | nindent 8 }}
     spec:
+      # Try to balance pods across zones
+      topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        # Wait until we have nodes
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            # match on this helm chart install
+            app: fog-report
+            helm.sh/chart: {{ include "fogReport.chart" . }}
+            {{- include "fogReport.selectorLabels" . | nindent 6 }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       initContainers:

--- a/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
@@ -30,8 +30,8 @@ spec:
           matchLabels:
             # match on this helm chart install
             app: fog-report
-            helm.sh/chart: {{ include "fogReport.chart" . }}
-            {{- include "fogReport.selectorLabels" . | nindent 12 }}
+            helm.sh/chart: {{ include "fogServices.chart" . }}
+            {{- include "fogServices.selectorLabels" . | nindent 12 }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       initContainers:

--- a/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             # match on this helm chart install
             app: fog-report
             helm.sh/chart: {{ include "fogReport.chart" . }}
-            {{- include "fogReport.selectorLabels" . | nindent 6 }}
+            {{- include "fogReport.selectorLabels" . | nindent 12 }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       initContainers:

--- a/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
@@ -20,6 +20,28 @@ spec:
         app: fog-view
         {{- include "fogServices.labels" . | nindent 8 }}
     spec:
+      # Try to balance pods across zones
+      topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+        maxSkew: 1
+        # Wait until we have nodes
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            # match on this helm chart install
+            app: fog-view
+            helm.sh/chart: {{ include "fogView.chart" . }}
+            {{- include "fogView.selectorLabels" . | nindent 6 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          # Require pods to be on separate nodes.
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              # match on this helm chart install
+              app: fog-view
+              helm.sh/chart: {{ include "fogView.chart" . }}
+              {{- include "fogView.selectorLabels" . | nindent 6 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:
@@ -105,8 +127,8 @@ spec:
             command:
             - "/usr/local/bin/grpc_health_probe"
             - "-addr=:3225"
-          # wait up to 2 hours for start up
-          failureThreshold: 240
+          # wait up to 4 hours for start up
+          failureThreshold: 480
           periodSeconds: 30
         # Will wait for startup probe to succeed. When this passes k8s won't kill the service.
         livenessProbe:

--- a/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
@@ -8,6 +8,11 @@ metadata:
     {{- include "fogServices.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.fogView.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 50%
   selector:
     matchLabels:
       app: fog-view
@@ -30,8 +35,8 @@ spec:
           matchLabels:
             # match on this helm chart install
             app: fog-view
-            helm.sh/chart: {{ include "fogView.chart" . }}
-            {{- include "fogView.selectorLabels" . | nindent 12 }}
+            helm.sh/chart: {{ include "fogServices.chart" . }}
+            {{- include "fogServices.selectorLabels" . | nindent 12 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -40,8 +45,8 @@ spec:
             labelSelector:
               # match on this helm chart install
               app: fog-view
-              helm.sh/chart: {{ include "fogView.chart" . }}
-              {{- include "fogView.selectorLabels" . | nindent 14 }}
+              helm.sh/chart: {{ include "fogServices.chart" . }}
+              {{- include "fogServices.selectorLabels" . | nindent 14 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:

--- a/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             # match on this helm chart install
             app: fog-view
             helm.sh/chart: {{ include "fogView.chart" . }}
-            {{- include "fogView.selectorLabels" . | nindent 6 }}
+            {{- include "fogView.selectorLabels" . | nindent 12 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -41,7 +41,7 @@ spec:
               # match on this helm chart install
               app: fog-view
               helm.sh/chart: {{ include "fogView.chart" . }}
-              {{- include "fogView.selectorLabels" . | nindent 6 }}
+              {{- include "fogView.selectorLabels" . | nindent 14 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -88,7 +88,7 @@ fogReport:
       POSTGRES_MAX_CONNECTIONS: '3'
 
 fogView:
-  replicaCount: 2
+  replicaCount: 4
   image:
     org: ''
     name: fogview


### PR DESCRIPTION
### Motivation

Fog-view may or may not complete in the 2 hour start up time. Bump the startup wait time to 4 hours.

In addition if we were to loose all the view pods in an envrionment we would be looking at several hours of downtime while view reloads.  To minimize the chance of a single node or availability zone taking down the entire view service, add topology  and anti-affinity rules.

- Anti-affinity rules for view, ingest and consensus to make sure each pod ends up on their own node. Report is stateless and fast to come up. We don't need to constrain it to specific nodes.
- Topology rules to enforce balanced distribution across availability zones.
- LabelsSelectors should enforce rules across the app *and* helm chart version.  This way when we have a new helm release version we don't share the constraint and block pod deployment.
- double checked testnet/mainnet and we have enough nodes to support consensus "required" rules for anti-affinity.
- adjust strategy on view to allow pods half the pods to be terminated during a rolling upgrade. This should allow view to be rotated even if there is only 4 nodes.

Bonus, `concurrency` rule on GHA to keep builds from overlapping on a branch. Simultaneous but separate branches are ok, just not to the same branch at the same time.

