### PR TITLE
Add a missing conversion for Receipt_one_of_masked_amount

### DIFF
--- a/api/src/convert/amount.rs
+++ b/api/src/convert/amount.rs
@@ -91,3 +91,18 @@ impl TryFrom<&external::TxOut_oneof_masked_amount> for MaskedAmount {
         }
     }
 }
+
+impl TryFrom<&external::Receipt_oneof_masked_amount> for MaskedAmount {
+    type Error = ConversionError;
+
+    fn try_from(source: &external::Receipt_oneof_masked_amount) -> Result<Self, Self::Error> {
+        match source {
+            external::Receipt_oneof_masked_amount::masked_amount_v1(masked_amount) => {
+                Ok(MaskedAmount::V1(masked_amount.try_into()?))
+            }
+            external::Receipt_oneof_masked_amount::masked_amount_v2(masked_amount) => {
+                Ok(MaskedAmount::V2(masked_amount.try_into()?))
+            }
+        }
+    }
+}

--- a/api/src/convert/amount.rs
+++ b/api/src/convert/amount.rs
@@ -92,6 +92,19 @@ impl TryFrom<&external::TxOut_oneof_masked_amount> for MaskedAmount {
     }
 }
 
+impl From<&MaskedAmount> for external::Receipt_oneof_masked_amount {
+    fn from(source: &MaskedAmount) -> Self {
+        match source {
+            MaskedAmount::V1(masked_amount) => {
+                external::Receipt_oneof_masked_amount::masked_amount_v1(masked_amount.into())
+            }
+            MaskedAmount::V2(masked_amount) => {
+                external::Receipt_oneof_masked_amount::masked_amount_v2(masked_amount.into())
+            }
+        }
+    }
+}
+
 impl TryFrom<&external::Receipt_oneof_masked_amount> for MaskedAmount {
     type Error = ConversionError;
 


### PR DESCRIPTION
In the previous commit we added a oneof to the Receipt proto. However we didn't add a conversion similar TxOut_one_of_masked_amount.

This is needed because in the proto codegen, each oneof corresponds to a different type tied to the struct it appears in.