### PR TITLE
Propagate BlockVersion creation error up through the FFI, if a user t…

### DIFF
--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -179,13 +179,18 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3);
 
 /* ==== McTransactionBuilder ==== */
 
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
 McTransactionBuilder* MC_NULLABLE mc_transaction_builder_create(
   uint64_t fee,
   uint64_t token_id,
   uint64_t tombstone_block,
   const McFogResolver* MC_NULLABLE fog_resolver,
   McTxOutMemoBuilder* MC_NONNULL memo_builder,
-  uint32_t block_version
+  uint32_t block_version,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(5);
 

--- a/libmobilecoin/src/error.rs
+++ b/libmobilecoin/src/error.rs
@@ -10,7 +10,7 @@ use mc_crypto_keys::KeyError;
 use mc_crypto_noise::CipherError;
 use mc_fog_kex_rng::Error as FogKexRngError;
 use mc_fog_report_validation::{ingest_report::Error as IngestReportError, FogPubkeyError};
-use mc_transaction_core::AmountError;
+use mc_transaction_core::{AmountError, BlockVersionError};
 use mc_transaction_std::TxBuilderError;
 use mc_util_serial::DecodeError;
 use protobuf::ProtobufError;
@@ -120,6 +120,12 @@ impl From<KeyError> for LibMcError {
 
 impl From<ApiDisplayError> for LibMcError {
     fn from(err: ApiDisplayError) -> Self {
+        LibMcError::InvalidInput(format!("{:?}", err))
+    }
+}
+
+impl From<BlockVersionError> for LibMcError {
+    fn from(err: BlockVersionError) -> Self {
         LibMcError::InvalidInput(format!("{:?}", err))
     }
 }


### PR DESCRIPTION
Previously, an "invalid" (too new)  BlockVersion would cause a rust panic due to the `.unwrap()` call in `mc_transaction_builder_create`. The correct way to deal with invalid BlockVersions is too propagate the error up through the FFI in the form of an `LibMcError:InvalidInput`

### Motivation

@garbageslam pointed out that the conditions for this panic could become common in the future and should be fixed asap. 

### Future Work
* Merge change into master but probably after we finish cherry picking 1.2.x changes.
