### PR TITLE
Add audited burns endpoint to mint auditor

### DIFF
--- a/mint-auditor/src/http_api/api_types.rs
+++ b/mint-auditor/src/http_api/api_types.rs
@@ -2,7 +2,10 @@
 
 //! Request and response types
 
-use crate::db::{AuditedMint, BlockAuditData, GnosisSafeDeposit, MintTx};
+use crate::db::{
+    AuditedBurn, AuditedMint, BlockAuditData, BurnTxOut, GnosisSafeDeposit, GnosisSafeWithdrawal,
+    MintTx,
+};
 use mc_common::HashMap;
 use mc_transaction_core::TokenId;
 use rocket::serde::Serialize;
@@ -35,4 +38,13 @@ pub struct AuditedMintResponse {
     pub audited: AuditedMint,
     pub mint: MintTx,
     pub deposit: GnosisSafeDeposit,
+}
+
+/// Audited burn with corresponding burn tx and gnosis safe withdrawal
+#[derive(Serialize, Debug, Eq, PartialEq)]
+#[allow(missing_docs)]
+pub struct AuditedBurnResponse {
+    pub audited: AuditedBurn,
+    pub burn: BurnTxOut,
+    pub withdrawal: GnosisSafeWithdrawal,
 }

--- a/mint-auditor/src/http_api/mod.rs
+++ b/mint-auditor/src/http_api/mod.rs
@@ -30,6 +30,7 @@ pub async fn start_http_server(db: MintAuditorDb, port: u16, host: String) {
                 routes::get_block_audit_data,
                 routes::get_last_block_audit_data,
                 routes::get_audited_mints,
+                routes::get_audited_burns,
             ],
         )
         .launch()

--- a/mint-auditor/src/http_api/routes.rs
+++ b/mint-auditor/src/http_api/routes.rs
@@ -5,7 +5,7 @@
 use crate::{
     db::Counters,
     http_api::{
-        api_types::{AuditedMintResponse, BlockAuditDataResponse},
+        api_types::{AuditedBurnResponse, AuditedMintResponse, BlockAuditDataResponse},
         service::MintAuditorHttpService,
     },
 };
@@ -59,6 +59,20 @@ pub fn get_audited_mints(
 ) -> Result<Json<Vec<AuditedMintResponse>>, String> {
     match service.get_audited_mints(offset, limit) {
         Ok(audited_mints) => Ok(Json(audited_mints)),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Get a paginated list of audited burns, along with corresponding burn tx and
+/// gnosis safe withdrawal
+#[get("/audited_burns?<offset>&<limit>")]
+pub fn get_audited_burns(
+    offset: Option<u64>,
+    limit: Option<u64>,
+    service: &State<MintAuditorHttpService>,
+) -> Result<Json<Vec<AuditedBurnResponse>>, String> {
+    match service.get_audited_burns(offset, limit) {
+        Ok(audited_burns) => Ok(Json(audited_burns)),
         Err(e) => Err(e.to_string()),
     }
 }

--- a/mint-auditor/src/http_api/service.rs
+++ b/mint-auditor/src/http_api/service.rs
@@ -3,8 +3,8 @@
 //! Mint auditor service for handling HTTP requests
 
 use crate::{
-    db::{AuditedMint, BlockAuditData, BlockBalance, Counters, MintAuditorDb},
-    http_api::api_types::{AuditedMintResponse, BlockAuditDataResponse},
+    db::{AuditedBurn, AuditedMint, BlockAuditData, BlockBalance, Counters, MintAuditorDb},
+    http_api::api_types::{AuditedBurnResponse, AuditedMintResponse, BlockAuditDataResponse},
     Error,
 };
 
@@ -72,6 +72,29 @@ impl MintAuditorHttpService {
 
         Ok(response)
     }
+
+    /// Get a paginated list of audited burns, along with corresponding burn tx
+    /// and gnosis safe withdrawal
+    pub fn get_audited_burns(
+        &self,
+        offset: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<Vec<AuditedBurnResponse>, Error> {
+        let conn = self.mint_auditor_db.get_conn()?;
+
+        let query_result = AuditedBurn::list_with_burn_and_withdrawal(offset, limit, &conn)?;
+
+        let response = query_result
+            .into_iter()
+            .map(|(audited, burn, withdrawal)| AuditedBurnResponse {
+                audited,
+                burn,
+                withdrawal,
+            })
+            .collect();
+
+        Ok(response)
+    }
 }
 
 #[cfg(test)]
@@ -79,10 +102,12 @@ mod tests {
     use super::*;
     use crate::db::{
         test_utils::{
-            append_and_sync, create_gnosis_safe_deposit, insert_gnosis_deposit,
-            insert_mint_tx_from_deposit, test_gnosis_config, TestDbContext,
+            append_and_sync, create_burn_tx_out, create_gnosis_safe_deposit,
+            create_gnosis_safe_withdrawal_from_burn_tx_out, insert_gnosis_deposit,
+            insert_gnosis_withdrawal, insert_mint_tx_from_deposit, test_gnosis_config,
+            TestDbContext,
         },
-        GnosisSafeDeposit, MintTx,
+        BurnTxOut, GnosisSafeDeposit, GnosisSafeWithdrawal, MintTx,
     };
     use mc_account_keys::AccountKey;
     use mc_blockchain_types::{BlockContents, BlockVersion};
@@ -228,5 +253,43 @@ mod tests {
         assert_eq!(paginated_mints.len(), 3);
         assert_eq!(paginated_mints[0].audited.id.unwrap(), 5);
         assert_eq!(paginated_mints[2].audited.id.unwrap(), 7);
+    }
+
+    #[test_with_logger]
+    fn test_get_audited_burns_service(logger: Logger) {
+        let config = &test_gnosis_config().safes[0];
+        let mut rng = mc_util_test_helper::get_seeded_rng();
+        let test_db_context = TestDbContext::default();
+        let burn_auditor_db = test_db_context.get_db_instance(logger.clone());
+        let conn = burn_auditor_db.get_conn().unwrap();
+        let token_id = config.tokens[0].token_id;
+        let service = MintAuditorHttpService::new(burn_auditor_db);
+
+        let mut withdrawals: Vec<GnosisSafeWithdrawal> = vec![];
+        let mut burns: Vec<BurnTxOut> = vec![];
+
+        for _ in 0..10 {
+            let mut burn = create_burn_tx_out(token_id, 100, &mut rng);
+            burn.insert(&conn).unwrap();
+            burns.push(burn.clone());
+            let mut withdrawal = create_gnosis_safe_withdrawal_from_burn_tx_out(&burn, &mut rng);
+            withdrawals.push(withdrawal.clone());
+            insert_gnosis_withdrawal(&mut withdrawal, &conn);
+            AuditedBurn::try_match_withdrawal_with_burn(&withdrawal, config, &conn).unwrap();
+        }
+
+        let all_audited_burns = service.get_audited_burns(None, None).unwrap();
+        assert_eq!(all_audited_burns.len(), 10);
+
+        assert_eq!(all_audited_burns[0].burn, burns[0]);
+        assert_eq!(
+            all_audited_burns[0].withdrawal.eth_tx_hash(),
+            withdrawals[0].eth_tx_hash()
+        );
+
+        let paginated_burns = service.get_audited_burns(Some(4), Some(3)).unwrap();
+        assert_eq!(paginated_burns.len(), 3);
+        assert_eq!(paginated_burns[0].audited.id.unwrap(), 5);
+        assert_eq!(paginated_burns[2].audited.id.unwrap(), 7);
     }
 }


### PR DESCRIPTION
Add route + service + model for getting a paginated list of audited burns along with corresponding burn txouts and gnosis safe withdrawals. This will be used by the frontend of the mint auditor.
