### PR TITLE
Split Fog View API into Client-facing and Store (Fog Router) APIs

### DIFF
--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -63,11 +63,18 @@ message MultiViewStoreQueryResponse {
     FogViewStoreDecryptionError decryption_error = 2;
 }
 
+/// Fulfills requests sent directly by a Fog client, e.g. a mobile phone using the SDK.
 service FogViewAPI {
     /// This is called to perform IX key exchange with the enclave before calling GetOutputs.
     rpc Auth(attest.AuthMessage) returns (attest.AuthMessage) {}
     /// Input should be an encrypted QueryRequest, result is an encrypted QueryResponse
     rpc Query(attest.Message) returns (attest.Message) {}
+}
+
+/// Fulfills requests sent by the Fog View Router. This is not meant to fulfill requests sent directly by the client.
+service FogViewStoreAPI {
+    /// This is called to perform IX key exchange with the enclave before calling GetOutputs.
+    rpc Auth(attest.AuthMessage) returns (attest.AuthMessage) {}
     /// Input should be an encrypted MultiViewStoreQueryRequest, result is an encrypted QueryResponse.
     rpc MultiViewStoreQuery(MultiViewStoreQueryRequest) returns (MultiViewStoreQueryResponse) {}
 }

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -32,6 +32,20 @@ impl UriScheme for FogViewScheme {
     const DEFAULT_INSECURE_PORT: u16 = 3225;
 }
 
+/// Fog View Store Scheme
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct FogViewStoreScheme {}
+
+impl UriScheme for FogViewStoreScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "fog-view-store";
+    const SCHEME_INSECURE: &'static str = "insecure-fog-view-store";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3225;
+}
+
 /// Fog Ledger Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct FogLedgerScheme {}
@@ -81,6 +95,8 @@ pub type FogIngestUri = Uri<FogIngestScheme>;
 pub type FogLedgerUri = Uri<FogLedgerScheme>;
 /// Uri used when talking to fog view router service.
 pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
+/// Uri used when talking to fog view store service.
+pub type FogViewStoreUri = Uri<FogViewStoreScheme>;
 /// Uri used when talking to fog-view service, with the right default ports and
 /// scheme.
 pub type FogViewUri = Uri<FogViewScheme>;
@@ -149,6 +165,16 @@ mod tests {
             "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
         )
         .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri =
+            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
+                .unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
         assert_eq!(
             uri.responder_id().unwrap(),

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -7,11 +7,11 @@ use clap::Parser;
 use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
 use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
-use mc_fog_uri::{FogViewRouterUri, FogViewUri};
+use mc_fog_uri::{FogViewRouterUri, FogViewStoreUri, FogViewUri};
 use mc_util_parse::parse_duration_in_seconds;
 use mc_util_uri::AdminUri;
 use serde::Serialize;
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 /// Configuration parameters for the MobileCoin Fog View Node
 #[derive(Clone, Parser, Serialize)]
@@ -34,7 +34,7 @@ pub struct MobileAcctViewConfig {
 
     /// gRPC listening URI for client requests.
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
-    pub client_listen_uri: FogViewUri,
+    pub client_listen_uri: ClientListenUri,
 
     /// Optional admin listening URI.
     #[clap(long, env = "MC_ADMIN_LISTEN_URI")]
@@ -67,6 +67,30 @@ pub struct MobileAcctViewConfig {
     /// Postgres config
     #[clap(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+}
+
+/// A FogViewServer can either fulfill client requests directly or fulfill Fog
+/// View Router requests, and these types of servers use different URLs.
+#[derive(Clone, Serialize)]
+pub enum ClientListenUri {
+    /// URI used by the FogViewServer when fulfilling direct client requests.
+    ClientFacing(FogViewUri),
+    /// URI used by the FogViewServer when fulfilling Fog View Router requests.
+    Store(FogViewStoreUri),
+}
+
+impl FromStr for ClientListenUri {
+    type Err = String;
+    fn from_str(input: &str) -> Result<Self, String> {
+        if let Ok(fog_view_uri) = FogViewUri::from_str(input) {
+            return Ok(ClientListenUri::ClientFacing(fog_view_uri));
+        }
+        if let Ok(fog_view_store_uri) = FogViewStoreUri::from_str(input) {
+            return Ok(ClientListenUri::Store(fog_view_store_uri));
+        }
+
+        Err("Incorrect ClientListenUri.".to_string())
+    }
 }
 
 /// Configuration parameters for the Fog View Router.

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -89,7 +89,7 @@ impl FromStr for ClientListenUri {
             return Ok(ClientListenUri::Store(fog_view_store_uri));
         }
 
-        Err("Incorrect ClientListenUri.".to_string())
+        Err(format!("Incorrect ClientListenUri string: {}.", input))
     }
 }
 

--- a/fog/view/server/src/fog_view_router_server.rs
+++ b/fog/view/server/src/fog_view_router_server.rs
@@ -23,7 +23,7 @@ impl FogViewRouterServer {
     pub fn new<E>(
         config: FogViewRouterConfig,
         enclave: E,
-        shards: Vec<view_grpc::FogViewApiClient>,
+        shards: Vec<view_grpc::FogViewStoreApiClient>,
         logger: Logger,
     ) -> FogViewRouterServer
     where

--- a/fog/view/server/src/fog_view_router_service.rs
+++ b/fog/view/server/src/fog_view_router_service.rs
@@ -6,7 +6,7 @@ use grpcio::{DuplexSink, RequestStream, RpcContext};
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse},
-    view_grpc::{FogViewApiClient, FogViewRouterApi},
+    view_grpc::{FogViewRouterApi, FogViewStoreApiClient},
 };
 use mc_fog_view_enclave_api::ViewEnclaveProxy;
 use mc_util_grpc::rpc_logger;
@@ -19,7 +19,7 @@ where
     E: ViewEnclaveProxy,
 {
     enclave: E,
-    shard_clients: Vec<Arc<FogViewApiClient>>,
+    shard_clients: Vec<Arc<FogViewStoreApiClient>>,
     logger: Logger,
 }
 
@@ -29,7 +29,7 @@ impl<E: ViewEnclaveProxy> FogViewRouterService<E> {
     ///
     /// TODO: Add a `view_store_clients` parameter of type FogApiClient, and
     /// perform view store authentication on each one.
-    pub fn new(enclave: E, shard_clients: Vec<FogViewApiClient>, logger: Logger) -> Self {
+    pub fn new(enclave: E, shard_clients: Vec<FogViewStoreApiClient>, logger: Logger) -> Self {
         let shard_clients = shard_clients.into_iter().map(Arc::new).collect();
         Self {
             enclave,

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -35,7 +35,7 @@ pub struct FogViewService<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> {
     /// GRPC request authenticator.
     authenticator: Arc<dyn Authenticator + Send + Sync>,
 
-    /// The FogViewUri for this FogViewService.
+    /// The ClientListenUri for this FogViewService.
     client_listen_uri: ClientListenUri,
 
     /// Slog logger object

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -33,7 +33,10 @@ use mc_fog_uri::{ConnectionUri, FogViewUri};
 use mc_fog_view_connection::FogViewGrpcClient;
 use mc_fog_view_enclave::SgxViewEnclave;
 use mc_fog_view_protocol::FogViewConnection;
-use mc_fog_view_server::{config::MobileAcctViewConfig as ViewConfig, server::ViewServer};
+use mc_fog_view_server::{
+    config::{ClientListenUri::ClientFacing, MobileAcctViewConfig as ViewConfig},
+    server::ViewServer,
+};
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::GrpcRetryConfig;
 use rand::{rngs::StdRng, SeedableRng};
@@ -61,7 +64,7 @@ fn get_test_environment(
     let server = {
         let config = ViewConfig {
             client_responder_id: ResponderId::from_str(&uri.addr()).unwrap(),
-            client_listen_uri: uri.clone(),
+            client_listen_uri: ClientFacing(uri.clone()),
             client_auth_token_secret: None,
             omap_capacity: view_omap_capacity,
             ias_spid: Default::default(),


### PR DESCRIPTION
### Motivation
#2189 implemented dynamic shard component discovery in the Fog Router. @jcape requested that we split the Fog View APIs into two- one for clients and one for fog view router instances. Splitting the API ensures that clients won't be able to hit the MultiViewQuery endpoint that router uses. This change also involves re-adding the `FogViewStoreUri`, which allows to disambiguate the APIs even more.