### PR TITLE
libmobilecoin changes for MobileCoin-Swift SDK transaction idempotence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,8 @@ dependencies = [
  "mc-util-serial",
  "mc-util-uri",
  "protobuf",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "sha2 0.10.2",
  "slip10_ed25519",

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -16,12 +16,12 @@ displaydoc = "0.2"
 generic-array = { version = "0.14", features = ["serde", "more_lengths"] }
 libc = "0.2"
 protobuf = "2.27.1"
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1" }
 rand_core = { version = "0.6", features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "1.0"
-rand = { version = "0.8", default-features = false }
-rand_chacha = { version = "0.3.1" }
 zeroize = "1.5"
 
 # Lock a specific cmake version that plays nicely with iOS. Note that 0.1.45 does not actually do that,

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -21,6 +21,8 @@ sha2 = { version = "0.10", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "1.0"
 zeroize = "1.5"
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1" }
 
 # Lock a specific cmake version that plays nicely with iOS. Note that 0.1.45 does not actually do that,
 # but there is an override to a specific commit of a currently-unreleased version in the root Cargo.toml.

--- a/libmobilecoin/Cargo.toml
+++ b/libmobilecoin/Cargo.toml
@@ -20,9 +20,9 @@ rand_core = { version = "0.6", features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 slip10_ed25519 = "0.1.3"
 tiny-bip39 = "1.0"
-zeroize = "1.5"
 rand = { version = "0.8", default-features = false }
 rand_chacha = { version = "0.3.1" }
+zeroize = "1.5"
 
 # Lock a specific cmake version that plays nicely with iOS. Note that 0.1.45 does not actually do that,
 # but there is an override to a specific commit of a currently-unreleased version in the root Cargo.toml.

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -50,7 +50,7 @@ MC_ATTRIBUTE_NONNULL(1);
 /// # Arguments
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
-/// * `out_word_pos` - pointer to buffer of 128 bytes where the current
+/// * `out_word_pos` - pointer to buffer of 16 bytes where the current
 ///   chacha20_rng wordpos will be returned
 ///
 /// # Errors

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -54,7 +54,7 @@ MC_ATTRIBUTE_NONNULL(1);
 /// # Errors
 ///
 /// * `LibMcError::Poison`
-void mc_chacha20_rng_get_word_pos(
+bool mc_chacha20_rng_get_word_pos(
     ChaCha20Rng* MC_NULLABLE chacha20_rng,
     const McBuffer* MC_NONNULL out_word_pos,
     McError* MC_NULLABLE * MC_NULLABLE out_error
@@ -72,7 +72,7 @@ MC_ATTRIBUTE_NONNULL(1,2);
 /// # Errors
 ///
 /// * `LibMcError::Poison`
-void mc_chacha20_set_word_pos(
+bool mc_chacha20_rng_set_word_pos(
     ChaCha20Rng* MC_NULLABLE chacha20_rng,
     const McBuffer* MC_NONNULL bytes,
     McError* MC_NULLABLE * MC_NULLABLE out_error
@@ -94,7 +94,7 @@ uint64_t mc_chacha20_rng_next_long(
 )
 MC_ATTRIBUTE_NONNULL(1);
 
-/// frees the ChaCha20Rng
+/// Frees the ChaCha20Rng
 ///
 /// # Preconditions
 /// 
@@ -105,7 +105,10 @@ MC_ATTRIBUTE_NONNULL(1);
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
-void mc_chacha20_rng_free(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+bool mc_chacha20_rng_free(
+    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+)
 MC_ATTRIBUTE_NONNULL(1);
 
 #ifdef __cplusplus

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -105,11 +105,8 @@ MC_ATTRIBUTE_NONNULL(1);
 /// # Arguments
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
-///
-/// * `chacha20_rng` - must be a valid ChaCha20Rng
 bool mc_chacha20_rng_free(
-    ChaCha20Rng* MC_NONNULL chacha20_rng,
-    McError* MC_NULLABLE * MC_NULLABLE out_error
+    ChaCha20Rng* MC_NONNULL chacha20_rng
 )
 MC_ATTRIBUTE_NONNULL(1);
 

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -11,18 +11,35 @@ extern "C" {
 
 typedef struct _ChaCha20Rng ChaCha20Rng;
 
-ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_long(uint64_t value);
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_long(
+    uint64_t value,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+);
 
-ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_bytes(const McBuffer* MC_NONNULL bytes)
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_bytes(
+    const McBuffer* MC_NONNULL bytes,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+)
 MC_ATTRIBUTE_NONNULL(1);
 
-void mc_chacha20_rng_get_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL out_word_pos)
+void mc_chacha20_rng_get_word_pos(
+    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    const McBuffer* MC_NONNULL out_word_pos,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+)
 MC_ATTRIBUTE_NONNULL(1,2);
 
-void mc_chacha20_set_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL bytes)
+void mc_chacha20_set_word_pos(
+    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    const McBuffer* MC_NONNULL bytes,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+)
 MC_ATTRIBUTE_NONNULL(1,2);
 
-uint64_t mc_chacha20_rng_next_long(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+uint64_t mc_chacha20_rng_next_long(
+    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    McError* MC_NULLABLE * MC_NULLABLE out_error
+)
 MC_ATTRIBUTE_NONNULL(1);
 
 void mc_chacha20_rng_free(ChaCha20Rng* MC_NULLABLE chacha20_rng)

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+#ifndef MC_CHACHA20_RNG_H_
+#define MC_CHACHA20_RNG_H_
+
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _ChaCha20Rng ChaCha20Rng;
+
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_long(uint64_t value);
+
+ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_bytes(const McBuffer* MC_NONNULL bytes)
+MC_ATTRIBUTE_NONNULL(1);
+
+void mc_chacha20_rng_get_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL out_word_pos)
+MC_ATTRIBUTE_NONNULL(1,2);
+
+void mc_chacha20_set_word_pos(ChaCha20Rng* MC_NULLABLE chacha20_rng, const McBuffer* MC_NONNULL bytes)
+MC_ATTRIBUTE_NONNULL(1,2);
+
+uint64_t mc_chacha20_rng_next_long(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+MC_ATTRIBUTE_NONNULL(1);
+
+void mc_chacha20_rng_free(ChaCha20Rng* MC_NULLABLE chacha20_rng)
+MC_ATTRIBUTE_NONNULL(1);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MC_CHACHA20_RNG_H_ */

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -11,17 +11,49 @@ extern "C" {
 
 typedef struct _ChaCha20Rng ChaCha20Rng;
 
+/// Returns a new ChaCha20Rng instance initialized with the
+/// seed value provided by the u64 long_val parameter
+///
+/// # Arguments
+///
+/// * `long_val` - an unsigned 64 bit value to use as the rng seed
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_long(
     uint64_t value,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 );
 
+/// Returns a new ChaCha20Rng instance initialized with the
+/// seed value provided by the bytes data, which must be at
+/// least 32 bytes (only the first 32 bytes will be used)
+///
+/// # Arguments
+///
+/// * `bytes` - 32 bytes of data to use as the rng seed
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 ChaCha20Rng* MC_NULLABLE mc_chacha20_rng_create_with_bytes(
     const McBuffer* MC_NONNULL bytes,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1);
 
+/// Returns the current word_pos of the ChaCha20Rng instance
+///
+/// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+/// * `out_word_pos` - pointer to buffer of 128 bytes where the current
+///   chacha20_rng wordpos will be returned
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 void mc_chacha20_rng_get_word_pos(
     ChaCha20Rng* MC_NULLABLE chacha20_rng,
     const McBuffer* MC_NONNULL out_word_pos,
@@ -29,6 +61,17 @@ void mc_chacha20_rng_get_word_pos(
 )
 MC_ATTRIBUTE_NONNULL(1,2);
 
+/// Sets the current word_pos of the ChaCha20Rng instance
+///
+/// /// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+/// * `out_word_pos` - pointer to buffer of 128 bytes where the current
+///   chacha20_rng wordpos will be returned
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 void mc_chacha20_set_word_pos(
     ChaCha20Rng* MC_NULLABLE chacha20_rng,
     const McBuffer* MC_NONNULL bytes,
@@ -36,12 +79,32 @@ void mc_chacha20_set_word_pos(
 )
 MC_ATTRIBUTE_NONNULL(1,2);
 
+/// Returns the next random u64 value from the ChaCha20Rng
+///
+/// /// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 uint64_t mc_chacha20_rng_next_long(
     ChaCha20Rng* MC_NULLABLE chacha20_rng,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1);
 
+/// frees the ChaCha20Rng
+///
+/// # Preconditions
+/// 
+/// * The ChaCha20Rng is no longer in use
+/// 
+/// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
 void mc_chacha20_rng_free(ChaCha20Rng* MC_NULLABLE chacha20_rng)
 MC_ATTRIBUTE_NONNULL(1);
 

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -106,9 +106,8 @@ MC_ATTRIBUTE_NONNULL(1);
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 bool mc_chacha20_rng_free(
-    ChaCha20Rng* MC_NONNULL chacha20_rng
-)
-MC_ATTRIBUTE_NONNULL(1);
+    ChaCha20Rng* MC_NULLABLE chacha20_rng
+);
 
 #ifdef __cplusplus
 }

--- a/libmobilecoin/include/chacha20_rng.h
+++ b/libmobilecoin/include/chacha20_rng.h
@@ -5,6 +5,8 @@
 
 #include "common.h"
 
+/* ==================== ChaCha20Rng ==================== */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -55,7 +57,7 @@ MC_ATTRIBUTE_NONNULL(1);
 ///
 /// * `LibMcError::Poison`
 bool mc_chacha20_rng_get_word_pos(
-    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    ChaCha20Rng* MC_NONNULL chacha20_rng,
     const McBuffer* MC_NONNULL out_word_pos,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
@@ -73,7 +75,7 @@ MC_ATTRIBUTE_NONNULL(1,2);
 ///
 /// * `LibMcError::Poison`
 bool mc_chacha20_rng_set_word_pos(
-    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    ChaCha20Rng* MC_NONNULL chacha20_rng,
     const McBuffer* MC_NONNULL bytes,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
@@ -89,7 +91,7 @@ MC_ATTRIBUTE_NONNULL(1,2);
 ///
 /// * `LibMcError::Poison`
 uint64_t mc_chacha20_rng_next_long(
-    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    ChaCha20Rng* MC_NONNULL chacha20_rng,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1);
@@ -106,7 +108,7 @@ MC_ATTRIBUTE_NONNULL(1);
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 bool mc_chacha20_rng_free(
-    ChaCha20Rng* MC_NULLABLE chacha20_rng,
+    ChaCha20Rng* MC_NONNULL chacha20_rng,
     McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(1);

--- a/libmobilecoin/include/libmobilecoin.h
+++ b/libmobilecoin/include/libmobilecoin.h
@@ -12,6 +12,6 @@
 #include "transaction.h"
 #include "bip39.h"
 #include "slip10.h"
-#include "rng.h"
+#include "chacha20_rng.h"
 
 #endif /* !LIBMOBILECOIN_H_ */

--- a/libmobilecoin/include/libmobilecoin.h
+++ b/libmobilecoin/include/libmobilecoin.h
@@ -12,5 +12,6 @@
 #include "transaction.h"
 #include "bip39.h"
 #include "slip10.h"
+#include "rng.h"
 
 #endif /* !LIBMOBILECOIN_H_ */

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -422,7 +422,7 @@ FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_bytes(FfiRefPtr
  * # Arguments
  *
  * * `chacha20_rng` - must be a valid ChaCha20Rng
- * * `out_word_pos` - pointer to buffer of 128 bytes where the current
+ * * `out_word_pos` - pointer to buffer of 16 bytes where the current
  *   chacha20_rng wordpos will be returned
  *
  * # Errors
@@ -472,8 +472,6 @@ uint64_t mc_chacha20_rng_next_long(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
  * * The ChaCha20Rng is no longer in use
  *
  * # Arguments
- *
- * * `chacha20_rng` - must be a valid ChaCha20Rng
  *
  * * `chacha20_rng` - must be a valid ChaCha20Rng
  */
@@ -836,11 +834,18 @@ bool mc_transaction_builder_ring_add_element(FfiMutPtr<McTransactionBuilderRing>
                                              FfiRefPtr<McBuffer> tx_out_proto_bytes,
                                              FfiRefPtr<McBuffer> membership_proof_proto_bytes);
 
+/**
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput`
+ */
 FfiOptOwnedPtr<McTransactionBuilder> mc_transaction_builder_create(uint64_t fee,
                                                                    uint64_t tombstone_block,
                                                                    FfiOptRefPtr<McFogResolver> fog_resolver,
                                                                    FfiMutPtr<McTxOutMemoBuilder> memo_builder,
-                                                                   uint32_t block_version);
+                                                                   uint32_t block_version,
+                                                                   FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 void mc_transaction_builder_free(FfiOptOwnedPtr<McTransactionBuilder> transaction_builder);
 

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -10,6 +10,8 @@
 
 #define LIB_MC_ERROR_CODE_PANIC -2
 
+#define LIB_MC_ERROR_CODE_POISON -3
+
 #define LIB_MC_ERROR_CODE_INVALID_INPUT 100
 
 #define LIB_MC_ERROR_CODE_INVALID_OUTPUT 101
@@ -97,6 +99,8 @@ typedef struct McRngCallback {
   FfiCallbackRng rng;
   FfiOptMutPtr<void> context;
 } McRngCallback;
+
+typedef ChaCha20Rng McChaCha20Rng;
 
 typedef FullyValidatedFogPubkey McFullyValidatedFogPubkey;
 
@@ -380,6 +384,100 @@ ssize_t mc_bip39_entropy_from_mnemonic(FfiStr mnemonic,
  * * `prefix` - must be a nul-terminated C string containing valid UTF-8.
  */
 FfiOptOwnedStr mc_bip39_words_by_prefix(FfiStr prefix);
+
+/**
+ * Returns a new ChaCha20Rng instance initialized with the
+ * seed value provided by the u64 long_val parameter
+ *
+ * # Arguments
+ *
+ * * `long_val` - an unsigned 64 bit value to use as the rng seed
+ *
+ * # Errors
+ *
+ * * `LibMcError::Poison`
+ */
+FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_long(uint64_t long_val,
+                                                                      FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * Returns a new ChaCha20Rng instance initialized with the
+ * seed value provided by the bytes data, which must be at
+ * least 32 bytes (only the first 32 bytes will be used)
+ *
+ * # Arguments
+ *
+ * * `bytes` - 32 bytes of data to use as the rng seed
+ *
+ * # Errors
+ *
+ * * `LibMcError::Poison`
+ */
+FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_bytes(FfiRefPtr<McBuffer> bytes,
+                                                                       FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * Returns the current word_pos of the ChaCha20Rng instance
+ *
+ * # Arguments
+ *
+ * * `chacha20_rng` - must be a valid ChaCha20Rng
+ * * `out_word_pos` - pointer to buffer of 128 bytes where the current
+ *   chacha20_rng wordpos will be returned
+ *
+ * # Errors
+ *
+ * * `LibMcError::Poison`
+ */
+void mc_chacha20_get_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                              FfiMutPtr<McMutableBuffer> out_word_pos,
+                              FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * Sets the current word_pos of the ChaCha20Rng instance
+ *
+ * /// # Arguments
+ *
+ * * `chacha20_rng` - must be a valid ChaCha20Rng
+ * * `out_word_pos` - pointer to buffer of 128 bytes where the current
+ *   chacha20_rng wordpos will be returned
+ *
+ * # Errors
+ *
+ * * `LibMcError::Poison`
+ */
+void mc_chacha20_set_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                              FfiRefPtr<McBuffer> bytes,
+                              FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * Returns the next random u64 value from the ChaCha20Rng
+ *
+ * /// # Arguments
+ *
+ * * `chacha20_rng` - must be a valid ChaCha20Rng
+ *
+ * # Errors
+ *
+ * * `LibMcError::Poison`
+ */
+uint64_t mc_chacha20_rng_next_long(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                                   FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+
+/**
+ * frees the ChaCha20Rng
+ *
+ * # Preconditions
+ *
+ * * The ChaCha20Rng is no longer in use
+ *
+ * # Arguments
+ *
+ * * `chacha20_rng` - must be a valid ChaCha20Rng
+ *
+ * * `chacha20_rng` - must be a valid ChaCha20Rng
+ */
+void mc_chacha20_rng_free(FfiOptOwnedPtr<Mutex<McChaCha20Rng>> chacha20_rng);
 
 bool mc_ristretto_private_validate(FfiRefPtr<McBuffer> ristretto_private,
                                    FfiMutPtr<bool> out_valid);

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -476,8 +476,7 @@ uint64_t mc_chacha20_rng_next_long(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
  *
  * * `chacha20_rng` - must be a valid ChaCha20Rng
  */
-bool mc_chacha20_rng_free(FfiOptOwnedPtr<Mutex<McChaCha20Rng>> chacha20_rng,
-                          FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+void mc_chacha20_rng_free(FfiOptOwnedPtr<Mutex<McChaCha20Rng>> chacha20_rng);
 
 bool mc_ristretto_private_validate(FfiRefPtr<McBuffer> ristretto_private,
                                    FfiMutPtr<bool> out_valid);

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -429,9 +429,9 @@ FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_bytes(FfiRefPtr
  *
  * * `LibMcError::Poison`
  */
-void mc_chacha20_get_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
-                              FfiMutPtr<McMutableBuffer> out_word_pos,
-                              FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_chacha20_rng_get_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                                  FfiMutPtr<McMutableBuffer> out_word_pos,
+                                  FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * Sets the current word_pos of the ChaCha20Rng instance
@@ -446,9 +446,9 @@ void mc_chacha20_get_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
  *
  * * `LibMcError::Poison`
  */
-void mc_chacha20_set_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
-                              FfiRefPtr<McBuffer> bytes,
-                              FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+bool mc_chacha20_rng_set_word_pos(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                                  FfiRefPtr<McBuffer> bytes,
+                                  FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 /**
  * Returns the next random u64 value from the ChaCha20Rng
@@ -477,7 +477,8 @@ uint64_t mc_chacha20_rng_next_long(FfiMutPtr<Mutex<McChaCha20Rng>> chacha20_rng,
  *
  * * `chacha20_rng` - must be a valid ChaCha20Rng
  */
-void mc_chacha20_rng_free(FfiOptOwnedPtr<Mutex<McChaCha20Rng>> chacha20_rng);
+bool mc_chacha20_rng_free(FfiOptOwnedPtr<Mutex<McChaCha20Rng>> chacha20_rng,
+                          FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 bool mc_ristretto_private_validate(FfiRefPtr<McBuffer> ristretto_private,
                                    FfiMutPtr<bool> out_valid);

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -411,6 +411,7 @@ FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_long(uint64_t l
  *
  * # Errors
  *
+ * * `LibMcError::InvalidInput`
  * * `LibMcError::Poison`
  */
 FfiOptOwnedPtr<Mutex<McChaCha20Rng>> mc_chacha20_rng_create_with_bytes(FfiRefPtr<McBuffer> bytes,
@@ -834,18 +835,11 @@ bool mc_transaction_builder_ring_add_element(FfiMutPtr<McTransactionBuilderRing>
                                              FfiRefPtr<McBuffer> tx_out_proto_bytes,
                                              FfiRefPtr<McBuffer> membership_proof_proto_bytes);
 
-/**
- *
- * # Errors
- *
- * * `LibMcError::InvalidInput`
- */
 FfiOptOwnedPtr<McTransactionBuilder> mc_transaction_builder_create(uint64_t fee,
                                                                    uint64_t tombstone_block,
                                                                    FfiOptRefPtr<McFogResolver> fog_resolver,
                                                                    FfiMutPtr<McTxOutMemoBuilder> memo_builder,
-                                                                   uint32_t block_version,
-                                                                   FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
+                                                                   uint32_t block_version);
 
 void mc_transaction_builder_free(FfiOptOwnedPtr<McTransactionBuilder> transaction_builder);
 

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -168,9 +168,9 @@ pub extern "C" fn mc_chacha20_rng_next_long(
 /// frees the ChaCha20Rng
 ///
 /// # Preconditions
-/// 
+///
 /// * The ChaCha20Rng is no longer in use
-/// 
+///
 /// # Arguments
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,4 +1,4 @@
-use crate::common::*;
+use crate::{common::*, LibMcError};
 use mc_util_ffi::*;
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
@@ -38,6 +38,7 @@ pub extern "C" fn mc_chacha20_rng_create_with_long(
 ///
 /// # Errors
 ///
+/// * `LibMcError::InvalidInput`
 /// * `LibMcError::Poison`
 #[no_mangle]
 pub extern "C" fn mc_chacha20_rng_create_with_bytes(
@@ -45,10 +46,14 @@ pub extern "C" fn mc_chacha20_rng_create_with_bytes(
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
     ffi_boundary_with_error(out_error, || {
+        if bytes.len() != 32 {
+            return Err(LibMcError::InvalidInput("seed bytes length must be exactly 32 bytes".to_owned()));
+        }
+
         let bytes: [u8; 32] = bytes
-            .as_slice()
+            .as_slice_of_len(32)?
             .try_into()
-            .expect("seed size must be 32 bytes");
+            .expect("seed bytes length must be exactly 32 bytes");
         Ok(Mutex::new(McChaCha20Rng::from_seed(bytes)))
     })
 }
@@ -96,12 +101,14 @@ pub extern "C" fn mc_chacha20_rng_set_word_pos(
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
-        chacha20_rng.lock()?.set_word_pos(u128::from_be_bytes(
-            bytes
-                .as_slice()
-                .try_into()
-                .expect("word_pos length is not exaclty 16 bytes"),
-        ));
+        if bytes.len() != 16 {
+            return Err(LibMcError::InvalidInput("bytes length must be exactly 16 bytes for word_pos".to_owned()));
+        }
+        let bytes: [u8; 16] = bytes
+            .as_slice_of_len(16)?
+            .try_into()
+            .expect("bytes length must be exactly 16 bytes for word_pos");
+        chacha20_rng.lock()?.set_word_pos(u128::from_be_bytes(bytes));
         Ok(())
     })
 }

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,0 +1,102 @@
+use crate::common::*;
+use mc_util_ffi::*;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+use rand_core::RngCore;
+use std::sync::Mutex;
+use std::convert::TryInto;
+
+
+pub type McChaCha20Rng = ChaCha20Rng;
+
+pub struct McU128 {
+    pub bytes: [u8; 16]    
+}
+
+impl McU128 {
+    pub fn from_u128(val: u128) -> McU128 {
+        McU128 {
+            bytes: val.to_be_bytes(),
+        }
+    }
+
+    pub fn to_u128(&self) -> u128 {
+        u128::from_be_bytes(self.bytes)
+    }
+}
+
+impl IntoFfi<McU128> for McU128 {
+    #[inline]
+    fn error_value() -> McU128 {
+        McU128 {
+            bytes: [u8::MAX; 16],
+        }
+    }
+
+    #[inline]
+    fn into_ffi(self) -> McU128 {
+        self
+    }
+}
+
+impl_into_ffi!(FfiOwnedPtr<McU128>);
+impl_into_ffi!(Mutex<McChaCha20Rng>);
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_create_with_long(long_val: u64) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
+    ffi_boundary(|| {
+        Mutex::new(McChaCha20Rng::seed_from_u64(long_val))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_create_with_bytes(bytes: FfiRefPtr<McBuffer>) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
+    ffi_boundary(|| {
+        let bytes: [u8; 32] = bytes.as_slice().try_into().expect("seed size must be 32 bytes");
+        Mutex::new(McChaCha20Rng::from_seed(bytes))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_get_word_pos(
+    chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
+    out_word_pos: FfiMutPtr<McMutableBuffer>,
+) {
+    ffi_boundary(|| {
+        let word_pos = chacha20_rng.lock().unwrap().get_word_pos();
+        let mc_u128 = McU128::from_u128(word_pos);
+
+        let out_word_pos = out_word_pos
+            .into_mut()
+            .as_slice_mut_of_len(16)
+            .expect("word_pos length is not exaclty 16 bytes");
+
+        out_word_pos.copy_from_slice(&mc_u128.bytes);
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_set_word_pos(chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>, bytes: FfiRefPtr<McBuffer>) {
+    ffi_boundary(|| {
+        let mc_u128 = McU128 {
+            bytes: bytes.as_slice().try_into().expect("word_pos length is not exaclty 16 bytes")
+        };
+        let word_pos = mc_u128.to_u128();
+        chacha20_rng.lock().unwrap().set_word_pos(word_pos);
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_next_long(chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>) -> u64 {
+    ffi_boundary(|| {
+        let next = chacha20_rng.lock().unwrap().next_u64();
+        next
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn mc_chacha20_rng_free(chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>) {
+    ffi_boundary(|| {
+        let _ = chacha20_rng;
+    })
+}

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,5 +1,7 @@
-use crate::common::{ffi_boundary_with_error, McBuffer, McError, McMutableBuffer};
-use crate::LibMcError;
+use crate::{
+    common::{ffi_boundary_with_error, McBuffer, McError, McMutableBuffer},
+    LibMcError,
+};
 use mc_util_ffi::{FfiMutPtr, FfiOptMutPtr, FfiOptOwnedPtr, FfiRefPtr};
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
@@ -47,10 +49,9 @@ pub extern "C" fn mc_chacha20_rng_create_with_bytes(
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
     ffi_boundary_with_error(out_error, || {
-        let bytes: [u8; 32] = bytes
-            .as_slice_of_len(32)?
-            .try_into()
-            .map_err(|_| LibMcError::InvalidInput("seed bytes length must be exactly 32 bytes".to_owned()))?;
+        let bytes: [u8; 32] = bytes.as_slice_of_len(32)?.try_into().map_err(|_| {
+            LibMcError::InvalidInput("seed bytes length must be exactly 32 bytes".to_owned())
+        })?;
         Ok(Mutex::new(McChaCha20Rng::from_seed(bytes)))
     })
 }
@@ -98,11 +99,14 @@ pub extern "C" fn mc_chacha20_rng_set_word_pos(
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> bool {
     ffi_boundary_with_error(out_error, || {
-        let bytes: [u8; 16] = bytes
-            .as_slice_of_len(16)?
-            .try_into()
-            .map_err(|_| LibMcError::InvalidInput("bytes length must be exactly 16 bytes for word_pos".to_owned()))?;
-        chacha20_rng.lock()?.set_word_pos(u128::from_be_bytes(bytes));
+        let bytes: [u8; 16] = bytes.as_slice_of_len(16)?.try_into().map_err(|_| {
+            LibMcError::InvalidInput(
+                "bytes length must be exactly 16 bytes for word_pos".to_owned(),
+            )
+        })?;
+        chacha20_rng
+            .lock()?
+            .set_word_pos(u128::from_be_bytes(bytes));
         Ok(())
     })
 }

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -6,38 +6,6 @@ use std::{convert::TryInto, sync::Mutex};
 
 pub type McChaCha20Rng = ChaCha20Rng;
 
-// McU128 facilitates conversion between u128 and 16 bytes of u8
-pub struct McU128 {
-    pub bytes: [u8; 16],
-}
-
-impl McU128 {
-    pub fn from_u128(val: u128) -> McU128 {
-        McU128 {
-            bytes: val.to_be_bytes(),
-        }
-    }
-
-    pub fn to_u128(&self) -> u128 {
-        u128::from_be_bytes(self.bytes)
-    }
-}
-
-impl IntoFfi<McU128> for McU128 {
-    #[inline]
-    fn error_value() -> McU128 {
-        McU128 {
-            bytes: [u8::MAX; 16],
-        }
-    }
-
-    #[inline]
-    fn into_ffi(self) -> McU128 {
-        self
-    }
-}
-
-impl_into_ffi!(FfiOwnedPtr<McU128>);
 impl_into_ffi!(Mutex<McChaCha20Rng>);
 
 /// Returns a new ChaCha20Rng instance initialized with the

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -138,9 +138,7 @@ pub extern "C" fn mc_chacha20_rng_next_long(
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 #[no_mangle]
-pub extern "C" fn mc_chacha20_rng_free(
-    chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>
-) {
+pub extern "C" fn mc_chacha20_rng_free(chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>) {
     ffi_boundary(|| {
         let _ = chacha20_rng;
     })

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
 use crate::common::*;
 use mc_util_ffi::*;
 use rand_chacha::ChaCha20Rng;
@@ -6,6 +8,7 @@ use std::{convert::TryInto, sync::Mutex};
 
 pub type McChaCha20Rng = ChaCha20Rng;
 
+// McU128 facilitates conversion between u128 and 16 bytes of u8
 pub struct McU128 {
     pub bytes: [u8; 16],
 }
@@ -39,26 +42,62 @@ impl IntoFfi<McU128> for McU128 {
 impl_into_ffi!(FfiOwnedPtr<McU128>);
 impl_into_ffi!(Mutex<McChaCha20Rng>);
 
+/// Returns a new ChaCha20Rng instance initialized with the
+/// seed value provided by the u64 long_val parameter
+///
+/// # Arguments
+///
+/// * `long_val` - an unsigned 64 bit value to use as the rng seed
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 #[no_mangle]
 pub extern "C" fn mc_chacha20_rng_create_with_long(
     long_val: u64,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
-    ffi_boundary(|| Mutex::new(McChaCha20Rng::seed_from_u64(long_val)))
+    ffi_boundary_with_error(out_error, || {
+        Ok(Mutex::new(McChaCha20Rng::seed_from_u64(long_val)))
+    })
 }
 
+/// Returns a new ChaCha20Rng instance initialized with the
+/// seed value provided by the bytes data, which must be at
+/// least 32 bytes (only the first 32 bytes will be used)
+///
+/// # Arguments
+///
+/// * `bytes` - 32 bytes of data to use as the rng seed
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 #[no_mangle]
 pub extern "C" fn mc_chacha20_rng_create_with_bytes(
     bytes: FfiRefPtr<McBuffer>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<Mutex<McChaCha20Rng>> {
-    ffi_boundary(|| {
+    ffi_boundary_with_error(out_error, || {
         let bytes: [u8; 32] = bytes
             .as_slice()
             .try_into()
             .expect("seed size must be 32 bytes");
-        Mutex::new(McChaCha20Rng::from_seed(bytes))
+        Ok(Mutex::new(McChaCha20Rng::from_seed(bytes)))
     })
 }
 
+/// Returns the current word_pos of the ChaCha20Rng instance
+///
+/// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+/// * `out_word_pos` - pointer to buffer of 128 bytes where the current
+///   chacha20_rng wordpos will be returned
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 #[no_mangle]
 pub extern "C" fn mc_chacha20_get_word_pos(
     chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
@@ -77,12 +116,24 @@ pub extern "C" fn mc_chacha20_get_word_pos(
     })
 }
 
+/// Sets the current word_pos of the ChaCha20Rng instance
+///
+/// /// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+/// * `out_word_pos` - pointer to buffer of 128 bytes where the current
+///   chacha20_rng wordpos will be returned
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 #[no_mangle]
 pub extern "C" fn mc_chacha20_set_word_pos(
     chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
     bytes: FfiRefPtr<McBuffer>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) {
-    ffi_boundary(|| {
+    ffi_boundary_with_error(out_error, || {
         let mc_u128 = McU128 {
             bytes: bytes
                 .as_slice()
@@ -90,18 +141,41 @@ pub extern "C" fn mc_chacha20_set_word_pos(
                 .expect("word_pos length is not exaclty 16 bytes"),
         };
         let word_pos = mc_u128.to_u128();
-        chacha20_rng.lock().unwrap().set_word_pos(word_pos);
+
+        chacha20_rng.lock()?.set_word_pos(word_pos);
+
+        Ok(())
     })
 }
 
+/// Returns the next random u64 value from the ChaCha20Rng
+///
+/// /// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+///
+/// # Errors
+///
+/// * `LibMcError::Poison`
 #[no_mangle]
-pub extern "C" fn mc_chacha20_rng_next_long(chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>) -> u64 {
-    ffi_boundary(|| {
-        let next = chacha20_rng.lock().unwrap().next_u64();
-        next
-    })
+pub extern "C" fn mc_chacha20_rng_next_long(
+    chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
+) -> u64 {
+    ffi_boundary_with_error(out_error, || Ok(chacha20_rng.lock()?.next_u64()))
 }
 
+/// frees the ChaCha20Rng
+///
+/// # Preconditions
+/// 
+/// * The ChaCha20Rng is no longer in use
+/// 
+/// # Arguments
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
+///
+/// * `chacha20_rng` - must be a valid ChaCha20Rng
 #[no_mangle]
 pub extern "C" fn mc_chacha20_rng_free(chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>) {
     ffi_boundary(|| {

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -99,7 +99,7 @@ pub extern "C" fn mc_chacha20_rng_create_with_bytes(
 ///
 /// * `LibMcError::Poison`
 #[no_mangle]
-pub extern "C" fn mc_chacha20_get_word_pos(
+pub extern "C" fn mc_chacha20_rng_get_word_pos(
     chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
     out_word_pos: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{ffi_boundary_with_error, McBuffer, McError, McMutableBuffer},
+    common::{ffi_boundary, ffi_boundary_with_error, McBuffer, McError, McMutableBuffer},
     LibMcError,
 };
 use mc_util_ffi::{FfiMutPtr, FfiOptMutPtr, FfiOptOwnedPtr, FfiRefPtr};
@@ -139,11 +139,9 @@ pub extern "C" fn mc_chacha20_rng_next_long(
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 #[no_mangle]
 pub extern "C" fn mc_chacha20_rng_free(
-    chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>,
-    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) -> bool {
-    ffi_boundary_with_error(out_error, || {
+    chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>
+) {
+    ffi_boundary(|| {
         let _ = chacha20_rng;
-        Ok(())
     })
 }

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -177,8 +177,12 @@ pub extern "C" fn mc_chacha20_rng_next_long(
 ///
 /// * `chacha20_rng` - must be a valid ChaCha20Rng
 #[no_mangle]
-pub extern "C" fn mc_chacha20_rng_free(chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>) {
-    ffi_boundary(|| {
+pub extern "C" fn mc_chacha20_rng_free(
+    chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
+) {
+    ffi_boundary_with_error(out_error, || {
         let _ = chacha20_rng;
+        Ok(())
     })
 }

--- a/libmobilecoin/src/chacha20_rng.rs
+++ b/libmobilecoin/src/chacha20_rng.rs
@@ -103,7 +103,7 @@ pub extern "C" fn mc_chacha20_get_word_pos(
     chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
     out_word_pos: FfiMutPtr<McMutableBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) {
+) -> bool {
     ffi_boundary_with_error(out_error, || {
         let word_pos = chacha20_rng.lock()?.get_word_pos();
         let mc_u128 = McU128::from_u128(word_pos);
@@ -128,11 +128,11 @@ pub extern "C" fn mc_chacha20_get_word_pos(
 ///
 /// * `LibMcError::Poison`
 #[no_mangle]
-pub extern "C" fn mc_chacha20_set_word_pos(
+pub extern "C" fn mc_chacha20_rng_set_word_pos(
     chacha20_rng: FfiMutPtr<Mutex<McChaCha20Rng>>,
     bytes: FfiRefPtr<McBuffer>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) {
+) -> bool {
     ffi_boundary_with_error(out_error, || {
         let mc_u128 = McU128 {
             bytes: bytes
@@ -180,7 +180,7 @@ pub extern "C" fn mc_chacha20_rng_next_long(
 pub extern "C" fn mc_chacha20_rng_free(
     chacha20_rng: FfiOptOwnedPtr<Mutex<McChaCha20Rng>>,
     out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
-) {
+) -> bool {
     ffi_boundary_with_error(out_error, || {
         let _ = chacha20_rng;
         Ok(())

--- a/libmobilecoin/src/common/buffer.rs
+++ b/libmobilecoin/src/common/buffer.rs
@@ -182,6 +182,26 @@ impl AsMut<[u8]> for McMutableBuffer<'_> {
     }
 }
 
+impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 16] {
+    type Error = LibMcError;
+
+    #[inline]
+    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
+        let src = src.as_slice_of_len(16)?;
+        // SAFETY: ok to unwrap because we just checked length
+        Ok(<&[u8; 16]>::try_from(src).unwrap())
+    }
+}
+
+impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 16] {
+    type Error = LibMcError;
+
+    #[inline]
+    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
+        Ok(*<&'a [u8; 16]>::try_from_ffi(src)?)
+    }
+}
+
 impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 32] {
     type Error = LibMcError;
 

--- a/libmobilecoin/src/common/buffer.rs
+++ b/libmobilecoin/src/common/buffer.rs
@@ -182,83 +182,21 @@ impl AsMut<[u8]> for McMutableBuffer<'_> {
     }
 }
 
-impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 16] {
+impl<'a, const N: usize> TryFromFfi<&McBuffer<'a>> for &'a [u8; N] {
     type Error = LibMcError;
-
     #[inline]
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        let src = src.as_slice_of_len(16)?;
+        let src = src.as_slice_of_len(N)?;
         // SAFETY: ok to unwrap because we just checked length
-        Ok(<&[u8; 16]>::try_from(src).unwrap())
+        Ok(<&[u8; N]>::try_from(src).unwrap())
     }
 }
 
-impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 16] {
+impl<'a, const N: usize> TryFromFfi<&McBuffer<'a>> for [u8; N] {
     type Error = LibMcError;
-
     #[inline]
     fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        Ok(*<&'a [u8; 16]>::try_from_ffi(src)?)
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 32] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        let src = src.as_slice_of_len(32)?;
-        // SAFETY: ok to unwrap because we just checked length
-        Ok(<&[u8; 32]>::try_from(src).unwrap())
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 32] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        Ok(*<&'a [u8; 32]>::try_from_ffi(src)?)
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 64] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        let src = src.as_slice_of_len(64)?;
-        // SAFETY: ok to unwrap because we just checked length
-        Ok(<&[u8; 64]>::try_from(src).unwrap())
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 64] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        Ok(*<&'a [u8; 64]>::try_from_ffi(src)?)
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for &'a [u8; 66] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        let src = src.as_slice_of_len(66)?;
-        // SAFETY: ok to unwrap because we just checked length
-        Ok(<&[u8; 66]>::try_from(src).unwrap())
-    }
-}
-
-impl<'a> TryFromFfi<&McBuffer<'a>> for [u8; 66] {
-    type Error = LibMcError;
-
-    #[inline]
-    fn try_from_ffi(src: &McBuffer<'a>) -> Result<Self, LibMcError> {
-        Ok(*<&'a [u8; 66]>::try_from_ffi(src)?)
+        Ok(*<&'a [u8; N]>::try_from_ffi(src)?)
     }
 }
 

--- a/libmobilecoin/src/error.rs
+++ b/libmobilecoin/src/error.rs
@@ -14,7 +14,7 @@ use mc_transaction_core::AmountError;
 use mc_transaction_std::TxBuilderError;
 use mc_util_serial::DecodeError;
 use protobuf::ProtobufError;
-use std::os::raw::c_int;
+use std::{os::raw::c_int, sync::PoisonError};
 
 impl From<LibMcError> for McError {
     fn from(err: LibMcError) -> Self {
@@ -52,6 +52,15 @@ pub enum LibMcError {
 
     /// Fog pubkey error: {0},
     FogPubkey(String),
+
+    /// Poison
+    Poison,
+}
+
+impl<T> From<PoisonError<T>> for LibMcError {
+    fn from(_src: PoisonError<T>) -> Self {
+        Self::Poison
+    }
 }
 
 mod error_codes {
@@ -59,6 +68,7 @@ mod error_codes {
 
     pub const LIB_MC_ERROR_CODE_UNKNOWN: c_int = -1;
     pub const LIB_MC_ERROR_CODE_PANIC: c_int = -2;
+    pub const LIB_MC_ERROR_CODE_POISON: c_int = -3;
 
     pub const LIB_MC_ERROR_CODE_INVALID_INPUT: c_int = 100;
     pub const LIB_MC_ERROR_CODE_INVALID_OUTPUT: c_int = 101;
@@ -92,6 +102,7 @@ impl LibMcError {
             }
             LibMcError::TransactionCrypto(_) => LIB_MC_ERROR_CODE_TRANSACTION_CRYPTO,
             LibMcError::FogPubkey(_) => LIB_MC_ERROR_CODE_FOG_PUBKEY,
+            LibMcError::Poison => LIB_MC_ERROR_CODE_POISON,
         }
     }
 

--- a/libmobilecoin/src/lib.rs
+++ b/libmobilecoin/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bip39;
 pub mod crypto;
 pub mod encodings;
 pub mod fog;
+pub mod chacha20_rng;
 pub mod keys;
 pub mod slip10;
 pub mod transaction;

--- a/libmobilecoin/src/lib.rs
+++ b/libmobilecoin/src/lib.rs
@@ -5,10 +5,10 @@ pub mod common;
 
 pub mod attest;
 pub mod bip39;
+pub mod chacha20_rng;
 pub mod crypto;
 pub mod encodings;
 pub mod fog;
-pub mod chacha20_rng;
 pub mod keys;
 pub mod slip10;
 pub mod transaction;


### PR DESCRIPTION
### NOTE: 
 * This PR replaces PR #2383 (this is rebased off master and includes PR feedback updates from #2383
 * I still need to validate latest commits with MobileCoin-Swift

### Changes to libmobilecoin/

 * expose ChaCha20Rng for MobileCoin-Swift

### Motivation

To support re-trying transaction submission without violating idempotency, Moby (and other clients) need the ability to re-create identical transaction data via the `prepareTransaction` family of methods on MobileCoinClient.

### In this PR
* Added ability to provide a deterministic RNG to prepareTransaction methods, so the client can re-create the rng state prior to the call, if needed, in order to deterministically re-create identical transaction data.

Pivotal Tracker: [[iOS] Moby Transaction Idempotence](https://www.pivotaltracker.com/story/show/182820695)