### PR TITLE
Fix responder ID usage in FVR

### DIFF
--- a/fog/view/server/src/error.rs
+++ b/fog/view/server/src/error.rs
@@ -33,6 +33,12 @@ impl From<mc_util_uri::UriParseError> for RouterServerError {
     }
 }
 
+impl From<mc_util_uri::UriConversionError> for RouterServerError {
+    fn from(src: mc_util_uri::UriConversionError) -> Self {
+        RouterServerError::ViewStoreError(format!("{}", src))
+    }
+}
+
 pub fn router_server_err_to_rpc_status(
     context: &str,
     src: RouterServerError,

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -19,7 +19,8 @@ use mc_fog_api::{
 use mc_fog_uri::FogViewStoreUri;
 use mc_fog_view_enclave_api::ViewEnclaveProxy;
 use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
-use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+use mc_util_uri::ConnectionUri;
+use std::{collections::BTreeMap, sync::Arc};
 
 const RETRY_COUNT: usize = 3;
 
@@ -222,7 +223,7 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
     view_store_url: FogViewStoreUri,
     logger: Logger,
 ) -> Result<(), RouterServerError> {
-    let view_store_id = ResponderId::from_str(&view_store_url.to_string())?;
+    let view_store_id = view_store_url.responder_id()?;
     let client_auth_request = enclave.view_store_init(view_store_id.clone())?;
     let grpc_env = Arc::new(
         grpcio::EnvBuilder::new()

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -8,6 +8,7 @@ use mc_fog_api::{
     view_grpc::FogViewStoreApiClient,
 };
 use mc_fog_uri::FogViewStoreUri;
+use mc_util_uri::ConnectionUri;
 use std::{str::FromStr, sync::Arc};
 
 /// The result of processing the MultiViewStoreQueryResponse from each Fog View
@@ -52,7 +53,7 @@ pub fn process_shard_responses(
         let store_uri = FogViewStoreUri::from_str(response.get_fog_view_store_uri())?;
         match response.get_status() {
             MultiViewStoreQueryResponseStatus::SUCCESS => {
-                let store_responder_id = ResponderId::from_str(&store_uri.to_string())?;
+                let store_responder_id = store_uri.responder_id()?;
                 new_query_responses.push((store_responder_id, response.take_query_response()));
             }
             // The shard was unable to produce a query response because the Fog View Store


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

Previously FVR was constructing the responder IDs ncorrectly: it was a wrapper around the stores' / router's URI. What we need it to be is "<host>:<port>"  which this change introduces.

This error was uncovered during unit testing. What happened is the store's thought responder ids were the url type and the router thought that the responder id was the host:port type.
