### PR TITLE
Collate shard response in constant time (obliviously)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,6 +4467,7 @@ dependencies = [
  "lazy_static",
  "mc-attest-api",
  "mc-attest-core",
+ "mc-attest-enclave-api",
  "mc-attest-net",
  "mc-attest-verifier",
  "mc-blockchain-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,7 +4467,6 @@ dependencies = [
  "lazy_static",
  "mc-attest-api",
  "mc-attest-core",
- "mc-attest-enclave-api",
  "mc-attest-net",
  "mc-attest-verifier",
  "mc-blockchain-types",

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -467,6 +467,19 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         Ok(backend_messages)
     }
 
+    pub fn backend_decrypt(
+        &self,
+        responder_id: ResponderId,
+        msg: EnclaveMessage<ClientSession>,
+    ) -> Result<Vec<u8>> {
+        // Ensure lock gets released as soon as we're done decrypting.
+        let mut backends = self.backends.lock()?;
+        backends
+            .get_mut(&responder_id)
+            .ok_or(Error::NotFound)
+            .and_then(|session| Ok(session.decrypt(&msg.aad, &msg.data)?))
+    }
+
     //
     // IAS related
     //

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -37,14 +37,8 @@ message FogViewRouterResponse {
 }
 
 message FogViewStoreDecryptionError {
-    /// The FogViewStoreUri for the specific Fog View Store that
-    /// tried to decrypt the MultiViewStoreQueryRequest and failed.
-    /// The client should subsequently authenticate with the machine
-    /// described by this URI.
-    string fog_view_store_uri = 1;
-
     /// An error message that describes the decryption error.
-    string error_message = 2;
+    string error_message = 1;
 }
 
 message MultiViewStoreQueryRequest {
@@ -58,9 +52,15 @@ message MultiViewStoreQueryResponse {
     //  query.
     attest.Message query_response = 1;
 
+    /// The FogViewStoreUri for the specific Fog View Store that
+    /// tried to decrypt the MultiViewStoreQueryRequest and failed.
+    /// The client should subsequently authenticate with the machine
+    /// described by this URI.
+    string fog_view_store_uri = 2;
+
     /// Optional error that gets returned when the Fog View Store
     /// cannot decrypt the MultiViewStoreQuery.
-    FogViewStoreDecryptionError decryption_error = 2;
+    FogViewStoreDecryptionError decryption_error = 3;
 }
 
 /// Fulfills requests sent directly by a Fog client, e.g. a mobile phone using the SDK.

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -6,7 +6,7 @@
 
 extern crate mc_fog_ocall_oram_storage_untrusted;
 
-use std::{path, result::Result as StdResult, sync::Arc};
+use std::{collections::BTreeMap, path, result::Result as StdResult, sync::Arc};
 
 use mc_attest_core::{
     IasNonce, Quote, QuoteNonce, Report, SgxError, TargetInfo, VerificationReport,
@@ -205,6 +205,19 @@ impl ViewEnclaveApi for SgxViewEnclave {
     ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::CreateMultiViewStoreQuery(
             client_query,
+        ))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
+    fn collate_shard_query_responses(
+        &self,
+        client_query_request: EnclaveMessage<ClientSession>,
+        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<ClientSession>>,
+    ) -> Result<EnclaveMessage<ClientSession>> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::CollateQueryResponses(
+            client_query_request,
+            shard_query_responses,
         ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -130,7 +130,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
             serialize(&ENCLAVE.create_multi_view_store_query_data(client_query))
         }
         ViewEnclaveRequest::CollateQueryResponses(client_query_request, shard_query_responses) => {
-            serialize(&ENCLAVE.collate_shard_query_responses(client_query_request, shard_query_responses))
+            serialize(
+                &ENCLAVE.collate_shard_query_responses(client_query_request, shard_query_responses),
+            )
         }
     }
     .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -129,6 +129,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         ViewEnclaveRequest::CreateMultiViewStoreQuery(client_query) => {
             serialize(&ENCLAVE.create_multi_view_store_query_data(client_query))
         }
+        ViewEnclaveRequest::CollateQueryResponses(client_query_request, shard_query_responses) => {
+            serialize(&ENCLAVE.collate_shard_query_responses(client_query_request, shard_query_responses))
+        }
     }
     .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -21,26 +21,14 @@ futures = "0.3"
 grpcio = "0.10.3"
 hex = "0.4"
 lazy_static = "1.4"
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_json = "1.0"
 
 # mobilecoin
 mc-attest-api = { path = "../../../attest/api" }
 mc-attest-core = { path = "../../../attest/core" }
-mc-attest-net = { path = "../../../attest/net" }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
+mc-attest-net = { path = "../../../attest/net" }
 mc-common = { path = "../../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../../crypto/keys" }
-mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
-mc-util-cli = { path = "../../../util/cli" }
-mc-util-from-random = { path = "../../../util/from-random" }
-mc-util-grpc = { path = "../../../util/grpc" }
-mc-util-metered-channel = { path = "../../../util/metered-channel" }
-mc-util-metrics = { path = "../../../util/metrics" }
-mc-util-parse = { path = "../../../util/parse" }
-mc-util-serial = { path = "../../../util/serial" }
-mc-util-telemetry = { path = "../../../util/telemetry", features = ["jaeger"] }
-mc-util-uri = { path = "../../../util/uri" }
 
 # fog
 mc-fog-api = { path = "../../api" }
@@ -51,27 +39,39 @@ mc-fog-types = { path = "../../types" }
 mc-fog-uri = { path = "../../uri" }
 mc-fog-view-enclave = { path = "../enclave" }
 mc-fog-view-enclave-api = { path = "../enclave/api" }
+mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }
+mc-util-cli = { path = "../../../util/cli" }
+mc-util-from-random = { path = "../../../util/from-random" }
+mc-util-grpc = { path = "../../../util/grpc" }
+mc-util-metered-channel = { path = "../../../util/metered-channel" }
+mc-util-metrics = { path = "../../../util/metrics" }
+mc-util-parse = { path = "../../../util/parse" }
+mc-util-serial = { path = "../../../util/serial" }
+mc-util-telemetry = { path = "../../../util/telemetry", features = ["jaeger"] }
+mc-util-uri = { path = "../../../util/uri" }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
-pem = "1.0"
-portpicker = "0.1.1"
-rand = "0.8"
-rand_core = "0.6"
-tempdir = "0.3"
 
 mc-attest-verifier = { path = "../../../attest/verifier" }
 mc-blockchain-types = { path = "../../../blockchain/types" }
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-crypto-x509-test-vectors = { path = "../../../crypto/x509/test-vectors" }
-mc-transaction-core = { path = "../../../transaction/core" }
-mc-util-encodings = { path = "../../../util/encodings" }
-mc-util-serial = { path = "../../../util/serial" }
-mc-util-test-helper = { path = "../../../util/test-helper" }
-mc-util-uri = { path = "../../../util/uri" }
 
 mc-fog-test-infra = { path = "../../test_infra" }
 mc-fog-types = { path = "../../types" }
 mc-fog-view-connection = { path = "../connection" }
 mc-fog-view-enclave-measurement = { path = "../enclave/measurement" }
 mc-fog-view-protocol = { path = "../protocol" }
+mc-transaction-core = { path = "../../../transaction/core" }
+mc-util-encodings = { path = "../../../util/encodings" }
+mc-util-serial = { path = "../../../util/serial" }
+mc-util-test-helper = { path = "../../../util/test-helper" }
+mc-util-uri = { path = "../../../util/uri" }
+pem = "1.0"
+portpicker = "0.1.1"
+rand = "0.8"
+rand_core = "0.6"
+tempdir = "0.3"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0"
 mc-attest-api = { path = "../../../attest/api" }
 mc-attest-core = { path = "../../../attest/core" }
 mc-attest-net = { path = "../../../attest/net" }
+mc-attest-enclave-api = { path = "../../../attest/enclave-api" }
 mc-common = { path = "../../../common", features = ["log"] }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-sgx-report-cache-untrusted = { path = "../../../sgx/report-cache/untrusted" }

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -236,6 +236,7 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewStoreApi for FogV
             }
             if let ClientListenUri::Store(fog_view_store_uri) = self.client_listen_uri.clone() {
                 let mut response = MultiViewStoreQueryResponse::new();
+                response.set_fog_view_store_uri(fog_view_store_uri.url().to_string());
                 for query in request.queries {
                     let result = self.query_impl(query);
                     if let Ok(attested_message) = result {
@@ -245,7 +246,6 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewStoreApi for FogV
                 }
 
                 let decryption_error = response.mut_decryption_error();
-                decryption_error.set_fog_view_store_uri(fog_view_store_uri.url().to_string());
                 decryption_error.set_error_message(
                     "Could not decrypt a query embedded in the MultiViewStoreQuery".to_string(),
                 );

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -128,7 +128,7 @@ where
                     )
                 })?;
 
-        let mut processed_shard_response_data = shard_responses_processor::process_shard_responses(
+        let processed_shard_response_data = shard_responses_processor::process_shard_responses(
             clients_and_responses,
         )
         .map_err(|err| {

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -160,9 +160,18 @@ where
         .await?;
     }
 
-    // TODO: Collate the query_responses into one response for the client. Make an
-    // enclave  method for this.
-    let response = FogViewRouterResponse::new();
+    let query_response = enclave
+        .collate_shard_query_responses(query.into(), query_responses)
+        .map_err(|err| {
+            router_server_err_to_rpc_status(
+                "Query: shard response collation",
+                RouterServerError::Enclave(err),
+                logger.clone(),
+            )
+        })?;
+
+    let mut response = FogViewRouterResponse::new();
+    response.set_query(query_response.into());
     Ok(response)
 }
 

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -3,8 +3,8 @@
 use crate::error::RouterServerError;
 use mc_attest_api::attest;
 use mc_common::ResponderId;
-use mc_fog_api::{view::MultiViewStoreQueryResponse, view_grpc::FogViewApiClient};
-use mc_fog_uri::FogViewUri;
+use mc_fog_api::{view::MultiViewStoreQueryResponse, view_grpc::FogViewStoreApiClient};
+use mc_fog_uri::FogViewStoreUri;
 use std::{str::FromStr, sync::Arc};
 
 /// The result of processing the MultiViewStoreQueryResponse from each Fog View
@@ -28,8 +28,6 @@ impl ProcessedShardResponseData {
         shard_clients_for_retry: Vec<Arc<FogViewStoreApiClient>>,
         view_store_uris_for_authentication: Vec<FogViewStoreUri>,
         new_query_responses: Vec<(ResponderId, attest::Message)>,
-        shard_clients_for_retry: Vec<Arc<FogViewApiClient>>,
-        view_store_uris_for_authentication: Vec<FogViewUri>,
     ) -> Self {
         ProcessedShardResponseData {
             shard_clients_for_retry,
@@ -51,7 +49,7 @@ pub fn process_shard_responses(
         // We did not receive a query_response for this shard.Therefore, we need to:
         //  (a) retry the query
         //  (b) authenticate with the Fog View Store that returned the decryption_error
-        let store_uri = FogViewUri::from_str(response.get_fog_view_store_uri())?;
+        let store_uri = FogViewStoreUri::from_str(response.get_fog_view_store_uri())?;
         if response.has_decryption_error() {
             shard_clients_for_retry.push(shard_client);
             view_store_uris_for_authentication.push(store_uri);


### PR DESCRIPTION
### Motivation
This PR uses the oblivious programming methods implemented in #2252 to obliviously collate shard responses for  Fog Router. 

