### PR TITLE
Make mob prompt use 1.10 and not 1.11

### DIFF
--- a/.mobconf
+++ b/.mobconf
@@ -1,3 +1,3 @@
 [image]
 url = mobilecoin/builder-install
-tag = v0.0.11
+tag = v0.0.10


### PR DESCRIPTION
Because 1.11 doesn't work at this revision, and CI is using 1.10

If we fix the code so that 1.11 works, then we can use it here and in CI at the same time.