### PR TITLE
[Added] CI/CD - GHA CD for master part 2

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -482,7 +482,7 @@ jobs:
             "block_version": "0",
             "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
             "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
-            "minting_config_enabled": "false",
+            "minting_config_enabled": "true",
             "ingest_color": "green",
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "version": "${{ env.RELEASE_2X_TAG }}",
@@ -580,8 +580,8 @@ jobs:
     runs-on: [self-hosted, Linux, small]
     needs:
     - test-v2-bv2-release
-    - generate-metadata
     - charts
+    - generate-metadata
     steps:
     - name: Deploy Release
       if: "! contains(github.event.head_commit.message, '[skip deploy-current-bv2-release]')"

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -549,11 +549,11 @@ jobs:
   test-v2-bv3-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - update-v2-to-bv3
+    - update-v2-to-bv2
     - generate-metadata
     steps:
     - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip test-current-bv3-release]')"
+      if: "! contains(github.event.head_commit.message, '[skip test-v2-bv3-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-test

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -546,7 +546,7 @@ jobs:
             "version": "${{ env.RELEASE_2X_TAG }}"
           }
 
-  test-v2-bv3-release:
+  test-v2-bv2-release:
     runs-on: [self-hosted, Linux, small]
     needs:
     - update-v2-to-bv2
@@ -579,7 +579,7 @@ jobs:
   deploy-current-bv2-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - test-v1-bv0-release
+    - test-v2-bv2-release
     - generate-metadata
     - charts
     steps:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -7,7 +7,8 @@ name: mobilecoin-dev-cd
 env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
-  PREVIOUS_RELEASE: v1.1.3-dev
+  RELEASE_1X_TAG: v1.1.3-dev
+  RELEASE_2X_TAG: v2.0.0-dev
 
 on:
   push:
@@ -35,7 +36,6 @@ jobs:
       docker_tag: ${{ steps.meta.outputs.docker_tag }}
       docker_org: ${{ env.DOCKER_ORG }}
       chart_repo: ${{ env.CHART_REPO }}
-      previous_release: ${{ env.PREVIOUS_RELEASE }}
 
     steps:
     - name: Checkout
@@ -400,16 +400,16 @@ jobs:
           }
 
 #######################################
-# Deploy previous release to namespace
+# Deploy 1.x release to namespace
 #######################################
-  previous-release-deploy:
+  deploy-v1-bv0-release:
     runs-on: [self-hosted, Linux, small]
     needs:
     - dev-reset
     - generate-metadata
     steps:
     - name: Deploy Release
-      if: "! contains(github.event.head_commit.message, '[skip previous-release-deploy]')"
+      if: "! contains(github.event.head_commit.message, '[skip deploy-v1-bv0-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-deploy
@@ -426,19 +426,19 @@ jobs:
             "minting_config_enabled": "false",
             "ingest_color": "blue",
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.previous_release }}",
+            "version": "${{ env.RELEASE_1X_TAG }}",
             "client_auth_enabled": "false",
             "use_static_wallet_seeds": "true"
           }
 
-  previous-release-test:
+  test-v1-bv0-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - previous-release-deploy
+    - deploy-v1-bv0-release
     - generate-metadata
     steps:
     - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip previous-release-test]')"
+      if: "! contains(github.event.head_commit.message, '[skip test-v1-bv0-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-test
@@ -458,17 +458,17 @@ jobs:
           }
 
 ###############################################
-# Deploy current version to namespace block v0
+# Deploy v2.x to namespace at block v0
 ###############################################
-  current-release-v0-deploy:
+
+  deploy-v2-bv0-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - previous-release-test
+    - test-v1-bv0-release
     - generate-metadata
-    - charts
     steps:
     - name: Deploy Release
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v0-deploy]')"
+      if: "! contains(github.event.head_commit.message, '[skip deploy-v2-bv0-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-deploy
@@ -482,22 +482,22 @@ jobs:
             "block_version": "0",
             "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
             "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
-            "minting_config_enabled": "true",
+            "minting_config_enabled": "false",
             "ingest_color": "green",
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.tag }}",
+            "version": "${{ env.RELEASE_2X_TAG }}",
             "client_auth_enabled": "false",
             "use_static_wallet_seeds": "true"
           }
 
-  current-release-v0-test:
+  test-v2-bv0-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - current-release-v0-deploy
+    - deploy-v2-bv0-release
     - generate-metadata
     steps:
     - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v0-test]')"
+      if: "! contains(github.event.head_commit.message, '[skip test-v2-bv0-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-test
@@ -508,25 +508,25 @@ jobs:
         display-workflow-run-url-interval: 30s
         inputs: |
           {
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "ingest_color": "green",
+            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "fog_distribution": "false",
             "testing_block_v0": "true",
             "testing_block_v2": "false",
             "client_auth_enabled": "false"
           }
 
-#################################################
-# Update current consensus to namespace block v1
-#################################################
-  current-release-v2-update:
+###############################################
+# Upgrade v2.x to block v2
+###############################################
+  update-v2-to-bv2:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - current-release-v0-test
+    - test-v2-bv0-release
     - generate-metadata
     steps:
     - name: Update consensus config
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v2-update]')"
+      if: "! contains(github.event.head_commit.message, '[skip update-v2-to-bv3-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-update-consensus
@@ -543,17 +543,17 @@ jobs:
             "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
             "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.tag }}"
+            "version": "${{ env.RELEASE_2X_TAG }}"
           }
 
-  current-release-v2-test:
+  test-v2-bv3-release:
     runs-on: [self-hosted, Linux, small]
     needs:
-    - current-release-v2-update
+    - update-v2-to-bv3
     - generate-metadata
     steps:
     - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v2-test]')"
+      if: "! contains(github.event.head_commit.message, '[skip test-current-bv3-release]')"
       uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
       with:
         workflow: mobilecoin-dispatch-dev-test
@@ -566,6 +566,122 @@ jobs:
           {
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "ingest_color": "green",
+            "fog_distribution": "false",
+            "testing_block_v0": "true",
+            "testing_block_v2": "true",
+            "client_auth_enabled": "false"
+          }
+
+
+###############################################
+# Deploy current version to namespace block v2
+###############################################
+  deploy-current-bv2-release:
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - test-v1-bv0-release
+    - generate-metadata
+    - charts
+    steps:
+    - name: Deploy Release
+      if: "! contains(github.event.head_commit.message, '[skip deploy-current-bv2-release]')"
+      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
+      with:
+        workflow: mobilecoin-dispatch-dev-deploy
+        token: ${{ secrets.ACTIONS_TOKEN }}
+        wait-for-completion: true
+        wait-for-completion-timeout: 30m
+        wait-for-completion-interval: 30s
+        display-workflow-run-url-interval: 30s
+        inputs: |
+          {
+            "block_version": "2",
+            "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
+            "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
+            "minting_config_enabled": "true",
+            "ingest_color": "blue",
+            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
+            "version": "${{ needs.generate-metadata.outputs.tag }}",
+            "client_auth_enabled": "false",
+            "use_static_wallet_seeds": "true"
+          }
+
+  test-current-bv2-release:
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - deploy-current-bv2-release
+    - generate-metadata
+    steps:
+    - name: Run MobileCoin integration tests
+      if: "! contains(github.event.head_commit.message, '[skip test-current-bv2-release]')"
+      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
+      with:
+        workflow: mobilecoin-dispatch-dev-test
+        token: ${{ secrets.ACTIONS_TOKEN }}
+        wait-for-completion: true
+        wait-for-completion-timeout: 30m
+        wait-for-completion-interval: 30s
+        display-workflow-run-url-interval: 30s
+        inputs: |
+          {
+            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
+            "ingest_color": "blue",
+            "fog_distribution": "false",
+            "testing_block_v0": "true",
+            "testing_block_v2": "true",
+            "client_auth_enabled": "false"
+          }
+
+#################################################
+# Update current consensus to namespace block v3
+#################################################
+  update-current-to-bv3:
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - test-current-bv2-release
+    - generate-metadata
+    steps:
+    - name: Update consensus config
+      if: "! contains(github.event.head_commit.message, '[skip update-current-to-bv3]')"
+      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
+      with:
+        workflow: mobilecoin-dispatch-dev-update-consensus
+        token: ${{ secrets.ACTIONS_TOKEN }}
+        wait-for-completion: true
+        wait-for-completion-timeout: 30m
+        wait-for-completion-interval: 30s
+        display-workflow-run-url-interval: 30s
+        inputs: |
+          {
+            "block_version": "3",
+            "client_auth_enabled": "false",
+            "minting_config_enabled": "true",
+            "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
+            "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
+            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
+            "version": "${{ needs.generate-metadata.outputs.tag }}"
+          }
+
+  test-current-bv3-release:
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - update-current-to-bv3
+    - generate-metadata
+    steps:
+    - name: Run MobileCoin integration tests
+      if: "! contains(github.event.head_commit.message, '[skip test-current-bv3-release]')"
+      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
+      with:
+        workflow: mobilecoin-dispatch-dev-test
+        token: ${{ secrets.ACTIONS_TOKEN }}
+        wait-for-completion: true
+        wait-for-completion-timeout: 30m
+        wait-for-completion-interval: 30s
+        display-workflow-run-url-interval: 30s
+        inputs: |
+          {
+            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
+            "ingest_color": "blue",
             "fog_distribution": "false",
             "testing_block_v0": "true",
             "testing_block_v2": "true",

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -454,6 +454,7 @@ jobs:
             "fog_distribution": "true",
             "testing_block_v0": "false",
             "testing_block_v2": "false",
+            "testing_block_v3": "false",
             "client_auth_enabled": "false"
           }
 
@@ -513,6 +514,7 @@ jobs:
             "fog_distribution": "false",
             "testing_block_v0": "true",
             "testing_block_v2": "false",
+            "testing_block_v3": "false",
             "client_auth_enabled": "false"
           }
 
@@ -567,8 +569,9 @@ jobs:
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "ingest_color": "green",
             "fog_distribution": "false",
-            "testing_block_v0": "true",
+            "testing_block_v0": "false",
             "testing_block_v2": "true",
+            "testing_block_v3": "false",
             "client_auth_enabled": "false"
           }
 
@@ -627,8 +630,9 @@ jobs:
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "ingest_color": "blue",
             "fog_distribution": "false",
-            "testing_block_v0": "true",
+            "testing_block_v0": "false",
             "testing_block_v2": "true",
+            "testing_block_v3": "false",
             "client_auth_enabled": "false"
           }
 
@@ -683,7 +687,8 @@ jobs:
             "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
             "ingest_color": "blue",
             "fog_distribution": "false",
-            "testing_block_v0": "true",
-            "testing_block_v2": "true",
+            "testing_block_v0": "false",
+            "testing_block_v2": "false",
+            "testing_block_v3": "true",
             "client_auth_enabled": "false"
           }

--- a/.github/workflows/mobilecoin-dispatch-dev-test.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-test.yaml
@@ -31,6 +31,11 @@ on:
         type: boolean
         required: false
         default: true
+      testing_block_v3:
+        description: "Run block v3 tests"
+        type: boolean
+        required: false
+        default: true
       client_auth_enabled:
         description: "Is client auth enabled?"
         type: boolean
@@ -43,9 +48,10 @@ jobs:
     with:
       namespace: ${{ github.event.inputs.namespace }}
       ingest_color: ${{ github.event.inputs.ingest_color }}
-      fog_distribution: ${{ github.event.inputs.fog_distribution == 'true' && 'true' || 'false' }}
-      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 == 'true' && 'true' || 'false' }}
-      testing_block_v2: ${{ github.event.inputs.testing_block_v2 == 'true' && 'true' || 'false' }}
+      fog_distribution: ${{ github.event.inputs.fog_distribution && 'true' || 'false' }}
+      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 && 'true' || 'false' }}
+      testing_block_v2: ${{ github.event.inputs.testing_block_v2 && 'true' || 'false' }}
+      testing_block_v3: ${{ github.event.inputs.testing_block_v3 && 'true' || 'false' }}
     secrets:
       RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
       RANCHER_URL: ${{ secrets.RANCHER_URL }}

--- a/.github/workflows/mobilecoin-dispatch-dev-test.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-test.yaml
@@ -48,10 +48,10 @@ jobs:
     with:
       namespace: ${{ github.event.inputs.namespace }}
       ingest_color: ${{ github.event.inputs.ingest_color }}
-      fog_distribution: ${{ github.event.inputs.fog_distribution && 'true' || 'false' }}
-      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 && 'true' || 'false' }}
-      testing_block_v2: ${{ github.event.inputs.testing_block_v2 && 'true' || 'false' }}
-      testing_block_v3: ${{ github.event.inputs.testing_block_v3 && 'true' || 'false' }}
+      fog_distribution: ${{ github.event.inputs.fog_distribution == 'true' && 'true' || 'false' }}
+      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 == 'true' && 'true' || 'false' }}
+      testing_block_v2: ${{ github.event.inputs.testing_block_v2 == 'true' && 'true' || 'false' }}
+      testing_block_v3: ${{ github.event.inputs.testing_block_v3 == 'true' && 'true' || 'false' }}
     secrets:
       RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
       RANCHER_URL: ${{ secrets.RANCHER_URL }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -101,7 +101,7 @@ on:
         required: false
 
 env:
-  FLIPSIDE: ${{ if inputs.fog_color == 'blue' && 'green' || 'blue' }}
+  FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
 
 jobs:
   list-values:

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -404,7 +404,7 @@ jobs:
           fog-sql-recovery-db-migrations
 
     - name: Activate primary ingest
-      uses: mobilecoinofficial/gha-k8s-toolbox@0939f3022bd3dda7b2ecf35497e442e60a0658f2
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: fog-ingest-activate
         ingest_color: ${{ inputs.ingest_color }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -418,7 +418,7 @@ jobs:
       with:
         action: helm-release-delete
         namespace: ${{ inputs.namespace }}
-        release_name: ${{ env.FLIPSIDE }}
+        release_name: fog-ingest-${{ env.FLIPSIDE }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -404,7 +404,7 @@ jobs:
           fog-sql-recovery-db-migrations
 
     - name: Activate primary ingest
-      uses: mobilecoinofficial/gha-k8s-toolbox@ad5c072ee5f1d8ef385d6f6edb8c6832fe1e2cf5
+      uses: mobilecoinofficial/gha-k8s-toolbox@72b2186f90f2a1e00b46f971343d78995ffd7833
       with:
         action: fog-ingest-activate
         ingest_color: ${{ inputs.ingest_color }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -100,6 +100,9 @@ on:
         description: "static wallet seed"
         required: false
 
+env:
+  FLIPSIDE: ${{ if inputs.fog_color == 'blue' && 'green' || 'blue' }}
+
 jobs:
   list-values:
     name: 👾 Environment Info 👾
@@ -377,11 +380,21 @@ jobs:
           fog-sql-recovery-db-migrations
 
     - name: Activate primary ingest
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      uses: mobilecoinofficial/gha-k8s-toolbox@ad5c072ee5f1d8ef385d6f6edb8c6832fe1e2cf5
       with:
         action: fog-ingest-activate
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
+    - name: Delete retired flipside ingest (if exists)
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-release-delete
+        namespace: ${{ inputs.namespace }}
+        release_name: ${{ env.FLIPSIDE }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -345,10 +345,34 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
 
-  fog-ingest-deploy:
+  fog-services-deploy:
     needs:
     - postgresql-deploy
     - consensus-deploy
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Deploy fog-services
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: fog-services
+        chart_version: ${{ inputs.version }}
+        chart_wait_timeout: 10m
+        # Set orderedReady for compatibility with 1.1.3 chart - remove after 1.2.x
+        chart_set: |
+          --set=image.org=${{ inputs.docker_image_org }}
+          --set=global.certManagerClusterIssuer=zerossl-prod-http
+          --set=fogLedger.podManagementPolicy=OrderedReady
+        release_name: fog-services
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
+  fog-ingest-deploy:
+    needs:
+    - fog-services-deploy
     runs-on: [self-hosted, Linux, small]
     steps:
     - name: Deploy fog-ingest
@@ -395,31 +419,6 @@ jobs:
         action: helm-release-delete
         namespace: ${{ inputs.namespace }}
         release_name: ${{ env.FLIPSIDE }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-
-  fog-services-deploy:
-    needs:
-    - postgresql-deploy
-    - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: Deploy fog-services
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: helm-deploy
-        chart_repo: ${{ inputs.chart_repo }}
-        chart_name: fog-services
-        chart_version: ${{ inputs.version }}
-        chart_wait_timeout: 10m
-        # Set orderedReady for compatibility with 1.1.3 chart - remove after 1.2.x
-        chart_set: |
-          --set=image.org=${{ inputs.docker_image_org }}
-          --set=global.certManagerClusterIssuer=zerossl-prod-http
-          --set=fogLedger.podManagementPolicy=OrderedReady
-        release_name: fog-services
-        namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -404,7 +404,7 @@ jobs:
           fog-sql-recovery-db-migrations
 
     - name: Activate primary ingest
-      uses: mobilecoinofficial/gha-k8s-toolbox@72b2186f90f2a1e00b46f971343d78995ffd7833
+      uses: mobilecoinofficial/gha-k8s-toolbox@0939f3022bd3dda7b2ecf35497e442e60a0658f2
       with:
         action: fog-ingest-activate
         ingest_color: ${{ inputs.ingest_color }}

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -67,6 +67,11 @@ on:
         type: string
         required: false
         default: 'true'
+      testing_block_v3:
+        description: "Run block v3 tests"
+        type: string
+        required: false
+        default: 'true'
     secrets:
       RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -98,6 +103,7 @@ jobs:
         echo fog_distribution ${{ inputs.fog_distribution }}
         echo testing_block_v0 ${{ inputs.testing_block_v0 }}
         echo testing_block_v2 ${{ inputs.testing_block_v2 }}
+        echo testing_block_v3 ${{ inputs.testing_block_v3 }}
 
   setup-environment:
     runs-on: [self-hosted, Linux, small]
@@ -203,8 +209,8 @@ jobs:
     env:
       SRC_KEYS_DIR: /tmp/sample_data/keys
       SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
-      DST_KEYS_DIR: /tmp/1.2-testing/keys
-      DST_FOG_KEYS_DIR: /tmp/1.2-testing/fog_keys
+      DST_KEYS_DIR: /tmp/2-testing/keys
+      DST_FOG_KEYS_DIR: /tmp/2-testing/fog_keys
       START_KEYS: '494'
       END_KEYS: '499'
     steps:
@@ -345,3 +351,139 @@ jobs:
           /test/fog-test-client.sh \
             --key-dir ${{ env.DST_FOG_KEYS_DIR }} \
             --token-id 1
+
+  testing-block-v3:
+    name: Testing for block version 3 ${{ inputs.testing_block_v3 == 'true' && '(run)' || '(skipped)' }}
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - testing-block-v2
+    env:
+      SRC_KEYS_DIR: /tmp/sample_data/keys
+      SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
+      DST_KEYS_DIR: /tmp/3-testing/keys
+      DST_FOG_KEYS_DIR: /tmp/3-testing/fog_keys
+      START_KEYS: '494'
+      END_KEYS: '499'
+    steps:
+    - name: Copy subset of non-fog keys
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /util/copy_account_keys.sh \
+            --src ${{ env.SRC_KEYS_DIR }} \
+            --dst ${{ env.DST_KEYS_DIR }} \
+            --start ${{ env.START_KEYS }} \
+            --end ${{ env.END_KEYS }}
+
+    - name: Copy subset of fog keys
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /util/copy_account_keys.sh \
+            --src ${{ env.SRC_FOG_KEYS_DIR }} \
+            --dst ${{ env.DST_FOG_KEYS_DIR }} \
+            --start ${{ env.START_KEYS }} \
+            --end ${{ env.END_KEYS }}
+
+    - name: Test - Minting config tx
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /test/minting-config-tx-test.sh \
+            --token-id 1
+
+    - name: Test - Minting tx
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /test/minting-tx-test.sh \
+            --key-dir ${{ env.DST_KEYS_DIR }} \
+            --token-id 1
+
+    - name: Test - mobilecoind-json integration
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /test/mobilecoind-json-integration-test.sh \
+            --key-dir ${{ env.DST_KEYS_DIR }}
+
+    - name: Test - mint-auditor
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /test/mint-auditor-test.sh \
+            --token-id 1
+
+    - name: Test - use drain_accounts to transfer id 1 balances to fog keys
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /util/drain_accounts.sh \
+            --src ${{ env.DST_KEYS_DIR }} \
+            --dst ${{ env.DST_FOG_KEYS_DIR }} \
+            --fee 1024 \
+            --token-id 1
+
+    - name: Test - fog-test-client token ids 0,1
+      if: inputs.testing_block_v3 == 'true'
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          /test/fog-test-client.sh \
+            --key-dir ${{ env.DST_FOG_KEYS_DIR }} \
+            --token-ids 0,1

--- a/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
+++ b/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
@@ -30,9 +30,8 @@ is_set MC_BRANCH
 
 # Default vars
 export MC_LEDGER_PATH=${MC_LEDGER_PATH:-"/ledger"}
-export MC_STATE_FILE=${MC_STATE_FILE:-"/ledger/.distribution-state"}
+export MC_STATE_FILE=${MC_STATE_FILE:-"${MC_LEDGER_PATH}/.distribution-state"}
 export MC_SENTRY_DSN=${LEDGER_DISTRIBUTION_SENTRY_DSN}
-
 
 if [[ -f "${MC_STATE_FILE}" ]]
 then

--- a/.internal-ci/test/fog-test-client.sh
+++ b/.internal-ci/test/fog-test-client.sh
@@ -74,6 +74,7 @@ then
     token_opt="--token-ids ${token_ids}"
 fi
 
+export RUST_LOG=info
 test_client \
     --key-dir "${key_dir}" \
     --consensus "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \


### PR DESCRIPTION
Add 1.1.3 bv0 -> 2.0.0 bv0 -> 2.0.0 bv2 -> current bv2 -> current bv3 upgrade testing.

- update job names to match upgrade path.
- create block version 3 set of tests
- reduce redundant tests between upgrade stages
- enhance fog-ingest activate/retire to use test_client to advance chain for old ingest retirement (mostly in gha-k8s-toolbox)
- minor fix in wrapper-ledger-distribution.sh to reduce the chance of confusing the state file path (thanks Joe!).
- smarter minting config tx test - wait for chain to advance before moving on.

