### PR TITLE
Add report fetching logic to FVR

### DIFF
--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -3,6 +3,7 @@
 
 //! MobileCoin Fog View Router target
 use grpcio::ChannelBuilder;
+use mc_attest_net::{Client, RaClient};
 use mc_common::logger::log;
 use mc_fog_api::view_grpc::FogViewStoreApiClient;
 use mc_fog_uri::FogViewStoreUri;
@@ -56,8 +57,14 @@ fn main() {
         fog_view_store_grpc_clients.push(fog_view_store_grpc_client);
     }
 
-    let mut router_server =
-        FogViewRouterServer::new(config, sgx_enclave, fog_view_store_grpc_clients, logger);
+    let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
+    let mut router_server = FogViewRouterServer::new(
+        config,
+        sgx_enclave,
+        ias_client,
+        fog_view_store_grpc_clients,
+        logger,
+    );
     router_server.start();
 
     loop {

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -135,6 +135,14 @@ pub struct FogViewRouterConfig {
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
     pub client_listen_uri: FogViewRouterUri,
 
+    /// PEM-formatted keypair to send with an Attestation Request.
+    #[clap(long, env = "MC_IAS_API_KEY")]
+    pub ias_api_key: String,
+
+    /// The IAS SPID to use when getting a quote
+    #[clap(long, env = "MC_IAS_SPID")]
+    pub ias_spid: ProviderId,
+
     // TODO: Add shard uris which are of type Vec<FogViewStoreUri>.
     /// The capacity to build the OMAP (ORAM hash table) with.
     /// About 75% of this capacity can be used.


### PR DESCRIPTION
### Motivation

Integration testing revealed that the Fog View Router needs to access the Sgx reports in order to perform attestation. This PR adds the necessary report fetching logic. 