### PR TITLE
new hash-tx-file subcommand: computes and prints the hash of mint-tx and mint-config-tx files.

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -187,6 +187,15 @@ fn main() {
                 .expect("failed writing output file");
         }
 
+        Commands::HashTxFile { tx_file } => match tx_file {
+            TxFile::MintConfigTx(tx) => {
+                println!("{}", hex::encode(&tx.prefix.hash()));
+            }
+            TxFile::MintTx(tx) => {
+                println!("{}", hex::encode(&tx.prefix.hash()));
+            }
+        }
+
         Commands::HashMintTx { params } => {
             let tx_prefix = params
                 .try_into_mint_tx_prefix(|| panic!("missing tombstone block"))

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -259,6 +259,14 @@ pub enum Commands {
         params: MintConfigTxPrefixParams,
     },
 
+    /// Produce a hash of a MintConfigTx or MintTx tranasaction from a JSON tx-file.
+    /// This is useful for offline/HSM signing.
+    HashTxFile {
+        /// The file to load
+        #[clap(long, parse(try_from_str = load_tx_file_from_path), env = "MC_MINTING_TX_FILE")]
+        tx_file: TxFile,
+    },
+
     /// Submit json-encoded MintConfigTx(s). If multiple transactions are
     /// provided, signatures will be merged.
     SubmitMintConfigTx {


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

Currently if you want to generate a mint-tx or mint-config-tx file and add one or more signatures to the file using a hardware signing key, you need to call hash-mint-tx or hash-mint-tx-config giving it all of the same params as you used in the generate-mint-tx or generate-mint-config-tx subcommands.

This is redundant, burdensome and error prone. The new hash-tx-file subcommand will output the needed hash reading those parameters from the specified tx-file.

shout out to Adam Corbo (https://github.com/hamburgerguy) for the first draft of this PR.

[Soundtrack of this PR]()
