### PR TITLE
master: [Fixes] CI/CD, chart, container - Fix consensus node bootstrap from scratch.

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -191,6 +191,7 @@ jobs:
         mkdir -p .tmp/seeds
         echo -n "${FOG_REPORT_SIGNING_CA_CERT}" > .tmp/seeds/FOG_REPORT_SIGNING_CA_CERT
         echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > .tmp/seeds/FOG_REPORT_SIGNING_CA_CERT_PATH
+        echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > .tmp/seeds/FOG_REPORT_URL
 
     - name: Create wallet key secrets
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.internal-ci/docker/entrypoints/node_hw.sh
+++ b/.internal-ci/docker/entrypoints/node_hw.sh
@@ -146,18 +146,8 @@ then
         cp /ledger/data.mdb "/ledger/data.mdb.$(date +%y%m%d-%H%M%S)"
         /usr/bin/mc-ledger-migration --ledger-db "${MC_LEDGER_PATH}"
     else
-        # Look for wallet keys seed - development and CD deploys
-        if [[ -n "${INITIAL_KEYS_SEED}" ]]
-        then
-            echo "INITIAL_KEYS_SEED found - populating origin data"
-            export INITIALIZE_LEDGER="true"
-
-            /usr/local/bin/generate_origin_data.sh
-
-            cp /tmp/sample_data/ledger/data.mdb "${MC_LEDGER_PATH}"
-
         # Try to find origin block from s3 archive - preserve existing data, testnet/mainnet
-        elif archive_curl "${MC_TX_SOURCE_URL}"
+        if archive_curl "${MC_TX_SOURCE_URL}"
         then
             echo "Remote archive ledger found - restore with ledger-from-archive"
             echo "  Note: RUST_LOG=warn so we don't get 1m+ lines of logs"
@@ -170,6 +160,17 @@ then
         then
             echo "Found origin ledger at ${ORIGIN_LEDGER_PATH}"
             cp "${ORIGIN_LEDGER_PATH}" "${MC_LEDGER_PATH}"
+
+        # Look for wallet keys seed - development and CD deploys
+        elif [[ -n "${INITIAL_KEYS_SEED}" ]]
+        then
+            echo "INITIAL_KEYS_SEED found - populating origin data"
+            export INITIALIZE_LEDGER="true"
+
+            /usr/local/bin/generate_origin_data.sh
+
+            cp /tmp/sample_data/ledger/data.mdb "${MC_LEDGER_PATH}"
+
         else
             # We ain't found nothin, bail out!
             echo "INITIAL_KEYS_SEED not set, no remote ledger and cannot find origin ledger file"

--- a/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
+++ b/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
@@ -18,6 +18,11 @@ is_set()
     fi
 }
 
+archive_curl()
+{
+    /usr/bin/curl -IfsSL --retry 3 "${1}00/00/00/00/00/00/00/0000000000000000.pb"
+}
+
 is_set MC_DEST
 is_set AWS_ACCESS_KEY_ID
 is_set AWS_SECRET_ACCESS_KEY
@@ -48,8 +53,17 @@ then
 
     export MC_START_FROM=last
 else
-    echo "mc.app:wrapper-ledger-distribution - no state file found MC_START_FROM=next"
-    export MC_START_FROM=next
+    echo "mc.app:wrapper-ledger-distribution - no state file found."
+    echo "mc.app:wrapper-ledger-distribution - checking for an existing block 0 in s3"
+
+    if archive_curl "${MC_TX_SOURCE_URL}"
+    then
+        echo "mc.app:wrapper-ledger-distribution - block 0 found in s3 MC_START_FROM=next"
+        export MC_START_FROM=next
+    else
+        echo "mc.app:wrapper-ledger-distribution - no s3 archive found MC_START_FROM=zero"
+        export MC_START_FROM=zero
+    fi
 fi
 
 /usr/bin/ledger-distribution

--- a/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
+++ b/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
@@ -20,7 +20,7 @@ is_set()
 
 archive_curl()
 {
-    /usr/bin/curl -IfsSL --retry 3 "${1}00/00/00/00/00/00/00/0000000000000000.pb"
+    /usr/bin/curl -IfsSL --retry 3 "${1}00/00/00/00/00/00/00/0000000000000000.pb" -o /dev/null
 }
 
 is_set MC_DEST

--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -101,6 +101,9 @@ spec:
             name: ias
         - configMapRef:
             name: {{ include "consensusNode.nodeConfig.configMap.name" . }}
+        - secretRef:
+            name: sample-keys-seeds
+            optional: true
         env:
         - name: PATH
           value: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64'
@@ -141,6 +144,9 @@ spec:
           mountPath: /keys
         - name: node-cert
           mountPath: /certs
+          readOnly: true
+        - name: wallet-seeds
+          mountPath: /wallet-seeds
           readOnly: true
         resources:
           {{- toYaml .Values.node.resources | nindent 10}}
@@ -197,6 +203,10 @@ spec:
       - name: node-cert
         secret:
           secretName: {{ include "consensusNode.fullname" . }}-internal-tls
+      - name: wallet-seeds
+        secret:
+          secretName: sample-keys-seeds
+          optional: true
       - name: ledger-db-dir
         {{- if eq .Values.node.persistence.enabled true }}
         persistentVolumeClaim:


### PR DESCRIPTION
Cherry-pick from release/v2

### Motivation
Fix the ability to bootstrap the network from scratch with a 2.x+ version container and charts. Useful for load testing.

- Add optional secrets for initial and fog keys seeds.
- Add MC_START_FROM=zero logic to ledger-distribution.


