### PR TITLE
Make outbuf_retry_id an in,out parameter, fix init-twice crash.

### DIFF
--- a/consensus/enclave/edl/enclave.edl
+++ b/consensus/enclave/edl/enclave.edl
@@ -14,7 +14,7 @@ enclave {
                                                [out, size=outbuf_len] uint8_t *outbuf,
                                                size_t outbuf_len,
                                                [out] size_t* outbuf_used,
-                                               [out] uint64_t* outbuf_retry_id);
+                                               [in, out] uint64_t* outbuf_retry_id);
 
     };
 };

--- a/fog/ingest/enclave/edl/enclave.edl
+++ b/fog/ingest/enclave/edl/enclave.edl
@@ -16,7 +16,7 @@ enclave {
                                                 [out, size=outbuf_len] uint8_t *outbuf,
                                                 size_t outbuf_len,
                                                 [out] size_t* outbuf_used,
-                                                [out] uint64_t* outbuf_retry_id);
+                                                [in, out] uint64_t* outbuf_retry_id);
 
     };
 };

--- a/fog/ledger/enclave/edl/enclave.edl
+++ b/fog/ledger/enclave/edl/enclave.edl
@@ -16,7 +16,7 @@ enclave {
                                                 [out, size=outbuf_len] uint8_t *outbuf,
                                                 size_t outbuf_len,
                                                 [out] size_t* outbuf_used,
-                                                [out] uint64_t* outbuf_retry_id);
+                                                [in, out] uint64_t* outbuf_retry_id);
 
     };
 };

--- a/fog/view/enclave/edl/enclave.edl
+++ b/fog/view/enclave/edl/enclave.edl
@@ -18,7 +18,7 @@ enclave {
                                               [out, size=outbuf_len] uint8_t *outbuf,
                                               size_t outbuf_len,
                                               [out] size_t* outbuf_used,
-                                              [out] uint64_t* outbuf_retry_id);
+                                              [in, out] uint64_t* outbuf_retry_id);
 
     };
 };


### PR DESCRIPTION
Correctly mark `outbuf_retry_id` as an `[in, out]` parameter.

TODO:

- [x] run local-network
- [ ] test deployment on sgx hw