### PR TITLE
Handle catch-up mode for consensus and mobilecoind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,7 @@ dependencies = [
  "mc-account-keys",
  "mc-attest-core",
  "mc-attest-enclave-api",
+ "mc-blockchain-test-utils",
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-enclave-api",
@@ -2820,9 +2821,8 @@ dependencies = [
  "mc-transaction-core-test-utils",
  "mc-util-from-random",
  "mc-util-serial",
+ "mc-util-test-helper",
  "mockall",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,6 @@ dependencies = [
  "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
  "mc-transaction-core",
- "mc-transaction-core-test-utils",
  "mc-util-build-info",
  "mc-util-cli",
  "mc-util-from-random",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,6 +4597,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
  "mc-util-telemetry",
+ "mc-util-test-helper",
  "mc-util-uri",
  "mockall",
  "protobuf",

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 mc-account-keys = { path = "../../../account-keys" }
 mc-attest-core = { path = "../../../attest/core" }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
+mc-blockchain-test-utils = { path = "../../../blockchain/test-utils" }
 mc-blockchain-types = { path = "../../../blockchain/types" }
 mc-common = { path = "../../../common" }
 mc-consensus-enclave-api = { path = "../api" }
@@ -19,7 +20,6 @@ mc-transaction-core = { path = "../../../transaction/core" }
 mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
+mc-util-test-helper = { path = "../../../util/test-helper" }
 
-mockall = "0.11.1"
-rand_core = "0.6"
-rand_hc = "0.3"
+mockall = "0.11"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -30,6 +30,7 @@ mc-crypto-multisig = { path = "../../crypto/multisig" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-ledger-sync = { path = "../../ledger/sync" }
 mc-peers = { path = "../../peers" }
+mc-sgx-report-cache-api = { path = "../../sgx/report-cache/api" }
 mc-sgx-report-cache-untrusted = { path = "../../sgx/report-cache/untrusted" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-transaction-std = { path = "../../transaction/std" }

--- a/consensus/service/src/byzantine_ledger/metadata_provider.rs
+++ b/consensus/service/src/byzantine_ledger/metadata_provider.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use std::sync::Arc;
+
+use mc_blockchain_types::{BlockData, BlockMetadata, BlockMetadataContents, QuorumSet};
+use mc_common::ResponderId;
+use mc_crypto_keys::Ed25519Pair;
+use mc_ledger_sync::BlockMetadataProvider;
+use mc_sgx_report_cache_api::ReportableEnclave;
+
+/// A [BlockMetadataProvider] that builds metadata from the configured quorum
+/// set, enclave's AVR, and message signing key.
+pub struct ConsensusMetadataProvider<E: ReportableEnclave> {
+    responder_id: ResponderId,
+    quorum_set: QuorumSet,
+    enclave: E,
+    msg_signer_key: Arc<Ed25519Pair>,
+}
+
+impl<E: ReportableEnclave> ConsensusMetadataProvider<E> {
+    pub fn new(
+        responder_id: ResponderId,
+        quorum_set: QuorumSet,
+        enclave: E,
+        msg_signer_key: Arc<Ed25519Pair>,
+    ) -> Self {
+        Self {
+            responder_id,
+            quorum_set,
+            enclave,
+            msg_signer_key,
+        }
+    }
+}
+
+impl<E: ReportableEnclave> BlockMetadataProvider for ConsensusMetadataProvider<E> {
+    fn get_metadata(&self, block_data: &BlockData) -> Option<BlockMetadata> {
+        let verification_report = self.enclave.get_ias_report().expect("failed to get AVR");
+        let contents = BlockMetadataContents::new(
+            block_data.block().id.clone(),
+            self.quorum_set.clone(),
+            verification_report,
+            self.responder_id.clone(),
+        );
+        Some(
+            BlockMetadata::from_contents_and_keypair(contents, &self.msg_signer_key)
+                .expect("failed to sign metadata"),
+        )
+    }
+}

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -544,9 +544,8 @@ mod tests {
             logger.clone(),
         )));
 
-        let enclave = ConsensusServiceMockEnclave::default();
-        enclave.blockchain_config.lock().unwrap().block_version = BLOCK_VERSION;
-        let verification_report = enclave.get_ias_report().unwrap();
+        let enclave = ConsensusServiceMockEnclave::new(BLOCK_VERSION, &mut rng);
+        let verification_report = enclave.verification_report.clone();
 
         let tx_manager = Arc::new(TxManagerImpl::new(
             enclave.clone(),
@@ -927,9 +926,8 @@ mod tests {
             logger.clone(),
         )));
 
-        let enclave = ConsensusServiceMockEnclave::default();
-        enclave.blockchain_config.lock().unwrap().block_version = BlockVersion::MAX;
-        let verification_report = enclave.get_ias_report().unwrap();
+        let enclave = ConsensusServiceMockEnclave::new(BlockVersion::MAX, &mut rng);
+        let verification_report = enclave.verification_report.clone();
 
         let tx_manager = Arc::new(TxManagerImpl::new(
             enclave.clone(),

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -6,10 +6,12 @@
 //! peers.
 
 mod ledger_sync_state;
+mod metadata_provider;
 mod pending_values;
 mod task_message;
 mod worker;
 
+use self::metadata_provider::ConsensusMetadataProvider;
 use crate::{
     byzantine_ledger::{task_message::TaskMessage, worker::ByzantineLedgerWorker},
     counters,
@@ -111,7 +113,7 @@ impl ByzantineLedger {
         L: Ledger + Clone + Sync + 'static,
         TXM: TxManager + Send + Sync + 'static,
         MTXM: MintTxManager + Send + Sync + 'static,
-        E: ConsensusEnclave + Send + Sync + 'static,
+        E: ConsensusEnclave + Clone + Send + Sync + 'static,
     >(
         node_id: NodeID,
         quorum_set: QuorumSet,
@@ -135,7 +137,7 @@ impl ByzantineLedger {
             let current_slot_index = ledger.num_blocks().unwrap();
             let node = Node::new(
                 node_id.clone(),
-                quorum_set,
+                quorum_set.clone(),
                 // Validation callback
                 Arc::new(move |scp_value| match scp_value {
                     ConsensusValue::TxHash(tx_hash) => tx_manager_validate
@@ -211,10 +213,17 @@ impl ByzantineLedger {
 
         // Start worker thread
         let worker_handle = {
-            let ledger_sync_service = LedgerSyncService::new(
+            let ledger_sync_service = LedgerSyncService::with_metadata_provider(
+                // Always generate metadata with this node's quorum set and AVR.
+                ConsensusMetadataProvider::new(
+                    node_id.responder_id.clone(),
+                    quorum_set,
+                    enclave.clone(),
+                    msg_signer_key.clone(),
+                ),
                 ledger.clone(),
                 peer_manager.clone(),
-                ReqwestTransactionsFetcher::new(tx_source_urls, logger.clone()).unwrap(), /* Unwrap? */
+                ReqwestTransactionsFetcher::new(tx_source_urls, logger.clone()).unwrap(),
                 logger.clone(),
             );
 
@@ -492,6 +501,7 @@ mod tests {
 
         // Local node.
         let (local_node_id, _, local_signer_key) = get_local_node_config(11);
+        let responder_id = local_node_id.responder_id.clone();
 
         // Local node's quorum set.
         let local_quorum_set =
@@ -536,6 +546,7 @@ mod tests {
 
         let enclave = ConsensusServiceMockEnclave::default();
         enclave.blockchain_config.lock().unwrap().block_version = BLOCK_VERSION;
+        let verification_report = enclave.get_ias_report().unwrap();
 
         let tx_manager = Arc::new(TxManagerImpl::new(
             enclave.clone(),
@@ -805,7 +816,7 @@ mod tests {
                 &ledger,
                 Msg::new(
                     local_node_id,
-                    local_quorum_set,
+                    local_quorum_set.clone(),
                     slot_index,
                     Topic::Externalize(ExternalizePayload {
                         C: Ballot::new(55, &[hash_tx_zero, hash_tx_one, hash_tx_two,]),
@@ -822,11 +833,21 @@ mod tests {
         assert_eq!(num_blocks + 1, num_blocks_after);
 
         // The block should have a valid signature.
-        let block = ledger.get_block(num_blocks).unwrap();
-        let signature = ledger.get_block_signature(num_blocks).unwrap();
+        let block_data = ledger.get_block_data(num_blocks).unwrap();
+        let signature = block_data.signature().unwrap();
+        signature.verify(block_data.block()).unwrap();
 
-        let signature_verification_result = signature.verify(&block);
-        assert!(signature_verification_result.is_ok());
+        // The block should have valid metadata with this node's quorum set and AVR.
+        let metadata = block_data.metadata().unwrap();
+        metadata.verify().unwrap();
+        assert_eq!(metadata.node_key(), &local_signer_key.public_key());
+        assert_eq!(metadata.contents().responder_id(), &responder_id);
+        assert_eq!(metadata.contents().block_id(), &block_data.block().id);
+        assert_eq!(metadata.contents().quorum_set(), &local_quorum_set);
+        assert_eq!(
+            metadata.contents().verification_report(),
+            &verification_report
+        );
     }
 
     #[test]
@@ -852,6 +873,7 @@ mod tests {
 
         // Local node.
         let (local_node_id, _, local_signer_key) = get_local_node_config(11);
+        let responder_id = local_node_id.responder_id.clone();
 
         // Local node's quorum set.
         let local_quorum_set =
@@ -907,6 +929,7 @@ mod tests {
 
         let enclave = ConsensusServiceMockEnclave::default();
         enclave.blockchain_config.lock().unwrap().block_version = BlockVersion::MAX;
+        let verification_report = enclave.get_ias_report().unwrap();
 
         let tx_manager = Arc::new(TxManagerImpl::new(
             enclave.clone(),
@@ -1111,7 +1134,7 @@ mod tests {
                 &ledger,
                 Msg::new(
                     local_node_id,
-                    local_quorum_set,
+                    local_quorum_set.clone(),
                     slot_index,
                     Topic::Externalize(ExternalizePayload {
                         C: Ballot::new(
@@ -1135,10 +1158,20 @@ mod tests {
         assert_eq!(num_blocks + 1, num_blocks_after);
 
         // The block should have a valid signature.
-        let block = ledger.get_block(num_blocks).unwrap();
-        let signature = ledger.get_block_signature(num_blocks).unwrap();
+        let block_data = ledger.get_block_data(num_blocks).unwrap();
+        let signature = block_data.signature().unwrap();
+        signature.verify(block_data.block()).unwrap();
 
-        let signature_verification_result = signature.verify(&block);
-        assert!(signature_verification_result.is_ok());
+        // The block should have valid metadata with this node's quorum set and AVR.
+        let metadata = block_data.metadata().unwrap();
+        metadata.verify().unwrap();
+        assert_eq!(metadata.node_key(), &local_signer_key.public_key());
+        assert_eq!(metadata.contents().responder_id(), &responder_id);
+        assert_eq!(metadata.contents().block_id(), &block_data.block().id);
+        assert_eq!(metadata.contents().quorum_set(), &local_quorum_set);
+        assert_eq!(
+            metadata.contents().verification_report(),
+            &verification_report
+        );
     }
 }

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -62,7 +62,6 @@ mc-fog-uri = { path = "../../uri" }
 [dev-dependencies]
 mc-fog-ingest-server-test-utils = { path = "test-utils" }
 mc-fog-test-infra = { path = "../../test_infra" }
-mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 mc-util-build-info = { path = "../../../util/build/info" }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-test-helper = { path = "../../../util/test-helper" }

--- a/ledger/db/src/ledger_db.rs
+++ b/ledger/db/src/ledger_db.rs
@@ -10,7 +10,7 @@ use lmdb::{
 };
 use mc_blockchain_types::{
     Block, BlockContents, BlockData, BlockID, BlockIndex, BlockMetadata, BlockSignature,
-    MAX_BLOCK_VERSION,
+    BlockVersion, MAX_BLOCK_VERSION,
 };
 use mc_common::{logger::global_log, HashMap};
 use mc_crypto_keys::CompressedRistrettoPublic;
@@ -172,7 +172,7 @@ impl Ledger for LedgerDB {
         let mut db_transaction = self.env.begin_rw_txn()?;
 
         // Validate the block is safe to append.
-        self.validate_append_block(block, block_contents, &db_transaction)?;
+        self.validate_append_block(block, block_contents, metadata, &db_transaction)?;
 
         // Write key images included in block.
         self.write_key_images(block.index, &block_contents.key_images, &mut db_transaction)?;
@@ -658,6 +658,7 @@ impl LedgerDB {
         &self,
         block: &Block,
         block_contents: &BlockContents,
+        metadata: Option<&BlockMetadata>,
         db_transaction: &impl Transaction,
     ) -> Result<(), Error> {
         // Check version is correct
@@ -772,6 +773,12 @@ impl LedgerDB {
             {
                 return Err(Error::DuplicateMintConfigTx);
             }
+        }
+
+        let block_version = BlockVersion::try_from(block.version)
+            .or(Err(Error::InvalidBlockVersion(block.version)))?;
+        if block_version.require_block_metadata() && metadata.is_none() {
+            return Err(Error::BlockMetadataRequired);
         }
 
         // All good
@@ -926,7 +933,7 @@ pub fn key_bytes_to_u64(bytes: &[u8]) -> u64 {
 mod ledger_db_test {
     use super::*;
     use crate::test_utils::{add_block_contents_to_ledger, add_txos_and_key_images_to_ledger};
-    use mc_blockchain_test_utils::get_blocks;
+    use mc_blockchain_test_utils::{get_blocks, make_block_metadata};
     use mc_crypto_keys::Ed25519Pair;
     use mc_transaction_core::{membership_proofs::compute_implied_merkle_root, BlockVersion};
     use mc_transaction_core_test_utils::{
@@ -2387,6 +2394,59 @@ mod ledger_db_test {
                     Err(Error::InvalidBlockVersion(invalid_block.version))
                 );
             }
+        }
+    }
+
+    #[test]
+    fn append_block_requires_metadata() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let mut ledger_db = create_db();
+
+        let origin = add_origin_block(&mut ledger_db);
+        let mut last_block = origin.block().clone();
+
+        // MAX_BLOCK_VERSION sets the current max block version
+        for block_version in BlockVersion::iterator() {
+            // In each iteration we add a few blocks with the same version.
+            for _ in 0..3 {
+                let outputs: Vec<TxOut> = (0..4)
+                    .map(|_i| create_test_tx_out(block_version, &mut rng))
+                    .collect();
+
+                let key_images: Vec<KeyImage> =
+                    (0..5).map(|_i| KeyImage::from(rng.next_u64())).collect();
+
+                let block_contents = BlockContents {
+                    key_images,
+                    outputs,
+                    ..Default::default()
+                };
+                last_block = Block::new_with_parent(
+                    block_version,
+                    &last_block,
+                    &Default::default(),
+                    &block_contents,
+                );
+
+                let metadata = make_block_metadata(last_block.id.clone(), &mut rng);
+
+                let result = ledger_db.append_block(&last_block, &block_contents, None, None);
+
+                if block_version.require_block_metadata() {
+                    assert_eq!(result, Err(Error::BlockMetadataRequired));
+                    ledger_db
+                        .append_block(&last_block, &block_contents, None, Some(&metadata))
+                        .unwrap();
+                } else {
+                    result.unwrap();
+                }
+            }
+
+            // All blocks should've been written (+ origin block).
+            assert_eq!(
+                ledger_db.num_blocks().unwrap(),
+                1 + (3 * (*block_version + 1)) as u64
+            );
         }
     }
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -42,4 +42,6 @@ mc-connection-test-utils = { path = "../../connection/test-utils" }
 mc-consensus-scp = { path = "../../consensus/scp", features = ["test_utils"] }
 mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-peers-test-utils = { path = "../../peers/test-utils" }
+mc-util-test-helper = { path = "../../util/test-helper" }
+
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/ledger/sync/src/lib.rs
+++ b/ledger/sync/src/lib.rs
@@ -1,19 +1,21 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 mod ledger_sync;
+mod metadata_provider;
 mod network_state;
 mod reqwest_transactions_fetcher;
 mod transactions_fetcher_trait;
 
-pub use ledger_sync::{
-    identify_safe_blocks, LedgerSync, LedgerSyncError, LedgerSyncService, LedgerSyncServiceThread,
-    MockLedgerSync,
-};
-pub use network_state::{NetworkState, PollingNetworkState, SCPNetworkState};
-pub use reqwest_transactions_fetcher::{
-    ReqwestTransactionsFetcher, ReqwestTransactionsFetcherError,
-};
-pub use transactions_fetcher_trait::{TransactionFetcherError, TransactionsFetcher};
-
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;
+
+pub use crate::{
+    ledger_sync::{
+        identify_safe_blocks, LedgerSync, LedgerSyncError, LedgerSyncService,
+        LedgerSyncServiceThread, MockLedgerSync,
+    },
+    metadata_provider::{BlockMetadataProvider, PassThroughMetadataProvider},
+    network_state::{NetworkState, PollingNetworkState, SCPNetworkState},
+    reqwest_transactions_fetcher::{ReqwestTransactionsFetcher, ReqwestTransactionsFetcherError},
+    transactions_fetcher_trait::{TransactionFetcherError, TransactionsFetcher},
+};

--- a/ledger/sync/src/metadata_provider.rs
+++ b/ledger/sync/src/metadata_provider.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use mc_blockchain_types::{BlockData, BlockMetadata};
+
+/// A helper trait used by [crate::LedgerSyncService] for configuring what
+/// metadata, if any, is appended for a given block.
+pub trait BlockMetadataProvider {
+    fn get_metadata(&self, block_data: &BlockData) -> Option<BlockMetadata>;
+}
+
+/// Default [BlockMetadataProvider], passes through the block metadata
+/// unmodified.
+#[derive(Copy, Clone, Default)]
+pub struct PassThroughMetadataProvider {}
+
+impl BlockMetadataProvider for PassThroughMetadataProvider {
+    fn get_metadata(&self, block_data: &BlockData) -> Option<BlockMetadata> {
+        block_data.metadata().cloned()
+    }
+}


### PR DESCRIPTION
* Make consensus catch-up mode override the downloaded metadata with its own; mobilecoind propagates the metadata it downloads.
* Re-enable check that requires block metadata from Block Version 3 onward. Partial revert of commit ce9eca0.

### Motivation

This is the last blocker to requiring block metadata, per https://github.com/mobilecoinfoundation/mcips/pull/43

### Future Work
* #2197