### PR TITLE
Implement enclave APIs that facilitate Fog View Router dynamic store discovery

### DIFF
--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::{string::ToString, vec::Vec};
 use digest::Digest;
 use mc_attest_ake::{
     AuthPending, AuthRequestOutput, AuthResponseInput, AuthResponseOutput, ClientAuthRequestInput,
-    NodeAuthRequestInput, NodeInitiate, Ready, Start, Transition,
+    ClientInitiate, NodeAuthRequestInput, NodeInitiate, Ready, Start, Transition,
 };
 use mc_attest_core::{
     IasNonce, Nonce, NonceError, Quote, QuoteNonce, Report, ReportData, TargetInfo,
@@ -36,8 +36,14 @@ const MAX_AUTH_PENDING_REQUESTS: usize = 64;
 /// Max number of peer sessions.
 const MAX_PEER_SESSIONS: usize = 64;
 
+/// Max number of backends that this enclave can connect to as a client.
+const MAX_BACKEND_CONNECTIONS: usize = 10000;
+
 /// Max number of client sessions.
 const MAX_CLIENT_SESSIONS: usize = 10000;
+
+/// Max number of auth requests for enclave backends.
+const MAX_BACKEND_AUTH_PENDING_REQUESTS: usize = 10000;
 
 /// Any additional "identities" (e.g. key material) for a given enclave that
 /// needs to become a part of the report. We provide some simple identities, and
@@ -75,6 +81,10 @@ pub struct AkeEnclaveState<EI: EnclaveIdentity> {
     /// A map of responder-ID to incomplete, outbound, AKE state.
     initiator_auth_pending: Mutex<LruCache<ResponderId, AuthPending<X25519, Aes256Gcm, Sha512>>>,
 
+    /// A map of responder-ID to incomplete, outbound AKE state for connections
+    /// to enclaves that serve as backends to the current enclave.
+    backend_auth_pending: Mutex<LruCache<ResponderId, AuthPending<X25519, Aes256Gcm, Sha512>>>,
+
     /// A map of channel ID outbound connection state.
     peer_outbound: Mutex<LruCache<PeerSession, Ready<Aes256Gcm>>>,
 
@@ -83,6 +93,10 @@ pub struct AkeEnclaveState<EI: EnclaveIdentity> {
 
     /// A map of channel ID to connection state
     clients: Mutex<LruCache<ClientSession, Ready<Aes256Gcm>>>,
+
+    /// A map of ResponderIds for each enclave that serves as a backend to the
+    /// current enclave.
+    backends: Mutex<LruCache<ResponderId, Ready<Aes256Gcm>>>,
 }
 
 impl<EI: EnclaveIdentity + Default> Default for AkeEnclaveState<EI> {
@@ -103,9 +117,11 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
             ias_pending: Mutex::new(LruCache::new(MAX_PENDING_QUOTES)),
             current_ias_report: Mutex::new(None),
             initiator_auth_pending: Mutex::new(LruCache::new(MAX_AUTH_PENDING_REQUESTS)),
+            backend_auth_pending: Mutex::new(LruCache::new(MAX_BACKEND_AUTH_PENDING_REQUESTS)),
             peer_outbound: Mutex::new(LruCache::new(MAX_PEER_SESSIONS)),
             peer_inbound: Mutex::new(LruCache::new(MAX_PEER_SESSIONS)),
             clients: Mutex::new(LruCache::new(MAX_CLIENT_SESSIONS)),
+            backends: Mutex::new(LruCache::new(MAX_BACKEND_CONNECTIONS)),
         }
     }
 
@@ -163,6 +179,45 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         } else {
             Err(Error::AlreadyInit)
         }
+    }
+
+    /// Constructs a ClientAuthRequest to be sent to an enclave backend.
+    pub fn backend_init(&self, backend_id: ResponderId) -> Result<ClientAuthRequest> {
+        let mut csprng = McRng::default();
+
+        let initiator = Start::new(backend_id.to_string());
+
+        let init_input = ClientInitiate::<X25519, Aes256Gcm, Sha512>::default();
+        let (initiator, auth_request_output) = initiator.try_next(&mut csprng, init_input)?;
+        self.backend_auth_pending.lock()?.put(backend_id, initiator);
+        let client_auth_request_data: Vec<u8> = auth_request_output.into();
+        Ok(client_auth_request_data.into())
+    }
+
+    /// Connect to an enclave backend as a client.
+    pub fn backend_connect(
+        &self,
+        backend_id: ResponderId,
+        backend_auth_response: ClientAuthResponse,
+    ) -> Result<()> {
+        let initiator = self
+            .backend_auth_pending
+            .lock()?
+            .pop(&backend_id)
+            .ok_or(Error::NotFound)?;
+
+        let mut csprng = McRng::default();
+
+        let auth_response_output_bytes: Vec<u8> = backend_auth_response.into();
+        let auth_response_event =
+            AuthResponseInput::new(auth_response_output_bytes.into(), self.get_verifier()?);
+        let (initiator, _verification_report) =
+            initiator.try_next(&mut csprng, auth_response_event)?;
+
+        let mut backends = self.backends.lock()?;
+        backends.put(backend_id, initiator);
+
+        Ok(())
     }
 
     /// Accept a client connection

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -87,6 +87,13 @@ pub enum ViewEnclaveRequest {
     /// Takes an encrypted fog_types::view::QueryRequest and returns a list of
     /// fog_types::view::QueryRequest.
     CreateMultiViewStoreQuery(EnclaveMessage<ClientSession>),
+    /// Begin a client connection to a Fog View Store discovered after
+    /// initialization.
+    ViewStoreInit(ResponderId),
+    /// Complete the client connection to a Fog View store that accepted our
+    /// client auth request. This is meant to be called after the enclave
+    /// has initialized and discovers a new Fog View Store.
+    ViewStoreConnect(ResponderId, ClientAuthResponse),
 }
 
 /// The parameters needed to initialize the view enclave
@@ -123,8 +130,21 @@ pub trait ViewEnclaveApi: ReportableEnclave {
     /// Accept an inbound authentication request
     fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession)>;
 
+    /// Complete the connection to a Fog View Store that our accepted our
+    /// ClientAuthRequest. This is meant to be called after the enclave has
+    /// initialized and discovers a new Fog View Store.
+    fn view_store_connect(
+        &self,
+        view_store_id: ResponderId,
+        view_store_auth_response: ClientAuthResponse,
+    ) -> Result<()>;
+
     /// Destroy a peer association
     fn client_close(&self, channel_id: ClientSession) -> Result<()>;
+
+    /// Begin a connection to a Fog View Store. The enclave calling this method
+    /// will act as a client to the Fog View Store.
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest>;
 
     /// Service a user's encrypted QueryRequest
     fn query(

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -91,8 +91,7 @@ pub enum ViewEnclaveRequest {
     /// initialization.
     ViewStoreInit(ResponderId),
     /// Complete the client connection to a Fog View store that accepted our
-    /// client auth request. This is meant to be called after the enclave
-    /// has initialized and discovers a new Fog View Store.
+    /// client auth request. This is meant to be called after [ViewStoreInit].
     ViewStoreConnect(ResponderId, ClientAuthResponse),
 }
 
@@ -130,7 +129,11 @@ pub trait ViewEnclaveApi: ReportableEnclave {
     /// Accept an inbound authentication request
     fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession)>;
 
-    /// Complete the connection to a Fog View Store that our accepted our
+    /// Begin a connection to a Fog View Store. The enclave calling this method
+    /// will act as a client to the Fog View Store.
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest>;
+
+    /// Complete the connection to a Fog View Store that has accepted our
     /// ClientAuthRequest. This is meant to be called after the enclave has
     /// initialized and discovers a new Fog View Store.
     fn view_store_connect(
@@ -141,10 +144,6 @@ pub trait ViewEnclaveApi: ReportableEnclave {
 
     /// Destroy a peer association
     fn client_close(&self, channel_id: ClientSession) -> Result<()>;
-
-    /// Begin a connection to a Fog View Store. The enclave calling this method
-    /// will act as a client to the Fog View Store.
-    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest>;
 
     /// Service a user's encrypted QueryRequest
     fn query(

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -129,6 +129,9 @@ pub trait ViewEnclaveApi: ReportableEnclave {
     /// Accept an inbound authentication request
     fn client_accept(&self, req: ClientAuthRequest) -> Result<(ClientAuthResponse, ClientSession)>;
 
+    /// Destroy a peer association
+    fn client_close(&self, channel_id: ClientSession) -> Result<()>;
+
     /// Begin a connection to a Fog View Store. The enclave calling this method
     /// will act as a client to the Fog View Store.
     fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest>;
@@ -141,9 +144,6 @@ pub trait ViewEnclaveApi: ReportableEnclave {
         view_store_id: ResponderId,
         view_store_auth_response: ClientAuthResponse,
     ) -> Result<()>;
-
-    /// Destroy a peer association
-    fn client_close(&self, channel_id: ClientSession) -> Result<()>;
 
     /// Service a user's encrypted QueryRequest
     fn query(

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -9,10 +9,7 @@ extern crate alloc;
 mod e_tx_out_store;
 use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
 
-use aes_gcm::Aes256Gcm;
 use alloc::vec::Vec;
-use core::ops::DerefMut;
-use mc_attest_ake::Ready;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage};
 use mc_common::{
@@ -45,13 +42,6 @@ where
 
     /// Logger object
     logger: Logger,
-
-    /// Encrypts a QueryRequest for each individual Fog View Store.
-    /// TODO: Use a BTreeMap<FogViewShardLoadBalancerID,
-    /// BTreeMap<FogViewStoreId, Ready<...>>>  when implement the cursoring
-    /// optimization. For right now, it's fine to leave as a Vec because a
-    /// follow up PR will implement cursoring.
-    store_encryptors: Mutex<Vec<Ready<Aes256Gcm>>>,
 }
 
 impl<OSC> ViewEnclave<OSC>
@@ -61,7 +51,6 @@ where
     pub fn new(logger: Logger) -> Self {
         Self {
             e_tx_out_store: Mutex::new(None),
-            store_encryptors: Mutex::new(Vec::new()),
             ake: Default::default(),
             logger,
         }
@@ -206,26 +195,9 @@ where
         &self,
         client_query: EnclaveMessage<ClientSession>,
     ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
-<<<<<<< HEAD
-        let client_query_bytes = self.ake.client_decrypt(client_query.clone())?;
-
-        let mut encryptors = self.store_encryptors.lock()?;
-        let mut results = Vec::with_capacity(encryptors.len());
-        for store_encryptor in encryptors.deref_mut() {
-            let aad = client_query.aad.clone();
-            let data = store_encryptor.encrypt(&aad, &client_query_bytes)?;
-            let channel_id = client_query.channel_id.clone();
-            results.push(EnclaveMessage {
-                aad,
-                channel_id,
-                data,
-            });
-        }
-=======
         Ok(self
             .ake
             .reencrypt_client_message_for_backends(client_query)?)
->>>>>>> 8b34d6bf (Rename)
     }
 
     fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -15,7 +15,10 @@ use core::ops::DerefMut;
 use mc_attest_ake::Ready;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage};
-use mc_common::logger::{log, Logger};
+use mc_common::{
+    logger::{log, Logger},
+    ResponderId,
+};
 use mc_crypto_ake_enclave::{AkeEnclaveState, NullIdentity};
 use mc_crypto_keys::X25519Public;
 use mc_fog_recovery_db_iface::FogUserEvent;
@@ -203,6 +206,7 @@ where
         &self,
         client_query: EnclaveMessage<ClientSession>,
     ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
+<<<<<<< HEAD
         let client_query_bytes = self.ake.client_decrypt(client_query.clone())?;
 
         let mut encryptors = self.store_encryptors.lock()?;
@@ -217,7 +221,24 @@ where
                 data,
             });
         }
+=======
+        Ok(self
+            .ake
+            .reencrypt_client_message_for_backends(client_query)?)
+>>>>>>> 8b34d6bf (Rename)
+    }
 
-        Ok(results)
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
+        Ok(self.ake.backend_init(view_store_id)?)
+    }
+
+    fn view_store_connect(
+        &self,
+        view_store_id: ResponderId,
+        view_store_auth_response: ClientAuthResponse,
+    ) -> Result<()> {
+        Ok(self
+            .ake
+            .backend_connect(view_store_id, view_store_auth_response)?)
     }
 }

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -155,8 +155,27 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn view_store_connect(
+        &self,
+        view_store_id: ResponderId,
+        view_store_auth_response: ClientAuthResponse,
+    ) -> Result<()> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreConnect(
+            view_store_id,
+            view_store_auth_response,
+        ))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn client_close(&self, channel_id: ClientSession) -> Result<()> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ClientClose(channel_id))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreInit(view_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -155,6 +155,12 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreInit(view_store_id))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn view_store_connect(
         &self,
         view_store_id: ResponderId,
@@ -170,12 +176,6 @@ impl ViewEnclaveApi for SgxViewEnclave {
 
     fn client_close(&self, channel_id: ClientSession) -> Result<()> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ClientClose(channel_id))?;
-        let outbuf = self.enclave_call(&inbuf)?;
-        mc_util_serial::deserialize(&outbuf[..])?
-    }
-
-    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
-        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreInit(view_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -155,6 +155,12 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn client_close(&self, channel_id: ClientSession) -> Result<()> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ClientClose(channel_id))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreInit(view_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
@@ -170,12 +176,6 @@ impl ViewEnclaveApi for SgxViewEnclave {
             view_store_id,
             view_store_auth_response,
         ))?;
-        let outbuf = self.enclave_call(&inbuf)?;
-        mc_util_serial::deserialize(&outbuf[..])?
-    }
-
-    fn client_close(&self, channel_id: ClientSession) -> Result<()> {
-        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ClientClose(channel_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -115,7 +115,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         }
         ViewEnclaveRequest::GetIasReport => serialize(&ENCLAVE.get_ias_report()),
         ViewEnclaveRequest::ClientAccept(msg) => serialize(&ENCLAVE.client_accept(msg)),
+        ViewEnclaveRequest::ViewStoreConnect(view_store_id, msg) => serialize(&ENCLAVE.view_store_connect(view_store_id, msg)),
         ViewEnclaveRequest::ClientClose(session) => serialize(&ENCLAVE.client_close(session)),
+        ViewEnclaveRequest::ViewStoreInit(view_store_id) => serialize(&ENCLAVE.view_store_init(view_store_id)),
         ViewEnclaveRequest::Query(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -115,9 +115,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         }
         ViewEnclaveRequest::GetIasReport => serialize(&ENCLAVE.get_ias_report()),
         ViewEnclaveRequest::ClientAccept(msg) => serialize(&ENCLAVE.client_accept(msg)),
+        ViewEnclaveRequest::ViewStoreInit(view_store_id) => serialize(&ENCLAVE.view_store_init(view_store_id)),
         ViewEnclaveRequest::ViewStoreConnect(view_store_id, msg) => serialize(&ENCLAVE.view_store_connect(view_store_id, msg)),
         ViewEnclaveRequest::ClientClose(session) => serialize(&ENCLAVE.client_close(session)),
-        ViewEnclaveRequest::ViewStoreInit(view_store_id) => serialize(&ENCLAVE.view_store_init(view_store_id)),
         ViewEnclaveRequest::Query(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }


### PR DESCRIPTION
### Motivation
The Fog View Router is responsible for taking incoming client requests, forwarding them to Fog View Shards, and then returning these received responses to the client. This PR adds three ake enclave methods (and corresponding view enclave methods) that facilitate this process. 

The first method, `backend_init`, allows an enclave to create a Noise auth request to another enclave that serves as a backend.A backend connection is one in which the current enclave is a client to another enclave. It is not the same as a peer connection, in which the current enclave sends peer messages to another enclave, and it's distinct from a client connection, in which the current enclave services client requests. The `backend_connect` method finishes the Noise connection process, and the `reencrypt_client_message_for_backends` takes a client message and makes a message for each connected backend.

Addresses the  `Implement shard component discovery in Fog Router" item in #2028. This item will be marked complete once the next PR, which uses these enclave methods to perform the dynamic store discovery, is merged.

This PR implements enclave methods described in the design doc's "Option 1: 'On The Fly' Authentication" [section](https://docs.google.com/document/d/1-ju5efGK6vvuYjxj1pKhfFcpgGlornuxZYvOC-nsbjs/edit#bookmark=id.d11a9antj10l). The one slight difference is the shape of the `Map` and that it's stored in the ake enclave rather than the Fog View enclave. (It went from being `Map<LoadBalancerHostPort, Map<StoreHostPort, Ready<_>>` to `Mutex<LruCache<ResponderId, Ready<Aes256Gcm>>>`.

### Future Work
* FogViewRouterService uses the `reencrypt_client_message_for_backends` method to create query requests for each Fog View Store
* FogViewRouterService uses the auth enclave methods to authenticate and connect to Fog View Stores via the "dynamic discovery" method. 