### PR TITLE
Statically link SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,8 +1055,7 @@ dependencies = [
 [[package]]
 name = "diesel"
 version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
+source = "git+https://github.com/mobilecoinofficial/diesel?rev=026f6379715d27c8be48396e5ca9059f4a263198#026f6379715d27c8be48396e5ca9059f4a263198"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2075,10 +2074,11 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,3 +227,6 @@ serde_cbor = { git = "https://github.com/mobilecoinofficial/cbor", rev = "4c886a
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
 x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "c1966b8743d320cd07a54191475e5c0f94b2ea30" }
+
+# Override diesel dependency with our fork, to statically link SQLite.
+diesel = { git = "https://github.com/mobilecoinofficial/diesel", rev = "026f6379715d27c8be48396e5ca9059f4a263198" }

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -33,9 +33,9 @@ mc-fog-types = { path = "../types" }
 
 chrono = "0.4"
 clap = { version = "3.2", features = ["derive", "env"] }
-diesel = { version = "1.4.8", features = ["chrono", "postgres", "r2d2"] }
+diesel = { version = "1.4", features = ["chrono", "postgres", "r2d2"] }
 diesel-derive-enum = { version = "1", features = ["postgres"] }
-diesel_migrations = { version = "1.4.0", features = ["postgres"] }
+diesel_migrations = { version = "1.4", features = ["postgres"] }
 displaydoc = { version = "0.2", default-features = false }
 prost = "0.10"
 r2d2 = "0.8.9"

--- a/mint-auditor/Cargo.toml
+++ b/mint-auditor/Cargo.toml
@@ -22,8 +22,9 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 
 clap = { version = "3.2", features = ["derive", "env"] }
-diesel = { version = "1.4.8", features = ["sqlite", "r2d2"] }
-diesel_migrations = { version = "1.4.0", features = ["sqlite"] }
+# Override diesel dependency with our fork, to statically link SQLite.
+diesel = { version = "1.4", features = ["sqlite-bundled", "r2d2"] }
+diesel_migrations = { version = "1.4", features = ["sqlite"] }
 displaydoc = "0.2"
 grpcio = "0.10.2"
 hex = "0.4"


### PR DESCRIPTION
Use our fork of `diesel` to statically link `libsqlite3`, to avoid a runtime dependency.


### Motivation

See #2165.

### Future Work
* Statically link `libpq`