### PR TITLE
Android SDK Expose TransactionBuilder RNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,7 @@ dependencies = [
  "mc-util-uri",
  "protobuf",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sha2 0.10.2",
  "slip10_ed25519",
  "tiny-bip39",

--- a/android-bindings/Cargo.toml
+++ b/android-bindings/Cargo.toml
@@ -46,6 +46,7 @@ generic-array = { version = "0.14", features = ["more_lengths", "serde"] }
 jni = { version = "0.19.0", default-features = false }
 protobuf = "2.27.1"
 rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1" }
 sha2 = { version = "0.10", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "0.8"

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.3-pre3'
+version '1.2.3-pre0'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.3-pre0'
+version '1.2.3'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-bindings/lib-wrapper/android-bindings/publish.gradle
+++ b/android-bindings/lib-wrapper/android-bindings/publish.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'maven-publish'
 
-version '1.2.2'
+version '1.2.3-pre3'
 group 'com.mobilecoin'
 
 Properties properties = new Properties()

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -65,10 +65,10 @@ use rand_chacha::ChaCha20Rng;
 use sha2::Sha512;
 use std::{
     collections::BTreeMap,
+    convert::TryInto,
     ops::DerefMut,
     str::FromStr,
     sync::{Mutex, MutexGuard},
-    convert::TryInto,
 };
 use zeroize::Zeroize;
 

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -2647,3 +2647,14 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_next_1bytes(
         },
     )
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_finalize_1jni(
+    env: JNIEnv,
+    obj: JObject,
+) {
+    jni_ffi_call(&env, |env| {
+        let _: McRng = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
+        Ok(())
+    })
+}

--- a/android-bindings/src/bindings.rs
+++ b/android-bindings/src/bindings.rs
@@ -61,13 +61,14 @@ use mc_util_from_random::FromRandom;
 use mc_util_uri::FogUri;
 use protobuf::Message;
 use rand::{rngs::StdRng, SeedableRng};
-use rand_chacha;
+use rand_chacha::ChaCha20Rng;
 use sha2::Sha512;
 use std::{
     collections::BTreeMap,
     ops::DerefMut,
     str::FromStr,
     sync::{Mutex, MutexGuard},
+    convert::TryInto,
 };
 use zeroize::Zeroize;
 
@@ -1765,6 +1766,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
     value: JObject,
     recipient: JObject,
     confirmation_number_out: jbyteArray,
+    java_rng: JObject,
 ) -> jlong {
     jni_ffi_call_or(
         || Ok(0),
@@ -1778,8 +1780,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1output(
             let recipient: MutexGuard<PublicAddress> =
                 env.get_rust_field(recipient, RUST_OBJ_FIELD)?;
 
-            let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0);//TODO: seed
-            let tx_out_context = tx_builder.add_output(value as u64, &recipient, &mut rng)?;
+            let mut rng: MutexGuard<ChaCha20Rng> =
+                env.get_rust_field(java_rng, RUST_OBJ_FIELD)?;
+            let tx_out_context = tx_builder.add_output(value as u64, &recipient, &mut *rng)?;
             let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
@@ -1811,6 +1814,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
     value: JObject,
     source_account_key: JObject,
     confirmation_number_out: jbyteArray,
+    java_rng: JObject,
 ) -> jlong {
     jni_ffi_call_or(
         || Ok(0),
@@ -1824,10 +1828,11 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_add_1change_
             let value = jni_big_int_to_u64(env, value)?;
             let change_destination: ChangeDestination =
                 ChangeDestination::from(&*source_account_key);
-            let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0);//TODO: seed
+            let mut rng: MutexGuard<ChaCha20Rng> =
+                env.get_rust_field(java_rng, RUST_OBJ_FIELD)?;
 
             let tx_out_context =
-                tx_builder.add_change_output(value, &change_destination, &mut rng)?;
+                tx_builder.add_change_output(value, &change_destination, &mut *rng)?;
             let confirmation_number = &tx_out_context.confirmation;
             if !confirmation_number_out.is_null() {
                 let len = env.get_array_length(confirmation_number_out)?;
@@ -1888,6 +1893,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_set_1fee(
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_build_1tx(
     env: JNIEnv,
     obj: JObject,
+    java_rng: JObject,
 ) -> jlong {
     jni_ffi_call_or(
         || Ok(0),
@@ -1896,8 +1902,9 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_TransactionBuilder_build_1tx(
             let tx_builder: TransactionBuilder<FogResolver> =
                 env.take_rust_field(obj, RUST_OBJ_FIELD)?;
 
-            let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0);//TODO: seed
-            let tx = tx_builder.build(&mut rng)?;
+            let mut rng: MutexGuard<ChaCha20Rng> =
+                env.get_rust_field(java_rng, RUST_OBJ_FIELD)?;
+            let tx = tx_builder.build(&mut *rng)?;
 
             let mbox = Box::new(Mutex::new(tx));
             let ptr: *mut Mutex<Tx> = Box::into_raw(mbox);
@@ -2600,7 +2607,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_init_1jni(
     )
 }
 
-/*#[no_mangle]
+#[no_mangle]
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_next_1int(
     env: JNIEnv,
     obj: JObject,
@@ -2613,7 +2620,7 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_next_1int(
             Ok(rng.next_u32() as jint)
         },
     )
-}*/
+}
 
 #[no_mangle]
 pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_next_1long(
@@ -2655,6 +2662,179 @@ pub unsafe extern "C" fn Java_com_mobilecoin_lib_DefaultRng_finalize_1jni(
 ) {
     jni_ffi_call(&env, |env| {
         let _: McRng = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
+        Ok(())
+    })
+}
+
+/********************************************************************
+ * ChaCha20Rng
+ */
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_seed_1from_1long(
+    env: JNIEnv,
+    _obj: JObject,
+    seed: jlong,
+) -> jobject {
+    jni_ffi_call_or(
+        || Ok(JObject::null().into_inner()),
+        &env,
+        |env| {
+            let rng = ChaCha20Rng::seed_from_u64(seed as u64);
+            let mbox = Box::new(Mutex::new(rng));
+            let ptr: *mut Mutex<ChaCha20Rng> = Box::into_raw(mbox);
+            Ok(env
+                .new_object(
+                    "com/mobilecoin/lib/ChaCha20Rng",
+                    "(J)V",
+                    &[
+                        jni::objects::JValue::Long(ptr as jlong)
+                    ],
+                )?
+                .into_inner())
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_seed_1from_1bytes(
+    env: JNIEnv,
+    _obj: JObject,
+    seed: jbyteArray,
+) -> jobject {
+    jni_ffi_call_or(
+        || Ok(JObject::null().into_inner()),
+        &env,
+        |env| {
+            let seed_bytes = env.convert_byte_array(seed)?
+                .try_into().unwrap();
+            let rng = ChaCha20Rng::from_seed(seed_bytes);
+            let mbox = Box::new(Mutex::new(rng));
+            let ptr: *mut Mutex<ChaCha20Rng> = Box::into_raw(mbox);
+            Ok(env
+                .new_object(
+                    "com/mobilecoin/lib/ChaCha20Rng",
+                    "(J)V",
+                    &[
+                        jni::objects::JValue::Long(ptr as jlong)
+                    ],
+                )?
+                .into_inner())
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_next_1int(
+    env: JNIEnv,
+    obj: JObject,
+) -> jint {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let mut rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            Ok(rng.next_u32() as jint)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_next_1long(
+    env: JNIEnv,
+    obj: JObject,
+) -> jlong {
+    jni_ffi_call_or(
+        || Ok(0),
+        &env,
+        |env| {
+            let mut rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            Ok(rng.next_u64() as jlong)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_next_1bytes(
+    env: JNIEnv,
+    obj: JObject,
+    length: jint,
+) -> jbyteArray {
+    jni_ffi_call_or(
+        || Ok(JObject::null().into_inner()),
+        &env,
+        |env| {
+            let mut rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            let mut bytes = vec![0; length as usize];
+            rng.fill_bytes(&mut bytes);
+            Ok(env.byte_array_from_slice(&bytes)?)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_get_1seed(
+    env: JNIEnv,
+    obj: JObject,
+) -> jbyteArray {
+    jni_ffi_call_or(
+        || Ok(JObject::null().into_inner()),
+        &env,
+        |env| {
+            let rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            Ok(env.byte_array_from_slice(&rng.get_seed())?)
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_get_1word_1pos(
+    env: JNIEnv,
+    obj: JObject,
+) -> jobject {
+    jni_ffi_call_or(
+        || Ok(JObject::null().into_inner()),
+        &env,
+        |env| {
+            let rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+            // Java is always big endian
+            let word_pos_bytes = rng.get_word_pos().to_be_bytes();
+            let word_pos = env.new_object(
+                "java/math/BigInteger",
+                "(I[B)V",
+                &[
+                    jni::objects::JValue::Int(1),
+                    env.byte_array_from_slice(&word_pos_bytes)?
+                        .into(),
+                ],
+            )?;
+            Ok(word_pos.into_inner())
+        },
+    )
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_set_1word_1pos(
+    env: JNIEnv,
+    obj: JObject,
+    word_pos_bytes: jbyteArray,
+) {
+    jni_ffi_call(&env, |env| {
+        let mut rng: MutexGuard<ChaCha20Rng> = env.get_rust_field(obj, RUST_OBJ_FIELD)?;
+        let word_pos: [u8; 16] = env.convert_byte_array(word_pos_bytes)?
+            .try_into().unwrap();
+        // Java is always big endian
+        rng.set_word_pos(u128::from_be_bytes(word_pos));
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Java_com_mobilecoin_lib_ChaCha20Rng_finalize_1jni(
+    env: JNIEnv,
+    obj: JObject,
+) {
+    jni_ffi_call(&env, |env| {
+        let _: ChaCha20Rng = env.take_rust_field(obj, RUST_OBJ_FIELD)?;
         Ok(())
     })
 }


### PR DESCRIPTION
* Expose McRng to the SDK
* Expose ChaCha20 to the SDK
* Parameterize TransactionBuilder bindings for an RNG from the SDK

### Motivation
These changes are needed in order to have transaction building idempotence at the SDK level. After these changes, the SDK will be able to build the same transaction more than once with the same inputs.

### Future Work
* Merge these and other 1.2.0+ changes into master
