### PR TITLE
Revert 1.2.2 to SGX 2.16 

### DIFF
--- a/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
+++ b/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
@@ -30,4 +30,4 @@ runs:
       path: ${{ inputs.path }}
       # Key is a hash of all the .rs, .proto and Cargo.toml files.
       # if code changes, invalidate cache and rebuild
-      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml') }}-rust-build-artifacts
+      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml', '**/.*edl', '.cargo/config') }}-rust-build-artifacts

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -60,7 +60,7 @@ jobs:
   build-rust-hardware-projects:
     runs-on: [self-hosted, Linux, large]
     container:
-      image: mobilecoin/rust-sgx-base@sha256:1be28a65be74022072feb929bb9b900cf303de3cd8d3a1af49d583407b0c002b
+      image: mobilecoin/rust-sgx-base:v0.0.10
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem
       MINTING_TRUST_ROOT_PUBLIC_KEY_PEM: ${{ github.workspace }}/.tmp/minting_trust_root.public.pem

--- a/.internal-ci/docker/Dockerfile.runtime-base
+++ b/.internal-ci/docker/Dockerfile.runtime-base
@@ -35,9 +35,9 @@ ENV LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm"
 # libsgx-enclave-common libsgx-epid libsgx-launch libsgx-pce-logic libsgx-urts
 # sgx-aesm-service
 # Use `apt show -a sgx-aesm-service` to find version
-ENV AESM_VERSION=2.17.100.3-focal1
+ENV AESM_VERSION=2.16.100.4-focal1
 # Use `apt show -a libsgx-pce-logic` to find the version thats compatible with aesm.
-ENV PCE_LOGIC_VERSION=1.14.100.3-focal1
+ENV PCE_LOGIC_VERSION=1.13.100.4-focal1
 
 
 # Install  packages

--- a/consensus/enclave/build.rs
+++ b/consensus/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 4;

--- a/consensus/enclave/trusted/build.rs
+++ b/consensus/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/service/BUILD.md
+++ b/consensus/service/BUILD.md
@@ -97,7 +97,7 @@ Recommended SDK and package installation:
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.16.100.4.bin"
 	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
@@ -112,8 +112,8 @@ chmod +x ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 
 # Install the SDK to /opt/intel/sgxsdk
-chmod +x ./sgx_linux_x64_sdk_2.17.100.3.bin
-./sgx_linux_x64_sdk_2.17.100.3.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.16.100.4.bin
+./sgx_linux_x64_sdk_2.16.100.4.bin --prefix=/opt/intel
 
 apt install libsgx-uae-service sgx-aesm-service
 

--- a/docker/install_sgx.sh
+++ b/docker/install_sgx.sh
@@ -24,7 +24,7 @@ cd /tmp
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.16.100.4.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 )
@@ -59,8 +59,8 @@ apt-get install -yq --no-install-recommends \
 
 # Install *after* pkg-config so that they get registered correctly.
 # pkg-config gets pulled in transitively via build-essential
-chmod +x ./sgx_linux_x64_sdk_2.17.100.3.bin
-./sgx_linux_x64_sdk_2.17.100.3.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.16.100.4.bin
+./sgx_linux_x64_sdk_2.16.100.4.bin --prefix=/opt/intel
 
 # Update .bashrc to source sgxsdk
 echo 'source /opt/intel/sgxsdk/environment' >> /root/.bashrc

--- a/fog/ingest/enclave/build.rs
+++ b/fog/ingest/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
 const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 3;

--- a/fog/ingest/enclave/trusted/build.rs
+++ b/fog/ingest/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/build.rs
+++ b/fog/ledger/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
 const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 3;

--- a/fog/ledger/enclave/trusted/build.rs
+++ b/fog/ledger/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/build.rs
+++ b/fog/view/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
 const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 3;

--- a/fog/view/enclave/trusted/build.rs
+++ b/fog/view/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.16.100.4";
 
 fn main() {
     let env = Environment::default();

--- a/ops/Dockerfile-consensus
+++ b/ops/Dockerfile-consensus
@@ -21,7 +21,7 @@ RUN apt-get update -q -q && \
 RUN source /etc/os-release && \
 	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin" && \
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin" && \
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.16.100.4.bin" && \
 	echo "deb [arch=amd64 signed-by=/usr/local/share/apt-keyrings/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 
 RUN mkdir -p /usr/local/share/apt-keyrings && \


### PR DESCRIPTION
### Motivation

Intel is pushing back the 2.17 SGX update until the workout some issues with the release.  This PR will revert the 1.2.2 maintenance release to use the 2.16 SGX SDK and AESM packages.

