### PR TITLE
fix mc-crypto-keys build

### DIFF
--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -12,7 +12,7 @@ mc-crypto-digestible-signature = { path = "../../crypto/digestible/signature" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-repr-bytes = { path = "../../util/repr-bytes" }
 
-base64 = { version = "0.13", default-features = false }
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }
 ed25519 = { version = "1.5", default-features = false, features = ["serde"] }


### PR DESCRIPTION
When setting up another repo, I discovered that this crate doesn't
build properly.

```
error[E0425]: cannot find function `encode_config` in crate `base64`
   --> mobilecoin/crypto/keys/src/x25519.rs:240:31
    |
240 |         let encoded = base64::encode_config(&der, B64_CONFIG);
    |                               ^^^^^^^^^^^^^ not found in `base64`

```

This happens because the `base64::encode_config` function is only
exposed when at least the `alloc` feature is selected. This commit
ensures that it is selected whenever this crate is built.