### PR TITLE
[Added] tools - Add mob prompt local user support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-dev:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -38,7 +38,7 @@ jobs:
 
   build-prod:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -58,7 +58,7 @@ jobs:
 
   build-and-test-wasm:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -73,7 +73,7 @@ jobs:
 
   lint-rust:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -90,7 +90,7 @@ jobs:
 
   build-and-test-go:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -130,7 +130,7 @@ jobs:
 
   docs:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -149,7 +149,7 @@ jobs:
 
   mc-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     strategy:
       matrix:
@@ -188,7 +188,7 @@ jobs:
 
   consensus-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     strategy:
       matrix:
@@ -221,7 +221,7 @@ jobs:
 
   fog-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     strategy:
       matrix:
@@ -269,7 +269,7 @@ jobs:
 
   fog-ingest-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -292,7 +292,7 @@ jobs:
 
   fog-conformance-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -332,7 +332,7 @@ jobs:
 
   fog-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code
@@ -468,7 +468,7 @@ jobs:
 
   mint-auditor-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.16
+    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-dev:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -38,7 +38,7 @@ jobs:
 
   build-prod:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -58,7 +58,7 @@ jobs:
 
   build-and-test-wasm:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -73,7 +73,7 @@ jobs:
 
   lint-rust:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -90,7 +90,7 @@ jobs:
 
   build-and-test-go:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -130,7 +130,7 @@ jobs:
 
   docs:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -149,7 +149,7 @@ jobs:
 
   mc-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     strategy:
       matrix:
@@ -188,7 +188,7 @@ jobs:
 
   consensus-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     strategy:
       matrix:
@@ -221,7 +221,7 @@ jobs:
 
   fog-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     strategy:
       matrix:
@@ -269,7 +269,7 @@ jobs:
 
   fog-ingest-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -292,7 +292,7 @@ jobs:
 
   fog-conformance-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -332,7 +332,7 @@ jobs:
 
   fog-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code
@@ -468,7 +468,7 @@ jobs:
 
   mint-auditor-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.0-test_entrypoint_mob_user
+    container: mobilecoin/builder-install:v0.0.17
 
     steps:
       - name: Check out code

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -62,7 +62,7 @@ jobs:
   build-rust-hardware-projects:
     runs-on: [self-hosted, Linux, large]
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.16
+      image: mobilecoin/rust-sgx-base:v0.0.17
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem
       MINTING_TRUST_ROOT_PUBLIC_KEY_PEM: ${{ github.workspace }}/.tmp/minting_trust_root.public.pem

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ rust_build_artifacts/
 go_build_artifacts/
 
 minting-trust-root*
+
+# new cache dir for mob prompt with user sccache
+.mob/

--- a/.mobconf
+++ b/.mobconf
@@ -1,4 +1,3 @@
 [image]
 url = mobilecoin/builder-install
-tag = v0.0.0-test_entrypoint_mob_user
-; tag = v0.0.16
+tag = v0.0.17

--- a/.mobconf
+++ b/.mobconf
@@ -1,3 +1,4 @@
 [image]
 url = mobilecoin/builder-install
-tag = v0.0.16
+tag = v0.0.0-test_entrypoint_mob_user
+; tag = v0.0.16

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -20,7 +20,7 @@ spec:
           topologyKey: "kubernetes.io/hostname"
   containers:
     - name: rust-builder-default
-      image: mobilecoin/builder-install:v0.0.16
+      image: mobilecoin/builder-install:v0.0.17
       env:
         - name: PATH
           value: "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64"

--- a/mob
+++ b/mob
@@ -51,6 +51,7 @@ tag = Image tag/version to use
 
 import argparse
 import configparser
+import grp
 import os
 import pathlib
 import platform
@@ -74,6 +75,7 @@ parser.add_argument("--ssh-agent", action='store_true', help='Use ssh-agent on h
 parser.add_argument("--expose", nargs='+', default=None, help="Any additional ports to expose")
 parser.add_argument("--publish", nargs='+', default=None, help="Any additional ports to publish, e.g. if running wallet locally.")
 parser.add_argument("--cmd", nargs='+', default=None, help="Run this command inside the bash shell instead of an interactive prompt")
+parser.add_argument("--run-as-root", action='store_true', help="run prompt as root instead of local user")
 
 args = parser.parse_args()
 
@@ -195,8 +197,6 @@ docker_run = ["docker",
               "run",
               # Remove container afterwards.
               "--rm",
-              # container doesn't know mount_point so we have to set this
-              "--env", "CARGO_HOME=" + mount_point + "/cargo",
               # Give docker its own subdirectory under target so it doesn't trash
               # the host target directory, but will still be cleaned up with it.
               "--env", "CARGO_TARGET_DIR=" + mount_point + "/target/docker",
@@ -206,6 +206,20 @@ docker_run = ["docker",
               "--env", "MC_CHAIN_ID=local",
               "--volume", mount_from + ":" + mount_point,
               "--workdir", workdir]
+
+# the entrypoint script will pick up these vars and set up the user.
+if not args.run_as_root:
+    # figure out user and group
+    uid = os.getuid()
+    gid = os.getgid()
+    username = os.getlogin()
+    groupname = grp.getgrgid(gid)[0]
+    docker_run.extend([
+            "--env", "EXTERNAL_UID=" + str(uid),
+            "--env", "EXTERNAL_GID=" + str(gid),
+            "--env", "EXTERNAL_USER=" + username,
+            "--env", "EXTERNAL_GROUP=" + groupname
+    ])
 
 # Add /dev/isgx if HW mode, and it is available
 # Mimicking bash checks `if [ -c /dev/isgx ]`
@@ -233,25 +247,6 @@ if git_commit:
 
 for pair in build_env:
     docker_run.extend(["--env", pair])
-
-# Enable sccache usage if sccache dir is found on the host.
-# We do this by mounting the dir into the container, and setting the sccache
-# environment variable, which can be picked up by Makefile. sccache is already
-# installed in the container.
-#
-# An alternative might be to run the sccache server outside the container, and
-# expose port 4226 so that they can talk, per
-# https://github.com/mozilla/sccache/blob/master/docs/Jenkins.md
-#
-# This tool is not used in jenkins anymore so we don't do that
-host_sccache_dir = os.path.expanduser("~/.cache/sccache")  # per docs this is the default for sccache
-if "SCCACHE_DIR" in os.environ:
-    host_sccache_dir = os.environ["SCCACHE_DIR"]
-if os.path.isdir(host_sccache_dir):
-    docker_run.extend([
-        "--env", "SCCACHE=/root/.cargo/bin/sccache",
-        "--volume", host_sccache_dir + ":" + "/root/.cache/sccache",
-    ])
 
 # If running interactively (with a tty), get a tty in the container also
 # This allows colored build logs when running locally without messing up logs in CI


### PR DESCRIPTION
### Motivation

Instead of running `mob prompt` as a root container, set up and switch to a matching local user. This should keep the files created in the `mob prompt` matching the local user. 

The builder-installer container now has an entrypoint script that if EXTERNAL_UID is passed in will setup a local user/group and setup the environment so local user should be able to build and test rust/go code.  Sudo has been added so users can sudo up to root with no password if they need elevated access.  The container still runs as the root user but switches down to the non-privileged user by default.

Caveats:
- This will not work from a windows cmd prompt, but should work from a WSL environment.

Changes:
- add `.mob` directory for preserving sccache and rust/cargo home and package cache.
- update `mob` to detect and pass in local ("external") uid, gid, username and groupname details.
- Remove sccache setup in `mob` - moved to setup in the builder-install container entrypoint.
- `--run-as-root` option for mob prompt to skip the non-privileged user setup.

docker-rust-sgx-base/builder-installer PR with entrypoint and user env setup logic: https://github.com/mobilecoinofficial/docker-rust-sgx-base/pull/20