### PR TITLE
put mint auditor integration test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,7 @@ jobs:
           WORK_DIR="$PWD/target/release/mc-local-network"
           MINTING_KEYS="$WORK_DIR/minting-keys"
           export MC_CHAIN_ID="local"
-          export LEDGER_BASE="$PWD/ledger"
+          export LEDGER_BASE="/tmp/local-network/ledger"
 
           cd /tmp/local-network
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
           MINT_AUDITOR_TESTS="$PWD/mint-auditor/tests"
 
           # These paths are created by the local_network.py script
-          WORK_DIR="$PWD/target/mc-local-network"
+          WORK_DIR="$PWD/target/release/mc-local-network"
           MINTING_KEYS="$WORK_DIR/minting-keys"
           export MC_CHAIN_ID="local"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,11 +588,11 @@ jobs:
           # Run the integration test
           cd "$MINT_AUDITOR_TESTS" && bash compile_proto.sh
           cd "$MINT_AUDITOR_TESTS" && python3 integration_test.py \
-                        --mobilecoind-addr localhost:4444 \
-                        --mint-auditor-addr localhost:7774 \
-                        --mint-client-bin "$BIN_DIR/mc-consensus-mint-client" \
-                        --node-url insecure-mc://localhost:3200 \
-                        --mint-signing-key "$MINTING_KEYS/minter1"
+             --mobilecoind-addr localhost:4444 \
+             --mint-auditor-addr localhost:7774 \
+             --node-url insecure-mc://localhost:3200 \
+             --mint-client-bin "$BIN_DIR/mc-consensus-mint-client" \
+             --mint-signing-key "$MINTING_KEYS/minter1"
 
       - name: Upload core dumps
         uses: ./.github/actions/upload-core-dumps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,115 @@ jobs:
       - name: Check dirty git
         uses: ./.github/actions/check-dirty-git
 
+  mint-auditor-local-network-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.16
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3'
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Build and generate sample data
+        run: |
+          # Generate enclave signing key
+          openssl genrsa -out Enclave_private.pem -3 3072
+          export CONSENSUS_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export INGEST_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export LEDGER_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export VIEW_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export MC_LOG=debug
+
+          # Build binaries
+          cargo build \
+              -p mc-admin-http-gateway \
+              -p mc-consensus-mint-client \
+              -p mc-consensus-service \
+              -p mc-crypto-x509-test-vectors \
+              -p mc-fog-distribution \
+              -p mc-fog-ingest-client \
+              -p mc-fog-ingest-server \
+              -p mc-fog-ledger-server \
+              -p mc-fog-report-server \
+              -p mc-fog-sql-recovery-db \
+              -p mc-fog-test-client \
+              -p mc-fog-view-server \
+              -p mc-ledger-distribution \
+              -p mc-mobilecoind \
+              -p mc-mobilecoind-dev-faucet \
+              -p mc-util-generate-sample-ledger \
+              -p mc-util-grpc-admin-tool \
+              -p mc-util-keyfile \
+              -p mc-util-seeded-ed25519-key-gen \
+              --release
+
+          BIN_DIR="$PWD/target/release"
+
+          # Run in temp dir to appease check-dirty-git.
+          mkdir -p /tmp/local-network
+          cd /tmp/local-network
+
+          # Generate sample keys and ledger.
+          "$BIN_DIR/sample-keys" --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          "$BIN_DIR/generate-sample-ledger" --txs 100
+
+          service postgresql start
+      - name: Run local network
+        env:
+          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
+          # create and drop PG databases.
+          TEST_DATABASE_URL: postgres://localhost
+        run: |
+          BIN_DIR="$PWD/target/release"
+          SCRIPT_DIR="$PWD/tools/local-network"
+          MINT_AUDITOR_TESTS="$PWD/mint-auditor/tests"
+          WORK_DIR="$PWD/target/mc-local-network"
+          MINTING_KEYS="$WORK_DIR/minting-keys"
+          export MC_CHAIN_ID="local"
+
+          cd /tmp/local-network
+
+          # Run local network in background.
+          MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
+          LEDGER_BASE="$PWD/ledger" \
+          python3 "$SCRIPT_DIR/local_network.py" --network-type dense5 --skip-build &
+          # Give it time to spin up
+          sleep 20
+
+          # Start the mint-auditor in the background.
+          "$BIN_DIR/mc-mint-auditor" \
+            scan-ledger \
+            --ledger-db "$WORK_DIR/mobilecoind-ledger-db" \
+            --mint-auditor-db "$WORK_DIR/mint-auditor" \
+            --listen-uri insecure-mint-auditor://0.0.0.0:7774/
+
+          # Give it some time also
+          sleep 5
+
+          # Authorize minters
+          python3 "$SCRIPT_DIR/authorize-minters.py"
+
+          # Wait for mint-config-tx to clear
+          sleep 5
+
+          # Run the integration test
+          cd "$MINT_AUDITOR_TESTS" && bash compile_proto.sh
+          cd "$MINT_AUDITOR_TESTS" && python3 integration_test.py \
+                        --mobilecoind-addr localhost:4444 \
+                        --mint-auditor-addr localhost:7774 \
+                        --mint-client-bin "$BIN_DIR/mc-consensus-mint-client" \
+                        --node-url mc://localhost:3200 \
+                        --mint-signing-key "$MINTING_KEYS/minter1"
+
+      - name: Upload core dumps
+        uses: ./.github/actions/upload-core-dumps
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
   publish-test-results:
     runs-on: [self-hosted, Linux, small]
     if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,7 +549,7 @@ jobs:
           # Generate sample keys and ledger.
           "$BIN_DIR/sample-keys" --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           "$BIN_DIR/generate-sample-ledger" --txs 100
-      - name: Run local network and mint auditor
+      - name: Run local network and mint auditor tests
         run: |
           BIN_DIR="$PWD/target/release"
           SCRIPT_DIR="$PWD/tools/local-network"
@@ -574,7 +574,7 @@ jobs:
             scan-ledger \
             --ledger-db "$WORK_DIR/mobilecoind-ledger-db" \
             --mint-auditor-db "$WORK_DIR/mint-auditor" \
-            --listen-uri insecure-mint-auditor://0.0.0.0:7774/
+            --listen-uri insecure-mint-auditor://0.0.0.0:7774/ &
 
           # Give it some time also
           sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,17 +531,9 @@ jobs:
               -p mc-consensus-mint-client \
               -p mc-consensus-service \
               -p mc-crypto-x509-test-vectors \
-              -p mc-fog-distribution \
-              -p mc-fog-ingest-client \
-              -p mc-fog-ingest-server \
-              -p mc-fog-ledger-server \
-              -p mc-fog-report-server \
-              -p mc-fog-sql-recovery-db \
-              -p mc-fog-test-client \
-              -p mc-fog-view-server \
               -p mc-ledger-distribution \
+              -p mc-mint-auditor \
               -p mc-mobilecoind \
-              -p mc-mobilecoind-dev-faucet \
               -p mc-util-generate-sample-ledger \
               -p mc-util-grpc-admin-tool \
               -p mc-util-keyfile \
@@ -557,17 +549,13 @@ jobs:
           # Generate sample keys and ledger.
           "$BIN_DIR/sample-keys" --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           "$BIN_DIR/generate-sample-ledger" --txs 100
-
-          service postgresql start
-      - name: Run local network
-        env:
-          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
-          # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+      - name: Run local network and mint auditor
         run: |
           BIN_DIR="$PWD/target/release"
           SCRIPT_DIR="$PWD/tools/local-network"
           MINT_AUDITOR_TESTS="$PWD/mint-auditor/tests"
+
+          # These paths are created by the local_network.py script
           WORK_DIR="$PWD/target/mc-local-network"
           MINTING_KEYS="$WORK_DIR/minting-keys"
           export MC_CHAIN_ID="local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,12 +559,12 @@ jobs:
           WORK_DIR="$PWD/target/release/mc-local-network"
           MINTING_KEYS="$WORK_DIR/minting-keys"
           export MC_CHAIN_ID="local"
+          export LEDGER_BASE="$PWD/ledger"
 
           cd /tmp/local-network
 
           # Run local network in background.
-          MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
-          LEDGER_BASE="$PWD/ledger" \
+          MC_LOG="info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
           python3 "$SCRIPT_DIR/local_network.py" --network-type dense5 --skip-build &
           # Give it time to spin up
           sleep 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,7 +591,7 @@ jobs:
                         --mobilecoind-addr localhost:4444 \
                         --mint-auditor-addr localhost:7774 \
                         --mint-client-bin "$BIN_DIR/mc-consensus-mint-client" \
-                        --node-url mc://localhost:3200 \
+                        --node-url insecure-mc://localhost:3200 \
                         --mint-signing-key "$MINTING_KEYS/minter1"
 
       - name: Upload core dumps

--- a/mint-auditor/README.md
+++ b/mint-auditor/README.md
@@ -52,8 +52,8 @@ $ ./tools/local-network/authorize-minters.py
 ```
 $ ./target/docker/release/mc-mint-auditor \
       scan-ledger \
-      --ledger-db /target/docker/release/mc-local-network/mobilecoind-ledger-db \
-      --mint-auditor-db /target/docker/release/mc-local-network/auditor-db \
+      --ledger-db ./target/docker/release/mc-local-network/mobilecoind-ledger-db \
+      --mint-auditor-db ./target/docker/release/mc-local-network/auditor-db \
       --listen-uri insecure-mint-auditor://127.0.0.1:7334/ &
 ```
 

--- a/mint-auditor/README.md
+++ b/mint-auditor/README.md
@@ -14,8 +14,8 @@ To run the mint auditor we can use `cargo`:
 ```
     cargo run -p mc-mint-auditor -- \
         scan-ledger \
-        --ledger-db /target/release/mc-local-network/node-ledger-0 \
-        --mint-auditor-db /target/release/mc-local-network/auditor-db \
+        --ledger-db ./target/release/mc-local-network/node-ledger-0 \
+        --mint-auditor-db ./target/release/mc-local-network/auditor-db \
         --listen-uri insecure-mint-auditor://127.0.0.1:7334/
 ```
 

--- a/mint-auditor/tests/.gitignore
+++ b/mint-auditor/tests/.gitignore
@@ -1,0 +1,2 @@
+*_pb2.py
+*_pb2_grpc.py

--- a/mint-auditor/tests/compile_proto.sh
+++ b/mint-auditor/tests/compile_proto.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 SCRIPT_DIR=$(dirname "$0")
 cd $SCRIPT_DIR
@@ -16,4 +16,4 @@ pip3 install grpcio grpcio-tools
 python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/external.proto
 python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/blockchain.proto
 python3 -m grpc_tools.protoc -I$MCD_API -I$CONSENSUS_API -I$MC_API --python_out=. --grpc_python_out=. $MCD_API/mobilecoind_api.proto
-python3 -m grpc_tools.protoc -I$MINT_AUDITOR_API --python_out=. --grpc_python_out=. $MINT_AUDITOR_API/mint_auditor.proto
+python3 -m grpc_tools.protoc -I$MC_API -I$MINT_AUDITOR_API --python_out=. --grpc_python_out=. $MINT_AUDITOR_API/mint_auditor.proto

--- a/mint-auditor/tests/compile_proto.sh
+++ b/mint-auditor/tests/compile_proto.sh
@@ -15,5 +15,7 @@ pip3 install grpcio grpcio-tools
 
 python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/external.proto
 python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/blockchain.proto
+python3 -m grpc_tools.protoc -I$MC_API --python_out=. $MC_API/quorum_set.proto
+python3 -m grpc_tools.protoc -I$MC_API -I$CONSENSUS_API --python_out=. $CONSENSUS_API/consensus_common.proto
 python3 -m grpc_tools.protoc -I$MCD_API -I$CONSENSUS_API -I$MC_API --python_out=. --grpc_python_out=. $MCD_API/mobilecoind_api.proto
-python3 -m grpc_tools.protoc -I$MC_API -I$MINT_AUDITOR_API --python_out=. --grpc_python_out=. $MINT_AUDITOR_API/mint_auditor.proto
+python3 -m grpc_tools.protoc -I$MC_API -I$CONSENSUS_API -I$MINT_AUDITOR_API --python_out=. --grpc_python_out=. $MINT_AUDITOR_API/mint_auditor.proto

--- a/tools/local-network/authorize-minters.py
+++ b/tools/local-network/authorize-minters.py
@@ -16,11 +16,11 @@ import time
 from local_network import *
 
 # Generate minter 1 and minter 2 ed25519 keys in the minting keys dir, if they don't already exist
-if not os.path.exists(f'{MINTING_KEYS_DIR}/minter1'}):
+if not os.path.exists(f'{MINTING_KEYS_DIR}/minter1'):
     subprocess.check_output(f'openssl genpkey -algorithm ed25519 -out {MINTING_KEYS_DIR}/minter1', shell=True)
     subprocess.check_output(f'openssl pkey -pubout -in {MINTING_KEYS_DIR}/minter1 -out {MINTING_KEYS_DIR}/minter1.pub', shell=True)
 
-if not os.path.exists(f'{MINTING_KEYS_DIR}/minter2'}):
+if not os.path.exists(f'{MINTING_KEYS_DIR}/minter2'):
     subprocess.check_output(f'openssl genpkey -algorithm ed25519 -out {MINTING_KEYS_DIR}/minter2', shell=True)
     subprocess.check_output(f'openssl pkey -pubout -in {MINTING_KEYS_DIR}/minter2 -out {MINTING_KEYS_DIR}/minter2.pub', shell=True)
 

--- a/tools/local-network/authorize-minters.py
+++ b/tools/local-network/authorize-minters.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+
+# This script can be run after starting a local network in order to generate and
+# authorize minters.
+#
+# It must be kept in sync with the governor setup in local_network.py
+#
+# This is a way to prepare the network for running the mint auditor integration tests
+
+import argparse
+import os
+import subprocess
+import time
+
+from local_network import *
+
+# Generate minter 1 and minter 2 ed25519 keys in the minting keys dir, if they don't already exist
+if not os.path.exists(f'{MINTING_KEYS_DIR}/minter1'}):
+    subprocess.check_output(f'openssl genpkey -algorithm ed25519 -out {MINTING_KEYS_DIR}/minter1', shell=True)
+    subprocess.check_output(f'openssl pkey -pubout -in {MINTING_KEYS_DIR}/minter1 -out {MINTING_KEYS_DIR}/minter1.pub', shell=True)
+
+if not os.path.exists(f'{MINTING_KEYS_DIR}/minter2'}):
+    subprocess.check_output(f'openssl genpkey -algorithm ed25519 -out {MINTING_KEYS_DIR}/minter2', shell=True)
+    subprocess.check_output(f'openssl pkey -pubout -in {MINTING_KEYS_DIR}/minter2 -out {MINTING_KEYS_DIR}/minter2.pub', shell=True)
+
+# Submit a MintConfigTx that allows minter1.private to mint up to 1 billion token 1 tokens.
+subprocess.check_output(' '.join([
+    f'cd {PROJECT_DIR} && exec {TARGET_DIR}/mc-consensus-mint-client',
+    'generate-and-submit-mint-config-tx',
+    f'--node insecure-mc://localhost:{BASE_CLIENT_PORT}',
+    f'--signing-key {MINTING_KEYS_DIR}/governor1',
+    f'--token-id 1',
+    f'--config 1000000000:1:{MINTING_KEYS_DIR}/minter1.pub',
+    '--total-mint-limit 10000000000'
+]), shell=True)
+
+# Submit a MintConfigTx that allows minter2.private to mint up to 1 billion token 2 tokens.
+subprocess.check_output(' '.join([
+    f'cd {PROJECT_DIR} && exec {TARGET_DIR}/mc-consensus-mint-client',
+    'generate-and-submit-mint-config-tx',
+    f'--node insecure-mc://localhost:{BASE_CLIENT_PORT}',
+    f'--signing-key {MINTING_KEYS_DIR}/governor2',
+    f'--token-id 2',
+    f'--config 1000000000:1:{MINTING_KEYS_DIR}/minter2.pub',
+    '--total-mint-limit 10000000000'
+]), shell=True)
+


### PR DESCRIPTION
This is useful for two reasons:
* Exercise mint auditor test earlier in case we break it
* Serve as an example for how to get a local network with mints
  and burns in it. This is helpful for local testing of bridge stuff.

The work here is two parts:
* There are small differences between how jenkins sets up minting
  and how the local network script does.
* The local network script signs a tokens file because this is required
  to start the network, but it doesn't authorize any minters, because
  it doesn't do anything further once the network starts up.
* Jenkins both creates governors and then uses the governors to
  authorize minters.
* The mint auditor integration test requires that minters are ready
  to go.
* Therefore, we make a python script (which imports and takes constants
  from local-network.py) to authorize minters, which can be done
  after the network has started.
* Then we make a ci step that starts a local network, then calls the
  authorize minters script, then starts the mint auditor integration
  test.