### PR TITLE
Add readiness API to ShardingStrategy

### DIFF
--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -41,14 +41,16 @@ message MultiViewStoreQueryRequest {
     repeated attest.Message queries = 1;
 }
 
-/// Errors that occur when the Fog View Store is unable to fulfill a MultiViewStoreQueryRequest.
-enum MultiViewStoreQueryResponseError {
+/// The status associated with a MultiViewStoreQueryResponse
+enum MultiViewStoreQueryResponseStatus {
+    /// The Fog View Store successfully fulfilled the request.
+    SUCCESS = 0;
     /// The Fog View Store is unable to decrypt a query within the MultiViewStoreQuery. It needs to be authenticated
     /// by the router.
-    AUTHENTICATION = 0;
+    AUTHENTICATION_ERROR = 1;
     /// The Fog View Store is not ready to service a MultiViewStoreQueryRequest. This might be because the store has
     /// not loaded enough blocks yet.
-    NOT_READY = 1;
+    NOT_READY = 2;
 }
 
 message MultiViewStoreQueryResponse {
@@ -63,8 +65,8 @@ message MultiViewStoreQueryResponse {
     /// described by this URI.
     string fog_view_store_uri = 2;
 
-    /// Optional error that gets returned when the Fog View Store fails to service a MultiViewStoreQueryRequest.
-    MultiViewStoreQueryResponseError error = 3;
+    /// Status that gets returned when the Fog View Store services a MultiViewStoreQueryRequest.
+    MultiViewStoreQueryResponseStatus status = 3;
 }
 
 /// Fulfills requests sent directly by a Fog client, e.g. a mobile phone using the SDK.

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -36,14 +36,19 @@ message FogViewRouterResponse {
     }
 }
 
-message FogViewStoreDecryptionError {
-    /// An error message that describes the decryption error.
-    string error_message = 1;
-}
-
 message MultiViewStoreQueryRequest {
     /// A list of queries encrypted for Fog View Stores.
     repeated attest.Message queries = 1;
+}
+
+/// Errors that occur when the Fog View Store is unable to fulfill a MultiViewStoreQueryRequest.
+enum MultiViewStoreQueryResponseError {
+    /// The Fog View Store is unable to decrypt a query within the MultiViewStoreQuery. It needs to be authenticated
+    /// by the router.
+    AUTHENTICATION = 0;
+    /// The Fog View Store is not ready to service a MultiViewStoreQueryRequest. This might be because the store has
+    /// not loaded enough blocks yet.
+    NOT_READY = 1;
 }
 
 message MultiViewStoreQueryResponse {
@@ -58,9 +63,8 @@ message MultiViewStoreQueryResponse {
     /// described by this URI.
     string fog_view_store_uri = 2;
 
-    /// Optional error that gets returned when the Fog View Store
-    /// cannot decrypt the MultiViewStoreQuery.
-    FogViewStoreDecryptionError decryption_error = 3;
+    /// Optional error that gets returned when the Fog View Store fails to service a MultiViewStoreQueryRequest.
+    MultiViewStoreQueryResponseError error = 3;
 }
 
 /// Fulfills requests sent directly by a Fog client, e.g. a mobile phone using the SDK.

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -7,7 +7,7 @@ use grpcio::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
 use mc_attest_api::attest;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
-    view::{MultiViewStoreQueryRequest, MultiViewStoreQueryResponse},
+    view::{MultiViewStoreQueryRequest, MultiViewStoreQueryResponse, MultiViewStoreQueryResponseError},
     view_grpc::{FogViewApi, FogViewStoreApi},
 };
 use mc_fog_recovery_db_iface::RecoveryDb;
@@ -281,10 +281,7 @@ where
                     }
                 }
 
-                let decryption_error = response.mut_decryption_error();
-                decryption_error.set_error_message(
-                    "Could not decrypt a query embedded in the MultiViewStoreQuery".to_string(),
-                );
+                response.set_error(MultiViewStoreQueryResponseError::AUTHENTICATION);
                 send_result(ctx, sink, Ok(response), logger)
             } else {
                 let rpc_permissions_error = rpc_permissions_error(

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -3,7 +3,10 @@
 use crate::error::RouterServerError;
 use mc_attest_api::attest;
 use mc_common::ResponderId;
-use mc_fog_api::{view::{MultiViewStoreQueryResponse, MultiViewStoreQueryResponseError}, view_grpc::FogViewStoreApiClient};
+use mc_fog_api::{
+    view::{MultiViewStoreQueryResponse, MultiViewStoreQueryResponseError},
+    view_grpc::FogViewStoreApiClient,
+};
 use mc_fog_uri::FogViewStoreUri;
 use std::{str::FromStr, sync::Arc};
 
@@ -47,9 +50,10 @@ pub fn process_shard_responses(
 
     for (shard_client, mut response) in clients_and_responses {
         let store_uri = FogViewStoreUri::from_str(response.get_fog_view_store_uri())?;
-        // The shard was unable to produce a query response because the Fog View Store it contacted
-        // isn't authenticated with the Fog View Router. Therefore we need to (a) retry the query
-        // (b) authenticate with the Fog View Store.
+        // The shard was unable to produce a query response because the Fog View Store
+        // it contacted isn't authenticated with the Fog View Router. Therefore
+        // we need to (a) retry the query (b) authenticate with the Fog View
+        // Store.
         if response.get_error() == MultiViewStoreQueryResponseError::AUTHENTICATION {
             shard_clients_for_retry.push(shard_client);
             view_store_uris_for_authentication.push(store_uri);

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -169,12 +169,11 @@ mod epoch_sharding_strategy_tests {
     }
 
     #[test]
-    fn is_ready_to_serve_tx_outs_first_epoch_processed_block_count_is_zero_less_than_50_percent_processed_returns_true(
-    ) {
+    fn is_ready_to_serve_tx_outs_allows_0_in_0_to_100_shard() {
         // The first epoch has a start block == 0.
         const START_BLOCK: BlockIndex = 0;
-        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 100;
-        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        const END_BLOCK_EXCLUSIVE: BlockIndex = 100;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
         let is_ready_to_serve_txouts = epoch_sharding_strategy.is_ready_to_serve_tx_outs(0.into());
@@ -183,12 +182,11 @@ mod epoch_sharding_strategy_tests {
     }
 
     #[test]
-    fn is_ready_to_serve_tx_outs_first_epoch_processed_block_count_is_zero_over_50_percent_processed_returns_true(
-    ) {
+    fn is_ready_to_serve_tx_outs_allows_70_in_0_to_100_shard() {
         // The first epoch has a start block == 0.
         const START_BLOCK: BlockIndex = 0;
-        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 100;
-        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        const END_BLOCK_EXCLUSIVE: BlockIndex = 100;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
         let is_ready_to_serve_txouts = epoch_sharding_strategy.is_ready_to_serve_tx_outs(70.into());
@@ -197,13 +195,12 @@ mod epoch_sharding_strategy_tests {
     }
 
     #[test]
-    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_less_than_50_percent_of_epoch_range_length_returns_false(
-    ) {
+    fn is_ready_to_serve_tx_outs_not_first_shard_prevents_less_than_minimum() {
         const START_BLOCK: BlockIndex = 100;
-        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
-        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
+        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
         let minimum_processed_block_count = epoch_block_range_length / 2;
-        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
         let is_ready_to_serve_txouts = epoch_sharding_strategy
@@ -213,13 +210,12 @@ mod epoch_sharding_strategy_tests {
     }
 
     #[test]
-    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_equals_50_percent_of_epoch_range_length_caught_up_returns_true(
-    ) {
+    fn is_ready_to_serve_tx_outs_not_first_shard_allows_minimum() {
         const START_BLOCK: BlockIndex = 100;
-        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
-        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
+        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
         let minimum_processed_block_count = epoch_block_range_length / 2;
-        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
         let is_ready_to_serve_txouts =
@@ -229,13 +225,12 @@ mod epoch_sharding_strategy_tests {
     }
 
     #[test]
-    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_greater_than_50_percent_of_epoch_range_length_caught_up_returns_true(
-    ) {
+    fn is_ready_to_serve_tx_outs_not_first_shard_allows_over_minimum() {
         const START_BLOCK: BlockIndex = 100;
-        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
-        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        const END_BLOCK_EXCLUSIVE: BlockIndex = 110;
+        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
         let minimum_processed_block_count = epoch_block_range_length / 2;
-        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
         let is_ready_to_serve_txouts = epoch_sharding_strategy

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -6,7 +6,7 @@
 //! TxOuts across Fog View Store instances.
 
 use mc_blockchain_types::BlockIndex;
-use mc_fog_types::common::BlockRange;
+use mc_fog_types::{common::BlockRange, BlockCount};
 use serde::Serialize;
 use std::str::FromStr;
 
@@ -14,6 +14,13 @@ use std::str::FromStr;
 pub trait ShardingStrategy {
     /// Returns true if the Fog View Store should process this block.
     fn should_process_block(&self, block_index: BlockIndex) -> bool;
+
+    /// Returns true if the Fog View Store is ready to serve TxOuts to the
+    /// client.
+    ///
+    /// Different sharding strategies might be ready to serve TxOuts when
+    /// different conditions have been met.
+    fn is_ready_to_serve_tx_outs(&self, processed_block_count: BlockCount) -> bool;
 }
 
 /// Determines whether or not to process a block's TxOuts based on the "epoch"
@@ -33,6 +40,10 @@ impl ShardingStrategy for EpochShardingStrategy {
     fn should_process_block(&self, block_index: BlockIndex) -> bool {
         self.epoch_block_range.contains(block_index)
     }
+
+    fn is_ready_to_serve_tx_outs(&self, processed_block_count: BlockCount) -> bool {
+        self.have_enough_blocks_been_processed(processed_block_count)
+    }
 }
 
 impl Default for EpochShardingStrategy {
@@ -47,6 +58,22 @@ impl EpochShardingStrategy {
     #[allow(dead_code)]
     pub fn new(epoch_block_range: BlockRange) -> Self {
         Self { epoch_block_range }
+    }
+
+    fn have_enough_blocks_been_processed(&self, processed_block_count: BlockCount) -> bool {
+        if self.is_first_epoch() {
+            return true;
+        }
+
+        let epoch_block_range_length =
+            self.epoch_block_range.end_block - self.epoch_block_range.start_block;
+        let minimum_processed_block_count = epoch_block_range_length / 2;
+
+        u64::from(processed_block_count) >= minimum_processed_block_count
+    }
+
+    fn is_first_epoch(&self) -> bool {
+        self.epoch_block_range.start_block == 0
     }
 }
 
@@ -139,5 +166,81 @@ mod epoch_sharding_strategy_tests {
             epoch_sharding_strategy.should_process_block(END_BLOCK_EXCLUSIVE + 1);
 
         assert!(!should_process_block)
+    }
+
+    #[test]
+    fn is_ready_to_serve_tx_outs_first_epoch_processed_block_count_is_zero_less_than_50_percent_processed_returns_true(
+    ) {
+        // The first epoch has a start block == 0.
+        const START_BLOCK: BlockIndex = 0;
+        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 100;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
+
+        let is_ready_to_serve_txouts = epoch_sharding_strategy.is_ready_to_serve_tx_outs(0.into());
+
+        assert!(is_ready_to_serve_txouts)
+    }
+
+    #[test]
+    fn is_ready_to_serve_tx_outs_first_epoch_processed_block_count_is_zero_over_50_percent_processed_returns_true(
+    ) {
+        // The first epoch has a start block == 0.
+        const START_BLOCK: BlockIndex = 0;
+        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 100;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
+
+        let is_ready_to_serve_txouts = epoch_sharding_strategy.is_ready_to_serve_tx_outs(70.into());
+
+        assert!(is_ready_to_serve_txouts)
+    }
+
+    #[test]
+    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_less_than_50_percent_of_epoch_range_length_returns_false(
+    ) {
+        const START_BLOCK: BlockIndex = 100;
+        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
+        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
+
+        let is_ready_to_serve_txouts = epoch_sharding_strategy
+            .is_ready_to_serve_tx_outs((minimum_processed_block_count - 1).into());
+
+        assert!(!is_ready_to_serve_txouts)
+    }
+
+    #[test]
+    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_equals_50_percent_of_epoch_range_length_caught_up_returns_true(
+    ) {
+        const START_BLOCK: BlockIndex = 100;
+        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
+        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
+
+        let is_ready_to_serve_txouts =
+            epoch_sharding_strategy.is_ready_to_serve_tx_outs(minimum_processed_block_count.into());
+
+        assert!(is_ready_to_serve_txouts)
+    }
+
+    #[test]
+    fn is_ready_to_serve_tx_outs_not_first_epoch_processed_block_count_greater_than_50_percent_of_epoch_range_length_caught_up_returns_true(
+    ) {
+        const START_BLOCK: BlockIndex = 100;
+        const END_BLOCK_NON_INCLUSIVE: BlockIndex = 110;
+        let epoch_block_range_length = END_BLOCK_NON_INCLUSIVE - START_BLOCK;
+        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_NON_INCLUSIVE);
+        let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
+
+        let is_ready_to_serve_txouts = epoch_sharding_strategy
+            .is_ready_to_serve_tx_outs((minimum_processed_block_count + 1).into());
+
+        assert!(is_ready_to_serve_txouts)
     }
 }


### PR DESCRIPTION
### Motivation

This PR implements  the "readiness" check for the `EpochShardingStrategy` (and also adds this functionality to the `ShardingStrategy` trait). This check is needed because a Fog View Store may not be ready to serve TxOuts given a certain sharding strategy. In the case of a  Fog View Store that employs the `EpochShardingStrategy, that store is not ready to serve TxOuts unless 50% of its TxOuts have been loaded. 