### PR TITLE
Use sharding strategy to tell view what blocks to process

### DIFF
--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -6,7 +6,9 @@ use mc_attest_net::{Client, RaClient};
 use mc_common::{logger::log, time::SystemTimeProvider};
 use mc_fog_sql_recovery_db::SqlRecoveryDb;
 use mc_fog_view_enclave::{SgxViewEnclave, ENCLAVE_FILE};
-use mc_fog_view_server::{config::MobileAcctViewConfig, server::ViewServer};
+use mc_fog_view_server::{
+    config::MobileAcctViewConfig, server::ViewServer, sharding_strategy::EpochShardingStrategy,
+};
 use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
@@ -64,6 +66,9 @@ fn main() {
         recovery_db,
         ias_client,
         SystemTimeProvider::default(),
+        // TODO: Change the EpochShardingStrategy to incorporate config values that specify
+        //  start and end block indices. See PR #2352
+        EpochShardingStrategy::default(),
         logger.clone(),
     );
     server.start();

--- a/fog/view/server/src/lib.rs
+++ b/fog/view/server/src/lib.rs
@@ -8,10 +8,10 @@ pub mod fog_view_router_server;
 pub mod fog_view_router_service;
 pub mod fog_view_service;
 pub mod server;
+pub mod sharding_strategy;
 
 mod block_tracker;
 mod counters;
 mod db_fetcher;
 mod router_request_handler;
 mod shard_responses_processor;
-mod sharding_strategy;

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -20,6 +20,7 @@ pub trait ShardingStrategy {
 ///
 /// In practice, the set of Fog View Shards will contain overlapping
 /// [epoch_block_ranges] in order to obfuscate which shard processed the TxOuts.
+#[derive(Clone)]
 pub struct EpochShardingStrategy {
     /// If a block falls within this range, then the Fog View Store should
     /// process its TxOuts.

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -36,6 +36,7 @@ use mc_fog_view_protocol::FogViewConnection;
 use mc_fog_view_server::{
     config::{ClientListenUri::ClientFacing, MobileAcctViewConfig as ViewConfig},
     server::ViewServer,
+    sharding_strategy::EpochShardingStrategy,
 };
 use mc_util_from_random::FromRandom;
 use mc_util_grpc::GrpcRetryConfig;
@@ -52,7 +53,7 @@ fn get_test_environment(
     logger: Logger,
 ) -> (
     SqlRecoveryDbTestContext,
-    ViewServer<SgxViewEnclave, AttestClient, SqlRecoveryDb>,
+    ViewServer<SgxViewEnclave, AttestClient, SqlRecoveryDb, EpochShardingStrategy>,
     FogViewGrpcClient,
 ) {
     let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
@@ -90,6 +91,7 @@ fn get_test_environment(
             db,
             ra_client,
             SystemTimeProvider::default(),
+            EpochShardingStrategy::default(),
             logger.clone(),
         );
         server.start();


### PR DESCRIPTION
<!-- List changes here -->

### Motivation
The previous PR (#2350) created the `EpochShardingStrategy`. This PR uses this concrete sharding strategy to tell Fog View which TxOuts its responsible for. 

### Future Work
- The next PR (#2352) allows for the sharding strategy to be passed as a CLI argument.