### PR TITLE
Return minimum highest processed block to client

### DIFF
--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -235,7 +235,7 @@ pub enum Error {
     EnclaveNotInitialized,
     /// Cipher encryption failed: {0}
     Cipher(CipherError),
-    /// Fog View Shard query response collation error
+    /// Fog View Shard query response collation error.
     QueryResponseCollation,
 }
 


### PR DESCRIPTION
### Motivation
Following @garbageslam's comments in #2351, we need to figure out a way to return the highest block count for which the Fog Router's returned TxOuts are valid. I.e. the client needs to be able to tie their balance to a certain block index.

To accomplish this, I (a) refactored the `blocks_processed` terminology to `blocks_observed` and  (b) we mark a block as observed whenever the db_fetcher sees a block (and doesn't necessarily process it, meaning adds its TxOuts to ORAM). This means that each shard will report that it saw a block even when it might be done processing.

This PR also modifies the enclave response collation code to return the minimum highest observed block index to the client. 

### Future Work
* We may consider adding a "is shard done processing it's blocks" method to the `ShardingStrategy` trait. We'd then only use a shard's highest observed block index if it is not done processing.