### PR TITLE
Mc crypto ring signature no alloc improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hkdf",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -2267,6 +2268,13 @@ dependencies = [
  "slip10_ed25519",
  "tiny-bip39",
  "zeroize",
+]
+
+[[package]]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
 ]
 
 [[package]]
@@ -3188,6 +3196,7 @@ dependencies = [
  "displaydoc",
  "hex_fmt",
  "mc-account-keys",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
  "mc-crypto-hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ cargo-features = ["named-profiles"]
 members = [
     "account-keys",
     "account-keys/slip10",
+    "account-keys/types",
     "admin-http-gateway",
     "android-bindings",
     "api",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -15,6 +15,7 @@ subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
+mc-account-keys-types = { path = "types" }
 mc-crypto-digestible = { path = "../crypto/digestible" }
 mc-crypto-hashes = { path = "../crypto/hashes" }
 mc-crypto-keys = { path = "../crypto/keys", default-features = false }

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -23,6 +23,7 @@ use core::{
     hash::{Hash, Hasher},
 };
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+use mc_account_keys_types::RingCtAddress;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
@@ -184,6 +185,16 @@ impl PublicAddress {
         } else {
             Some(&self.fog_report_id)
         }
+    }
+}
+
+impl RingCtAddress for PublicAddress {
+    fn view_public_key(&self) -> &RistrettoPublic {
+        &self.view_public_key
+    }
+
+    fn spend_public_key(&self) -> &RistrettoPublic {
+        &self.spend_public_key
     }
 }
 

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+authors = ["MobileCoin"]
+edition = "2021"
+readme = "README.md"
+
+[dependencies]
+# MobileCoin dependencies
+mc-crypto-keys = { path = "../../crypto/keys", default-features = false }

--- a/account-keys/types/src/lib.rs
+++ b/account-keys/types/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Traits and wrapper types connected to MobileCoin account keys.
+//! This crate is intended to have a small footprint and be maximally portable.
+
+#![no_std]
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+mod traits;
+
+pub use traits::RingCtAddress;

--- a/account-keys/types/src/traits.rs
+++ b/account-keys/types/src/traits.rs
@@ -3,7 +3,7 @@ use mc_crypto_keys::RistrettoPublic;
 /// An object which has represents a subaddress, and has RingCT-style
 /// view and spend public keys.
 pub trait RingCtAddress {
-    /// Get the subaddress' view public key 
+    /// Get the subaddress' view public key
     fn view_public_key(&self) -> &RistrettoPublic;
     /// Get the subaddress' spend public key
     fn spend_public_key(&self) -> &RistrettoPublic;

--- a/account-keys/types/src/traits.rs
+++ b/account-keys/types/src/traits.rs
@@ -1,6 +1,6 @@
 use mc_crypto_keys::RistrettoPublic;
 
-/// An object which has represents a subaddress, and has RingCT-style
+/// An object which represents a subaddress, and has RingCT-style
 /// view and spend public keys.
 pub trait RingCtAddress {
     /// Get the subaddress' view public key

--- a/account-keys/types/src/traits.rs
+++ b/account-keys/types/src/traits.rs
@@ -1,0 +1,10 @@
+use mc_crypto_keys::RistrettoPublic;
+
+/// An object which has represents a subaddress, and has RingCT-style
+/// view and spend public keys.
+pub trait RingCtAddress {
+    /// Get the subaddress' view public key 
+    fn view_public_key(&self) -> &RistrettoPublic;
+    /// Get the subaddress' spend public key
+    fn spend_public_key(&self) -> &RistrettoPublic;
+}

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -648,6 +648,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hkdf",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -659,6 +660,13 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
 ]
 
 [[package]]
@@ -1082,7 +1090,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hex_fmt",
- "mc-account-keys",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -18,7 +18,7 @@ subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
-mc-account-keys = { path = "../../account-keys", default-features = false }
+mc-account-keys-types = { path = "../../account-keys/types", default-features = false }
 mc-crypto-digestible = { path = "../../crypto/digestible", features = ["dalek", "derive"] }
 mc-crypto-hashes = { path = "../../crypto/hashes" }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
@@ -36,6 +36,7 @@ curve25519-dalek = { version = "4.0.0-pre.2", default-features = false, features
 proptest = { version = "1.0", default-features = false, features = ["default-code-coverage"] }
 tempdir = "0.3"
 
+mc-account-keys = { path = "../../account-keys", default-features = false }
 mc-crypto-digestible-test-utils = { path = "../../crypto/digestible/test-utils" }
 mc-util-serial = { path = "../../util/serial", features = ["std"] }
 mc-util-test-helper = { path = "../../util/test-helper" }

--- a/crypto/ring-signature/src/lib.rs
+++ b/crypto/ring-signature/src/lib.rs
@@ -21,8 +21,8 @@ pub mod proptest_fixtures;
 
 pub use amount::{Commitment, CompressedCommitment};
 pub use ring_signature::{
-    generators, CryptoRngCore, CurveScalar, Error, KeyImage, PedersenGens,
-    ReducedTxOut, RingMLSAG, Scalar,
+    generators, CryptoRngCore, CurveScalar, Error, KeyImage, PedersenGens, ReducedTxOut, RingMLSAG,
+    Scalar,
 };
 
 /// Get the shared secret for a transaction output.

--- a/crypto/ring-signature/src/lib.rs
+++ b/crypto/ring-signature/src/lib.rs
@@ -21,7 +21,7 @@ pub mod proptest_fixtures;
 
 pub use amount::{Commitment, CompressedCommitment};
 pub use ring_signature::{
-    generators, CryptoRngCore, CurveScalar, Error, GeneratorCache, KeyImage, PedersenGens,
+    generators, CryptoRngCore, CurveScalar, Error, KeyImage, PedersenGens,
     ReducedTxOut, RingMLSAG, Scalar,
 };
 

--- a/crypto/ring-signature/src/onetime_keys.rs
+++ b/crypto/ring-signature/src/onetime_keys.rs
@@ -75,7 +75,7 @@ use crate::domain_separators::HASH_TO_SCALAR_DOMAIN_TAG;
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
 };
-use mc_account_keys::PublicAddress;
+use mc_account_keys_types::RingCtAddress;
 use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 
@@ -98,7 +98,7 @@ fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
 /// * `recipient` - The recipient subaddress `(C,D)`.
 pub fn create_tx_out_target_key(
     tx_private_key: &RistrettoPrivate,
-    recipient: &PublicAddress,
+    recipient: &impl RingCtAddress,
 ) -> RistrettoPublic {
     // `Hs( r * C)`
     let Hs: Scalar = {
@@ -198,7 +198,7 @@ pub fn create_shared_secret(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mc_account_keys::AccountKey;
+    use mc_account_keys::{AccountKey, PublicAddress};
     use mc_util_from_random::FromRandom;
     use mc_util_test_helper::run_with_several_seeds;
 

--- a/crypto/ring-signature/src/ring_signature/mod.rs
+++ b/crypto/ring-signature/src/ring_signature/mod.rs
@@ -8,14 +8,12 @@ pub use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 
 mod curve_scalar;
 mod error;
-mod generator_cache;
 mod key_image;
 mod mlsag;
 
 pub use self::{
     curve_scalar::CurveScalar,
     error::Error,
-    generator_cache::GeneratorCache,
     key_image::KeyImage,
     mlsag::{CryptoRngCore, ReducedTxOut, RingMLSAG},
 };

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hkdf",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -679,6 +680,13 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
 ]
 
 [[package]]
@@ -996,7 +1004,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hex_fmt",
- "mc-account-keys",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hkdf",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -683,6 +684,13 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
 ]
 
 [[package]]
@@ -965,7 +973,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hex_fmt",
- "mc-account-keys",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hkdf",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -689,6 +690,13 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "mc-account-keys-types"
+version = "1.3.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
 ]
 
 [[package]]
@@ -1006,7 +1014,7 @@ dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "hex_fmt",
- "mc-account-keys",
+ "mc-account-keys-types",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",

--- a/transaction/core/src/ring_ct/generator_cache.rs
+++ b/transaction/core/src/ring_ct/generator_cache.rs
@@ -2,7 +2,7 @@
 
 //! A simple generator cache
 
-use super::{generators, PedersenGens};
+use mc_crypto_ring_signature::{generators, PedersenGens};
 use alloc::collections::BTreeMap;
 use mc_transaction_types::TokenId;
 

--- a/transaction/core/src/ring_ct/generator_cache.rs
+++ b/transaction/core/src/ring_ct/generator_cache.rs
@@ -2,8 +2,8 @@
 
 //! A simple generator cache
 
-use mc_crypto_ring_signature::{generators, PedersenGens};
 use alloc::collections::BTreeMap;
+use mc_crypto_ring_signature::{generators, PedersenGens};
 use mc_transaction_types::TokenId;
 
 /// GeneratorCache is a simple object which caches computations of

--- a/transaction/core/src/ring_ct/mod.rs
+++ b/transaction/core/src/ring_ct/mod.rs
@@ -3,10 +3,12 @@
 //! MobileCoin RingCT implementation
 
 mod error;
+mod generator_cache;
 mod rct_bulletproofs;
 
 pub use self::{
     error::Error,
+    generator_cache::GeneratorCache,
     rct_bulletproofs::{
         InputRing, OutputSecret, PresignedInputRing, SignatureRctBulletproofs, SignedInputRing,
     },

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -18,7 +18,7 @@ use curve25519_dalek::{
 use mc_common::HashSet;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
 use mc_crypto_ring_signature::{
-    Commitment, CompressedCommitment, GeneratorCache, KeyImage, ReducedTxOut, RingMLSAG, Scalar,
+    Commitment, CompressedCommitment, KeyImage, ReducedTxOut, RingMLSAG, Scalar,
 };
 use mc_crypto_ring_signature_signer::{RingSigner, SignableInputRing};
 use mc_util_serial::prost::Message;
@@ -31,7 +31,7 @@ use crate::{
     constants::FEE_BLINDING,
     domain_separators::EXTENDED_MESSAGE_DOMAIN_TAG,
     range_proofs::{check_range_proofs, generate_range_proofs},
-    ring_ct::Error,
+    ring_ct::{Error, GeneratorCache},
     Amount, BlockVersion,
 };
 

--- a/transaction/core/src/signed_contingent_input.rs
+++ b/transaction/core/src/signed_contingent_input.rs
@@ -3,14 +3,14 @@
 //! A signed contingent input as described in MCIP #31
 
 use crate::{
-    ring_ct::{OutputSecret, PresignedInputRing, SignedInputRing},
+    ring_ct::{OutputSecret, PresignedInputRing, SignedInputRing, GeneratorCache},
     tx::TxIn,
     Amount, TokenId,
 };
 use alloc::vec::Vec;
 use displaydoc::Display;
 use mc_crypto_ring_signature::{
-    Commitment, CompressedCommitment, CurveScalar, Error as RingSignatureError, GeneratorCache,
+    Commitment, CompressedCommitment, CurveScalar, Error as RingSignatureError,
     KeyImage, RingMLSAG,
 };
 use prost::Message;

--- a/transaction/core/src/signed_contingent_input.rs
+++ b/transaction/core/src/signed_contingent_input.rs
@@ -3,15 +3,14 @@
 //! A signed contingent input as described in MCIP #31
 
 use crate::{
-    ring_ct::{OutputSecret, PresignedInputRing, SignedInputRing, GeneratorCache},
+    ring_ct::{GeneratorCache, OutputSecret, PresignedInputRing, SignedInputRing},
     tx::TxIn,
     Amount, TokenId,
 };
 use alloc::vec::Vec;
 use displaydoc::Display;
 use mc_crypto_ring_signature::{
-    Commitment, CompressedCommitment, CurveScalar, Error as RingSignatureError,
-    KeyImage, RingMLSAG,
+    Commitment, CompressedCommitment, CurveScalar, Error as RingSignatureError, KeyImage, RingMLSAG,
 };
 use prost::Message;
 


### PR DESCRIPTION
This implements two changes discussed in a meeting on Wednesday.
This helps to move us closer towards making `mc-crypto-ring-signature` not depends on the `alloc` crate, so that it can be used more easily on a Trezor without requiring the rust standard allocator.