### PR TITLE
Simplify the situation around ProposeTxResult vs. TransactionValidationError

### DIFF
--- a/connection/src/error.rs
+++ b/connection/src/error.rs
@@ -10,7 +10,6 @@ use grpcio::Error as GrpcError;
 use mc_blockchain_types::ConvertError;
 use mc_consensus_api::{consensus_common::ProposeTxResult, ConversionError};
 use mc_crypto_noise::CipherError;
-use mc_transaction_core::validation::TransactionValidationError;
 use std::{array::TryFromSliceError, result::Result as StdResult};
 
 pub type Result<T> = StdResult<T, Error>;
@@ -31,8 +30,8 @@ pub enum Error {
     Cipher(CipherError),
     /// Attestation failure: {0}
     Attestation(Box<dyn AttestationError + 'static>),
-    /// Transaction validation failure: {0}
-    TransactionValidation(TransactionValidationError),
+    /// Transaction validation failure: {0:?}: {1}
+    TransactionValidation(ProposeTxResult, String),
     /// Other error: {0}
     Other(String),
 }
@@ -86,14 +85,6 @@ impl From<ConversionError> for Error {
 impl From<TryFromSliceError> for Error {
     fn from(_src: TryFromSliceError) -> Self {
         ConversionError::ArrayCastError.into()
-    }
-}
-
-impl From<ProposeTxResult> for Error {
-    fn from(src: ProposeTxResult) -> Self {
-        src.try_into()
-            .map(Self::TransactionValidation)
-            .unwrap_or_else(|err| Error::Other(err.into()))
     }
 }
 

--- a/connection/src/lib.rs
+++ b/connection/src/lib.rs
@@ -25,4 +25,5 @@ pub use crate::{
 };
 
 pub use mc_common::trace_time as _trace_time;
+pub use mc_consensus_api::consensus_common::ProposeTxResult;
 pub use retry as _retry;

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -429,7 +429,10 @@ impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
         if resp.get_result() == ProposeTxResult::Ok {
             Ok(resp.get_block_count())
         } else {
-            Err(resp.get_result().into())
+            Err(Error::TransactionValidation(
+                resp.get_result(),
+                resp.get_err_msg().to_owned(),
+            ))
         }
     }
 }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -105,4 +105,7 @@ message ProposeTxResponse {
 
     /// The block version which is in effect right now
     uint32 block_version = 3;
+
+    /// Human-readable error message, in case of nonzero ProposeTxResult
+    string err_msg = 4;
 }

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 use mc_api::ConversionError;
 use mc_transaction_core::{
-    mint::MintValidationError, ring_ct, ring_signature::Error as RingSignatureError,
-    validation::TransactionValidationError as Error, BlockVersion, InputRuleError, TokenId,
+    mint::MintValidationError, validation::TransactionValidationError as Error, BlockVersion,
+    InputRuleError, TokenId,
 };
 
 /// Convert TransactionValidationError --> ProposeTxResult.
@@ -67,63 +67,6 @@ impl From<Error> for ProposeTxResult {
                 Self::InputRuleMaxTombstoneBlockExceeded
             }
             Error::UnknownMaskedAmountVersion => Self::UnknownMaskedAmountVersion,
-        }
-    }
-}
-
-/// Convert ProposeTxResult --> TransactionValidationError.
-impl TryInto<Error> for ProposeTxResult {
-    type Error = &'static str;
-
-    fn try_into(self) -> Result<Error, Self::Error> {
-        match self {
-            Self::Ok => Err("Ok value cannot be convererted into TransactionValidationError"),
-            Self::InputsProofsLengthMismatch => Ok(Error::InputsProofsLengthMismatch),
-            Self::NoInputs => Ok(Error::NoInputs),
-            Self::TooManyInputs => Ok(Error::TooManyInputs),
-            Self::InsufficientInputSignatures => Ok(Error::InsufficientInputSignatures),
-            Self::InvalidInputSignature => Ok(Error::InvalidInputSignature),
-            Self::InvalidTransactionSignature => Ok(Error::InvalidTransactionSignature(
-                ring_ct::Error::RingSignature(RingSignatureError::InvalidSignature),
-            )),
-            Self::InvalidRangeProof => Ok(Error::InvalidRangeProof),
-            Self::InsufficientRingSize => Ok(Error::InsufficientRingSize),
-            Self::TombstoneBlockExceeded => Ok(Error::TombstoneBlockExceeded),
-            Self::TombstoneBlockTooFar => Ok(Error::TombstoneBlockTooFar),
-            Self::NoOutputs => Ok(Error::NoOutputs),
-            Self::TooManyOutputs => Ok(Error::TooManyOutputs),
-            Self::ExcessiveRingSize => Ok(Error::ExcessiveRingSize),
-            Self::DuplicateRingElements => Ok(Error::DuplicateRingElements),
-            Self::UnsortedRingElements => Ok(Error::UnsortedRingElements),
-            Self::UnequalRingSizes => Ok(Error::UnequalRingSizes),
-            Self::UnsortedKeyImages => Ok(Error::UnsortedKeyImages),
-            Self::ContainsSpentKeyImage => Ok(Error::ContainsSpentKeyImage),
-            Self::DuplicateKeyImages => Ok(Error::DuplicateKeyImages),
-            Self::DuplicateOutputPublicKey => Ok(Error::DuplicateOutputPublicKey),
-            Self::ContainsExistingOutputPublicKey => Ok(Error::ContainsExistingOutputPublicKey),
-            Self::MissingTxOutMembershipProof => Ok(Error::MissingTxOutMembershipProof),
-            Self::InvalidTxOutMembershipProof => Ok(Error::InvalidTxOutMembershipProof),
-            Self::InvalidRistrettoPublicKey => Ok(Error::InvalidRistrettoPublicKey),
-            Self::InvalidLedgerContext => Ok(Error::InvalidLedgerContext),
-            Self::Ledger => Ok(Error::Ledger(String::default())),
-            Self::MembershipProofValidationError => Ok(Error::MembershipProofValidationError),
-            Self::TxFeeError => Ok(Error::TxFeeError),
-            Self::KeyError => Ok(Error::KeyError),
-            Self::UnsortedInputs => Ok(Error::UnsortedInputs),
-            Self::MissingMemo => Ok(Error::MissingMemo),
-            Self::MemosNotAllowed => Ok(Error::MemosNotAllowed),
-            Self::TokenNotYetConfigured => Ok(Error::TokenNotYetConfigured),
-            Self::MissingMaskedTokenId => Ok(Error::MissingMaskedTokenId),
-            Self::MaskedTokenIdNotAllowed => Ok(Error::MaskedTokenIdNotAllowed),
-            Self::UnsortedOutputs => Ok(Error::UnsortedOutputs),
-            Self::InputRulesNotAllowed => Ok(Error::InputRulesNotAllowed),
-            Self::InputRuleMissingRequiredOutput => {
-                Ok(Error::InputRule(InputRuleError::MissingRequiredOutput))
-            }
-            Self::InputRuleMaxTombstoneBlockExceeded => {
-                Ok(Error::InputRule(InputRuleError::MaxTombstoneBlockExceeded))
-            }
-            Self::UnknownMaskedAmountVersion => Ok(Error::UnknownMaskedAmountVersion),
         }
     }
 }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -91,6 +91,7 @@ impl ClientApiService {
                 counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
                 let result = ProposeTxResult::from(cause.clone());
                 response.set_result(result);
+                response.set_err_msg(cause.to_string());
             }
             err
         })?;

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -28,7 +28,7 @@ use mc_common::{
     HashMap, HashSet,
 };
 use mc_connection::{
-    Error as ConnectionError, HardcodedCredentialsProvider, RetryError,
+    Error as ConnectionError, HardcodedCredentialsProvider, ProposeTxResult, RetryError,
     RetryableBlockchainConnection, RetryableUserTxConnection, SyncConnection, ThickClient,
 };
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
@@ -43,7 +43,6 @@ use mc_transaction_core::{
     ring_signature::KeyImage,
     tokens::Mob,
     tx::{Tx, TxOut, TxOutMembershipProof},
-    validation::TransactionValidationError,
     Amount, BlockVersion, Token, TokenId,
 };
 use mc_transaction_std::{EmptyMemoBuilder, InputCredentials, TransactionBuilder};
@@ -644,7 +643,8 @@ fn submit_tx(
                 tries,
             }) => {
                 if let ConnectionError::TransactionValidation(
-                    TransactionValidationError::TombstoneBlockExceeded,
+                    ProposeTxResult::TombstoneBlockExceeded,
+                    _,
                 ) = error
                 {
                     log::debug!(
@@ -653,7 +653,8 @@ fn submit_tx(
                     return false;
                 }
                 if let ConnectionError::TransactionValidation(
-                    TransactionValidationError::ContainsSpentKeyImage,
+                    ProposeTxResult::ContainsSpentKeyImage,
+                    _,
                 ) = error
                 {
                     log::info!(

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -3,7 +3,7 @@
 //! MobileCoin SDK Errors
 
 use displaydoc::Display;
-use mc_connection::Error as ConnectionError;
+use mc_connection::{Error as ConnectionError, ProposeTxResult};
 use mc_consensus_api::ConversionError;
 use mc_crypto_keys::KeyError;
 use mc_fog_enclave_connection::Error as EnclaveConnectionError;
@@ -12,8 +12,7 @@ use mc_fog_report_connection::Error as FogResolutionError;
 use mc_fog_types::view::FogTxOutError;
 use mc_fog_view_protocol::TxOutPollingError;
 use mc_transaction_core::{
-    validation::TransactionValidationError, AmountError, BlockVersionError,
-    SignedContingentInputError, TxOutConversionError,
+    AmountError, BlockVersionError, SignedContingentInputError, TxOutConversionError,
 };
 use mc_transaction_std::{SignedContingentInputBuilderError, TxBuilderError};
 use mc_util_uri::UriParseError;
@@ -118,8 +117,8 @@ pub enum Error {
     /// Failed to decode ledger server response: {0}
     Conversion(ConversionError),
 
-    /// Proposed transcation rejected: {0}
-    TxRejected(TransactionValidationError),
+    /// Proposed transcation rejected: {0:?}: {1}
+    TxRejected(ProposeTxResult, String),
 
     /// Could not parse uri: {0}
     Uri(UriParseError),
@@ -149,7 +148,7 @@ pub enum Error {
 impl From<ConnectionError> for Error {
     fn from(x: ConnectionError) -> Error {
         match x {
-            ConnectionError::TransactionValidation(tve) => Error::TxRejected(tve),
+            ConnectionError::TransactionValidation(tve, msg) => Error::TxRejected(tve, msg),
             other => Error::ConsensusConnection(other),
         }
     }
@@ -176,12 +175,6 @@ impl From<LedgerConnectionError> for Error {
 impl From<KeyImageQueryError> for Error {
     fn from(x: KeyImageQueryError) -> Error {
         Error::KeyImageQuery(x)
-    }
-}
-
-impl From<TransactionValidationError> for Error {
-    fn from(x: TransactionValidationError) -> Error {
-        Error::TxRejected(x)
     }
 }
 


### PR DESCRIPTION
Note: This PR came out of this discussion on another PR: https://github.com/mobilecoinfoundation/mobilecoin/pull/2484#discussion_r966436661 and also discussion in discord

`TransactionValidationError` is an error type created by `mc-transaction-core` in the validation routines. This is the actual low level error returned by validation, and is marshalled across the consensus enclave boundary when something fails.

`ProposeTxResult` is a protobuf enum defined in the consensus_common.proto file. When a submission happens, but fails due to a transaction validation error, we return a grpc success, but with a nonzero "status code" in the form of `ProposeTxResult`. This is supposed to capture the details of the `TransactionValidationError`. In terms of code, the `ProposeTxResult` type is created in a crate that uses `std` and cannot be represented in the enclave.

Currently, we support converting `TransactionValidationError` to `ProposeTxResult`, which is necessary to convert errors returned by the enclaves to errors that can go into a grpc response.

But, we also support the reverse conversion, for no particularly good reason. `ThickClient` exercises the reverse conversion, so that non-zero `ProposeTxResult` get converted into a transaction-core / enclave error type when they are returned to the caller.

This conversion creates a bunch of complexity because it seems bad for it to be lossy, but making it not lossy is very complicated and imposes constraints on what kinds of data these errors can contain. It is better if the transaction-core code can do whatever it wants with it's error types, without regard to concerns about marshalling them into protobuf, which should be a higher-level concern.

The idea here is:
* Remove the conversion from `ProposeTxResult` back into `TransactionValidationError`. Only the one direction is supported. Once it is turned into a grpc error type, it doesn't get converted back into the enclave error type later.
* The consensus client api service now returns both the `ProposeTxResult` status code and an error message, which is the display-string of the original error, in the protobuf response. This is a non-breaking change.
* On the thick client side, instead of trying to reconstruct the `TransactionValidationError`, we just return the `ProposeTxResult` and the error string.

This promotes a separation of concerns -- now the transaction-core error code doesn't need to support any particular conversions to support funky deserialization strategies.

This also frees us to make the `ProposeTxResult` status code a little bit less granular if we want. Developers can always get all the details from the err_msg string to debug something, and we don't have to create more status codes for every possible transaction validation error, unless we think the client will actually handle those failure modes differently. (In a recent draft PR, we got up to 65 distinct ways that a transaction can fail at one point, but client code only actually checks for one or two of them.) It also means that we can put data in the transaction validation errors even if we don't have a good way to reconstruct it from `ProposeTxResult`.