### PR TITLE
[Fixed] CI/CD - wrong context for namespace variable in reset/delete workflow

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -114,7 +114,7 @@ jobs:
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: namespace-delete
-        namespace: ${{ github.event.inputs.namespace }}
+        namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}


### PR DESCRIPTION
### Motivation

Fix the context for the namespace variable in the delete namespace part of the reset/delete workflow.

