### PR TITLE
Add audited mints endpint to mint auditor

### DIFF
--- a/mint-auditor/src/db/models/audited_mint.rs
+++ b/mint-auditor/src/db/models/audited_mint.rs
@@ -288,11 +288,16 @@ impl AuditedMint {
             .inner_join(mint_txs::table)
             .inner_join(gnosis_safe_deposits::table);
 
-        if let (Some(o), Some(l)) = (offset, limit) {
-            query = query.offset(o as i64).limit(l as i64);
+        if let Some(o) = offset {
+            query = query.offset(o as i64);
+        }
+
+        if let Some(l) = limit {
+            query = query.limit(l as i64);
         }
 
         Ok(query
+            .order_by(audited_mints::id)
             .select((
                 audited_mints::all_columns,
                 mint_txs::all_columns,

--- a/mint-auditor/src/http_api/api_types.rs
+++ b/mint-auditor/src/http_api/api_types.rs
@@ -2,7 +2,7 @@
 
 //! Request and response types
 
-use crate::db::BlockAuditData;
+use crate::db::{AuditedMint, BlockAuditData, GnosisSafeDeposit, MintTx};
 use mc_common::HashMap;
 use mc_transaction_core::TokenId;
 use rocket::serde::Serialize;
@@ -26,4 +26,13 @@ impl BlockAuditDataResponse {
                 .collect(),
         }
     }
+}
+
+/// Audited mint with corresponding mint tx and gnosis safe deposit
+#[derive(Serialize, Debug, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub struct AuditedMintResponse {
+    pub audited: AuditedMint,
+    pub mint: MintTx,
+    pub deposit: GnosisSafeDeposit,
 }

--- a/mint-auditor/src/http_api/mod.rs
+++ b/mint-auditor/src/http_api/mod.rs
@@ -29,6 +29,7 @@ pub async fn start_http_server(db: MintAuditorDb, port: u16, host: String) {
                 routes::get_counters,
                 routes::get_block_audit_data,
                 routes::get_last_block_audit_data,
+                routes::get_audited_mints,
             ],
         )
         .launch()

--- a/mint-auditor/src/http_api/routes.rs
+++ b/mint-auditor/src/http_api/routes.rs
@@ -4,7 +4,10 @@
 
 use crate::{
     db::Counters,
-    http_api::{api_types::BlockAuditDataResponse, service::MintAuditorHttpService},
+    http_api::{
+        api_types::{AuditedMintResponse, BlockAuditDataResponse},
+        service::MintAuditorHttpService,
+    },
 };
 use rocket::{get, serde::json::Json, State};
 
@@ -42,6 +45,20 @@ pub fn get_last_block_audit_data(
 ) -> Result<Json<BlockAuditDataResponse>, String> {
     match service.get_last_block_audit_data() {
         Ok(block_audit_data) => Ok(Json(block_audit_data)),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Get a paginated list of audited mints, along with corresponding mint tx and
+/// gnosis safe deposit
+#[get("/audited_mints?<offset>&<limit>")]
+pub fn get_audited_mints(
+    offset: Option<u64>,
+    limit: Option<u64>,
+    service: &State<MintAuditorHttpService>,
+) -> Result<Json<Vec<AuditedMintResponse>>, String> {
+    match service.get_audited_mints(offset, limit) {
+        Ok(audited_mints) => Ok(Json(audited_mints)),
         Err(e) => Err(e.to_string()),
     }
 }

--- a/mint-auditor/src/http_api/service.rs
+++ b/mint-auditor/src/http_api/service.rs
@@ -62,11 +62,11 @@ impl MintAuditorHttpService {
         let query_result = AuditedMint::list_with_mint_and_deposit(offset, limit, &conn)?;
 
         let response = query_result
-            .iter()
+            .into_iter()
             .map(|(audited, mint, deposit)| AuditedMintResponse {
-                audited: audited.clone(),
-                mint: mint.clone(),
-                deposit: deposit.clone(),
+                audited: audited,
+                mint: mint,
+                deposit: deposit,
             })
             .collect();
 

--- a/mint-auditor/src/http_api/service.rs
+++ b/mint-auditor/src/http_api/service.rs
@@ -64,9 +64,9 @@ impl MintAuditorHttpService {
         let response = query_result
             .into_iter()
             .map(|(audited, mint, deposit)| AuditedMintResponse {
-                audited: audited,
-                mint: mint,
-                deposit: deposit,
+                audited,
+                mint,
+                deposit,
             })
             .collect();
 


### PR DESCRIPTION
Add endpoint to list audited mints joined to mint tx and gnosis deposit

Motivation
The frontend for the mint auditor will need this endpoint

Future Work
audited burns endpoint

this is based off of https://github.com/Shramp/mobilecoin/pull/1. it was easier to copy-paste the few changes in that diff than fix the merge conflicts.
