### PR TITLE
Add ci.yml and actions from master

### DIFF
--- a/.github/actions/check-dirty-git/action.yml
+++ b/.github/actions/check-dirty-git/action.yml
@@ -1,0 +1,17 @@
+name: Check dirty git
+description: Check the git status of the current directory, and raise an error if there are uncommitted changes.
+
+runs:
+  using: composite
+  steps:
+    - name: Checking dirty git
+      shell: bash
+      run: |
+        # Workaround for https://github.com/actions/checkout/issues/766
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+        if [[ -n $(git status --porcelain) ]]; then
+          echo "repo is dirty"
+          git status
+          exit 1
+        fi

--- a/.github/actions/run-mc-tests/action.yml
+++ b/.github/actions/run-mc-tests/action.yml
@@ -1,0 +1,56 @@
+name: Run MC tests
+
+inputs:
+  args:
+    description: Additional args
+    required: false
+    default:
+  junit_artifact:
+    description: Artifact name to upload JUnit XML files
+    required: false
+    default: junit-xml
+  junit_xml_filename:
+    description: Destination to rename junit.xml
+    required: false
+    default: junit.xml
+
+runs:
+  using: composite
+  steps:
+    - name: Check for nextest
+      id: meta
+      shell: bash
+      run: |
+        NEXTEST_PRESENT=$(command -v cargo-nextest >/dev/null && echo true || echo false)
+        echo ::set-output name=nextest_present::$NEXTEST_PRESENT
+    - name: Install cargo nextest
+      if: steps.meta.outputs.nextest_present != 'true'
+      uses: taiki-e/install-action@nextest
+    - name: Run MC tests
+      shell: bash
+      env:
+        RUST_BACKTRACE: 1
+        MC_LOG: debug
+      # Run tests, with JUnit XML output (configured via .config/nextest.toml)
+      # at `target/nextest/ci/junit.xml`
+      run: |
+        cargo nextest run \
+            --locked \
+            --profile ci \
+            --no-fail-fast \
+            ${{ inputs.args }}
+    - name: Upload core dumps
+      if: failure()
+      uses: ./.github/actions/upload-core-dumps
+    - name: Rename junit.xml
+      if: success() || failure()
+      shell: bash
+      run: mv target/nextest/ci/junit.xml target/${{ inputs.junit_xml_filename }}
+    - name: Upload JUnit XML
+      uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: ${{ inputs.junit_artifact }}
+        path: target/${{ inputs.junit_xml_filename }}
+    - name: Check dirty git
+      uses: ./.github/actions/check-dirty-git

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,81 @@
+name: Set up Rust and associated tools
+
+inputs:
+  components:
+    description: Comma-separated list of the additional components to install, e.g. 'clippy, rustfmt'
+    default:
+    required: false
+  default:
+    description: Set installed toolchain as a default toolchain
+    default: "true"
+    required: false
+  profile:
+    description: Rust toolchain profile
+    default: minimal
+    required: false
+  sgx_sdk:
+    description: Whether to install SGX SDK
+    default: "true"
+    required: false
+  sccache:
+    description: Whether to use sccache
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # TODO(remoun): Re-enable after fixing missing binaries in target/ dirs.
+    #- name: Set up dependency cache
+    #  uses: Swatinem/rust-cache@v1
+    - name: Set up env vars
+      id: env
+      shell: bash
+      # "You can make an environment variable available to any subsequent steps
+      # in a workflow job by defining or updating the environment variable
+      # and writing this to the GITHUB_ENV environment file."
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+      run: |
+        # Temp workaround for non-executable cbindgen
+        [[ -f /opt/cargo/bin/cbindgen ]] && chmod 0755 /opt/cargo/bin/cbindgen
+
+        # build config
+        echo 'IAS_MODE=DEV' >> $GITHUB_ENV
+        echo 'SGX_MODE=SW' >> $GITHUB_ENV
+        # test/run config
+        echo 'RUST_BACKTRACE=1' >> $GITHUB_ENV
+        echo 'SKIP_SLOW_TESTS=1' >> $GITHUB_ENV
+        # Remove the file size limit on core dump files
+        ulimit -c unlimited
+
+        HOST_TARGET_TRIPLE="$(rustc -Vv | sed -n 's/^host: //p')"
+        echo "HOST_TARGET_TRIPLE=$HOST_TARGET_TRIPLE" >> $GITHUB_ENV
+
+        CARGO_PRESENT=$(command -v cargo >/dev/null && echo true || echo false)
+        echo ::set-output name=cargo_present::$CARGO_PRESENT
+
+    # Install rust per `rust-toolchain`. No-op most of the time.
+    - name: Install Rust
+      if: steps.env.outputs.cargo_present != 'true'
+      uses: actions-rs/toolchain@v1
+      with:
+        # Honors rust-toolchain file, installing that version.
+        components: ${{ inputs.components }}
+        default: ${{ inputs.default }}
+        profile: ${{ inputs.profile }}
+    - name: Install SGX SDK
+      # NB: Actions' inputs are all strings.
+      if: ${{ inputs.sgx_sdk == 'true' }}
+      shell: bash
+      run: |
+        [[ -d /opt/intel/sgxsdk ]] || ./docker/install_sgx.sh
+        # Ideally we'd just add "source /opt/intel/sgxsdk/environment" to
+        # GITHUB_ENV, but it has a custom parser that rejects that.
+        source /opt/intel/sgxsdk/environment
+        echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "$SGX_SDK/bin" >> $GITHUB_PATH
+        echo "$SGX_SDK/bin/x64" >> $GITHUB_PATH
+    - name: Setup sccache
+      if: ${{ inputs.sccache == 'true' }}
+      uses: ./.github/actions/sccache

--- a/.github/actions/upload-core-dumps/action.yml
+++ b/.github/actions/upload-core-dumps/action.yml
@@ -1,0 +1,12 @@
+name: Upload core dumps
+description: Uploads generated core* files as a build artifact.
+
+runs:
+  using: composite
+  steps:
+    - name: Upload core dumps
+      uses: actions/upload-artifact@v3
+      with:
+        name: core_dumps
+        path: core*
+        if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,590 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  MC_TELEMETRY: 0
+
+permissions:
+  checks: write
+
+jobs:
+  build-dev:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Cargo build (SW/IAS dev)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          # This build dies with linker OOM, so limit the number of concurrent jobs.
+          args: --locked -j 4
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  build-prod:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Cargo build (HW/IAS prod)
+        env:
+          SGX_MODE: HW
+          IAS_MODE: PROD
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --locked
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  build-and-test-wasm:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build and test the wasm-test crate
+        env:
+          SGX_MODE: HW
+          IAS_MODE: PROD
+        run: wasm-pack test --node wasm-test
+
+  lint-rust:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          components: rustfmt, clippy
+      - name: Run lint script
+        run: ./tools/lint.sh
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+
+  build-and-test-go:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            /home/runner/.cache/go-build
+            /home/runner/Library/Caches/go-build
+            /home/runner/go/pkg/mod
+          key: v1-go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            v1-go-${{ runner.os }}
+      - name: Set up Go
+        uses: actions/setup-go@v3
+      - name: Build go
+        working-directory: go-grpc-gateway
+        run: ./install_tools.sh && ./build.sh
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+      - name: Lint Go code
+        working-directory: go-grpc-gateway
+        run: ./lint.sh
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+      - name: Build rust testing stub
+        working-directory: go-grpc-gateway/testing
+        env:
+          SGX_MODE: SW
+          IAS_MODE: DEV
+        run: cargo build --locked
+      - name: Run curl test
+        working-directory: go-grpc-gateway
+        run: ./test.sh
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  docs:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Generate docs
+        run: cargo doc --no-deps && tar -C target -czvf /tmp/doc.tgz doc/
+      - name: Store docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: doc.tgz
+          path: /tmp/doc.tgz
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  mc-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    strategy:
+      matrix:
+        num_runners: [2]
+        runner_index: [1, 2]
+      # Run each shard to completion.
+      fail-fast: false
+    env:
+      NUM_RUNNERS: ${{ matrix.num_runners }}
+      RUNNER_INDEX: ${{ matrix.runner_index }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: List packages to test
+        run: |
+          cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | \
+            grep -v -e mc-fog -e mc-consensus | \
+            awk "{ print \"-p \" \$1 }" | \
+            sort > /tmp/test-packages
+          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+            tee /tmp/mc-test-packages
+          # Hack: mc-util-sample-ledger needs mc-util-keyfile bins.
+          # TODO: Replace with artifact deps when that does not require
+          # additional cargo flags.
+          grep -q generate-sample-ledger /tmp/mc-test-packages && \
+            echo '-p mc-util-keyfile' >> /tmp/mc-test-packages || true
+      - name: Run tests
+        uses: ./.github/actions/run-mc-tests
+        with:
+          args: $(cat /tmp/mc-test-packages)
+          junit_xml_filename: junit-mc-tests-${{matrix.runner_index}}.xml
+
+
+  consensus-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    strategy:
+      matrix:
+        num_runners: [2]
+        runner_index: [1, 2]
+      # Run each shard to completion.
+      fail-fast: false
+    env:
+      NUM_RUNNERS: ${{ matrix.num_runners }}
+      RUNNER_INDEX: ${{ matrix.runner_index }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: List packages to test
+        run: |
+          cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | \
+            awk "/mc-consensus/ { print \"-p \" \$1 }" | \
+            sort > /tmp/test-packages
+          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+            tee /tmp/consensus-test-packages
+      - name: Run tests
+        uses: ./.github/actions/run-mc-tests
+        with:
+          args: $(cat /tmp/consensus-test-packages)
+          junit_xml_filename: junit-consensus-tests-${{matrix.runner_index}}.xml
+
+
+  fog-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    strategy:
+      matrix:
+        num_runners: [2]
+        runner_index: [1, 2]
+      # Run each shard to completion.
+      fail-fast: false
+    env:
+      NUM_RUNNERS: ${{ matrix.num_runners }}
+      RUNNER_INDEX: ${{ matrix.runner_index }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: List packages to test
+        run: |
+          cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | \
+            awk "/mc-fog/ { print \"-p \" \$1 }" | \
+            grep -v mc-fog-ingest | \
+            sort > /tmp/test-packages
+          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+            tee /tmp/fog-test-packages
+          # Hack: mc-fog-distribution needs bins from
+          # mc-util-{keyfile,generate-sample-ledger}.
+          # TODO: Replace with artifact deps when that does not require
+          # additional cargo flags.
+          grep -q fog-distribution /tmp/fog-test-packages && \
+            echo '-p mc-util-keyfile -p mc-util-generate-sample-ledger' >> /tmp/fog-test-packages || true
+      - name: Start postgres
+        run: service postgresql start
+      - name: Run tests
+        uses: ./.github/actions/run-mc-tests
+        with:
+          # The fog-overseer tests are large and sometimes fail to build;
+          # limiting the number of build-jobs helps with that.
+          args: $(cat /tmp/fog-test-packages) --build-jobs 4
+          junit_xml_filename: junit-fog-tests-${{matrix.runner_index}}.xml
+        env:
+          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
+          # create and drop PG databases.
+          TEST_DATABASE_URL: postgres://localhost
+
+
+  fog-ingest-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Start postgres
+        run: service postgresql start
+      - name: Run tests
+        uses: ./.github/actions/run-mc-tests
+        with:
+          # These tests time out without release mode.
+          args: -p 'mc-fog-ingest-*' --release
+          junit_xml_filename: junit-fog-ingest-tests.xml
+        env:
+          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
+          # create and drop PG databases.
+          TEST_DATABASE_URL: postgres://localhost
+
+
+  fog-conformance-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          # FIXME: This fails with Python 3.10: "AttributeError: module
+          # 'importlib' has no attribute 'abc'. Did you mean: '_abc'?"
+          python-version: '3.9'
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Set up environment
+        working-directory: tools/fog-local-network
+        run: |
+          python3 -m venv env
+          . ./env/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          ./build.sh
+
+          service postgresql start
+      - name: fog_conformance_tests.py
+        working-directory: tools/fog-local-network
+        env:
+          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
+          # create and drop PG databases.
+          TEST_DATABASE_URL: postgres://localhost
+        run: |
+          . ./env/bin/activate
+          python3 fog_conformance_tests.py --release
+      - name: Upload core dumps
+        uses: ./.github/actions/upload-core-dumps
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+
+  fog-local-network-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3'
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Build and generate sample data
+        run: |
+          # Generate enclave signing key
+          openssl genrsa -out Enclave_private.pem -3 3072
+          export CONSENSUS_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export INGEST_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export LEDGER_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export VIEW_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export MC_LOG=debug
+
+          # Build binaries
+          cargo build \
+              -p mc-admin-http-gateway \
+              -p mc-consensus-mint-client \
+              -p mc-consensus-service \
+              -p mc-crypto-x509-test-vectors \
+              -p mc-fog-distribution \
+              -p mc-fog-ingest-client \
+              -p mc-fog-ingest-server \
+              -p mc-fog-ledger-server \
+              -p mc-fog-report-server \
+              -p mc-fog-sql-recovery-db \
+              -p mc-fog-test-client \
+              -p mc-fog-view-server \
+              -p mc-ledger-distribution \
+              -p mc-mobilecoind \
+              -p mc-mobilecoind-dev-faucet \
+              -p mc-util-generate-sample-ledger \
+              -p mc-util-grpc-admin-tool \
+              -p mc-util-keyfile \
+              -p mc-util-seeded-ed25519-key-gen \
+              --release
+
+          BIN_DIR="$PWD/target/release"
+
+          # Run in temp dir to appease check-dirty-git.
+          mkdir -p /tmp/fog-local-network
+          cd /tmp/fog-local-network
+
+          # Generate sample keys and ledger.
+          FOG_AUTHORITY_ROOT=$("$BIN_DIR/mc-crypto-x509-test-vectors" --type=chain --test-name=ok_rsa_head)
+          "$BIN_DIR/sample-keys" --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          "$BIN_DIR/generate-sample-ledger" --txs 100
+
+          # Generate sample Fog keys.
+          "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
+
+          service postgresql start
+      - name: Run local network
+        env:
+          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
+          # create and drop PG databases.
+          TEST_DATABASE_URL: postgres://localhost
+        run: |
+          BIN_DIR="$PWD/target/release"
+          SCRIPT_DIR="$PWD/tools/fog-local-network"
+          export MC_CHAIN_ID="local"
+
+          cd /tmp/fog-local-network
+
+          # Run local network in background.
+          MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
+          LEDGER_BASE="$PWD/ledger" \
+          python3 "$SCRIPT_DIR/fog_local_network.py" --network-type dense5 --skip-build &
+          # Give it time to spin up
+          sleep 20
+
+          # Run fog-distribution client to exercise Fog
+          "$BIN_DIR/fog-distribution" \
+              --sample-data-dir . \
+              --max-threads 1 \
+              --peer insecure-mc://localhost:3200/ \
+              --peer insecure-mc://localhost:3201/ \
+              --peer insecure-mc://localhost:3202/ \
+              --peer insecure-mc://localhost:3203/ \
+              --peer insecure-mc://localhost:3204/ \
+              --num-tx-to-send 10
+          # Give it time to spin up
+          sleep 20
+
+          # Run test-client
+          "$BIN_DIR/test_client" \
+              --consensus insecure-mc://localhost:3200/ \
+              --consensus insecure-mc://localhost:3201/ \
+              --consensus insecure-mc://localhost:3202/ \
+              --consensus insecure-mc://localhost:3203/ \
+              --consensus insecure-mc://localhost:3204/ \
+              --num-clients 4 \
+              --num-transactions 200 \
+              --consensus-wait 300 \
+              --transfer-amount 20 \
+              --fog-view insecure-fog-view://localhost:8200 \
+              --fog-ledger insecure-fog-ledger://localhost:8200 \
+              --key-dir "$PWD/fog_keys"
+
+          # Run mobilecoind-dev-faucet
+          MC_LOG="info" \
+          "$BIN_DIR"/mobilecoind-dev-faucet \
+            --keyfile "$PWD/keys/account_keys_0.json" \
+            --peer insecure-mc://localhost:3200/ \
+            --peer insecure-mc://localhost:3201/ \
+            --peer insecure-mc://localhost:3202/ \
+            --peer insecure-mc://localhost:3203/ \
+            --peer insecure-mc://localhost:3204/ &
+
+          # Give it time to spin up
+          sleep 20
+
+          # Try hitting the faucet
+          curl -s localhost:9090/status
+          curl -s localhost:9090/ -d '{"b58_address": "5KBMnd8cs5zPsytGgZrjmQ8z9VJYThuh1B39pKzDERTfzm3sVGQxnZPC8JEWP69togpSPRz3e6pBsLzwnMjrXTbDqoRTQ8VF98sQu7LqjL5"}' -X POST
+          curl -s localhost:9090/ -d '{"b58_address": "5KBMnd8cs5zPsytGgZrjmQ8z9VJYThuh1B39pKzDERTfzm3sVGQxnZPC8JEWP69togpSPRz3e6pBsLzwnMjrXTbDqoRTQ8VF98sQu7LqjL5"}' -X POST
+
+          # Try triggering slam twice and see that it doesn't get stuck
+          curl -s localhost:9090/slam -X POST
+          sleep 20
+          curl -s localhost:9090/slam -X POST
+
+      - name: Upload core dumps
+        uses: ./.github/actions/upload-core-dumps
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  mint-auditor-local-network-tests:
+    runs-on: [self-hosted, Linux, large]
+    container: mobilecoin/builder-install:v0.0.17
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3'
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Build and generate sample data
+        run: |
+          # Generate enclave signing key
+          openssl genrsa -out Enclave_private.pem -3 3072
+          export CONSENSUS_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export INGEST_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export LEDGER_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export VIEW_ENCLAVE_PRIVKEY="$PWD/Enclave_private.pem"
+          export MC_LOG=debug
+
+          # Build binaries
+          cargo build \
+              -p mc-admin-http-gateway \
+              -p mc-consensus-mint-client \
+              -p mc-consensus-service \
+              -p mc-crypto-x509-test-vectors \
+              -p mc-ledger-distribution \
+              -p mc-mint-auditor \
+              -p mc-mobilecoind \
+              -p mc-util-generate-sample-ledger \
+              -p mc-util-grpc-admin-tool \
+              -p mc-util-keyfile \
+              -p mc-util-seeded-ed25519-key-gen \
+              --release
+
+          BIN_DIR="$PWD/target/release"
+
+          # Run in temp dir to appease check-dirty-git.
+          mkdir -p /tmp/local-network
+          cd /tmp/local-network
+
+          # Generate sample keys and ledger.
+          "$BIN_DIR/sample-keys" --num 10 --seed=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          "$BIN_DIR/generate-sample-ledger" --txs 100
+      - name: Run local network and mint auditor tests
+        run: |
+          BIN_DIR="$PWD/target/release"
+          SCRIPT_DIR="$PWD/tools/local-network"
+          MINT_AUDITOR_TESTS="$PWD/mint-auditor/tests"
+
+          # These paths are created by the local_network.py script
+          WORK_DIR="$PWD/target/release/mc-local-network"
+          MINTING_KEYS="$WORK_DIR/minting-keys"
+          export MC_CHAIN_ID="local"
+          export LEDGER_BASE="/tmp/local-network/ledger"
+
+          cd /tmp/local-network
+
+          # Run local network in background.
+          MC_LOG="info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
+          python3 "$SCRIPT_DIR/local_network.py" --network-type dense5 --skip-build &
+          # Give it time to spin up
+          sleep 20
+
+          # Start the mint-auditor in the background.
+          "$BIN_DIR/mc-mint-auditor" \
+            scan-ledger \
+            --ledger-db "$WORK_DIR/mobilecoind-ledger-db" \
+            --mint-auditor-db "$WORK_DIR/mint-auditor" \
+            --listen-uri insecure-mint-auditor://0.0.0.0:7774/ &
+
+          # Give it some time also
+          sleep 20
+
+          # Authorize minters
+          python3 "$SCRIPT_DIR/authorize-minters.py"
+
+          # Wait for mint-config-tx to clear
+          sleep 5
+
+          # Run the integration test
+          cd "$MINT_AUDITOR_TESTS" && bash compile_proto.sh
+          cd "$MINT_AUDITOR_TESTS" && python3 integration_test.py \
+             --mobilecoind-addr localhost:4444 \
+             --mint-auditor-addr localhost:7774 \
+             --node-url insecure-mc://localhost:3200 \
+             --mint-client-bin "$BIN_DIR/mc-consensus-mint-client" \
+             --mint-signing-key "$MINTING_KEYS/minter1"
+
+      - name: Upload core dumps
+        uses: ./.github/actions/upload-core-dumps
+      - name: Check dirty git
+        uses: ./.github/actions/check-dirty-git
+
+  publish-test-results:
+    runs-on: [self-hosted, Linux, small]
+    if: success() || failure()
+    needs:
+      - mc-tests
+      - consensus-tests
+      - fog-tests
+      - fog-ingest-tests
+    steps:
+    - name: Download XML reports
+      if: success() || failure()
+      uses: actions/download-artifact@v3
+      with:
+        name: junit-xml
+    - name: Publish Test Report
+      if: success() || failure()
+      uses: mikepenz/action-junit-report@v3
+      with:
+        check_name: Test Report
+        report_paths: '**/*.xml'
+
+# via https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
- Copy our GHA CI from `master` to `release/v2`.

### Motivation

Right now, `release/v2` only has CI from CircleCI, and `master` only has CI from GHA. Unfortunately, turning on CircleCI for `release/v2` breaks CI on `master`, and leaving it off means no CI on `release/v2`.

### Future Work
- [ ] Turn off CircleCI for good once this is merged.