### PR TITLE
Add check to mint client to ensure public address doesn't have fog

### DIFF
--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -161,6 +161,9 @@ impl MintTxPrefixParams {
         self,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTxPrefix, String> {
+        if !self.recipient.fog_url.is_empty() {
+            return Err(format!("This recipient has a fog url, but minting to fog users is not supported right now: '{}'", self.recipient.fog_url));
+        }
         let tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
         let nonce = get_or_generate_nonce(self.nonce);
         Ok(MintTxPrefix {

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -161,8 +161,8 @@ impl MintTxPrefixParams {
         self,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTxPrefix, String> {
-        if !self.recipient.fog_url.is_empty() {
-            return Err(format!("This recipient has a fog url, but minting to fog users is not supported right now: '{}'", self.recipient.fog_url));
+        if let Some(fog_url) = self.recipient.fog_report_url() {
+            return Err(format!("This recipient has a fog url, but minting to fog users is not supported right now: '{}'", fog_url));
         }
         let tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
         let nonce = get_or_generate_nonce(self.nonce);


### PR DESCRIPTION
The mint client reads from a b58 address when it creates a MintTxPrefix, but it doesn't (before this commit) check if that is actually a fog address. If it is, the fog part will get silently removed, and then the fog user won't find it.

This change makes it give an error message.