### PR TITLE
Add a utility to dump a LedgerDB as JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5273,6 +5273,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-dump-ledger"
+version = "1.3.0-pre0"
+dependencies = [
+ "clap 3.2.8",
+ "displaydoc",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-ledger-db",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "mc-util-encodings"
 version = "1.3.0-pre0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ members = [
     "util/build/script",
     "util/build/sgx",
     "util/cli",
+    "util/dump-ledger",
     "util/encodings",
     "util/ffi",
     "util/from-random",

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mc-util-dump-ledger"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2021"
+
+[[bin]]
+name = "dump-ledger"
+path = "src/bin/dump_ledger.rs"
+
+[dependencies]
+mc-blockchain-types = { path = "../../blockchain/types" }
+mc-common = { path = "../../common", features = ["log", "loggers"] }
+mc-ledger-db = { path = "../../ledger/db" }
+
+clap = { version = "3.2", features = ["derive", "env"] }
+displaydoc = "0.2"
+serde_json = "1.0"
+
+[dev-dependencies]
+mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
+
+tempfile = "3.3"

--- a/util/dump-ledger/src/bin/dump_ledger.rs
+++ b/util/dump-ledger/src/bin/dump_ledger.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A utility to dump a ledger's contents as JSON.
+
+#![deny(missing_docs)]
+
+use clap::Parser;
+use mc_ledger_db::LedgerDB;
+use mc_util_dump_ledger::{dump_ledger, DumpParams};
+use std::path::PathBuf;
+
+/// Configuration.
+#[derive(Debug, Parser)]
+struct Config {
+    /// Path to [LedgerDB].
+    #[clap(long, env = "MC_LEDGER_DB")]
+    pub ledger_db: PathBuf,
+
+    #[clap(flatten)]
+    pub params: DumpParams,
+}
+
+fn main() {
+    mc_common::setup_panic_handler();
+
+    let config = Config::parse();
+
+    let ledger_db = LedgerDB::open(&config.ledger_db).expect("failed to open LedgerDB");
+
+    let json = dump_ledger(&ledger_db, config.params).expect("failed to dump LedgerDB");
+
+    println!("{}", json);
+}

--- a/util/dump-ledger/src/error.rs
+++ b/util/dump-ledger/src/error.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Error types.
+
+use displaydoc::Display;
+use mc_ledger_db::Error as LedgerError;
+use serde_json::Error as JsonError;
+
+/// Convenience wrapper for `Result` with [Error].
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error enum.
+#[derive(Debug, Display)]
+pub enum Error {
+    /// Ledger: {0}
+    Ledger(LedgerError),
+    /// JSON: {0}
+    Json(JsonError),
+}
+
+impl From<LedgerError> for Error {
+    fn from(src: LedgerError) -> Self {
+        Self::Ledger(src)
+    }
+}
+
+impl From<JsonError> for Error {
+    fn from(src: JsonError) -> Self {
+        Self::Json(src)
+    }
+}

--- a/util/dump-ledger/src/lib.rs
+++ b/util/dump-ledger/src/lib.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A utility to dump a ledger's contents as JSON.
+
+#![deny(missing_docs)]
+
+mod error;
+
+use clap::Parser;
+use mc_blockchain_types::BlockIndex;
+use mc_ledger_db::Ledger;
+use serde_json::to_string_pretty as to_json;
+
+pub use error::{Error, Result};
+
+/// Parameters for [dump_ledger].
+#[derive(Debug, Clone, Parser)]
+pub struct DumpParams {
+    /// Optional first index; defaults to 0.
+    #[clap(long, short, env = "MC_FIRST_INDEX")]
+    pub first_index: Option<BlockIndex>,
+    /// Optional last index; defaults to `num_blocks - 1`.
+    #[clap(long, short, env = "MC_LAST_INDEX")]
+    pub last_index: Option<BlockIndex>,
+}
+
+/// Dump the blocks in the given [Ledger] to JSON.
+pub fn dump_ledger(ledger: &impl Ledger, params: DumpParams) -> Result<String> {
+    let first = params.first_index.unwrap_or(0);
+    let last = match params.last_index {
+        Some(last) => last,
+        None => ledger.num_blocks()? - 1,
+    };
+
+    let blocks = (first..=last)
+        .map(|block_index| Ok(ledger.get_block_data(block_index)?))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(to_json(&blocks)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use mc_ledger_db::test_utils::mock_ledger::get_mock_ledger_and_blocks;
+
+    use super::*;
+
+    #[test]
+    fn without_overrides() {
+        let (ledger, blocks) = get_mock_ledger_and_blocks(10);
+        let json = dump_ledger(
+            &ledger,
+            DumpParams {
+                first_index: None,
+                last_index: None,
+            },
+        )
+        .unwrap();
+        let expected_json = to_json(&blocks).unwrap();
+
+        assert_eq!(json, expected_json);
+    }
+
+    #[test]
+    fn override_first() {
+        let (ledger, blocks) = get_mock_ledger_and_blocks(10);
+        let json = dump_ledger(
+            &ledger,
+            DumpParams {
+                first_index: Some(2),
+                last_index: None,
+            },
+        )
+        .unwrap();
+        let expected_json = to_json(&blocks[2..]).unwrap();
+
+        assert_eq!(json, expected_json);
+    }
+
+    #[test]
+    fn override_last() {
+        let (ledger, blocks) = get_mock_ledger_and_blocks(10);
+        let json = dump_ledger(
+            &ledger,
+            DumpParams {
+                first_index: None,
+                last_index: Some(5),
+            },
+        )
+        .unwrap();
+        let expected_json = to_json(&blocks[..6]).unwrap();
+
+        assert_eq!(json, expected_json);
+    }
+
+    #[test]
+    fn both_overrides() {
+        let (ledger, blocks) = get_mock_ledger_and_blocks(10);
+        let json = dump_ledger(
+            &ledger,
+            DumpParams {
+                first_index: Some(2),
+                last_index: Some(5),
+            },
+        )
+        .unwrap();
+        let expected_json = to_json(&blocks[2..=5]).unwrap();
+
+        assert_eq!(json, expected_json);
+    }
+}

--- a/util/generate-sample-ledger/src/lib.rs
+++ b/util/generate-sample-ledger/src/lib.rs
@@ -94,6 +94,8 @@ pub fn bootstrap_ledger(
         });
     }
 
+    log::info!(logger, "Wrote LedgerDB to {:?}", path);
+
     // Write conf.json
     let mut file = std::fs::File::create("conf.json").expect("File creation");
     use std::io::Write;


### PR DESCRIPTION
Dumps the blocks in a `LedgerDB` with optional overrides to restrict the range of block indexes, to inspect the blocks in the `LedgerDB`. Supports #2104 and #2197

Also make `generate_sample_ledger` input and output paths configurable.

Sample commands:
```
# Generate a ledger with 10 blocks
$ tools/local-network/bootstrap.sh
$ cargo run -p mc-util-generate-sample-ledger -- --output-dir test_ledger --keys-dir target/sample_data/keys --blocks=10 --txs 3
2022-07-13 19:28:43.915690200 UTC INFO Making 600 outputs of 416666000000000000 picoMOB across 20 recipients (3 outputs per recipient, 1 tokens, 10 blocks)., mc.module: mc_util_generate_sample_ledger, mc.src: util/generate-sample-ledger/src/lib.rs:56
2022-07-13 19:29:04.049277200 UTC INFO Wrote LedgerDB to "test_ledger", mc.module: mc_util_generate_sample_ledger, mc.src: util/generate-sample-ledger/src/lib.rs:97

# Dump ledger
$ cargo run -p mc-util-dump-ledger -- --ledger-db test_ledger > test.json

# Outputs ~248KB of JSON over 133k lines.
$ wc -lc test.json
 133078 2479826 test.json

# Try a couple of queries
$ jq -aC < test.json 'map(has("metadata"))' | less
[
  true,
  true,
  true,
  true,
  true,
  true,
  true,
  true,
  true,
  true
]

$ jq -aC < test.json 'map(.metadata.contents.quorum_set.threshold)' | less 
[
  6,
  1,
  19,
  8,
  32,
  18,
  2,
  17,
  12,
  13
]
```