### PR TITLE
Watcher, standalone node_hw operational fixes.

### DIFF
--- a/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
+++ b/.github/actions/mobilecoin-cache-rust-binaries/action.yaml
@@ -10,10 +10,6 @@ inputs:
     required: false
     default: |
       rust_build_artifacts
-  # hash_files:
-  #   description: "list of files/globs to hash"
-  #   required: false
-  #   default: "'**/*.rs', '**/*.proto', '**/Cargo.toml'"
 
 outputs:
   cache-hit:
@@ -30,4 +26,4 @@ runs:
       path: ${{ inputs.path }}
       # Key is a hash of all the .rs, .proto and Cargo.toml files.
       # if code changes, invalidate cache and rebuild
-      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml') }}-rust-build-artifacts
+      key: ${{ inputs.cache_buster }}-${{ runner.os }}-${{ hashFiles('**/*.rs', '**/*.proto', '**/Cargo.toml', '**/*.edl', '.cargo/config') }}-rust-build-artifacts

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -12,7 +12,7 @@ env:
 on:
   push:
     branches:
-    - release/v[0-9]+
+    - release/v*
     - feature/*
     - develop
 

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -12,7 +12,7 @@ env:
 on:
   push:
     branches:
-    - release/v[0-9]+.[0-9]+.[0-9]+
+    - release/v[0-9]+
     - feature/*
     - develop
 

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -125,8 +125,33 @@ jobs:
       run: |
         .internal-ci/util/print_details.sh
 
+  # Reset consensus nodes between releases - if there's existing data, we'll
+  # restore from S3.
+  reset-releases:
+    runs-on: [self-hosted, Linux, small]
+    strategy:
+      matrix:
+        chart:
+        - consensus-node-1
+        - consensus-node-2
+        - consensus-node-3
+        - consensus-node-4
+        - consensus-node-5
+    steps:
+    - name: Delete release
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-release-delete
+        namespace: ${{ inputs.namespace }}
+        release_name: ${{ matrix.chart }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
   setup-environment:
     runs-on: [self-hosted, Linux, small]
+    needs:
+    - reset-releases
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.internal-ci/docker/Dockerfile.node_hw
+++ b/.internal-ci/docker/Dockerfile.node_hw
@@ -7,7 +7,7 @@
 ARG REPO_ORG=mobilecoin
 FROM ${REPO_ORG}/runtime-base:latest
 
-# Install logstash
+# Install logstash to ship logs when used as a standalone container.
 ARG LOGSTASH_VERSION=7.16.3
 ARG LOGSTASH_URL=https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-${LOGSTASH_VERSION}-linux-x64.tar.gz
 
@@ -37,8 +37,9 @@ COPY ${ORIGIN_DATA_DIR}/ledger /var/lib/mobilecoin/origin_data
 
 # Supervisord
 COPY .internal-ci/docker/support/node_hw/supervisor/conf.d /etc/supervisor/conf.d
+
+# Logstash config
 COPY .internal-ci/docker/support/node_hw/logstash.conf /opt/logstash/config/
-#COPY .internal-ci/docker/support/node_hw/filebeat.yml /etc/filebeat/filebeat.yml
 
 # Wrapper scripts
 COPY .internal-ci/docker/support/node_hw/bin /usr/local/bin

--- a/.internal-ci/docker/Dockerfile.node_hw
+++ b/.internal-ci/docker/Dockerfile.node_hw
@@ -7,6 +7,14 @@
 ARG REPO_ORG=mobilecoin
 FROM ${REPO_ORG}/runtime-base:latest
 
+# Install logstash
+ARG LOGSTASH_VERSION=7.16.3
+ARG LOGSTASH_URL=https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-${LOGSTASH_VERSION}-linux-x64.tar.gz
+
+RUN  mkdir -p /opt/logstash \
+  && curl --retry 5 -sSfL ${LOGSTASH_URL} \
+   | tar --strip-components 1 -xvz -C /opt/logstash
+
 # Copy binaries
 ARG RUST_BIN_PATH=target/release
 COPY ${RUST_BIN_PATH}/consensus-service /usr/bin/
@@ -29,7 +37,8 @@ COPY ${ORIGIN_DATA_DIR}/ledger /var/lib/mobilecoin/origin_data
 
 # Supervisord
 COPY .internal-ci/docker/support/node_hw/supervisor/conf.d /etc/supervisor/conf.d
-COPY .internal-ci/docker/support/node_hw/filebeat.yml /etc/filebeat/filebeat.yml
+COPY .internal-ci/docker/support/node_hw/logstash.conf /opt/logstash/config/
+#COPY .internal-ci/docker/support/node_hw/filebeat.yml /etc/filebeat/filebeat.yml
 
 # Wrapper scripts
 COPY .internal-ci/docker/support/node_hw/bin /usr/local/bin

--- a/.internal-ci/docker/Dockerfile.runtime-base
+++ b/.internal-ci/docker/Dockerfile.runtime-base
@@ -18,10 +18,6 @@ RUN  apt-get update \
       libpq5 \
       jq
 
-# Install Filebeat repo
-RUN  curl --retry 5 -fL https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add - \
-  && echo "deb https://artifacts.elastic.co/packages/oss-8.x/apt stable main" > /etc/apt/sources.list.d/elastic-8.x.list
-
 # Install SGX AESM repo
 COPY .internal-ci/docker/support/intel-sgx-archive-keyring.gpg /etc/apt/trusted.gpg.d/
 RUN  echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ focal main" > /etc/apt/sources.list.d/intel-sgx.list
@@ -42,7 +38,6 @@ ENV PCE_LOGIC_VERSION=1.13.100.4-focal1
 # Install  packages
 RUN  apt-get update \
   && apt-get install -y \
-      filebeat \
       sgx-aesm-service=${AESM_VERSION} \
       libsgx-epid=${AESM_VERSION} \
       libsgx-ae-epid=${AESM_VERSION} \

--- a/.internal-ci/docker/entrypoints/node_hw.sh
+++ b/.internal-ci/docker/entrypoints/node_hw.sh
@@ -124,8 +124,8 @@ then
         export ES_INDEX=${ES_INDEX:-"filebeat"}
         export MC_LOG_UDP_JSON=127.0.0.1:16666
 
-        # enable filebeat in supervisord
-        sed -i '' 's/numprocs=0/numprocs=1/g' /etc/supervisor/conf.d/filebeat.conf
+        # enable logstash in supervisord
+        sed -i -e 's/numprocs=0/numprocs=1/g' /etc/supervisor/conf.d/logstash.conf
     fi
 
     # Ledger

--- a/.internal-ci/docker/support/node_hw/logstash.conf
+++ b/.internal-ci/docker/support/node_hw/logstash.conf
@@ -1,0 +1,21 @@
+input {
+    udp {
+        host => "127.0.0.1"
+        port => "16666"
+        codec => "json"
+        add_field => {
+            "mc.network" => "${MC_BRANCH}"
+            "mc.local_node_id" => "${MC_CLIENT_RESPONDER_ID}"
+        }
+    }
+}
+
+output {
+    opensearch {
+        hosts => ["${ES_HOST}:${ES_PORT}"]
+        user => "${ES_USERNAME}"
+        password => "${ES_PASSWORD}"
+        index => "${ES_INDEX:logstash}-%{+yyyy.MM.dd}"
+        action => "create"
+    }
+}

--- a/.internal-ci/docker/support/node_hw/supervisor/conf.d/logstash.conf
+++ b/.internal-ci/docker/support/node_hw/supervisor/conf.d/logstash.conf
@@ -1,0 +1,15 @@
+; Copyright (c) 2018-2022 The MobileCoin Foundation
+[program:logstash]
+priority=10
+; if we don't start in 60 seconds go to fatal
+startsecs=60
+; don't start by default, entrypoint will sed 1 if ES vars are set
+numprocs=0
+command=/opt/logstash/bin/logstash
+    -f /opt/logstash/config/logstash.conf
+
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+autorestart=true

--- a/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- toYaml .Values.watcher.podAnnotations | nindent 8 }}
+        {{- toYaml $.Values.watcher.podAnnotations | nindent 8 }}
       labels:
         app: watcher
         instance: {{ .watchername }}
@@ -34,7 +34,7 @@ spec:
       initContainers:
         - name: watcherdb-restore
           image: "amazon/aws-cli:2.0.19"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [ "/bin/bash" ]
           env:
 {{- if .s3EndpointUrl }}
@@ -76,8 +76,8 @@ spec:
 {{- end}}
       containers:
         - name: watcher
-          image: mobilecoin/watcher:{{ $.Values.images.tag }}
-          imagePullPolicy: IfNotPresent
+          image: '{{ $.Values.image.org | default $.Values.image.org }}/{{ $.Values.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}'
+          imagePullPolicy: Always
           command: ["/usr/bin/mc-watcher", "--watcher-db", "/watcher", "--sources-path", "/config/sources.toml", "--store-block-data"]
           ports:
             - name: watcher-mgmt
@@ -95,7 +95,7 @@ spec:
 {{- if eq $.Values.watcher.backupEnabled true }}
         - name: watcherdb-backup
           image: "amazon/aws-cli:2.0.19"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command: [ "/bin/bash" ]
           env:
 {{- if .s3EndpointUrl }}

--- a/.internal-ci/helm/watcher/values.yaml
+++ b/.internal-ci/helm/watcher/values.yaml
@@ -1,5 +1,7 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
-images:
+image:
+  org: mobilecoin
+  name: watcher
   tag: ""
 
 consensusPeers: []

--- a/.internal-ci/util/manual_republish_existing_build.sh
+++ b/.internal-ci/util/manual_republish_existing_build.sh
@@ -11,7 +11,7 @@ usage()
 {
 cat << USAGE
 Usage:
-${0} [--pull] [--images] [--charts] --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag
+${0} [--pull] [--push] [--images|--image IMG] [--charts|--chart CHART] --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag
     --pull - pull down binaries from source-tag images
     --images - build images
     --charts - build charts

--- a/.internal-ci/util/manual_republish_existing_build.sh
+++ b/.internal-ci/util/manual_republish_existing_build.sh
@@ -6,90 +6,210 @@
 #   Use with caution.
 
 set -e
-set -x
 
-echo "no foot-guns, check the tag vars and remove this exit 0 to use!"
-exit 0
+usage()
+{
+cat << USAGE
+Usage:
+${0} [--pull] [--images] [--charts] --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag
+    --pull - pull down binaries from source-tag images
+    --images - build images
+    --charts - build charts
+    --push - push images and or charts
+    --source-tag - source tag to pull binaries from
+    --target-tag - target tag to build images/charts as
+    --image "node_hw" - build a specific image
+    --chart "consensus" - build a specific chart
+
+example: pull images and extract binaries
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --pull
+
+example: build images for local usage (no push)
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --images
+
+example: build images and push to image repo
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --images --push
+
+example: build charts for local usage (no push)
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --charts
+
+example: build charts and push to harbor for local
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --charts --push
+
+example: do it all pull, build, push
+    ${0} --source-tag v1.2.2-dev --target-tag v1.2.3-some-tag --pull --images --charts --push
+USAGE
+}
+
+is_set()
+{
+    var_name="${1}"
+    if [ -z "${!var_name}" ]
+    then
+        echo "${var_name} is not set."
+        usage
+        exit 1
+    fi
+}
+
+while (( "$#" ))
+do
+    case "${1}" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        --source-tag )
+            source_tag="${2}"
+            shift 2
+            ;;
+        --target-tag )
+            target_tag="${2}"
+            shift 2
+            ;;
+        --pull)
+            pull=1
+            shift
+            ;;
+        --push)
+            push=1
+            shift
+            ;;
+        --images)
+            img=all
+            shift
+            ;;
+        --charts)
+            chrt=all
+            shift
+            ;;
+        --chart)
+            chrt="${2}"
+            shift 2
+            ;;
+        --image)
+            img="${2}"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: unknown option"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+is_set source_tag
+is_set target_tag
 
 source_org=mobilecoin
-source_tag=v1.2.1-dev
 
 push_org=mobilecoin
-push_tag=v1.2.2-dev
+push_tag="${target_tag}"
 
-images=(bootstrap-tools fogingest fog-ledger fogreport fogview go-grpc-gateway mobilecoind node_hw fog-test-client)
+images=(bootstrap-tools fogingest fog-ledger fogreport fogview go-grpc-gateway mobilecoind node_hw fog-test-client watcher)
 
-charts=(consensus-node consensus-node-config fog-ingest fog-ingest-config fog-services fog-services-config mc-core-common-config mc-core-dev-env-setup mobilecoind)
+charts=(consensus-node consensus-node-config fog-ingest fog-ingest-config fog-services fog-services-config mc-core-common-config mc-core-dev-env-setup mobilecoind watcher)
 
-for i in "${images[@]}"
-do
-    docker rm "${i}" || true
-    docker pull "${source_org}/${i}:${source_tag}"
-    docker create --name "${i}" "${source_org}/${i}:${source_tag}"
-done
+if [[ -n "${pull}" ]]
+then
+    for i in "${images[@]}"
+    do
+        docker rm "${i}" || true
+        docker pull "${source_org}/${i}:${source_tag}"
+        docker create --name "${i}" "${source_org}/${i}:${source_tag}"
+    done
 
-mkdir -p target/release
-pushd target/release || exit 1
-docker cp "bootstrap-tools:/usr/local/bin/fog-sql-recovery-db-migrations" ./
-docker cp "bootstrap-tools:/usr/local/bin/generate-sample-ledger" ./
-docker cp "bootstrap-tools:/usr/local/bin/sample-keys" ./
-docker cp "bootstrap-tools:/usr/local/bin/fog-distribution" ./
-docker cp "bootstrap-tools:/usr/local/bin/fog_ingest_client" ./
-docker cp "bootstrap-tools:/usr/local/bin/mc-consensus-mint-client" ./
-docker cp "bootstrap-tools:/usr/local/bin/mc-util-seeded-ed25519-key-gen" ./
-docker cp "bootstrap-tools:/usr/local/bin/fog-report-cli" ./
-docker cp "bootstrap-tools:/usr/local/bin/read-pubfile" ./
-docker cp "bootstrap-tools:/usr/local/bin/mc-util-grpc-token-generator" ./
-docker cp "bootstrap-tools:/usr/local/bin/test_client" ./
-docker cp "mobilecoind:/usr/bin/mc-mint-auditor" ./
-docker cp "mobilecoind:/usr/bin/mobilecoind-json" ./
-docker cp "mobilecoind:/enclaves/libingest-enclave.css" ./
-docker cp "fog-ledger:/usr/bin/libledger-enclave.signed.so" ./
-docker cp "fog-ledger:/usr/bin/ledger_server" ./
-docker cp "fog-ledger:/usr/bin/mobilecoind" ./
-docker cp "fog-ledger:/usr/bin/mc-admin-http-gateway" ./
-docker cp "fog-ledger:/usr/bin/mc-ledger-migration" ./
-docker cp "fog-ledger:/usr/bin/mc-util-grpc-admin-tool" ./
-docker cp "fogingest:/usr/bin/libingest-enclave.signed.so" ./
-docker cp "fogingest:/usr/bin/fog_ingest_server" ./
-docker cp "fogreport:/usr/bin/report_server" ./
-docker cp "fogview:/usr/bin/libview-enclave.signed.so" ./
-docker cp "fogview:/usr/bin/fog_view_server" ./
-docker cp "go-grpc-gateway:/usr/bin/go-grpc-gateway" ./grpc-proxy
-docker cp "node_hw:/usr/bin/consensus-service" ./
-docker cp "node_hw:/usr/bin/ledger-distribution" ./
-docker cp "node_hw:/usr/bin/ledger-from-archive" ./
-docker cp "node_hw:/usr/bin/libconsensus-enclave.signed.so" ./
-popd || exit 1
+    mkdir -p target/release
+    pushd target/release || exit 1
+    docker cp "bootstrap-tools:/usr/local/bin/fog-sql-recovery-db-migrations" ./
+    docker cp "bootstrap-tools:/usr/local/bin/generate-sample-ledger" ./
+    docker cp "bootstrap-tools:/usr/local/bin/sample-keys" ./
+    docker cp "bootstrap-tools:/usr/local/bin/fog-distribution" ./
+    docker cp "bootstrap-tools:/usr/local/bin/fog_ingest_client" ./
+    docker cp "bootstrap-tools:/usr/local/bin/mc-consensus-mint-client" ./
+    docker cp "bootstrap-tools:/usr/local/bin/mc-util-seeded-ed25519-key-gen" ./
+    docker cp "bootstrap-tools:/usr/local/bin/fog-report-cli" ./
+    docker cp "bootstrap-tools:/usr/local/bin/read-pubfile" ./
+    docker cp "bootstrap-tools:/usr/local/bin/mc-util-grpc-token-generator" ./
+    docker cp "bootstrap-tools:/usr/local/bin/test_client" ./
+    docker cp "mobilecoind:/usr/bin/mc-mint-auditor" ./
+    docker cp "mobilecoind:/usr/bin/mobilecoind-json" ./
+    docker cp "mobilecoind:/enclaves/libingest-enclave.css" ./
+    docker cp "fog-ledger:/usr/bin/libledger-enclave.signed.so" ./
+    docker cp "fog-ledger:/usr/bin/ledger_server" ./
+    docker cp "fog-ledger:/usr/bin/mobilecoind" ./
+    docker cp "fog-ledger:/usr/bin/mc-admin-http-gateway" ./
+    docker cp "fog-ledger:/usr/bin/mc-ledger-migration" ./
+    docker cp "fog-ledger:/usr/bin/mc-util-grpc-admin-tool" ./
+    docker cp "fogingest:/usr/bin/libingest-enclave.signed.so" ./
+    docker cp "fogingest:/usr/bin/fog_ingest_server" ./
+    docker cp "fogreport:/usr/bin/report_server" ./
+    docker cp "fogview:/usr/bin/libview-enclave.signed.so" ./
+    docker cp "fogview:/usr/bin/fog_view_server" ./
+    docker cp "go-grpc-gateway:/usr/bin/go-grpc-gateway" ./grpc-proxy
+    docker cp "node_hw:/usr/bin/consensus-service" ./
+    docker cp "node_hw:/usr/bin/ledger-distribution" ./
+    docker cp "node_hw:/usr/bin/ledger-from-archive" ./
+    docker cp "node_hw:/usr/bin/libconsensus-enclave.signed.so" ./
+    docker cp "watcher:/usr/bin/mc-watcher" ./
+    popd || exit 1
+fi
 
-for i in "${images[@]}"
-do
-    docker build -t "${push_org}/${i}:${push_tag}" \
-        --build-arg="GO_BIN_PATH=target/release" \
-        --build-arg="REPO_ORG=${push_org}" \
-        -f ".internal-ci/docker/Dockerfile.${i}" \
-        .
-done
+if [[ "${img}" != "all" ]]
+then
+    images=(${img})
+fi
 
-for i in "${images[@]}"
-do
-    docker push "${push_org}/${i}:${push_tag}"
-done
+if [[ -n "${img}" ]]
+then
+    for i in "${images[@]}"
+    do
+        echo "-- Building Image ${i}"
+        docker build -t "${push_org}/${i}:${push_tag}" \
+            --build-arg="GO_BIN_PATH=target/release" \
+            --build-arg="REPO_ORG=${push_org}" \
+            -f ".internal-ci/docker/Dockerfile.${i}" \
+            .
+    done
 
-mkdir -p ".tmp/charts"
+    if [[ -n "${push}" ]]
+    then
+        for i in "${images[@]}"
+        do
+            echo "-- Pushing Image ${i}"
+            docker push "${push_org}/${i}:${push_tag}"
+        done
+    fi
+fi
 
-for c in "${charts[@]}"
-do
-    helm dependency update ".internal-ci/helm/${c}"
-    helm package ".internal-ci/helm/${c}" \
-        -d ".tmp/charts" \
-        --app-version="${push_tag}" \
-        --version="${push_tag}"
-done
+if [[ "${chrt}" != "all" ]]
+then
+    charts=(${chrt})
+fi
 
-for c in "${charts[@]}"
-do
-    # helm repo add mcf-public --username <your-name> \
-    #   https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
-    helm cm-push --force ".tmp/charts/${c}-${push_tag}.tgz" mcf-public
-done
+if [[ -n "${chrt}" ]]
+then
+    mkdir -p ".tmp/charts"
+
+    for c in "${charts[@]}"
+    do
+        echo "-- Building Chart ${c}"
+        helm dependency update ".internal-ci/helm/${c}"
+        helm package ".internal-ci/helm/${c}" \
+            -d ".tmp/charts" \
+            --app-version="${push_tag}" \
+            --version="${push_tag}"
+    done
+
+    if [[ -n "${push}" ]]
+    then
+        for c in "${charts[@]}"
+        do
+            echo "-- Pushing Chart ${c}"
+            # helm repo add mcf-public --username <your-name> \
+            #   https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
+            helm cm-push --force ".tmp/charts/${c}-${push_tag}.tgz" mcf-public
+        done
+    fi
+fi


### PR DESCRIPTION
### Motivation

Some of these fixes could be worked around, but the standalone container logging needs to work for our Consensus Node Operator partners.

Operational fixes for pieces that are not part of the core stack or tested in the core CD workflow.

- fix `watcher` helm chart syntax and default image/version selection.
- Fix standalone logging. 
  - Move logging tools install out of runtime-base to node_hw. node_hw is the only part our node operators run as a standalone container.
  - Fix typo in entrypoint that prevented logging from being enabled.
  - Move from filebeat to logstash for opensearch support when running as a stand alone container.
- flags and options for the "manual" build script.

GHA CD fixes 

- Fix binary cache to invalidate on changes to .edl and .cargo/config files.
- Remove consensus nodes (and their volumes) between deployment/upgrade steps.
  - 1.1.3 deployment doesn't have topology rules. If we upgrade and preserve volumes we can end up in a place where the volume zone constrain conflicts with the topology constraint making the pods unschedulable.  

