### PR TITLE
Adding serdr_str to several structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,6 +3153,7 @@ dependencies = [
  "rand_core 0.6.3",
  "rand_hc 0.3.1",
  "serde",
+ "serde_str",
  "subtle",
  "tempdir",
  "zeroize",
@@ -5080,6 +5081,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.3",
  "serde",
+ "serde_str",
  "sha2 0.10.5",
  "subtle",
  "tempdir",
@@ -5126,6 +5128,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.3",
  "serde",
+ "serde_str",
  "sha2 0.10.5",
  "subtle",
  "yaml-rust",
@@ -5138,7 +5141,9 @@ version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
+ "prost",
  "serde",
+ "serde_str",
  "subtle",
  "zeroize",
 ]
@@ -7287,6 +7292,15 @@ checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_str"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26e850fb9dfec51e9fea9dd582030761a4ef011d31b32d904f740961bd16a48"
+dependencies = [
  "serde",
 ]
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1179,6 +1179,7 @@ dependencies = [
  "prost",
  "rand_core",
  "serde",
+ "serde_str",
  "subtle",
  "zeroize",
 ]
@@ -1353,6 +1354,7 @@ dependencies = [
  "prost",
  "rand_core",
  "serde",
+ "serde_str",
  "sha2",
  "subtle",
  "zeroize",
@@ -1364,7 +1366,9 @@ version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
+ "prost",
  "serde",
+ "serde_str",
  "subtle",
  "zeroize",
 ]
@@ -1747,6 +1751,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_str"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26e850fb9dfec51e9fea9dd582030761a4ef011d31b32d904f740961bd16a48"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -13,6 +13,7 @@ hex_fmt = "0.3"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_str = { version = "0.1", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 

--- a/crypto/ring-signature/signer/src/traits.rs
+++ b/crypto/ring-signature/signer/src/traits.rs
@@ -56,6 +56,7 @@ pub enum OneTimeKeyDeriveData {
     /// The one-time private key for the output
     OneTimeKey(RistrettoPrivate),
     /// The subaddress index which owns the output
+    #[serde(with = "serde_str")]
     SubaddressIndex(u64),
 }
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -18,6 +18,7 @@ merlin = { version = "3.0", default-features = false }
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_str = { version = "0.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }

--- a/transaction/core/src/amount/v1.rs
+++ b/transaction/core/src/amount/v1.rs
@@ -35,6 +35,7 @@ pub struct MaskedAmountV1 {
 
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
     #[prost(fixed64, required, tag = "2")]
+    #[serde(with = "serde_str")]
     pub masked_value: u64,
 
     /// `masked_token_id = token_id XOR_8 Blake2B(token_id_mask |

--- a/transaction/core/src/amount/v2.rs
+++ b/transaction/core/src/amount/v2.rs
@@ -42,6 +42,7 @@ pub struct MaskedAmountV2 {
 
     /// `masked_value = value XOR_8 Blake2B(value_mask | shared_secret)`
     #[prost(fixed64, required, tag = "2")]
+    #[serde(with = "serde_str")]
     pub masked_value: u64,
 
     /// `masked_token_id = token_id XOR_8 Blake2B(token_id_mask |

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -163,15 +163,18 @@ pub struct TxPrefix {
 
     /// Fee paid to the foundation for this transaction
     #[prost(uint64, tag = "3")]
+    #[serde(with = "serde_str")]
     pub fee: u64,
 
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "4")]
+    #[serde(with = "serde_str")]
     pub tombstone_block: u64,
 
     /// Token id for the fee output of this transaction
     #[prost(fixed64, tag = "5")]
     #[digestible(omit_when = 0)]
+    #[serde(with = "serde_str")]
     pub fee_token_id: u64,
 }
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -16,6 +16,7 @@ prost = { version = "0.11", default-features = false, features = ["prost-derive"
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_str = { version = "0.1", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = "1"

--- a/transaction/std/src/transaction_builder.rs
+++ b/transaction/std/src/transaction_builder.rs
@@ -78,6 +78,7 @@ pub struct UnsignedTx {
     pub output_secrets: Vec<OutputSecret>,
 
     /// Block version
+    #[serde(with = "serde_str")]
     pub block_version: BlockVersion,
 }
 

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -8,7 +8,9 @@ readme = "README.md"
 [dependencies]
 # External dependencies
 displaydoc = { version = "0.2", default-features = false }
+prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_str = { version = "0.1.0", default-features = false }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 

--- a/transaction/types/src/amount.rs
+++ b/transaction/types/src/amount.rs
@@ -9,11 +9,13 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// An amount of some token, in the "base" (u64) denomination.
-#[derive(Clone, Copy, Debug, Digestible, Eq, PartialEq, Zeroize, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Digestible, Eq, Serialize, PartialEq, Zeroize)]
 pub struct Amount {
     /// The "raw" value of this amount as a u64
+    #[serde(with = "serde_str")]
     pub value: u64,
     /// The token-id which is the denomination of this amount
+    #[serde(with = "serde_str")]
     pub token_id: TokenId,
 }
 


### PR DESCRIPTION
This enables (de)serialization of u64s to/from strings, to prevent precision loss during transit