### PR TITLE
Update Receipt proto schema for MaskedAmountV2 changes

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -340,7 +340,10 @@ message Receipt {
 
     // Amount of the TxOut.
     // Note: This value is self-reported by the sender and is unverifiable.
-    MaskedAmount masked_amount = 4;
+    oneof masked_amount {
+        MaskedAmount masked_amount_v1 = 4;
+        MaskedAmount masked_amount_v2 = 5;
+    };
 }
 
 /// The signature over an IAS JSON reponse, created by Intel


### PR DESCRIPTION
After masked amount v2, MaskedAmounts are always stored in a proto oneof, which their versioning information is derived from. It's generally going to be a bug if a MaskedAmount is not stored in a oneof this way, because the recipient will not be able to infer which version it is.

Brian ran into this when updating full-service. It likely will impact SDKs also.

Fixes #2530 