### PR TITLE
Create recovery_db method that queries expired ingest invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
 name = "mc-fog-recovery-db-iface"
 version = "2.0.0"
 dependencies = [
+ "chrono",
  "displaydoc",
  "mc-attest-core",
  "mc-blockchain-types",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
 name = "mc-fog-recovery-db-iface"
 version = "2.0.0"
 dependencies = [
+ "chrono",
  "displaydoc",
  "mc-attest-core",
  "mc-blockchain-types",

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -18,5 +18,6 @@ mc-fog-kex-rng = { path = "../kex_rng" }
 mc-fog-types = { path = "../types" }
 
 # third-party
+chrono = "0.4"
 displaydoc = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -18,6 +18,6 @@ mc-fog-kex-rng = { path = "../kex_rng" }
 mc-fog-types = { path = "../types" }
 
 # third-party
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 mod types;
 
 use alloc::{string::String, vec::Vec};
+use chrono::NaiveDateTime;
 use core::fmt::{Debug, Display};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_kex_rng::KexRngPubkey;
@@ -314,7 +315,7 @@ pub trait RecoveryDb {
     /// `expired_timestamp`.
     fn get_expired_invocations(
         &self,
-        expired_epoch_timestamp_secs: u64,
+        expiration: NaiveDateTime,
     ) -> Result<Vec<ExpiredInvocationRecord>, Self::Error>;
 }
 

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -18,8 +18,8 @@ use mc_fog_types::view::TxOutSearchResult;
 pub use mc_blockchain_types::Block;
 pub use mc_fog_types::{common::BlockRange, ETxOutRecord};
 pub use types::{
-    AddBlockDataStatus, FogUserEvent, IngestInvocationId, IngestableRange, IngressPublicKeyRecord,
-    IngressPublicKeyStatus, ReportData,
+    AddBlockDataStatus, ExpiredInvocationRecord, FogUserEvent, IngestInvocationId, IngestableRange,
+    IngressPublicKeyRecord, IngressPublicKeyStatus, ReportData,
 };
 
 /// Contains fields that are used as filters in  queries for ingress keys.
@@ -309,6 +309,13 @@ pub trait RecoveryDb {
 
     /// Get the highest block index for which we have any data at all.
     fn get_highest_known_block_index(&self) -> Result<Option<u64>, Self::Error>;
+
+    /// Returns all ingest invocations have not been active since the
+    /// `expired_timestamp`.
+    fn get_expired_invocations(
+        &self,
+        expired_epoch_timestamp_secs: u64,
+    ) -> Result<Vec<ExpiredInvocationRecord>, Self::Error>;
 }
 
 /// The report database interface.

--- a/fog/recovery_db_iface/src/types.rs
+++ b/fog/recovery_db_iface/src/types.rs
@@ -122,7 +122,7 @@ impl IngressPublicKeyRecord {
     }
 }
 
-/// Records pertaining to expired ingest invocations. An invocation's expiratoin
+/// Records pertaining to expired ingest invocations. An invocation's expiration
 /// status is determined by using its `last_active_at` timestamp, i.e. when it
 /// was last used.
 pub struct ExpiredInvocationRecord {

--- a/fog/recovery_db_iface/src/types.rs
+++ b/fog/recovery_db_iface/src/types.rs
@@ -6,6 +6,7 @@
 use core::{fmt, ops::Deref};
 use mc_attest_core::VerificationReport;
 use mc_crypto_keys::CompressedRistrettoPublic;
+use mc_fog_kex_rng::KexRngPubkey;
 use mc_fog_types::{
     common::BlockRange,
     view::{DecommissionedIngestInvocation, RngRecord},
@@ -120,6 +121,19 @@ impl IngressPublicKeyRecord {
     }
 }
 
+/// Records pertaining to expired ingest invocations. An invocation's expiratoin
+/// status is determined by using its `last_active_at` timestamp, i.e. when it
+/// was last used.
+pub struct ExpiredInvocationRecord {
+    /// The id for the expired ingest invocation.
+    pub ingest_invocation_id: i64,
+
+    /// The expired egress key.
+    pub egress_public_key: KexRngPubkey,
+
+    /// The last time the expired key was active.
+    pub last_active_at: u64,
+}
 /// Possible user events to be returned to end users.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum FogUserEvent {

--- a/fog/recovery_db_iface/src/types.rs
+++ b/fog/recovery_db_iface/src/types.rs
@@ -3,6 +3,7 @@
 //! Database API types
 //! These are not user-facing, the user facing versions are in fog-types crate.
 
+use chrono::NaiveDateTime;
 use core::{fmt, ops::Deref};
 use mc_attest_core::VerificationReport;
 use mc_crypto_keys::CompressedRistrettoPublic;
@@ -132,7 +133,7 @@ pub struct ExpiredInvocationRecord {
     pub egress_public_key: KexRngPubkey,
 
     /// The last time the expired key was active.
-    pub last_active_at: u64,
+    pub last_active_at: NaiveDateTime,
 }
 /// Possible user events to be returned to end users.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -270,7 +270,7 @@ impl SqlRecoveryDb {
         expiration: NaiveDateTime,
     ) -> Result<Vec<ExpiredInvocationRecord>, Error> {
         use schema::ingest_invocations::dsl;
-        let query = schema::ingest_invocations::dsl::ingest_invocations
+        let query = dsl::ingest_invocations
             .select((
                 dsl::id,
                 dsl::rng_version,
@@ -479,7 +479,7 @@ impl SqlRecoveryDb {
 
             // Write new invocation.
             let now =
-                diesel::select(diesel::dsl::now).get_result::<chrono::NaiveDateTime>(&conn)?;
+                diesel::select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
 
             let obj = models::NewIngestInvocation {
                 ingress_public_key: (*ingress_public_key).into(),
@@ -1450,7 +1450,7 @@ impl RecoveryDb for SqlRecoveryDb {
     }
 
     /// Returns all ingest invocations have not been active since the
-    /// `expired_timestamp`.
+    /// `expiration`.
     fn get_expired_invocations(
         &self,
         expiration: NaiveDateTime,

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -478,8 +478,7 @@ impl SqlRecoveryDb {
             }
 
             // Write new invocation.
-            let now =
-                diesel::select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
+            let now = diesel::select(diesel::dsl::now).get_result::<NaiveDateTime>(&conn)?;
 
             let obj = models::NewIngestInvocation {
                 ingress_public_key: (*ingress_public_key).into(),

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1160,6 +1160,7 @@ dependencies = [
 name = "mc-fog-recovery-db-iface"
 version = "2.0.0"
 dependencies = [
+ "chrono",
  "displaydoc",
  "mc-attest-core",
  "mc-blockchain-types",


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

As described in #2337, we'd like to create a tool that cleans up expired egress keys. In effect, this means that we'd like to identify ingest invocations, which are associated with egress keys, that have a `'last_active_at` timestamp before some specified time. 

This PR adds the `RecoveryDb` method and corresponding `SqlRecoveryDb` implementation that allows us to identify expired egress keys.

RFC: This is the first time, to my knowledge, that we are handling diesel / PSQL timestamps and specifying them in the `RecoveryDb` trait, which is `no_std`. I chose to use `chrono::NaiveDateTime` because it's one of the types that `diesel` provides a `ToSql` conversion for AND it doesn't require `std`. Let me know your thoughts.

### Future Work
* Create an executable that uses this method to either print the expired keys or delete them from the DB.