### PR TITLE
Use getpass package instead of os.getlogin to get username

### DIFF
--- a/mob
+++ b/mob
@@ -51,6 +51,7 @@ tag = Image tag/version to use
 
 import argparse
 import configparser
+import getpass
 import grp
 import os
 import pathlib
@@ -212,7 +213,7 @@ if not args.run_as_root:
     # figure out user and group
     uid = os.getuid()
     gid = os.getgid()
-    username = os.getlogin()
+    username = getpass.getuser()
     groupname = grp.getgrgid(gid)[0]
     docker_run.extend([
             "--env", "EXTERNAL_UID=" + str(uid),


### PR DESCRIPTION
with the current version of the script, I consistently get this error

```
$ ./mob prompt
v0.0.17: Pulling from mobilecoin/builder-install
Digest: sha256:d7aae94cebd3b51b9b499ac47a91a7ddf05987be2f174b8e869d5a7c305106e2
Status: Image is up to date for mobilecoin/builder-install:v0.0.17
docker.io/mobilecoin/builder-install:v0.0.17
Traceback (most recent call last):
  File "/home/chris/mobilecoinofficial/mobilecoin3/./mob", line 215, in <module>
    username = os.getlogin()
OSError: [Errno 6] No such device or address
```

I am not sure why, I'm just using the MATE Terminal.

Following guidance from stackoverflow
(https://stackoverflow.com/questions/4399617/python-os-getlogin-problem)

I tried the `pwd` version, which worked for me.
However, docs, and that answer, seem to say that this should be actually be `getpass.getuser()`.

https://docs.python.org/3/library/getpass.html#getpass.getuser

The docs say that falls back to the pwd thing, and should be prefered.

I tested that version also and it works for me also.