### PR TITLE
add missing env to mob prompt invocation

### DIFF
--- a/mob
+++ b/mob
@@ -200,6 +200,8 @@ docker_run = ["docker",
               # Give docker its own subdirectory under target so it doesn't trash
               # the host target directory, but will still be cleaned up with it.
               "--env", "CARGO_TARGET_DIR=" + mount_point + "/target/docker",
+              # This is required to run the fog unit tests
+              "--env", "TEST_DATABSE_URL=postgres://localhost",
               "--volume", mount_from + ":" + mount_point,
               "--workdir", workdir]
 

--- a/mob
+++ b/mob
@@ -201,7 +201,7 @@ docker_run = ["docker",
               # the host target directory, but will still be cleaned up with it.
               "--env", "CARGO_TARGET_DIR=" + mount_point + "/target/docker",
               # This is required to run the fog unit tests
-              "--env", "TEST_DATABSE_URL=postgres://localhost",
+              "--env", "TEST_DATABASE_URL=postgres://localhost",
               "--volume", mount_from + ":" + mount_point,
               "--workdir", workdir]
 


### PR DESCRIPTION
this env was added as a requirement recently to run the fog unit tests, but it was not added to the mob prompt tool.