### PR TITLE
added hash-tx-file subcommand to print the hash of a mint-tx or mint-config-tx file (#2406)

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -187,6 +187,15 @@ fn main() {
                 .expect("failed writing output file");
         }
 
+        Commands::HashTxFile { tx_file } => match tx_file {
+            TxFile::MintConfigTx(tx) => {
+                println!("{}", hex::encode(&tx.prefix.hash()));
+            }
+            TxFile::MintTx(tx) => {
+                println!("{}", hex::encode(&tx.prefix.hash()));
+            }
+        }
+
         Commands::HashMintTx { params } => {
             let tx_prefix = params
                 .try_into_mint_tx_prefix(|| panic!("missing tombstone block"))

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -263,6 +263,14 @@ pub enum Commands {
         params: MintConfigTxPrefixParams,
     },
 
+    /// Produce a hash of a MintConfigTx or MintTx tranasaction from a JSON tx-file.
+    /// This is useful for offline/HSM signing.
+    HashTxFile {
+        /// The file to load
+        #[clap(long, parse(try_from_str = load_tx_file_from_path), env = "MC_MINTING_TX_FILE")]
+        tx_file: TxFile,
+    },
+
     /// Submit json-encoded MintConfigTx(s). If multiple transactions are
     /// provided, signatures will be merged.
     SubmitMintConfigTx {


### PR DESCRIPTION
Cherypick of #2406 