### PR TITLE
[Fixes] CI/CD - Update GHA CD and metadata script to support new release branch patterns

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -12,9 +12,10 @@ env:
 on:
   push:
     branches:
-    - release/v*
     - feature/*
-    - develop
+    - release/*
+    tags:
+      - v[0-9]+*
 
 # don't run more than one at a time for a branch/tag
 concurrency: mobilecoin-dev-cd-${{ github.ref }}
@@ -27,7 +28,6 @@ jobs:
     name: 👾 Environment Info 👾
     runs-on: [self-hosted, Linux, small]
     outputs:
-      branch: ${{ steps.meta.outputs.branch }}
       namespace: ${{ steps.meta.outputs.namespace }}
       tag: ${{ steps.meta.outputs.tag }}
       docker_tag: ${{ steps.meta.outputs.docker_tag }}
@@ -330,8 +330,8 @@ jobs:
           REPO_ORG=${{ env.DOCKER_ORG }}
           RUST_BIN_PATH=rust_build_artifacts
           GO_BIN_PATH=go_build_artifacts
-        cache-from: type=registry,ref=${{ env.DOCKER_ORG }}/${{ matrix.image }}:buildcache-${{ needs.generate-metadata.outputs.branch }}
-        cache-to: type=registry,ref=${{ env.DOCKER_ORG }}/${{ matrix.image }}:buildcache-${{ needs.generate-metadata.outputs.branch }}
+        cache-from: type=registry,ref=${{ env.DOCKER_ORG }}/${{ matrix.image }}:buildcache-${{ needs.generate-metadata.outputs.namespace }}
+        cache-to: type=registry,ref=${{ env.DOCKER_ORG }}/${{ matrix.image }}:buildcache-${{ needs.generate-metadata.outputs.namespace }}
         context: .
         file: .internal-ci/docker/Dockerfile.${{ matrix.image }}
         labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -8,14 +8,6 @@ set -e
 
 export TMPDIR=".tmp"
 
-error_exit()
-{
-  msg="${1}"
-
-  echo "${msg}" 1>&2
-  exit 1
-}
-
 is_set()
 {
   var_name="${1}"
@@ -25,66 +17,107 @@ is_set()
   fi
 }
 
+normalize_ref_name()
+{
+    name="${1}"
+
+    echo "${name}" | sed -E 's/(feature|release)\///' | sed -e 's/[._/]/-/g'
+}
+
 # check for github reference variables.
 is_set GITHUB_REF_NAME
 is_set GITHUB_REF_TYPE
 is_set GITHUB_RUN_NUMBER
 is_set GITHUB_SHA
 
-if [[ "${GITHUB_REF_TYPE}" != "branch" ]]
-then
-    echo "not a 'branch' reference type - ${GITHUB_REF_TYPE}"
-    exit 1
-fi
+# Make sure prefix is less that 18 characters or k8s limits.
+namespace_prefix="mc"
+branch="${GITHUB_REF_NAME}"
+sha="sha-${GITHUB_SHA:0:8}"
 
-# Remove leading branch designator.
-branch=$(echo "${GITHUB_REF_NAME}" | sed -E 's/(feature|deploy|release)\///')
+case "${GITHUB_REF_TYPE}" in
+    tag)
+        # check for valid tag and set outputs
+        version="${GITHUB_REF_NAME}"
+        if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.* ]]
+        then
+            echo "GitHub Tag ${version} is not valid semver."
+            exit 1
+        fi
 
-if [[ "${GITHUB_REF_NAME}" =~ ^release/ ]]
-then
-    echo "Release Branch detected: ${GITHUB_REF_NAME}"
-    version="${branch}"
-    # check to see if remaining version is basic semver
-    if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-    then
-        echo "release/<version> not basic semver: ${version}"
-        echo "branch name invalid"
+        if [[ "${version}" =~ - ]]
+        then
+            echo "Found pre-release tag."
+            # set artifact tag
+            tag="${version}"
+            docker_tag="type=raw,value=${version},priority=20%0Atype=raw,value=${version}.${GITHUB_RUN_NUMBER}.${sha},priority=10"
+        else
+            echo "Found release tag."
+            # set artifact tag
+            tag="${version}-dev"
+            #set docker metadata action compatible tag. Short tag + metadata tag.
+            docker_tag="type=raw,value=${version}-dev,priority=20%0Atype=raw,value=${version}-dev.${GITHUB_RUN_NUMBER}.${sha},priority=10"
+        fi
+
+        normalized_tag=$(normalize_ref_name "${tag}")
+
+        namespace="${namespace_prefix}-${normalized_tag}"
+
+        # just make sure we have these set to avoid weird edge cases.
+        is_set tag
+        is_set docker_tag
+    ;;
+    branch)
+        # Check for valid branches. Using case if we want add more or split branch types later.
+        case "${branch}" in
+            release/*|feature/*)
+                # All branch builds will just have a "dummy" tag.
+                version="v0"
+
+                echo "Clean up branch. Remove feature|deploy|release prefix and replace ._/ with -"
+                normalized_branch="$(normalize_ref_name "${branch}")"
+
+                # Check and truncate branch name if total tag length exceeds the 63 character K8s label value limit.
+                label_limit=63
+                version_len=${#version}
+                sha_len=${#sha}
+                run_number_len=${#GITHUB_RUN_NUMBER}
+                # number of separators in tag
+                dots=3
+
+                cutoff=$((label_limit - version_len - sha_len - run_number_len - dots))
+
+                if [[ ${#normalized_branch} -gt ${cutoff} ]]
+                then
+                    cut_branch=$(echo "${normalized_branch}" | cut -c -${cutoff})
+                    echo "Your branch name ${normalized_branch} + metadata exceeds the maximum length for K8s identifiers, truncating to ${cut_branch}"
+                    normalized_branch="${cut_branch}"
+                fi
+
+                echo "Before: '${branch}'"
+                echo "After: '${normalized_branch}'"
+
+                # Set artifact tag
+                tag="${version}-${normalized_branch}.${GITHUB_RUN_NUMBER}.${sha}"
+                # Set docker metadata action compatible tag
+                docker_tag="type=raw,value=${tag}"
+                # Set namespace from normalized branch value
+                namespace="${namespace_prefix}-${normalized_branch}"
+            ;;
+            *)
+                echo "Branch: ${branch} is not a release/ or feature/ branch"
+                exit 1
+            ;;
+        esac
+    ;;
+    *)
+        echo "${GITHUB_REF_TYPE} is an unknown GitHub Reference Type"
         exit 1
-    fi
-else
-    version="v0.0.0"
-    echo "Not a release branch, set default version of v0.0.0"
-fi
-
-echo "Clean up branch. Remove feature|deploy|release prefix and replace ._/ with - '${branch}'"
-branch=$(echo "${branch}" | sed -e 's/[._/]/-/g')
-sha="${GITHUB_SHA:0:8}"
-
-# Set tag/docker_tag
-tag="${version}-${branch}.${GITHUB_RUN_NUMBER}.sha-${sha}"
-docker_tag="type=raw,value=${tag}"
-
-# override tag/docker_tag for release
-if [[ "${GITHUB_REF_NAME}" =~ ^release/ ]]
-then
-    docker_tag="type=raw,value=${version}-dev,priority=20%0Atype=raw,value=${version}-${GITHUB_RUN_NUMBER}.sha-${sha},priority=10"
-    tag=${version}-dev
-fi
-
-# Get commit flags
-if [ -f "${GITHUB_EVENT_PATH}" ]
-then
-    # override tag if commit message has [tag="tag"]
-    msg=$(jq -r '.head_commit.message' < "${GITHUB_EVENT_PATH}")
-    if [[ "${msg}" =~ /\[tag=.*\]/ ]]
-    then
-        tag=$(echo "${msg}" | sed -r 's/.*\[use=(.*)\].*/\1/')
-    fi
-fi
+    ;;
+esac
 
 echo "::set-output name=version::${version}"
-echo "::set-output name=branch::${branch}"
-echo "::set-output name=namespace::mc-${branch}"
+echo "::set-output name=namespace::${namespace}"
 echo "::set-output name=sha::${sha}"
 echo "::set-output name=tag::${tag}"
 echo "::set-output name=docker_tag::${docker_tag}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [unreleased]
+
+### Fixed
+
+#### CI/CD
+
+- Fix metadata script for new release branch patterns. ([#2298])
 
 ## [1.2.2] - 2022-06-09
 


### PR DESCRIPTION
### Motivation

GHA
- move to release/* and semver compatible tags
- Remove the redundant "branch" output and change to using "namespace" in the GHA CD.

metadata.sh
- Rework how the metadata script to support the move to new `release/v2` branch pattern. 
- Clean up script for clearer logic flow.
- Truncate `really-super-extra-there-s-no-way-you-need-this-way-too-long` branch names so we don't exceed the 63 character limit in a lot of K8s identifier values.

### Future Work

We are starting to use similar logic for dynamic testing environments in some of the other MobileCoin projects. Break this functionality out in to it's own discrete GitHub Action for reuse on other projects.
