### PR TITLE
allow specifying a fog hint when minting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
               --consensus insecure-mc://localhost:3203/ \
               --consensus insecure-mc://localhost:3204/ \
               --num-clients 4 \
-              --num-transactions 200 \
+              --num-transactions 40 \
               --consensus-wait 300 \
               --transfer-amount 20 \
               --fog-view insecure-fog-view://localhost:8200 \
@@ -487,7 +487,7 @@ jobs:
               --consensus insecure-mc://localhost:3203/ \
               --consensus insecure-mc://localhost:3204/ \
               --num-clients 4 \
-              --num-transactions 200 \
+              --num-transactions 40 \
               --consensus-wait 300 \
               --transfer-amount 20 \
               --token-ids 0,1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,12 +406,16 @@ jobs:
           BIN_DIR="$PWD/target/release"
           SCRIPT_DIR="$PWD/tools/fog-local-network"
           export MC_CHAIN_ID="local"
+          export MC_LOG=info
+          # This is needed since we want to capture the output of mc-consensus-tool, and we can't have the
+          # logs getting in the way.
+          export MC_LOG_STDERR=1
 
           cd /tmp/fog-local-network
+          export LEDGER_BASE="$PWD/ledger"
 
           # Run local network in background.
-          MC_LOG="debug,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
-          LEDGER_BASE="$PWD/ledger" \
+          MC_LOG="info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,rusoto_core=error,h2=error,reqwest=error,rocket=error,<unknown>=error" \
           python3 "$SCRIPT_DIR/fog_local_network.py" --network-type dense5 --skip-build &
 
           # Give it time to spin up
@@ -421,26 +425,21 @@ jobs:
             done
           done
 
+          # Save some typing
+          export MC_PEER=insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/
+
           # Run fog-distribution client to exercise Fog
+          echo "Running fog distro"
           "$BIN_DIR/fog-distribution" \
               --sample-data-dir . \
               --max-threads 1 \
-              --peer insecure-mc://localhost:3200/ \
-              --peer insecure-mc://localhost:3201/ \
-              --peer insecure-mc://localhost:3202/ \
-              --peer insecure-mc://localhost:3203/ \
-              --peer insecure-mc://localhost:3204/ \
               --num-tx-to-send 10
 
           # Give it time to quiet down
-          "$BIN_DIR/mc-consensus-tool" wait-for-quiet \
-              insecure-mc://localhost:3200/ \
-              insecure-mc://localhost:3201/ \
-              insecure-mc://localhost:3202/ \
-              insecure-mc://localhost:3203/ \
-              insecure-mc://localhost:3204/
+          "$BIN_DIR/mc-consensus-tool" wait-for-quiet
 
           # Run test-client
+          echo "Running test client"
           "$BIN_DIR/test_client" \
               --consensus insecure-mc://localhost:3200/ \
               --consensus insecure-mc://localhost:3201/ \
@@ -455,15 +454,51 @@ jobs:
               --fog-ledger insecure-fog-ledger://localhost:8200 \
               --key-dir "$PWD/fog_keys"
 
+          PRE_AUTH_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet)
+
+          # Authorize minters
+          echo "Authorizing minters"
+          python3 "$SCRIPT_DIR/../local-network/authorize-minters.py"
+
+          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_AUTH_BLOCK_INDEX)
+          echo "Done waiting, PRE_MINT_BLOCK_INDEX=${PRE_MINT_BLOCK_INDEX}"
+
+          # Mint 1 million token1's to the first 4 fog accounts
+          echo "Minting"
+          for ACCOUNT_NUM in $(seq 0 3); do
+              "$BIN_DIR/mc-consensus-mint-client" \
+                  "generate-and-submit-mint-tx" \
+                  --node insecure-mc://localhost:3200/ \
+                  --signing-key "$BIN_DIR/mc-local-network/minting-keys/minter1" \
+                  --recipient $(cat fog_keys/account_keys_${ACCOUNT_NUM}.b58pub) \
+                  --fog-ingest-enclave-css "$BIN_DIR/ingest-enclave.css" \
+                  --token-id 1 \
+                  --amount 1000000
+          done
+
+          "$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_MINT_BLOCK_INDEX
+
+          # Run test-client
+          echo "Running test client (tokens 0 and 1)"
+          "$BIN_DIR/test_client" \
+              --consensus insecure-mc://localhost:3200/ \
+              --consensus insecure-mc://localhost:3201/ \
+              --consensus insecure-mc://localhost:3202/ \
+              --consensus insecure-mc://localhost:3203/ \
+              --consensus insecure-mc://localhost:3204/ \
+              --num-clients 4 \
+              --num-transactions 200 \
+              --consensus-wait 300 \
+              --transfer-amount 20 \
+              --token-ids 0,1 \
+              --fog-view insecure-fog-view://localhost:8200 \
+              --fog-ledger insecure-fog-ledger://localhost:8200 \
+              --key-dir "$PWD/fog_keys"
+
           # Run mobilecoind-dev-faucet
           MC_LOG="info" \
           "$BIN_DIR"/mobilecoind-dev-faucet \
-            --keyfile "$PWD/keys/account_keys_0.json" \
-            --peer insecure-mc://localhost:3200/ \
-            --peer insecure-mc://localhost:3201/ \
-            --peer insecure-mc://localhost:3202/ \
-            --peer insecure-mc://localhost:3203/ \
-            --peer insecure-mc://localhost:3204/ &
+            --keyfile "$PWD/keys/account_keys_0.json" &
 
           # Give it time to spin up
           for i in $(seq 0 60); do
@@ -478,12 +513,7 @@ jobs:
           # Try triggering slam twice and see that it doesn't get stuck
           curl -s localhost:9090/slam -X POST
 
-          "$BIN_DIR/mc-consensus-tool" wait-for-quiet \
-              insecure-mc://localhost:3200/ \
-              insecure-mc://localhost:3201/ \
-              insecure-mc://localhost:3202/ \
-              insecure-mc://localhost:3203/ \
-              insecure-mc://localhost:3204/
+          "$BIN_DIR/mc-consensus-tool" wait-for-quiet
 
           curl -s localhost:9090/slam -X POST
 
@@ -570,7 +600,7 @@ jobs:
           export MC_LOG_STDERR=1
 
           # Used by mc-consensus-tool
-          export MC_PEERS="insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/"
+          export MC_PEER=insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/
 
           cd /tmp/fog-local-network
           export LEDGER_BASE="$PWD/ledger"
@@ -586,12 +616,14 @@ jobs:
             done
           done
 
+          PRE_AUTH_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet)
+
           # Authorize minters
           echo "Authorizing minters"
           python3 "$SCRIPT_DIR/../local-network/authorize-minters.py"
 
           echo "Waiting for quiet after authorizing minters..."
-          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet)
+          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_AUTH_BLOCK_INDEX)
           echo "Done waiting, PRE_MINT_BLOCK_INDEX=${PRE_MINT_BLOCK_INDEX}"
 
           # Mint 1 million token1's to the first 4 accounts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+checksum = "d5c2ca00549910ec251e3bd15f87aeeb206c9456b9a77b43ff6c97c54042a472"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -1388,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs_extra"
@@ -2673,6 +2673,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5722,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -5737,9 +5738,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -6262,9 +6263,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -6331,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c8babc29389186697fe5a2a4859d697825496b83db5d0b65271cdc0488e88c"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,8 +2274,9 @@ dependencies = [
  "mc-crypto-x509-test-vectors",
  "mc-fog-report-validation-test-utils",
  "mc-test-vectors-b58-encodings",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
+ "mc-transaction-extra",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-from-random",
@@ -2840,9 +2882,9 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -3243,8 +3285,8 @@ dependencies = [
  "mc-fog-report-connection",
  "mc-fog-report-resolver",
  "mc-ledger-db",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-cli",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
@@ -4033,9 +4075,10 @@ dependencies = [
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
  "mc-sgx-css",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
+ "mc-transaction-extra",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-grpc",
@@ -4159,7 +4202,7 @@ dependencies = [
  "mc-fog-uri",
  "mc-sgx-css",
  "mc-transaction-core",
- "mc-transaction-std",
+ "mc-transaction-extra",
  "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
@@ -4460,9 +4503,9 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-rand",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-lmdb",
  "mc-util-metrics",
@@ -4597,8 +4640,9 @@ dependencies = [
  "mc-ledger-sync",
  "mc-mobilecoind-api",
  "mc-sgx-css",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
+ "mc-transaction-extra",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
@@ -4636,7 +4680,7 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-consensus-api",
- "mc-transaction-std",
+ "mc-transaction-builder",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
@@ -4662,8 +4706,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-resolver",
  "mc-mobilecoind-api",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-serial",
@@ -4690,6 +4734,7 @@ dependencies = [
  "mc-mobilecoind-api",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-extra",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-serial",
@@ -4965,7 +5010,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-test-vectors-definitions",
- "mc-transaction-std",
+ "mc-transaction-extra",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -4986,12 +5031,44 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-oblivious-traits",
  "mc-test-vectors-definitions",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "mc-transaction-builder"
+version = "2.1.0-pre0"
+dependencies = [
+ "assert_matches",
+ "cfg-if 1.0.0",
+ "curve25519-dalek",
+ "displaydoc",
+ "hmac 0.12.1",
+ "maplit",
+ "mc-account-keys",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation",
+ "mc-fog-report-validation-test-utils",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-serial",
+ "mc-util-test-helper",
+ "prost",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "subtle",
+ "yaml-rust",
+ "zeroize",
 ]
 
 [[package]]
@@ -5020,8 +5097,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-validation-test-utils",
  "mc-ledger-db",
+ "mc-transaction-builder",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-transaction-types",
  "mc-util-from-random",
  "mc-util-repr-bytes",
@@ -5056,7 +5133,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-std"
+name = "mc-transaction-extra"
 version = "2.1.0-pre0"
 dependencies = [
  "assert_matches",
@@ -5066,14 +5143,16 @@ dependencies = [
  "hmac 0.12.1",
  "maplit",
  "mc-account-keys",
+ "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
+ "mc-crypto-ring-signature",
  "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation",
  "mc-fog-report-validation-test-utils",
  "mc-transaction-core",
  "mc-transaction-types",
  "mc-util-from-random",
+ "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",
  "prost",
@@ -5392,6 +5471,7 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_cbor",
+ "serde_json",
  "serde_with",
 ]
 
@@ -5469,8 +5549,8 @@ dependencies = [
  "mc-account-keys",
  "mc-api",
  "mc-crypto-keys",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "rand 0.8.5",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -5669,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multer"
@@ -7251,11 +7331,24 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
 dependencies = [
  "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,16 +33,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
- "ctr",
+ "ctr 0.8.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.3",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -51,11 +72,25 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "cipher 0.3.0",
+ "ctr 0.8.0",
+ "ghash 0.4.4",
+ "subtle",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+dependencies = [
+ "aead 0.5.1",
+ "aes 0.8.2",
+ "cipher 0.4.3",
+ "ctr 0.9.2",
+ "ghash 0.5.0",
  "subtle",
 ]
 
@@ -265,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "binascii"
@@ -520,15 +555,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.14",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -632,6 +668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.13"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
@@ -686,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -753,11 +799,11 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.10.1",
  "base64",
  "hkdf",
  "hmac 0.12.1",
@@ -906,11 +952,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -930,7 +977,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -1412,9 +1468,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1427,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1437,15 +1493,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1454,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-lite"
@@ -1475,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1486,21 +1542,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1560,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1578,7 +1634,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
- "polyval",
+ "polyval 0.5.3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.0",
 ]
 
 [[package]]
@@ -1603,7 +1669,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 name = "go-grpc-gateway-testing"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -1917,6 +1983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,9 +2060,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2021,9 +2096,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libloading"
@@ -2242,7 +2317,7 @@ dependencies = [
 name = "mc-admin-http-gateway"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -2299,8 +2374,8 @@ dependencies = [
 name = "mc-attest-ake"
 version = "2.1.0-pre0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.4.3",
+ "aes-gcm 0.9.4",
  "cargo-emit",
  "digest 0.10.5",
  "displaydoc",
@@ -2324,7 +2399,7 @@ dependencies = [
 name = "mc-attest-api"
 version = "2.1.0-pre0"
 dependencies = [
- "aead",
+ "aead 0.4.3",
  "cargo-emit",
  "digest 0.10.5",
  "futures",
@@ -2567,7 +2642,7 @@ dependencies = [
 name = "mc-connection"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "cookie",
  "displaydoc",
  "grpcio",
@@ -2631,7 +2706,7 @@ dependencies = [
 name = "mc-consensus-enclave"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "cargo-emit",
  "lazy_static",
  "mc-attest-ake",
@@ -2773,7 +2848,7 @@ dependencies = [
 name = "mc-consensus-mint-client"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "grpcio",
  "hex",
@@ -2832,7 +2907,7 @@ dependencies = [
 name = "mc-consensus-scp-play"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-common",
  "mc-consensus-scp",
  "mc-transaction-core",
@@ -2862,7 +2937,7 @@ version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "chrono",
- "clap 4.0.13",
+ "clap 4.0.18",
  "curve25519-dalek",
  "displaydoc",
  "fs_extra",
@@ -2926,7 +3001,7 @@ name = "mc-consensus-service-config"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "hex",
  "mc-attest-core",
@@ -2951,7 +3026,7 @@ dependencies = [
 name = "mc-consensus-tool"
 version = "2.0.0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "mc-common",
  "mc-connection",
@@ -2965,7 +3040,7 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "digest 0.10.5",
  "mc-attest-ake",
  "mc-attest-core",
@@ -2985,7 +3060,7 @@ dependencies = [
 name = "mc-crypto-box"
 version = "2.1.0-pre0"
 dependencies = [
- "aead",
+ "aead 0.4.3",
  "digest 0.10.5",
  "displaydoc",
  "hkdf",
@@ -3102,7 +3177,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "displaydoc",
  "generic-array",
  "mc-util-serial",
@@ -3130,8 +3205,8 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "2.1.0-pre0"
 dependencies = [
- "aead",
- "aes-gcm",
+ "aead 0.4.3",
+ "aes-gcm 0.9.4",
  "digest 0.10.5",
  "displaydoc",
  "generic-array",
@@ -3216,7 +3291,7 @@ name = "mc-crypto-x509-test-vectors"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-crypto-keys",
  "mc-util-build-script",
  "pem",
@@ -3281,7 +3356,7 @@ dependencies = [
 name = "mc-fog-distribution"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "crossbeam-channel",
  "curve25519-dalek",
  "grpcio",
@@ -3314,7 +3389,7 @@ dependencies = [
 name = "mc-fog-enclave-connection"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "cookie",
  "displaydoc",
  "grpcio",
@@ -3339,7 +3414,7 @@ name = "mc-fog-ingest-client"
 version = "2.1.0-pre0"
 dependencies = [
  "assert_cmd",
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "grpcio",
  "hex",
@@ -3495,7 +3570,7 @@ dependencies = [
 name = "mc-fog-ingest-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "dirs",
  "displaydoc",
  "futures",
@@ -3707,7 +3782,7 @@ dependencies = [
 name = "mc-fog-ledger-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -3779,7 +3854,7 @@ dependencies = [
 name = "mc-fog-load-testing"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "mc-account-keys",
  "mc-blockchain-test-utils",
@@ -3825,7 +3900,7 @@ dependencies = [
 name = "mc-fog-ocall-oram-storage-trusted"
 version = "2.1.0-pre0"
 dependencies = [
- "aes",
+ "aes 0.7.5",
  "aligned-cmov",
  "balanced-tree-index",
  "blake2",
@@ -3850,7 +3925,7 @@ dependencies = [
 name = "mc-fog-overseer-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "grpcio",
  "lazy_static",
@@ -3934,7 +4009,7 @@ name = "mc-fog-report-cli"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "hex",
  "mc-account-keys",
@@ -3989,7 +4064,7 @@ dependencies = [
 name = "mc-fog-report-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4057,7 +4132,7 @@ name = "mc-fog-sample-paykit"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4156,7 +4231,7 @@ name = "mc-fog-sql-recovery-db"
 version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 4.0.13",
+ "clap 4.0.18",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
@@ -4190,7 +4265,7 @@ name = "mc-fog-sql-recovery-db-cleanup"
 version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-common",
  "mc-fog-recovery-db-iface",
  "mc-fog-sql-recovery-db",
@@ -4201,7 +4276,7 @@ dependencies = [
 name = "mc-fog-test-client"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "grpcio",
  "hex_fmt",
@@ -4235,7 +4310,7 @@ dependencies = [
 name = "mc-fog-test-infra"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "digest 0.10.5",
  "hex",
  "mc-account-keys",
@@ -4413,7 +4488,7 @@ dependencies = [
 name = "mc-fog-view-load-test"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4455,7 +4530,7 @@ dependencies = [
 name = "mc-fog-view-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4535,7 +4610,7 @@ dependencies = [
 name = "mc-ledger-distribution"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "dirs",
  "displaydoc",
  "mc-api",
@@ -4558,7 +4633,7 @@ dependencies = [
 name = "mc-ledger-from-archive"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-api",
  "mc-common",
  "mc-ledger-db",
@@ -4569,7 +4644,7 @@ dependencies = [
 name = "mc-ledger-migration"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "lmdb-rkv",
  "mc-common",
  "mc-ledger-db",
@@ -4616,8 +4691,8 @@ dependencies = [
 name = "mc-mobilecoind"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
- "clap 4.0.13",
+ "aes-gcm 0.9.4",
+ "clap 4.0.18",
  "crossbeam-channel",
  "displaydoc",
  "grpcio",
@@ -4706,7 +4781,7 @@ name = "mc-mobilecoind-dev-faucet"
 version = "2.1.0-pre0"
 dependencies = [
  "async-channel",
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "grpcio",
  "hex",
@@ -4737,7 +4812,7 @@ dependencies = [
 name = "mc-mobilecoind-json"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "hex",
  "mc-api",
@@ -4764,11 +4839,11 @@ version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "cipher 0.3.0",
+ "ctr 0.8.0",
+ "ghash 0.4.4",
  "subtle",
  "zeroize",
 ]
@@ -4906,7 +4981,7 @@ dependencies = [
 name = "mc-sgx-css-dump"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "hex_fmt",
  "mc-sgx-css",
 ]
@@ -5088,7 +5163,7 @@ dependencies = [
 name = "mc-transaction-core"
 version = "2.1.0-pre0"
 dependencies = [
- "aes",
+ "aes 0.7.5",
  "assert_matches",
  "bulletproofs-og",
  "crc",
@@ -5193,7 +5268,7 @@ dependencies = [
 name = "mc-util-b58-decoder"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "hex",
  "mc-api",
 ]
@@ -5203,7 +5278,7 @@ name = "mc-util-build-enclave"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "cargo_metadata 0.15.0",
+ "cargo_metadata 0.15.1",
  "displaydoc",
  "mbedtls",
  "mbedtls-sys-auto",
@@ -5256,7 +5331,7 @@ dependencies = [
 name = "mc-util-cli"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-util-build-info",
 ]
 
@@ -5264,7 +5339,7 @@ dependencies = [
 name = "mc-util-dump-ledger"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "mc-blockchain-types",
  "mc-common",
@@ -5299,7 +5374,7 @@ dependencies = [
 name = "mc-util-generate-sample-ledger"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-account-keys",
  "mc-blockchain-test-utils",
  "mc-common",
@@ -5319,7 +5394,7 @@ name = "mc-util-grpc"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.13",
+ "clap 4.0.18",
  "cookie",
  "displaydoc",
  "futures",
@@ -5352,7 +5427,7 @@ dependencies = [
 name = "mc-util-grpc-admin-tool"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -5363,7 +5438,7 @@ dependencies = [
 name = "mc-util-grpc-token-generator"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-common",
  "mc-util-grpc",
  "mc-util-parse",
@@ -5379,7 +5454,7 @@ name = "mc-util-keyfile"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "hex",
  "mc-account-keys",
@@ -5467,7 +5542,7 @@ dependencies = [
 name = "mc-util-seeded-ed25519-key-gen"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "mc-crypto-keys",
  "mc-util-from-random",
  "mc-util-parse",
@@ -5503,7 +5578,7 @@ dependencies = [
 name = "mc-util-test-helper"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "itertools",
  "lazy_static",
  "mc-account-keys",
@@ -5558,7 +5633,7 @@ dependencies = [
 name = "mc-wasm-test"
 version = "2.1.0-pre0"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "mc-account-keys",
  "mc-api",
  "mc-crypto-keys",
@@ -5573,7 +5648,7 @@ dependencies = [
 name = "mc-watcher"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.13",
+ "clap 4.0.18",
  "displaydoc",
  "futures",
  "grpcio",
@@ -6162,9 +6237,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plotters"
@@ -6216,7 +6291,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.4.0",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.0",
 ]
 
 [[package]]
@@ -6322,9 +6409,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -6573,7 +6660,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -6651,7 +6738,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "redox_syscall",
 ]
 
@@ -7261,7 +7348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
  "debugid",
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "hex",
  "serde",
  "serde_json",
@@ -7273,9 +7360,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -7310,9 +7397,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7321,9 +7408,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -7426,9 +7513,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
  "digest 0.10.5",
  "keccak",
@@ -7705,9 +7792,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8201,6 +8288,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8224,7 +8321,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "serde",
 ]
 
@@ -8242,9 +8339,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -8327,9 +8424,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8368,9 +8465,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513df541345bb9fcc07417775f3d51bbb677daf307d8035c0afafd87dc2e6599"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -8382,9 +8479,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6150d36a03e90a3cf6c12650be10626a9902d70c5270fd47d7a47e5389a10d56"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,37 +33,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "aead"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
- "ctr 0.8.0",
+ "ctr",
  "opaque-debug",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher 0.4.3",
- "cpufeatures",
 ]
 
 [[package]]
@@ -72,25 +51,11 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead 0.4.3",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.8.0",
- "ghash 0.4.4",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
-dependencies = [
- "aead 0.5.1",
- "aes 0.8.2",
- "cipher 0.4.3",
- "ctr 0.9.2",
- "ghash 0.5.0",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
  "subtle",
 ]
 
@@ -173,9 +138,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.5"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5c2ca00549910ec251e3bd15f87aeeb206c9456b9a77b43ff6c97c54042a472"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -300,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "binascii"
@@ -555,16 +520,15 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
+checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.14",
  "serde",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
@@ -668,16 +632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
 dependencies = [
  "atty",
  "bitflags",
@@ -732,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -799,11 +753,11 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.16.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
- "aes-gcm 0.10.1",
+ "aes-gcm",
  "base64",
  "hkdf",
  "hmac 0.12.1",
@@ -952,12 +906,11 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -977,16 +930,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher 0.4.3",
+ "cipher",
 ]
 
 [[package]]
@@ -1031,41 +975,6 @@ dependencies = [
  "serde",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1444,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
@@ -1468,9 +1377,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1483,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1493,15 +1402,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1510,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -1531,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1542,21 +1451,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1616,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1634,17 +1543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug",
- "polyval 0.5.3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.0",
+ "polyval",
 ]
 
 [[package]]
@@ -1669,7 +1568,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 name = "go-grpc-gateway-testing"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -1930,12 +1829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,15 +1874,6 @@ name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
-
-[[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "instant"
@@ -2060,9 +1944,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2096,9 +1980,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -2317,7 +2201,7 @@ dependencies = [
 name = "mc-admin-http-gateway"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -2349,9 +2233,8 @@ dependencies = [
  "mc-crypto-x509-test-vectors",
  "mc-fog-report-validation-test-utils",
  "mc-test-vectors-b58-encodings",
- "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-extra",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-from-random",
@@ -2374,8 +2257,8 @@ dependencies = [
 name = "mc-attest-ake"
 version = "2.1.0-pre0"
 dependencies = [
- "aead 0.4.3",
- "aes-gcm 0.9.4",
+ "aead",
+ "aes-gcm",
  "cargo-emit",
  "digest 0.10.5",
  "displaydoc",
@@ -2399,7 +2282,7 @@ dependencies = [
 name = "mc-attest-api"
 version = "2.1.0-pre0"
 dependencies = [
- "aead 0.4.3",
+ "aead",
  "cargo-emit",
  "digest 0.10.5",
  "futures",
@@ -2642,7 +2525,7 @@ dependencies = [
 name = "mc-connection"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "cookie",
  "displaydoc",
  "grpcio",
@@ -2706,38 +2589,26 @@ dependencies = [
 name = "mc-consensus-enclave"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm",
  "cargo-emit",
- "lazy_static",
- "mc-attest-ake",
- "mc-attest-api",
  "mc-attest-core",
  "mc-attest-enclave-api",
- "mc-attest-net",
  "mc-attest-verifier",
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-consensus-enclave-edl",
  "mc-crypto-keys",
- "mc-crypto-rand",
  "mc-enclave-boundary",
- "mc-fog-test-infra",
- "mc-ledger-db",
  "mc-sgx-panic-edl",
  "mc-sgx-report-cache-api",
- "mc-sgx-report-cache-untrusted",
  "mc-sgx-slog-edl",
  "mc-sgx-types",
  "mc-sgx-urts",
  "mc-transaction-core",
- "mc-transaction-core-test-utils",
  "mc-util-build-script",
  "mc-util-build-sgx",
- "mc-util-metrics",
  "mc-util-serial",
  "pkg-config",
- "sha2 0.10.6",
 ]
 
 [[package]]
@@ -2760,7 +2631,6 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2848,18 +2718,24 @@ dependencies = [
 name = "mc-consensus-mint-client"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "grpcio",
  "hex",
  "mc-account-keys",
  "mc-api",
+ "mc-attest-verifier",
  "mc-common",
  "mc-consensus-api",
  "mc-consensus-enclave-api",
  "mc-consensus-service-config",
  "mc-crypto-keys",
  "mc-crypto-multisig",
+ "mc-crypto-rand",
+ "mc-fog-report-connection",
+ "mc-fog-report-resolver",
+ "mc-fog-report-validation",
+ "mc-sgx-css",
  "mc-transaction-core",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -2901,7 +2777,7 @@ dependencies = [
 name = "mc-consensus-scp-play"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-common",
  "mc-consensus-scp",
  "mc-transaction-core",
@@ -2931,7 +2807,7 @@ version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "chrono",
- "clap 4.0.18",
+ "clap 4.0.13",
  "curve25519-dalek",
  "displaydoc",
  "fs_extra",
@@ -2964,9 +2840,9 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -2995,7 +2871,7 @@ name = "mc-consensus-service-config"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "hex",
  "mc-attest-core",
@@ -3020,7 +2896,7 @@ dependencies = [
 name = "mc-consensus-tool"
 version = "2.0.0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "mc-common",
  "mc-connection",
@@ -3034,7 +2910,7 @@ dependencies = [
 name = "mc-crypto-ake-enclave"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "digest 0.10.5",
  "mc-attest-ake",
  "mc-attest-core",
@@ -3054,7 +2930,7 @@ dependencies = [
 name = "mc-crypto-box"
 version = "2.1.0-pre0"
 dependencies = [
- "aead 0.4.3",
+ "aead",
  "digest 0.10.5",
  "displaydoc",
  "hkdf",
@@ -3171,7 +3047,7 @@ dependencies = [
 name = "mc-crypto-message-cipher"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "displaydoc",
  "generic-array",
  "mc-util-serial",
@@ -3199,8 +3075,8 @@ dependencies = [
 name = "mc-crypto-noise"
 version = "2.1.0-pre0"
 dependencies = [
- "aead 0.4.3",
- "aes-gcm 0.9.4",
+ "aead",
+ "aes-gcm",
  "digest 0.10.5",
  "displaydoc",
  "generic-array",
@@ -3285,7 +3161,7 @@ name = "mc-crypto-x509-test-vectors"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-crypto-keys",
  "mc-util-build-script",
  "pem",
@@ -3350,7 +3226,7 @@ dependencies = [
 name = "mc-fog-distribution"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "crossbeam-channel",
  "curve25519-dalek",
  "grpcio",
@@ -3367,8 +3243,8 @@ dependencies = [
  "mc-fog-report-connection",
  "mc-fog-report-resolver",
  "mc-ledger-db",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
@@ -3383,7 +3259,7 @@ dependencies = [
 name = "mc-fog-enclave-connection"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.9.4",
+ "aes-gcm",
  "cookie",
  "displaydoc",
  "grpcio",
@@ -3408,7 +3284,7 @@ name = "mc-fog-ingest-client"
 version = "2.1.0-pre0"
 dependencies = [
  "assert_cmd",
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "grpcio",
  "hex",
@@ -3564,7 +3440,7 @@ dependencies = [
 name = "mc-fog-ingest-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "dirs",
  "displaydoc",
  "futures",
@@ -3776,7 +3652,7 @@ dependencies = [
 name = "mc-fog-ledger-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -3848,7 +3724,7 @@ dependencies = [
 name = "mc-fog-load-testing"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "mc-account-keys",
  "mc-blockchain-test-utils",
@@ -3894,7 +3770,7 @@ dependencies = [
 name = "mc-fog-ocall-oram-storage-trusted"
 version = "2.1.0-pre0"
 dependencies = [
- "aes 0.7.5",
+ "aes",
  "aligned-cmov",
  "balanced-tree-index",
  "blake2",
@@ -3919,7 +3795,7 @@ dependencies = [
 name = "mc-fog-overseer-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "grpcio",
  "lazy_static",
@@ -4003,7 +3879,7 @@ name = "mc-fog-report-cli"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "hex",
  "mc-account-keys",
@@ -4058,7 +3934,7 @@ dependencies = [
 name = "mc-fog-report-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4126,7 +4002,7 @@ name = "mc-fog-sample-paykit"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4157,10 +4033,9 @@ dependencies = [
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
  "mc-sgx-css",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-extra",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-grpc",
@@ -4225,7 +4100,7 @@ name = "mc-fog-sql-recovery-db"
 version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 4.0.18",
+ "clap 4.0.13",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
@@ -4259,7 +4134,7 @@ name = "mc-fog-sql-recovery-db-cleanup"
 version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-common",
  "mc-fog-recovery-db-iface",
  "mc-fog-sql-recovery-db",
@@ -4270,7 +4145,7 @@ dependencies = [
 name = "mc-fog-test-client"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "grpcio",
  "hex_fmt",
@@ -4284,7 +4159,7 @@ dependencies = [
  "mc-fog-uri",
  "mc-sgx-css",
  "mc-transaction-core",
- "mc-transaction-extra",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
@@ -4304,7 +4179,7 @@ dependencies = [
 name = "mc-fog-test-infra"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "digest 0.10.5",
  "hex",
  "mc-account-keys",
@@ -4482,7 +4357,7 @@ dependencies = [
 name = "mc-fog-view-load-test"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4524,7 +4399,7 @@ dependencies = [
 name = "mc-fog-view-server"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4585,9 +4460,9 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-rand",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-lmdb",
  "mc-util-metrics",
@@ -4604,7 +4479,7 @@ dependencies = [
 name = "mc-ledger-distribution"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "dirs",
  "displaydoc",
  "mc-api",
@@ -4627,7 +4502,7 @@ dependencies = [
 name = "mc-ledger-from-archive"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-api",
  "mc-common",
  "mc-ledger-db",
@@ -4638,7 +4513,7 @@ dependencies = [
 name = "mc-ledger-migration"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "lmdb-rkv",
  "mc-common",
  "mc-ledger-db",
@@ -4685,8 +4560,8 @@ dependencies = [
 name = "mc-mobilecoind"
 version = "2.1.0-pre0"
 dependencies = [
- "aes-gcm 0.9.4",
- "clap 4.0.18",
+ "aes-gcm",
+ "clap 4.0.13",
  "crossbeam-channel",
  "displaydoc",
  "grpcio",
@@ -4722,9 +4597,8 @@ dependencies = [
  "mc-ledger-sync",
  "mc-mobilecoind-api",
  "mc-sgx-css",
- "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-extra",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
@@ -4762,7 +4636,7 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-consensus-api",
- "mc-transaction-builder",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
@@ -4775,7 +4649,7 @@ name = "mc-mobilecoind-dev-faucet"
 version = "2.1.0-pre0"
 dependencies = [
  "async-channel",
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "grpcio",
  "hex",
@@ -4788,8 +4662,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-resolver",
  "mc-mobilecoind-api",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-serial",
@@ -4806,7 +4680,7 @@ dependencies = [
 name = "mc-mobilecoind-json"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "hex",
  "mc-api",
@@ -4816,7 +4690,6 @@ dependencies = [
  "mc-mobilecoind-api",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-extra",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-serial",
@@ -4833,11 +4706,11 @@ version = "0.9.5-pre1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d530bc1c22cc6b8e315cbe565a951c69b475542fd499a25d04f0a478c17ca6b"
 dependencies = [
- "aead 0.4.3",
- "aes 0.7.5",
- "cipher 0.3.0",
- "ctr 0.8.0",
- "ghash 0.4.4",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
  "subtle",
  "zeroize",
 ]
@@ -4975,7 +4848,7 @@ dependencies = [
 name = "mc-sgx-css-dump"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "hex_fmt",
  "mc-sgx-css",
 ]
@@ -5092,7 +4965,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-test-vectors-definitions",
- "mc-transaction-extra",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -5113,8 +4986,8 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-oblivious-traits",
  "mc-test-vectors-definitions",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -5122,42 +4995,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-builder"
-version = "2.1.0-pre0"
-dependencies = [
- "assert_matches",
- "cfg-if 1.0.0",
- "curve25519-dalek",
- "displaydoc",
- "hmac 0.12.1",
- "maplit",
- "mc-account-keys",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation",
- "mc-fog-report-validation-test-utils",
- "mc-transaction-core",
- "mc-transaction-extra",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-serial",
- "mc-util-test-helper",
- "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.6",
- "subtle",
- "yaml-rust",
- "zeroize",
-]
-
-[[package]]
 name = "mc-transaction-core"
 version = "2.1.0-pre0"
 dependencies = [
- "aes 0.7.5",
+ "aes",
  "assert_matches",
  "bulletproofs-og",
  "crc",
@@ -5179,8 +5020,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-validation-test-utils",
  "mc-ledger-db",
- "mc-transaction-builder",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-transaction-types",
  "mc-util-from-random",
  "mc-util-repr-bytes",
@@ -5215,7 +5056,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-extra"
+name = "mc-transaction-std"
 version = "2.1.0-pre0"
 dependencies = [
  "assert_matches",
@@ -5225,16 +5066,14 @@ dependencies = [
  "hmac 0.12.1",
  "maplit",
  "mc-account-keys",
- "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
- "mc-crypto-ring-signature",
  "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation",
  "mc-fog-report-validation-test-utils",
  "mc-transaction-core",
  "mc-transaction-types",
  "mc-util-from-random",
- "mc-util-repr-bytes",
  "mc-util-serial",
  "mc-util-test-helper",
  "prost",
@@ -5262,7 +5101,7 @@ dependencies = [
 name = "mc-util-b58-decoder"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "hex",
  "mc-api",
 ]
@@ -5272,7 +5111,7 @@ name = "mc-util-build-enclave"
 version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "cargo_metadata 0.15.1",
+ "cargo_metadata 0.15.0",
  "displaydoc",
  "mbedtls",
  "mbedtls-sys-auto",
@@ -5325,7 +5164,7 @@ dependencies = [
 name = "mc-util-cli"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-util-build-info",
 ]
 
@@ -5333,7 +5172,7 @@ dependencies = [
 name = "mc-util-dump-ledger"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "mc-blockchain-types",
  "mc-common",
@@ -5368,7 +5207,7 @@ dependencies = [
 name = "mc-util-generate-sample-ledger"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-account-keys",
  "mc-blockchain-test-utils",
  "mc-common",
@@ -5388,7 +5227,7 @@ name = "mc-util-grpc"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.18",
+ "clap 4.0.13",
  "cookie",
  "displaydoc",
  "futures",
@@ -5421,7 +5260,7 @@ dependencies = [
 name = "mc-util-grpc-admin-tool"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -5432,7 +5271,7 @@ dependencies = [
 name = "mc-util-grpc-token-generator"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-common",
  "mc-util-grpc",
  "mc-util-parse",
@@ -5448,7 +5287,7 @@ name = "mc-util-keyfile"
 version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "hex",
  "mc-account-keys",
@@ -5536,7 +5375,7 @@ dependencies = [
 name = "mc-util-seeded-ed25519-key-gen"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "mc-crypto-keys",
  "mc-util-from-random",
  "mc-util-parse",
@@ -5553,7 +5392,6 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_cbor",
- "serde_json",
  "serde_with",
 ]
 
@@ -5572,7 +5410,7 @@ dependencies = [
 name = "mc-util-test-helper"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "itertools",
  "lazy_static",
  "mc-account-keys",
@@ -5627,12 +5465,12 @@ dependencies = [
 name = "mc-wasm-test"
 version = "2.1.0-pre0"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.7",
  "mc-account-keys",
  "mc-api",
  "mc-crypto-keys",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "rand 0.8.5",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -5642,7 +5480,7 @@ dependencies = [
 name = "mc-watcher"
 version = "2.1.0-pre0"
 dependencies = [
- "clap 4.0.18",
+ "clap 4.0.13",
  "displaydoc",
  "futures",
  "grpcio",
@@ -5804,9 +5642,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -5819,9 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -5831,9 +5669,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 
 [[package]]
 name = "multer"
@@ -6231,9 +6069,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -6285,19 +6123,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
- "universal-hash 0.4.0",
-]
-
-[[package]]
-name = "polyval"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "opaque-debug",
- "universal-hash 0.5.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6356,9 +6182,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -6403,9 +6229,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -6425,9 +6251,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "45c8babc29389186697fe5a2a4859d697825496b83db5d0b65271cdc0488e88c"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
@@ -6654,7 +6480,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -6732,7 +6558,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.7",
  "redox_syscall",
 ]
 
@@ -7342,7 +7168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823923ae5f54a729159d720aa12181673044ee5c79cbda3be09e56f885e5468f"
 dependencies = [
  "debugid",
- "getrandom 0.2.8",
+ "getrandom 0.2.7",
  "hex",
  "serde",
  "serde_json",
@@ -7354,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -7391,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7402,9 +7228,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -7425,24 +7251,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.0.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -7507,9 +7320,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
 dependencies = [
  "digest 0.10.5",
  "keccak",
@@ -7786,9 +7599,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8282,16 +8095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "universal-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8315,7 +8118,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.7",
  "serde",
 ]
 
@@ -8333,9 +8136,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"
@@ -8418,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8459,9 +8262,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "513df541345bb9fcc07417775f3d51bbb677daf307d8035c0afafd87dc2e6599"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -8473,9 +8276,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "6150d36a03e90a3cf6c12650be10626a9902d70c5270fd47d7a47e5389a10d56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,26 +2631,38 @@ dependencies = [
 name = "mc-consensus-enclave"
 version = "2.1.0-pre0"
 dependencies = [
+ "aes-gcm",
  "cargo-emit",
+ "lazy_static",
+ "mc-attest-ake",
+ "mc-attest-api",
  "mc-attest-core",
  "mc-attest-enclave-api",
+ "mc-attest-net",
  "mc-attest-verifier",
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-consensus-enclave-edl",
  "mc-crypto-keys",
+ "mc-crypto-rand",
  "mc-enclave-boundary",
+ "mc-fog-test-infra",
+ "mc-ledger-db",
  "mc-sgx-panic-edl",
  "mc-sgx-report-cache-api",
+ "mc-sgx-report-cache-untrusted",
  "mc-sgx-slog-edl",
  "mc-sgx-types",
  "mc-sgx-urts",
  "mc-transaction-core",
+ "mc-transaction-core-test-utils",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "mc-util-metrics",
  "mc-util-serial",
  "pkg-config",
+ "sha2 0.10.6",
 ]
 
 [[package]]

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -423,6 +423,9 @@ message MintTxPrefix {
 
     /// The block index at which this transaction is no longer valid.
     uint64 tombstone_block = 6;
+
+    /// The (optional) encrypted fog hint of the minted TxOut.
+    EncryptedFogHint e_fog_hint = 7;
 }
 
 /// A mint transaction coupled with a signature over it.

--- a/api/src/convert/mint_tx.rs
+++ b/api/src/convert/mint_tx.rs
@@ -35,11 +35,12 @@ impl TryFrom<&external::MintTxPrefix> for MintTxPrefix {
     fn try_from(source: &external::MintTxPrefix) -> Result<Self, Self::Error> {
         let view_public_key = RistrettoPublic::try_from(source.get_view_public_key())?;
         let spend_public_key = RistrettoPublic::try_from(source.get_spend_public_key())?;
-        let e_fog_hint = if source.get_e_fog_hint().get_data().is_empty() {
+        let e_fog_hint_data = source.get_e_fog_hint().get_data();
+        let e_fog_hint = if e_fog_hint_data.is_empty() {
             None
         } else {
             Some(
-                EncryptedFogHint::try_from(source.get_e_fog_hint().get_data())
+                EncryptedFogHint::try_from(e_fog_hint_data)
                     .map_err(|_| ConversionError::ArrayCastError)?,
             )
         };

--- a/api/src/convert/mint_tx.rs
+++ b/api/src/convert/mint_tx.rs
@@ -5,7 +5,7 @@
 use crate::{external, ConversionError};
 use mc_crypto_keys::RistrettoPublic;
 use mc_crypto_multisig::MultiSig;
-use mc_transaction_core::mint::{MintTx, MintTxPrefix};
+use mc_transaction_core::{encrypted_fog_hint::EncryptedFogHint, mint::{MintTx, MintTxPrefix}};
 
 /// Convert MintTxPrefix --> external::MintTxPrefix.
 impl From<&MintTxPrefix> for external::MintTxPrefix {
@@ -17,6 +17,10 @@ impl From<&MintTxPrefix> for external::MintTxPrefix {
         dst.set_spend_public_key((&src.spend_public_key).into());
         dst.set_nonce(src.nonce.clone());
         dst.set_tombstone_block(src.tombstone_block);
+        if let Some(e_fog_hint) = &src.e_fog_hint {
+            let hint_bytes = e_fog_hint.as_ref().to_vec();
+            dst.mut_e_fog_hint().set_data(hint_bytes);
+        }
         dst
     }
 }
@@ -28,6 +32,12 @@ impl TryFrom<&external::MintTxPrefix> for MintTxPrefix {
     fn try_from(source: &external::MintTxPrefix) -> Result<Self, Self::Error> {
         let view_public_key = RistrettoPublic::try_from(source.get_view_public_key())?;
         let spend_public_key = RistrettoPublic::try_from(source.get_spend_public_key())?;
+        let e_fog_hint = if source.get_e_fog_hint().get_data().is_empty() {
+            None
+        } else {
+            Some(EncryptedFogHint::try_from(source.get_e_fog_hint().get_data())
+            .map_err(|_| ConversionError::ArrayCastError)?)
+        };
 
         Ok(Self {
             token_id: source.get_token_id(),
@@ -36,6 +46,7 @@ impl TryFrom<&external::MintTxPrefix> for MintTxPrefix {
             spend_public_key,
             nonce: source.get_nonce().to_vec(),
             tombstone_block: source.get_tombstone_block(),
+            e_fog_hint,
         })
     }
 }
@@ -86,6 +97,7 @@ mod tests {
                 spend_public_key: RistrettoPublic::from_random(&mut rng),
                 nonce: vec![3u8; 32],
                 tombstone_block: rng.next_u64(),
+                e_fog_hint: Some(EncryptedFogHint::fake_onetime_hint(&mut rng)),
             },
             signature: test_multi_sig(),
         };

--- a/api/src/convert/mint_tx.rs
+++ b/api/src/convert/mint_tx.rs
@@ -5,7 +5,10 @@
 use crate::{external, ConversionError};
 use mc_crypto_keys::RistrettoPublic;
 use mc_crypto_multisig::MultiSig;
-use mc_transaction_core::{encrypted_fog_hint::EncryptedFogHint, mint::{MintTx, MintTxPrefix}};
+use mc_transaction_core::{
+    encrypted_fog_hint::EncryptedFogHint,
+    mint::{MintTx, MintTxPrefix},
+};
 
 /// Convert MintTxPrefix --> external::MintTxPrefix.
 impl From<&MintTxPrefix> for external::MintTxPrefix {
@@ -35,8 +38,10 @@ impl TryFrom<&external::MintTxPrefix> for MintTxPrefix {
         let e_fog_hint = if source.get_e_fog_hint().get_data().is_empty() {
             None
         } else {
-            Some(EncryptedFogHint::try_from(source.get_e_fog_hint().get_data())
-            .map_err(|_| ConversionError::ArrayCastError)?)
+            Some(
+                EncryptedFogHint::try_from(source.get_e_fog_hint().get_data())
+                    .map_err(|_| ConversionError::ArrayCastError)?,
+            )
         };
 
         Ok(Self {

--- a/consensus/api/proto/consensus_client.proto
+++ b/consensus/api/proto/consensus_client.proto
@@ -27,6 +27,7 @@ enum MintValidationResultCode {
     NoGovernors = 10;
     NonceAlreadyUsed = 11;
     NoMatchingMintConfig = 12;
+    MintingToFogNotSupported = 13;
 }
 
 message MintValidationResult {

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -149,6 +149,10 @@ impl From<MintValidationError> for MintValidationResult {
                 code: MintValidationResultCode::NoMatchingMintConfig,
                 ..Default::default()
             },
+            MintValidationError::MintingToFogNotSupported => Self {
+                code: MintValidationResultCode::MintingToFogNotSupported,
+                ..Default::default()
+            },
         }
     }
 }
@@ -191,6 +195,9 @@ impl TryInto<MintValidationError> for MintValidationResult {
             MintValidationResultCode::NonceAlreadyUsed => Ok(MintValidationError::NonceAlreadyUsed),
             MintValidationResultCode::NoMatchingMintConfig => {
                 Ok(MintValidationError::NoMatchingMintConfig)
+            }
+            MintValidationResultCode::MintingToFogNotSupported => {
+                Ok(MintValidationError::MintingToFogNotSupported)
             }
         }
     }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -896,7 +896,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 && !config.block_version.minting_to_fog_addresses_is_supported()
             {
                 return Err(Error::BlockVersion(
-                    "Minting to fog addresses is not supported in this block version",
+                    "Minting to fog addresses is not supported in this block version".into(),
                 ));
             }
             let output = mint_output(

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -973,6 +973,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
 ///
 /// The counter value should be used for each "context" where we mint multiple
 /// outputs to prevent this issue.
+#[allow(clippy::too_many_arguments)]
 fn mint_output<T: Digestible>(
     block_version: BlockVersion,
     recipient: &PublicAddress,

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -892,6 +892,13 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 &mint_tx.prefix.spend_public_key,
                 &mint_tx.prefix.view_public_key,
             );
+            if mint_tx.prefix.e_fog_hint.is_some()
+                && !config.block_version.minting_to_fog_addresses_is_supported()
+            {
+                return Err(Error::BlockVersion(
+                    "Minting to fog addresses is not supported in this block version",
+                ));
+            }
             let output = mint_output(
                 config.block_version,
                 &recipient,

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -892,13 +892,6 @@ impl ConsensusEnclave for SgxConsensusEnclave {
                 &mint_tx.prefix.spend_public_key,
                 &mint_tx.prefix.view_public_key,
             );
-            if mint_tx.prefix.e_fog_hint.is_some()
-                && !config.block_version.minting_to_fog_addresses_is_supported()
-            {
-                return Err(Error::BlockVersion(
-                    "Minting to fog addresses is not supported in this block version".into(),
-                ));
-            }
             let output = mint_output(
                 config.block_version,
                 &recipient,
@@ -965,6 +958,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
 /// * `parent_block` - The parent block.
 /// * `transactions` - The transactions that are included in the current block.
 /// * `amount` - Output amount.
+/// * `e_fog_hint` - Optional encrypted fog hint to use
 /// * `counter` - An additional counter used to disambiguate hashes, when the
 ///   same amount is minted repeatedly
 ///

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -14,12 +14,18 @@ path = "src/bin/main.rs"
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
 mc-api = { path = "../../api" }
+mc-attest-verifier = { path = "../../attest/verifier" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-enclave-api = { path = "../../consensus/enclave/api" }
 mc-consensus-service-config = { path = "../../consensus/service/config" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-crypto-multisig = { path = "../../crypto/multisig" }
+mc-crypto-rand = { path = "../../crypto/rand" }
+mc-fog-report-connection = { path = "../../fog/report/connection" }
+mc-fog-report-resolver = { path = "../../fog/report/resolver" }
+mc-fog-report-validation = { path = "../../fog/report/validation" }
+mc-sgx-css = { path = "../../sgx/css" }
 mc-transaction-core = { path = "../../transaction/core" }
 mc-util-from-random = { path = "../../util/from-random" }
 mc-util-grpc = { path = "../../util/grpc" }

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -25,13 +25,14 @@ fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
     let config = Config::parse();
 
+    let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
+
     match config.command {
         Commands::GenerateAndSubmitMintConfigTx {
             node,
             params,
             chain_id,
         } => {
-            let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
             let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&node, &logger);
             let client_api = ConsensusClientApiClient::new(ch.clone());
             let blockchain_api = BlockchainApiClient::new(ch);
@@ -114,7 +115,6 @@ fn main() {
                 signature: MultiSig::new(signatures),
             };
 
-            let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
             let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&node, &logger);
             let client_api = ConsensusClientApiClient::new(ch);
 
@@ -138,7 +138,6 @@ fn main() {
             chain_id,
             fog_ingest_enclave_css,
         } => {
-            let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
             let ch =
                 ChannelBuilder::default_channel_builder(env.clone()).connect_to_uri(&node, &logger);
             let client_api = ConsensusClientApiClient::new(ch.clone());
@@ -181,15 +180,11 @@ fn main() {
             fog_ingest_enclave_css,
             params,
         } => {
-            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| {
-                let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
-
-                FogBits {
-                    chain_id: chain_id.expect("Chain id should be passed when fog is used"),
-                    css_signature: signature,
-                    grpc_env: env,
-                    logger: logger.clone(),
-                }
+            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogBits {
+                chain_id: chain_id.expect("Chain id should be passed when fog is used"),
+                css_signature: signature,
+                grpc_env: env,
+                logger: logger.clone(),
             });
 
             let tx = params
@@ -253,7 +248,6 @@ fn main() {
                 signature: MultiSig::new(signatures),
             };
 
-            let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
             let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&node, &logger);
             let client_api = ConsensusClientApiClient::new(ch);
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -211,8 +211,6 @@ fn main() {
         },
 
         Commands::HashMintTx { params } => {
-            // Fixme: we should panic if fog css is supplied I think, since this
-            // hash won't be deterministic then.
             let tx_prefix = params
                 .try_into_mint_tx_prefix(None, || panic!("missing tombstone block"))
                 .expect("failed creating tx prefix");

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -10,7 +10,7 @@ use mc_consensus_api::{
     empty::Empty,
 };
 use mc_consensus_enclave_api::GovernorsSigner;
-use mc_consensus_mint_client::{printers, Commands, Config, TxFile};
+use mc_consensus_mint_client::{printers, Commands, Config, FogBits, TxFile};
 use mc_crypto_keys::{Ed25519Pair, Ed25519Private, Signer};
 use mc_crypto_multisig::MultiSig;
 use mc_transaction_core::{
@@ -136,14 +136,23 @@ fn main() {
             node,
             params,
             chain_id,
+            fog_ingest_enclave_css,
         } => {
             let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
-            let ch = ChannelBuilder::default_channel_builder(env).connect_to_uri(&node, &logger);
+            let ch =
+                ChannelBuilder::default_channel_builder(env.clone()).connect_to_uri(&node, &logger);
             let client_api = ConsensusClientApiClient::new(ch.clone());
             let blockchain_api = BlockchainApiClient::new(ch);
 
+            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogBits {
+                chain_id: chain_id.clone(),
+                css_signature: signature,
+                grpc_env: env.clone(),
+                logger: logger.clone(),
+            });
+
             let tx = params
-                .try_into_mint_tx(|| {
+                .try_into_mint_tx(maybe_fog_bits, || {
                     let last_block_info = blockchain_api
                         .get_last_block_info(&Empty::new())
                         .expect("get last block info");
@@ -166,9 +175,25 @@ fn main() {
             exit(resp.get_result().get_code().value());
         }
 
-        Commands::GenerateMintTx { out, params } => {
+        Commands::GenerateMintTx {
+            out,
+            chain_id,
+            fog_ingest_enclave_css,
+            params,
+        } => {
+            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| {
+                let env = Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
+
+                FogBits {
+                    chain_id: chain_id.expect("Chain id should be passed when fog is used"),
+                    css_signature: signature,
+                    grpc_env: env,
+                    logger: logger.clone(),
+                }
+            });
+
             let tx = params
-                .try_into_mint_tx(|| panic!("missing tombstone block"))
+                .try_into_mint_tx(maybe_fog_bits, || panic!("missing tombstone block"))
                 .expect("failed creating tx");
 
             TxFile::from(tx)
@@ -186,8 +211,10 @@ fn main() {
         },
 
         Commands::HashMintTx { params } => {
+            // Fixme: we should panic if fog css is supplied I think, since this
+            // hash won't be deterministic then.
             let tx_prefix = params
-                .try_into_mint_tx_prefix(|| panic!("missing tombstone block"))
+                .try_into_mint_tx_prefix(None, || panic!("missing tombstone block"))
                 .expect("failed creating tx prefix");
 
             // Print the nonce, since if we generated it randomlly then there is no way to

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -10,7 +10,7 @@ use mc_consensus_api::{
     empty::Empty,
 };
 use mc_consensus_enclave_api::GovernorsSigner;
-use mc_consensus_mint_client::{printers, Commands, Config, FogBits, TxFile};
+use mc_consensus_mint_client::{printers, Commands, Config, FogContext, TxFile};
 use mc_crypto_keys::{Ed25519Pair, Ed25519Private, Signer};
 use mc_crypto_multisig::MultiSig;
 use mc_transaction_core::{
@@ -143,7 +143,7 @@ fn main() {
             let client_api = ConsensusClientApiClient::new(ch.clone());
             let blockchain_api = BlockchainApiClient::new(ch);
 
-            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogBits {
+            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogContext {
                 chain_id: chain_id.clone(),
                 css_signature: signature,
                 grpc_env: env.clone(),
@@ -180,7 +180,7 @@ fn main() {
             fog_ingest_enclave_css,
             params,
         } => {
-            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogBits {
+            let maybe_fog_bits = fog_ingest_enclave_css.map(|signature| FogContext {
                 chain_id: chain_id.expect("Chain id should be passed when fog is used"),
                 css_signature: signature,
                 grpc_env: env,

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -2,7 +2,7 @@
 
 //! Command line configuration for the consensus mint client.
 
-use crate::TxFile;
+use crate::{FogBits, TxFile};
 use clap::{Args, Parser, Subcommand};
 use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
@@ -11,12 +11,14 @@ use mc_crypto_keys::{
     DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, Signer,
 };
 use mc_crypto_multisig::{MultiSig, SignerSet};
+use mc_sgx_css::Signature;
 use mc_transaction_core::{
     mint::{
         constants::NONCE_LENGTH, MintConfig, MintConfigTx, MintConfigTxPrefix, MintTx, MintTxPrefix,
     },
     TokenId,
 };
+use mc_util_parse::load_css_file;
 use mc_util_uri::ConsensusClientUri;
 use rand::{thread_rng, RngCore};
 use std::{
@@ -176,12 +178,21 @@ pub struct MintTxPrefixParams {
 impl MintTxPrefixParams {
     pub fn try_into_mint_tx_prefix(
         self,
+        fog_bits: Option<FogBits>,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTxPrefix, String> {
-        if let Some(fog_url) = self.recipient.fog_report_url() {
-            return Err(format!("This recipient has a fog url, but minting to fog users is not supported right now: '{}'", fog_url));
-        }
-        let tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
+        let mut tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
+        let e_fog_hint = if let Some(fog_url) = self.recipient.fog_report_url() {
+            if let Some(fog_bits) = fog_bits {
+                let (e_fog_hint, pubkey_expiry) = fog_bits.get_e_fog_hint(&self.recipient)?;
+                tombstone_block = core::cmp::min(tombstone_block, pubkey_expiry);
+                Some(e_fog_hint)
+            } else {
+                return Err(format!("This recipient has a fog url, but a CSS to validate fog public keys was not supplied: '{}'", fog_url));
+            }
+        } else {
+            None
+        };
         let nonce = get_or_generate_nonce(self.nonce);
         Ok(MintTxPrefix {
             token_id: *self.token_id,
@@ -190,7 +201,7 @@ impl MintTxPrefixParams {
             spend_public_key: *self.recipient.spend_public_key(),
             nonce,
             tombstone_block,
-            e_fog_hint: None,
+            e_fog_hint,
         })
     }
 }
@@ -221,11 +232,12 @@ pub struct MintTxParams {
 impl MintTxParams {
     pub fn try_into_mint_tx(
         self,
+        fog_bits: Option<FogBits>,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTx, String> {
         let prefix = self
             .prefix_params
-            .try_into_mint_tx_prefix(fallback_tombstone_block)?;
+            .try_into_mint_tx_prefix(fog_bits, fallback_tombstone_block)?;
         let message = prefix.hash();
 
         let mut signatures = self
@@ -321,6 +333,11 @@ pub enum Commands {
         #[clap(long, env = "MC_CONSENSUS_URI")]
         node: ConsensusClientUri,
 
+        /// Fog ingest enclave CSS file (needed in order to enable minting
+        /// to fog recipients).
+        #[clap(long, value_parser = load_css_file, env = "MC_FOG_INGEST_ENCLAVE_CSS")]
+        fog_ingest_enclave_css: Option<Signature>,
+
         #[clap(flatten)]
         params: MintTxParams,
     },
@@ -330,6 +347,16 @@ pub enum Commands {
         /// Filename to write the mint configuration to.
         #[clap(long, env = "MC_MINTING_OUT_FILE")]
         out: PathBuf,
+
+        /// Fog ingest enclave CSS file (needed in order to enable minting
+        /// to fog recipients).
+        #[clap(long, value_parser = load_css_file, env = "MC_FOG_INGEST_ENCLAVE_CSS")]
+        fog_ingest_enclave_css: Option<Signature>,
+
+        /// The chain id of the network we expect to connect to. This is only
+        /// needed if fog is used.
+        #[clap(long, env = "MC_CHAIN_ID")]
+        chain_id: Option<String>,
 
         #[clap(flatten)]
         params: MintTxParams,
@@ -479,13 +506,6 @@ fn parse_public_address(b58: &str) -> Result<PublicAddress, String> {
     if printable_wrapper.has_public_address() {
         let public_address = PublicAddress::try_from(printable_wrapper.get_public_address())
             .map_err(|err| format!("failed converting b58 public address '{}': {}", b58, err))?;
-
-        if public_address.fog_report_url().is_some() {
-            return Err(format!(
-                "b58 address '{}' is a fog address, which is not supported",
-                b58
-            ));
-        }
 
         Ok(public_address)
     } else {

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -348,7 +348,7 @@ pub enum Commands {
 
         /// Fog ingest enclave CSS file (needed in order to enable minting
         /// to fog recipients).
-        #[clap(long, value_parser = load_css_file, env = "MC_FOG_INGEST_ENCLAVE_CSS")]
+        #[clap(long, value_parser = load_css_file, env = "MC_FOG_INGEST_ENCLAVE_CSS", requires = "chain_id")]
         fog_ingest_enclave_css: Option<Signature>,
 
         /// The chain id of the network we expect to connect to. This is only

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -190,6 +190,7 @@ impl MintTxPrefixParams {
             spend_public_key: *self.recipient.spend_public_key(),
             nonce,
             tombstone_block,
+            e_fog_hint: None,
         })
     }
 }

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -2,7 +2,7 @@
 
 //! Command line configuration for the consensus mint client.
 
-use crate::{FogBits, TxFile};
+use crate::{FogContext, TxFile};
 use clap::{Args, Parser, Subcommand};
 use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
@@ -178,7 +178,7 @@ pub struct MintTxPrefixParams {
 impl MintTxPrefixParams {
     pub fn try_into_mint_tx_prefix(
         self,
-        fog_bits: Option<FogBits>,
+        fog_bits: Option<FogContext>,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTxPrefix, String> {
         let mut tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
@@ -230,7 +230,7 @@ pub struct MintTxParams {
 impl MintTxParams {
     pub fn try_into_mint_tx(
         self,
-        fog_bits: Option<FogBits>,
+        fog_bits: Option<FogContext>,
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintTx, String> {
         let prefix = self

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -89,7 +89,11 @@ fn get_fog_ingest_verifier(signature: Signature) -> Verifier {
             signature.product_id(),
             signature.version(),
         );
-        mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+        mr_signer_verifier.allow_hardening_advisories(&[
+            "INTEL-SA-00334",
+            "INTEL-SA-00615",
+            "INTEL-SA-00657",
+        ]);
         mr_signer_verifier
     };
 

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -17,7 +17,7 @@ use std::{str::FromStr, sync::Arc};
 
 /// Data and objects needed to resolve a fog address and build an encrypted
 /// fog hint in a one-off way appropriate for a CLI tool
-pub struct FogBits {
+pub struct FogContext {
     /// The chain id of the network we expect to connect to
     pub chain_id: String,
     /// The css file (loaded as signature) that we will verify report against
@@ -28,7 +28,7 @@ pub struct FogBits {
     pub logger: Logger,
 }
 
-impl FogBits {
+impl FogContext {
     /// Get an encrypted fog hint for a TxOut belonging to a paritcular public
     /// address
     ///

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Bits for correctly creating encrypted fog hints when minting
+
+use grpcio::Environment;
+use mc_account_keys::PublicAddress;
+use mc_attest_verifier::{MrSignerVerifier, Verifier, DEBUG_ENCLAVE};
+use mc_common::logger::Logger;
+use mc_crypto_rand::McRng;
+use mc_fog_report_connection::GrpcFogReportConnection;
+use mc_fog_report_resolver::FogResolver;
+use mc_fog_report_validation::{FogPubkeyResolver, FullyValidatedFogPubkey};
+use mc_sgx_css::Signature;
+use mc_transaction_core::{encrypted_fog_hint::EncryptedFogHint, fog_hint::FogHint};
+use mc_util_uri::FogUri;
+use std::{str::FromStr, sync::Arc};
+
+/// Data and objects needed to resolve a fog address and build an encrypted
+/// fog hint in a one-off way appropriate for a CLI tool
+pub struct FogBits {
+    pub chain_id: String,
+    pub css_signature: Signature,
+    pub grpc_env: Arc<Environment>,
+    pub logger: Logger,
+}
+
+impl FogBits {
+    /// Get an encrypted fog hint for a TxOut belonging to a paritcular public
+    /// address
+    ///
+    /// Arguments:
+    /// * public_address
+    ///
+    /// Returns:
+    /// * Encrypted fog hint
+    /// * pubkey_expiry of the fog key that was used. This must bound the
+    ///   tombstone block
+    pub fn get_e_fog_hint(
+        &self,
+        public_address: &PublicAddress,
+    ) -> Result<(EncryptedFogHint, u64), String> {
+        let validated_fog_pubkey = self.resolve_one_fog_url(public_address)?;
+
+        Ok((
+            FogHint::from(public_address)
+                .encrypt(&validated_fog_pubkey.pubkey, &mut McRng::default()),
+            validated_fog_pubkey.pubkey_expiry,
+        ))
+    }
+
+    /// Make a connection to fog report and get the fog reports for a particular
+    /// public address. Then validate them against this public address' fog
+    /// sig. Returns either a fully validated fog pubkey for this address,
+    /// or an error.
+    fn resolve_one_fog_url(
+        &self,
+        public_address: &PublicAddress,
+    ) -> Result<FullyValidatedFogPubkey, String> {
+        let fog_uri = FogUri::from_str(public_address.fog_report_url().ok_or("Missing fog url")?)
+            .map_err(|err| format!("Invalid fog uri: {}", err))?;
+
+        let conn = GrpcFogReportConnection::new(
+            self.chain_id.clone(),
+            self.grpc_env.clone(),
+            self.logger.clone(),
+        );
+
+        let responses = conn
+            .fetch_fog_reports(core::slice::from_ref(&fog_uri).iter().cloned())
+            .map_err(|err| format!("Error fetching fog reports: {}", err))?;
+
+        let verifier = get_fog_ingest_verifier(self.css_signature.clone());
+        let resolver = FogResolver::new(responses, &verifier);
+        resolver
+            .map_err(|err| format!("Could not get FogPubkey resolved: {}", err))?
+            .get_fog_pubkey(public_address)
+            .map_err(|err| format!("Could not validate fog pubkey: {}", err))
+    }
+}
+
+fn get_fog_ingest_verifier(signature: Signature) -> Verifier {
+    let mr_signer_verifier = {
+        let mut mr_signer_verifier = MrSignerVerifier::new(
+            signature.mrsigner().into(),
+            signature.product_id(),
+            signature.version(),
+        );
+        mr_signer_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+        mr_signer_verifier
+    };
+
+    let mut verifier = Verifier::default();
+    verifier.debug(DEBUG_ENCLAVE).mr_signer(mr_signer_verifier);
+    verifier
+}

--- a/consensus/mint-client/src/lib.rs
+++ b/consensus/mint-client/src/lib.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 mod config;
+mod fog;
 mod tx_file;
 
 pub mod printers;
 
 pub use config::{Commands, Config};
+pub use fog::FogBits;
 pub use tx_file::TxFile;

--- a/consensus/mint-client/src/lib.rs
+++ b/consensus/mint-client/src/lib.rs
@@ -7,5 +7,5 @@ mod tx_file;
 pub mod printers;
 
 pub use config::{Commands, Config};
-pub use fog::FogBits;
+pub use fog::FogContext;
 pub use tx_file::TxFile;

--- a/consensus/tool/src/main.rs
+++ b/consensus/tool/src/main.rs
@@ -25,7 +25,7 @@ use std::{sync::Arc, time::Duration};
 /// $ STOP_BLOCK=$(mc-consensus-tool wait-for-quiet \
 /// mc://localhost:3200 mc://localhost:3201 mc://localhost:3202)
 ///
-/// $ MC_PEERS=mc://localhost:3200,mc://localhost:3201 \
+/// $ MC_PEER=mc://localhost:3200,mc://localhost:3201 \
 /// mc-consensus-tool wait-for-block --index=$(STOP_BLOCK)
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "mc-consensus-tool")]
@@ -35,7 +35,7 @@ pub struct Config {
     pub tool_command: ToolCommand,
 
     /// Consensus_uri's to connect to
-    #[clap(global = true, use_value_delimiter = true, env = "MC_PEERS")]
+    #[clap(global = true, use_value_delimiter = true, env = "MC_PEER")]
     pub consensus_uris: Vec<ConsensusClientUri>,
 }
 
@@ -61,7 +61,7 @@ pub enum ToolCommand {
     /// block_index on STDOUT.
     WaitForQuiet {
         /// Number of seconds the network must stop moving for.
-        #[clap(long, env = "MC_PERIOD", default_value = "20")]
+        #[clap(long, env = "MC_PERIOD", default_value = "40")]
         period: u64,
 
         /// Wait for quiet at some block index greater than this number.
@@ -88,6 +88,10 @@ fn main() {
             (uri.clone(), BlockchainApiClient::new(ch))
         })
         .collect();
+
+    if blockchain_conns.is_empty() {
+        panic!("No consensus uris specified")
+    }
 
     match config.tool_command {
         ToolCommand::Status => {

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -1144,6 +1144,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn input_selection_heuristic_few_inputs() {
+        let inputs: Vec<u64> = vec![20];
+        assert_eq!(input_selection_heuristic(&inputs, 1, 16), Ok(vec![0]));
+        assert_eq!(input_selection_heuristic(&inputs, 10, 16), Ok(vec![0]));
+        assert_eq!(input_selection_heuristic(&inputs, 19, 16), Ok(vec![0]));
+        assert_eq!(input_selection_heuristic(&inputs, 20, 16), Ok(vec![0]));
+        assert_eq!(
+            input_selection_heuristic(&inputs, 21, 16),
+            Err(InputSelectionError::InsufficientFunds)
+        );
+    }
+
+    #[test]
     fn input_selection_heuristic_3_inputs() {
         let inputs: Vec<u64> = vec![1, 1, 1, 4, 9, 1, 1, 1, 19, 2, 1];
 

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -826,7 +826,7 @@ impl Client {
         let mut sampled_indices: HashSet<u64> = HashSet::default();
         while sampled_indices.len() < num_requested {
             let index = rng.gen_range(0..sample_limit) as u64;
-            if !all_avoid_indices.contains(&index) {
+            if !all_avoid_indices.contains(&index) && !sampled_indices.contains(index) {
                 sampled_indices.insert(index);
             }
         }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -826,7 +826,7 @@ impl Client {
         let mut sampled_indices: HashSet<u64> = HashSet::default();
         while sampled_indices.len() < num_requested {
             let index = rng.gen_range(0..sample_limit) as u64;
-            if !all_avoid_indices.contains(&index) && !sampled_indices.contains(index) {
+            if !all_avoid_indices.contains(&index) && !sampled_indices.contains(&index) {
                 sampled_indices.insert(index);
             }
         }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -715,7 +715,7 @@ impl TestClient {
         let tok1_val = 1 + thread_rng().gen_range(0..self.policy.transfer_amount);
         let tok2_val = 1 + thread_rng().gen_range(0..self.policy.transfer_amount);
 
-        log::debug!(
+        log::info!(
             self.logger,
             "Attempting to {} swap ({}) of {} and ({}) of {}",
             if is_partial_fill {
@@ -935,12 +935,12 @@ impl TestClient {
     pub fn run_test(&self, num_transactions: usize) -> Result<(), TestClientError> {
         let client_count = self.account_keys.len() as usize;
         assert!(client_count > 1);
-        log::debug!(self.logger, "Creating {} clients", client_count);
+        log::info!(self.logger, "Creating {} clients", client_count);
         let clients = self.build_clients(client_count);
 
         // Send test transfers in each configured token id
         for token_id in &self.policy.token_ids {
-            log::debug!(
+            log::info!(
                 self.logger,
                 "Generating and testing {} transactions",
                 token_id
@@ -948,7 +948,7 @@ impl TestClient {
 
             let start_time = Instant::now();
             for ti in 0..num_transactions {
-                log::debug!(self.logger, "Transation: {:?}", ti);
+                log::info!(self.logger, "Test Transfer: {:?}", ti);
 
                 let source_index = ti % client_count;
                 let target_index = (ti + 1) % client_count;
@@ -965,6 +965,7 @@ impl TestClient {
 
                 // Attempt double spend on the last transaction. This is an expensive test.
                 if ti == num_transactions - 1 {
+                    log::info!(self.logger, "attemping double spend test");
                     let mut source_client_lk = source_client.lock().expect("mutex poisoned");
                     self.attempt_double_spend(&mut source_client_lk, &transaction)?;
                 }
@@ -980,14 +981,14 @@ impl TestClient {
 
         // Now, run some tests of the atomic swaps functionality
         if self.policy.token_ids.len() > 1 {
-            log::debug!(
+            log::info!(
                 self.logger,
                 "Generating and testing atomic swap transactions"
             );
 
             let start_time = Instant::now();
             for ti in 0..num_transactions {
-                log::debug!(self.logger, "Transation: {:?}", ti);
+                log::info!(self.logger, "Test Swap: {:?}", ti);
 
                 let source_index = ti % client_count;
                 let target_index = (ti + 1) % client_count;

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -111,7 +111,6 @@ class FogIngest:
 
         print(f'Starting fog ingest {self.name}')
         cmd = ' '.join([
-            'MC_LOG=trace',
             DATABASE_URL_ENV,
             f'exec {self.target_dir}/fog_ingest_server',
             f'--ledger-db={self.ledger_db_path}',

--- a/transaction/core/src/mint/tx.rs
+++ b/transaction/core/src/mint/tx.rs
@@ -2,7 +2,7 @@
 
 //! Minting transactions.
 
-use crate::domain_separators::MINT_TX_PREFIX_DOMAIN_TAG;
+use crate::{domain_separators::MINT_TX_PREFIX_DOMAIN_TAG, encrypted_fog_hint::EncryptedFogHint};
 use alloc::vec::Vec;
 use core::fmt;
 use mc_crypto_digestible::{Digestible, MerlinTranscript};
@@ -40,6 +40,10 @@ pub struct MintTxPrefix {
     /// The block index at which this transaction is no longer valid.
     #[prost(uint64, tag = "6")]
     pub tombstone_block: u64,
+
+    /// Optional, encrypted fog hint, if you are trying to mint to a fog user.
+    #[prost(message, tag = "7")]
+    pub e_fog_hint: Option<EncryptedFogHint>,
 }
 
 impl MintTxPrefix {

--- a/transaction/core/src/mint/validation/error.rs
+++ b/transaction/core/src/mint/validation/error.rs
@@ -44,4 +44,7 @@ pub enum Error {
 
     /// No matching mint configuration
     NoMatchingMintConfig,
+
+    /// Minting to fog is not supported at this block version
+    MintingToFogNotSupported,
 }

--- a/transaction/core/src/mint/validation/tx.rs
+++ b/transaction/core/src/mint/validation/tx.rs
@@ -122,6 +122,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![
@@ -161,6 +162,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![
@@ -203,6 +205,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![
@@ -245,6 +248,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![
@@ -271,6 +275,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
@@ -295,6 +300,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);
@@ -321,6 +327,7 @@ mod tests {
             spend_public_key: RistrettoPublic::from_random(&mut rng),
             nonce: vec![1u8; NONCE_LENGTH],
             tombstone_block: 10,
+            e_fog_hint: None,
         };
         let message = prefix.hash();
         let signature = MultiSig::new(vec![signer_1.try_sign(message.as_ref()).unwrap()]);

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -123,6 +123,7 @@ pub fn create_mint_tx_to_recipient(
         spend_public_key: *recipient.spend_public_key(),
         nonce,
         tombstone_block: 10,
+        e_fog_hint: Default::default(),
     };
 
     let message = prefix.hash();

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -123,7 +123,7 @@ pub fn create_mint_tx_to_recipient(
         spend_public_key: *recipient.spend_public_key(),
         nonce,
         tombstone_block: 10,
-        e_fog_hint: Default::default(),
+        e_fog_hint: None,
     };
 
     let message = prefix.hash();

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -101,6 +101,12 @@ impl BlockVersion {
         self.0 >= 2
     }
 
+    /// Minting_to_fog_addresses is supported in v3
+    /// [MCIP #53](https://github.com/mobilecoinfoundation/mcips/pull/53)
+    pub fn minting_to_fog_addresses_is_supported(&self) -> bool {
+        self.0 >= 3
+    }
+
     /// The extended message digest is used when signing MLSAGs
     /// in v2 and higher. This is described in
     /// [MCIP #25](https://github.com/mobilecoinfoundation/mcips/pull/25).


### PR DESCRIPTION
Consensus will now accept a MintTx that includes an encrypted fog hint. This allows that e.g. a cross-chain bridge can be used directly from a phone, and the cross-chain bridge is responsible for figuring out the fog part (and not the mobilecoin consensus network).