### PR TITLE
Add FeeMap to MockBlockchainConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,6 +4687,7 @@ dependencies = [
  "mc-connection",
  "mc-connection-test-utils",
  "mc-consensus-api",
+ "mc-consensus-enclave-api",
  "mc-consensus-enclave-measurement",
  "mc-consensus-scp",
  "mc-crypto-digestible",

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -39,18 +39,13 @@ pub struct MockBlockchainConnection<L: Ledger + Sync> {
 }
 
 impl<L: Ledger + Sync> MockBlockchainConnection<L> {
-    pub fn new(
-        uri: ConsensusClientUri,
-        ledger: L,
-        latency_millis: u64,
-        fee_map: Option<FeeMap>,
-    ) -> Self {
+    pub fn new(uri: ConsensusClientUri, ledger: L, latency_millis: u64, fee_map: FeeMap) -> Self {
         Self {
             uri,
             ledger,
             latency_millis,
             proposed_txs: Vec::new(),
-            fee_map: fee_map.unwrap_or_default(),
+            fee_map,
         }
     }
 }
@@ -152,7 +147,7 @@ mod tests {
         let mock_ledger = get_mock_ledger(25);
         assert_eq!(mock_ledger.num_blocks().unwrap(), 25);
         let mut mock_peer =
-            MockBlockchainConnection::new(test_client_uri(123), mock_ledger, 50, None);
+            MockBlockchainConnection::new(test_client_uri(123), mock_ledger, 50, FeeMap::default());
 
         {
             // Get a subset of the peer's blocks.

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -50,7 +50,7 @@ impl<L: Ledger + Sync> MockBlockchainConnection<L> {
             ledger,
             latency_millis,
             proposed_txs: Vec::new(),
-            fee_map: fee_map.unwrap_or(FeeMap::default()),
+            fee_map: fee_map.unwrap_or_default(),
         }
     }
 }

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -22,6 +22,7 @@ mc-blockchain-types = { path = "../blockchain/types" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }
 mc-consensus-api = { path = "../consensus/api" }
+mc-consensus-enclave-api = { path = "../consensus/enclave/api" }
 mc-consensus-enclave-measurement = { path = "../consensus/enclave/measurement" }
 mc-consensus-scp = { path = "../consensus/scp" }
 mc-crypto-digestible = { path = "../crypto/digestible", features = ["derive"] }

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -133,8 +133,8 @@ pub fn setup_server<FPR: FogPubkeyResolver + Default + Send + Sync + 'static>(
     Service,
     ConnectionManager<MockBlockchainConnection<LedgerDB>>,
 ) {
-    let peer1 = MockBlockchainConnection::new(test_client_uri(1), ledger_db.clone(), 0);
-    let peer2 = MockBlockchainConnection::new(test_client_uri(2), ledger_db.clone(), 0);
+    let peer1 = MockBlockchainConnection::new(test_client_uri(1), ledger_db.clone(), 0, None);
+    let peer2 = MockBlockchainConnection::new(test_client_uri(2), ledger_db.clone(), 0, None);
 
     let node_ids = vec![
         peer1.uri().host_and_port_responder_id().unwrap(),

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -17,6 +17,7 @@ use mc_account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX};
 use mc_common::logger::{log, Logger};
 use mc_connection::{Connection, ConnectionManager};
 use mc_connection_test_utils::{test_client_uri, MockBlockchainConnection};
+use mc_consensus_enclave_api::FeeMap;
 use mc_consensus_scp::QuorumSet;
 use mc_crypto_rand::{CryptoRng, RngCore};
 use mc_fog_report_validation_test_utils::{FogPubkeyResolver, MockFogResolver};
@@ -133,8 +134,10 @@ pub fn setup_server<FPR: FogPubkeyResolver + Default + Send + Sync + 'static>(
     Service,
     ConnectionManager<MockBlockchainConnection<LedgerDB>>,
 ) {
-    let peer1 = MockBlockchainConnection::new(test_client_uri(1), ledger_db.clone(), 0, None);
-    let peer2 = MockBlockchainConnection::new(test_client_uri(2), ledger_db.clone(), 0, None);
+    let peer1 =
+        MockBlockchainConnection::new(test_client_uri(1), ledger_db.clone(), 0, FeeMap::default());
+    let peer2 =
+        MockBlockchainConnection::new(test_client_uri(2), ledger_db.clone(), 0, FeeMap::default());
 
     let node_ids = vec![
         peer1.uri().host_and_port_responder_id().unwrap(),


### PR DESCRIPTION
Adding the fee map to support MockBlockchainConnections having fees for more than just the MOB token, specified by the test setup.