### PR TITLE
libmobilecoin changes for MobileCoin-Swift SDK transaction idempotence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,8 @@ dependencies = [
  "mc-util-serial",
  "mc-util-uri",
  "protobuf",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "sha2 0.10.2",
  "slip10_ed25519",

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -21,6 +21,8 @@ sha2 = { version = "0.10", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "0.8"
 zeroize = "1.5"
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1" }
 
 # Lock a specific cmake version that plays nicely with iOS. Note that 0.1.45 does not actually do that,
 # but there is an override to a specific commit of a currently-unreleased version in the root Cargo.toml.

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+#ifndef MC_CHACHA20_RNG_H_
+#define MC_CHACHA20_RNG_H_
+
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _ChaCha20Rng ChaCha20Rng;
+
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_long(uint64_t value);
+
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_bytes(const McBuffer* MC_NONNULL bytes)
+MC_ATTRIBUTE_NONNULL(1);
+
+void mc_chacha20_rng_get_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL out_word_pos)
+MC_ATTRIBUTE_NONNULL(1,2);
+
+void mc_chacha20_set_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL bytes)
+MC_ATTRIBUTE_NONNULL(1,2);
+
+uint64_t mc_chacha20_rng_next_long(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+MC_ATTRIBUTE_NONNULL(1);
+
+void mc_chacha20_rng_free(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+MC_ATTRIBUTE_NONNULL(1);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MC_CHACHA20_RNG_H_ */

--- a/libmobilecoin/include/libmobilecoin.h
+++ b/libmobilecoin/include/libmobilecoin.h
@@ -12,5 +12,6 @@
 #include "transaction.h"
 #include "bip39.h"
 #include "slip10.h"
+#include "rng.h"
 
 #endif /* !LIBMOBILECOIN_H_ */

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,0 +1,102 @@
+use crate::common::*;
+use mc_util_ffi::*;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rand_core::RngCore;
+use std::sync::Mutex;
+use std::convert::TryInto;
+
+
+pub type McChaCha20Rng = ChaCha20Rng;
+
+pub struct McU128 {
+    pub bytes: [u8; 16]    
+}
+
+impl McU128 {
+    pub fn from_u128(val: u128) -> McU128 {
+        McU128 {
+            bytes: val.to_be_bytes(),
+        }
+    }
+
+    pub fn to_u128(&self) -> u128 {
+        u128::from_be_bytes(self.bytes)
+    }
+}
+
+impl IntoFfi<McU128> for McU128 {
+    #[inline]
+    fn error_value() -> McU128 {
+        McU128 {
+            bytes: [u8::MAX; 16],
+        }
+    }
+
+    #[inline]
+    fn into_ffi(self) -> McU128 {
+        self
+    }
+}
+
+impl_into_ffi!(FfiOwnedPtr<McU128>);
+impl_into_ffi!(Mutex<McChaCha20Rng>);
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_create_with_long(long_val: u64) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
+    ffi_boundary(|| {
+        Mutex::new(McChaCha20Rng::seed_from_u64(long_val))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_create_with_bytes(bytes: FfiRefPtr<McBuffer>) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
+    ffi_boundary(|| {
+        let bytes: [u8; 32] = bytes.as_slice().try_into().expect("seed size must be 32 bytes");
+        Mutex::new(McChaCha20Rng::from_seed(bytes))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_get_word_pos(
+    chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
+    out_word_pos: FfiMutPtr<McMutableBuffer>,
+) {
+    ffi_boundary(|| {
+        let word_pos = chacha20_rng.lock().unwrap().get_word_pos();
+        let mc_u128 = McU128::from_u128(word_pos);
+
+        let out_word_pos = out_word_pos
+            .into_mut()
+            .as_slice_mut_of_len(16)
+            .expect("word_pos length is not exaclty 16 bytes");
+
+        out_word_pos.copy_from_slice(&mc_u128.bytes);
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_set_word_pos(chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>, bytes: FfiRefPtr<McBuffer>) {
+    ffi_boundary(|| {
+        let mc_u128 = McU128 {
+            bytes: bytes.as_slice().try_into().expect("word_pos length is not exaclty 16 bytes")
+        };
+        let word_pos = mc_u128.to_u128();
+        chacha20_rng.lock().unwrap().set_word_pos(word_pos);
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_next_long(chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>) -> u64 {
+    ffi_boundary(|| {
+        let next = chacha20_rng.lock().unwrap().next_u64();
+        next
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_free(chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>) {
+    ffi_boundary(|| {
+        let _ = chacha20_rng;
+    })
+}

--- a/libmobilecoin/src/common/buffer.rs
+++ b/libmobilecoin/src/common/buffer.rs
@@ -178,6 +178,26 @@ impl AsMut<[u8]> for McMutableBuffer<'_> {
     }
 }
 
+impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 16] {
+    type Error = LibMcError;
+
+    #[inline]
+    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
+        let src = src.as_slice_of_len(16)?;
+        // SAFETY: ok to unwrap because we just checked length
+        Ok(<&[u8; 16]>::try_from(src).unwrap())
+    }
+}
+
+impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 16] {
+    type Error = LibMcError;
+
+    #[inline]
+    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
+        Ok(*<&'a [u8; 16]>::try_from_ffi(src)?)
+    }
+}
+
 impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 32] {
     type Error = LibMcError;
 

--- a/libmobilecoin/src/error.rs
+++ b/libmobilecoin/src/error.rs
@@ -14,7 +14,7 @@ use mc_transaction_core::AmountError;
 use mc_transaction_std::TxBuilderError;
 use mc_util_serial::DecodeError;
 use protobuf::ProtobufError;
-use std::os::raw::c_int;
+use std::{os::raw::c_int, sync::PoisonError};
 
 impl From<LibMcError> for McError {
     fn from(err: LibMcError) -> Self {
@@ -52,6 +52,15 @@ pub enum LibMcError {
 
     /// Fog pubkey error: {0},
     FogPubkey(String),
+
+    /// Poison
+    Poison,
+}
+
+impl<T> From<PoisonError<T>> for LibMcError {
+    fn from(_src: PoisonError<T>) -> Self {
+        Self::Poison
+    }
 }
 
 mod error_codes {
@@ -59,6 +68,7 @@ mod error_codes {
 
     pub const LIB_MC_ERROR_CODE_UNKNOWN: c_int = -1;
     pub const LIB_MC_ERROR_CODE_PANIC: c_int = -2;
+    pub const LIB_MC_ERROR_CODE_POISON: c_int = -3;
 
     pub const LIB_MC_ERROR_CODE_INVALID_INPUT: c_int = 100;
     pub const LIB_MC_ERROR_CODE_INVALID_OUTPUT: c_int = 101;
@@ -92,6 +102,7 @@ impl LibMcError {
             }
             LibMcError::TransactionCrypto(_) => LIB_MC_ERROR_CODE_TRANSACTION_CRYPTO,
             LibMcError::FogPubkey(_) => LIB_MC_ERROR_CODE_FOG_PUBKEY,
+            LibMcError::Poison => LIB_MC_ERROR_CODE_POISON,
         }
     }
 

--- a/libmobilecoin/src/lib.rs
+++ b/libmobilecoin/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bip39;
 pub mod crypto;
 pub mod encodings;
 pub mod fog;
+pub mod chacha20_rng;
 pub mod keys;
 pub mod slip10;
 pub mod transaction;

--- a/libmobilecoin/src/lib.rs
+++ b/libmobilecoin/src/lib.rs
@@ -5,10 +5,10 @@ pub mod common;
 
 pub mod attest;
 pub mod bip39;
+pub mod chacha20_rng;
 pub mod crypto;
 pub mod encodings;
 pub mod fog;
-pub mod chacha20_rng;
 pub mod keys;
 pub mod slip10;
 pub mod transaction;


### PR DESCRIPTION
NOTE: Worked off the release/v1.3 branch so that's where the PR is set up for, but can cherry-pick / merge in the changes to whatever branch we might need...lmk.

### Changes to libmobilecoin/

 * expose ChaCha20Rng for MobileCoin-Swift

### Motivation

To support re-trying transaction submission without violating idempotency, Moby (and other clients) need the ability to re-create identical transaction data via the `prepareTransaction` family of methods on MobileCoinClient.

### In this PR
* Added ability to provide a deterministic RNG to prepareTransaction methods, so the client can re-create the rng state prior to the call, if needed, in order to deterministically re-create identical transaction data.

Pivotal Tracker: [[iOS] Moby Transaction Idempotence](https://www.pivotaltracker.com/story/show/182820695)
