### PR TITLE
Json typing definitions

### DIFF
--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
+#![no_std]
+
 extern crate alloc;
 use alloc::vec::Vec;
 
@@ -98,7 +100,7 @@ mod json_u64 {
     }
 
     impl TryFrom<&json_u128::JsonU128> for JsonU64 {
-        type Error = std::num::TryFromIntError;
+        type Error = core::num::TryFromIntError;
 
         fn try_from(src: &json_u128::JsonU128) -> Result<JsonU64, Self::Error> {
             let u128_src = u128::from(src);

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -103,7 +103,7 @@ mod json_u64 {
         fn try_from(src: &json_u128::JsonU128) -> Result<JsonU64, Self::Error> {
             let u128_src = u128::from(src);
             let u64_src = u64::try_from(u128_src)?;
-            return Ok(JsonU64::from(&u64_src));
+            Ok(JsonU64::from(&u64_src))
         }
     }
 
@@ -171,9 +171,9 @@ mod json_u128 {
         }
     }
 
-    impl Into<f64> for JsonU128 {
-        fn into(self: JsonU128) -> f64 {
-            self.0 as f64
+    impl From<JsonU128> for f64 {
+        fn from(src: JsonU128) -> f64 {
+            src.0 as f64
         }
     }
 

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -266,3 +266,26 @@ mod json_u64_tests {
         assert_eq!(deserialized, the_struct);
     }
 }
+
+#[cfg(test)]
+mod json_u128_tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(PartialEq, Serialize, Deserialize, Debug)]
+    struct TestStruct {
+        nums: Vec<JsonU128>,
+        block: JsonU128,
+    }
+
+    #[test]
+    fn test_serialize_jsonu128_struct() {
+        let the_struct = TestStruct {
+            nums: (&[0, 1, 2, u128::MAX]).iter().map(Into::into).collect(),
+            block: JsonU128(u128::MAX - 1),
+        };
+        let serialized = serialize(&the_struct).unwrap();
+        let deserialized: TestStruct = deserialize(&serialized).unwrap();
+        assert_eq!(deserialized, the_struct);
+    }
+}


### PR DESCRIPTION
Tokens are allowed to be defined with an arbitrary precision, and are frequently defined with 18 decimal places of precision on the Ethereum network (ETH uses 18 decimals, and other tokens frequently follow suit). When converted to an integer representation of the number, this frequently overflows the json-specific `JsonU64` data type we've been using to represent the transfer values.

This PR seeks to add a json representation of the u128 data type to handle this case, and implement some of the necessary cross-type conversion functionality. This will allow the Reserve Auditor to accept the raw transaction values, and handle them without overflow issues.