### PR TITLE
Add NonceAuthRequest, NonceAuthResponse, NonceSession

### DIFF
--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 pub use error::{Error, Result};
 
 use alloc::vec::Vec;
-use core::hash::Hash;
+use core::hash::{Hash, Hasher};
 use mc_attest_core::{QuoteNonce, Report};
 use serde::{Deserialize, Serialize};
 
@@ -149,7 +149,7 @@ impl Session for PeerSession {
 
 /// An opaque bytestream used as a session ID for a session which uses explicit
 /// nonces.
-#[derive(Clone, Debug, Default, Deserialize, Hash, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialOrd, Serialize)]
 pub struct NonceSession {
     channel_id: Vec<u8>,
     nonce: u64,
@@ -202,6 +202,12 @@ impl From<Vec<u8>> for NonceSession {
 impl From<NonceSession> for Vec<u8> {
     fn from(src: NonceSession) -> Self {
         src.channel_id
+    }
+}
+
+impl Hash for NonceSession {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.channel_id.hash(state)
     }
 }
 

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -155,6 +155,29 @@ pub struct NonceSession {
     nonce: u64,
 }
 
+impl NonceSession {
+    /// Create a new nonce session from a vector and nonce.
+    ///
+    /// This takes a pre-created Vec in order to remove an extra allocation that
+    /// would be required when converting from a NonceMessage to an
+    /// [`EnclaveMessage`]`<`[`NonceSession`]`>`.
+    pub fn new(channel_id: Vec<u8>, nonce: u64) -> Self {
+        Self { channel_id, nonce }
+    }
+
+    /// Retrieves the nonce for this session
+    pub fn peek_nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    /// Retrieves a copy of the nonce, and increments it for the next time.
+    pub fn get_nonce(&mut self) -> u64 {
+        let retval = self.nonce;
+        self.nonce += 1;
+        retval
+    }
+}
+
 impl AsRef<[u8]> for NonceSession {
     fn as_ref(&self) -> &[u8] {
         self.channel_id.as_ref()

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -35,6 +35,7 @@ macro_rules! impl_newtype_vec_inout {
 impl_newtype_vec_inout! {
     ClientAuthRequest; ClientAuthResponse; ClientSession;
     PeerAuthRequest; PeerAuthResponse; PeerSession;
+    NonceAuthRequest; NonceAuthResponse;
 }
 
 /// The raw authentication request message, sent from an initiator to a
@@ -56,6 +57,16 @@ pub struct PeerAuthRequest(Vec<u8>);
 /// initiator.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct PeerAuthResponse(Vec<u8>);
+
+/// The raw authentication request message, sent from an initiator to a
+/// responder.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct NonceAuthRequest(Vec<u8>);
+
+/// The raw authentication response message, sent from a responder to an
+/// initiator.
+#[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct NonceAuthResponse(Vec<u8>);
 
 /// Inbound and outbound messages to/from an enclave.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -134,4 +145,50 @@ pub struct PeerSession(Vec<u8>);
 impl Session for PeerSession {
     type Request = PeerAuthRequest;
     type Response = PeerAuthResponse;
+}
+
+/// An opaque bytestream used as a session ID for a session which uses explicit
+/// nonces.
+#[derive(Clone, Debug, Default, Deserialize, Hash, PartialOrd, Serialize)]
+pub struct NonceSession {
+    channel_id: Vec<u8>,
+    nonce: u64,
+}
+
+impl AsRef<[u8]> for NonceSession {
+    fn as_ref(&self) -> &[u8] {
+        self.channel_id.as_ref()
+    }
+}
+
+impl<'bytes> From<&'bytes [u8]> for NonceSession {
+    fn from(src: &'bytes [u8]) -> Self {
+        Self::from(Vec::from(src))
+    }
+}
+
+impl From<Vec<u8>> for NonceSession {
+    fn from(channel_id: Vec<u8>) -> Self {
+        NonceSession {
+            channel_id,
+            nonce: 0,
+        }
+    }
+}
+
+impl From<NonceSession> for Vec<u8> {
+    fn from(src: NonceSession) -> Self {
+        src.channel_id
+    }
+}
+
+impl PartialEq for NonceSession {
+    fn eq(&self, other: &Self) -> bool {
+        self.channel_id == other.channel_id
+    }
+}
+
+impl Session for NonceSession {
+    type Request = NonceAuthRequest;
+    type Response = NonceAuthResponse;
 }


### PR DESCRIPTION
- Add NonceAuthRequest
- Add NonceAuthResponse
- Add NonceSession
- Add NonceMessage <=> EnclaveMessage&lt;NonceSession>
- Remove EnclaveNonceMessage

### Motivation

This is part of the explicit nonce work, it creates the types necessary for going into/out of our attest-ake machinery in attest-enclave-api.

### Future Work
- Update attest-ake machinery to use nonce variants.
- Update ake-enclave to support nonce sessions
- Update fog view store to use nonce sessions

