### PR TITLE
Make telemetry opt-in

### DIFF
--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -28,16 +28,8 @@ fn main() {
     let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
 
-    // Telemetry is disabled if MC_TELEMETRY is set to "0"
-    let telemetry_enabled = !std::env::var("MC_TELEMETRY")
-        .map(|val| val == "0")
-        .unwrap_or(false);
-
-    let _tracer = if telemetry_enabled {
-        Some(setup_default_tracer(env!("CARGO_PKG_NAME")).expect("Failed setting telemetry tracer"))
-    } else {
-        None
-    };
+    let _tracer =
+        setup_default_tracer(env!("CARGO_PKG_NAME")).expect("Failed setting telemetry tracer");
 
     let mut mr_signer_verifier =
         MrSignerVerifier::from(mc_consensus_enclave_measurement::sigstruct());

--- a/util/telemetry/src/jaeger.rs
+++ b/util/telemetry/src/jaeger.rs
@@ -1,0 +1,54 @@
+use displaydoc::Display;
+use opentelemetry::{sdk, trace::TraceError, KeyValue};
+
+#[derive(Debug, Display)]
+pub enum Error {
+    /// Trace error: {0}
+    Trace(TraceError),
+
+    /// Get hostname error: {0}
+    GetHostname(std::io::Error),
+
+    /// Failed converting hostname to string
+    HostnameToString,
+}
+
+/// Set up a default tracer with no additional tags.
+/// Telemetry is enabled iff env.MC_TELEMETRY is set to "1" or "true".
+pub fn setup_default_tracer(service_name: &str) -> Result<Option<sdk::trace::Tracer>, Error> {
+    setup_default_tracer_with_tags(service_name, &[])
+}
+
+/// Set up a default tracer with the given extra tags.
+/// Telemetry is enabled iff env.MC_TELEMETRY is set to "1" or "true".
+pub fn setup_default_tracer_with_tags(
+    service_name: &str,
+    extra_tags: &[(&'static str, String)],
+) -> Result<Option<sdk::trace::Tracer>, Error> {
+    let telemetry_enabled = std::env::var("MC_TELEMETRY")
+        .map(|val| val == "0" || val.to_lowercase() == "true")
+        .unwrap_or(false);
+    if !telemetry_enabled {
+        return Ok(None);
+    }
+
+    let local_hostname = hostname::get().map_err(Error::GetHostname)?;
+
+    let mut tags = vec![KeyValue::new(
+        "hostname",
+        local_hostname
+            .to_str()
+            .ok_or(Error::HostnameToString)?
+            .to_owned(),
+    )];
+    for (key, value) in extra_tags.iter() {
+        tags.push(KeyValue::new(*key, value.clone()));
+    }
+
+    opentelemetry_jaeger::new_pipeline()
+        .with_service_name(service_name)
+        .with_trace_config(sdk::trace::Config::default().with_resource(sdk::Resource::new(tags)))
+        .install_simple()
+        .map_err(Error::Trace)
+        .map(Some)
+}

--- a/util/telemetry/src/jaeger.rs
+++ b/util/telemetry/src/jaeger.rs
@@ -26,7 +26,7 @@ pub fn setup_default_tracer_with_tags(
     extra_tags: &[(&'static str, String)],
 ) -> Result<Option<sdk::trace::Tracer>, Error> {
     let telemetry_enabled = std::env::var("MC_TELEMETRY")
-        .map(|val| val == "0" || val.to_lowercase() == "true")
+        .map(|val| val == "1" || val.to_lowercase() == "true")
         .unwrap_or(false);
     if !telemetry_enabled {
         return Ok(None);

--- a/util/telemetry/src/lib.rs
+++ b/util/telemetry/src/lib.rs
@@ -83,48 +83,8 @@ pub fn start_block_span<T: Tracer>(
     block_span_builder(tracer, span_name, block_index).start(tracer)
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "jaeger")] {
-        use displaydoc::Display;
-        use opentelemetry::{trace::TraceError, KeyValue, sdk};
+#[cfg(feature = "jaeger")]
+mod jaeger;
 
-        #[derive(Debug, Display)]
-        pub enum Error {
-            /// Trace error: {0}
-            Trace(TraceError),
-
-            /// Get hostname error: {0}
-            GetHostname(std::io::Error),
-
-            /// Failed converting hostname to string
-            HostnameToString,
-        }
-
-        pub fn setup_default_tracer_with_tags(service_name: &str, extra_tags: &[(&'static str, String)]) -> Result<sdk::trace::Tracer, Error> {
-            let local_hostname = hostname::get().map_err(Error::GetHostname)?;
-
-            let mut tags = vec![KeyValue::new(
-                "hostname",
-                local_hostname
-                    .to_str()
-                    .ok_or(Error::HostnameToString)?
-                    .to_owned(),
-            )];
-            for (key, value) in extra_tags.iter() {
-                tags.push(KeyValue::new(*key, value.clone()));
-            }
-
-            opentelemetry_jaeger::new_pipeline()
-                .with_service_name(service_name)
-                .with_trace_config(
-                    sdk::trace::Config::default()
-                        .with_resource(sdk::Resource::new(tags)))
-                .install_simple()
-                .map_err(Error::Trace)
-        }
-
-        pub fn setup_default_tracer(service_name: &str) -> Result<sdk::trace::Tracer, Error> {
-            setup_default_tracer_with_tags(service_name, &[])
-        }
-    }
-}
+#[cfg(feature = "jaeger")]
+pub use jaeger::{setup_default_tracer, setup_default_tracer_with_tags, Error};


### PR DESCRIPTION
Enabled by setting `env.MC_TELEMETRY` to `1` or `true`.

Previously `mobilecoind` had an opt-out with `MC_TELEMETRY=0`. Now all clients have telemetry disabled by default.