### PR TITLE
Fix VerificationSignature Parsing Issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,7 @@ dependencies = [
 name = "mc-attest-verifier-types"
 version = "2.0.0"
 dependencies = [
+ "base64",
  "displaydoc",
  "hex",
  "hex_fmt",

--- a/attest/net/src/ias.rs
+++ b/attest/net/src/ias.rs
@@ -9,7 +9,7 @@ use mc_attest_core::{
     EpidGroupId, IasNonce, Quote, SigRL, VerificationReport, VerificationSignature,
 };
 use mc_common::logger::global_log;
-use mc_util_encodings::{FromBase64, FromHex, ToBase64};
+use mc_util_encodings::{FromBase64, ToBase64};
 use percent_encoding::percent_decode;
 use reqwest::{
     blocking::Client,

--- a/attest/net/src/ias.rs
+++ b/attest/net/src/ias.rs
@@ -102,7 +102,7 @@ impl RaClient for IasClient {
         let sig_str = headers
             .get(IAS_SIGNATURE)
             .ok_or(Error::MissingSignatureError)?;
-        let sig = VerificationSignature::from_hex(sig_str.to_str()?)?;
+        let sig = VerificationSignature::from_base64(sig_str.to_str()?)?;
 
         let pem_str = percent_decode(
             headers

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -9,6 +9,7 @@ description = "This crate contains the type definitions for attestation"
 mc-crypto-digestible = { path = "../../../crypto/digestible" }
 mc-util-encodings = { path = "../../../util/encodings" }
 
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 displaydoc = { version = "0.2", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 hex_fmt = "0.3"

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -6,7 +6,7 @@ use alloc::{string::String, vec::Vec};
 use core::fmt::{Debug, Display};
 use hex_fmt::{HexFmt, HexList};
 use mc_crypto_digestible::Digestible;
-use mc_util_encodings::{Error as EncodingError, FromHex};
+use mc_util_encodings::{Error as EncodingError, FromBase64, FromHex};
 use prost::{
     bytes::{Buf, BufMut},
     encoding::{self, DecodeContext, WireType},
@@ -101,6 +101,14 @@ impl FromHex for VerificationSignature {
     fn from_hex(s: &str) -> Result<Self, EncodingError> {
         // 2 hex chars per byte
         Ok(hex::decode(s)?.into())
+    }
+}
+
+impl FromBase64 for VerificationSignature {
+    type Error = EncodingError;
+
+    fn from_base64(s: &str) -> Result<Self, EncodingError> {
+        Ok(base64::decode(s)?.into())
     }
 }
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
 name = "mc-attest-verifier-types"
 version = "2.0.0"
 dependencies = [
+ "base64",
  "displaydoc",
  "hex",
  "hex_fmt",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
 name = "mc-attest-verifier-types"
 version = "2.0.0"
 dependencies = [
+ "base64",
  "displaydoc",
  "hex",
  "hex_fmt",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
 name = "mc-attest-verifier-types"
 version = "2.0.0"
 dependencies = [
+ "base64",
  "displaydoc",
  "hex",
  "hex_fmt",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
 name = "mc-attest-verifier-types"
 version = "2.0.0"
 dependencies = [
+ "base64",
  "displaydoc",
  "hex",
  "hex_fmt",


### PR DESCRIPTION
- Implement FromBase64 for VerificationSignature
- Use it in IasClient, not FromHex.

### Motivation

We need to be able to parse responses from IAS.

