### PR TITLE
Add account key abstractions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2168,6 +2168,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+dependencies = [
+ "displaydoc",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "rand_core 0.6.4",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-account-keys"
 version = "2.0.0"
 dependencies = [
@@ -3046,6 +3060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-crypto-memo-mac"
+version = "2.0.0"
+dependencies = [
+ "hmac 0.12.1",
+ "mc-crypto-keys",
+ "sha2 0.10.5",
+]
+
+[[package]]
 name = "mc-crypto-message-cipher"
 version = "2.0.0"
 dependencies = [
@@ -3139,6 +3162,7 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "mc-abstract-account-keys",
  "mc-account-keys",
  "mc-crypto-dalek",
  "mc-crypto-digestible-test-utils",
@@ -5114,6 +5138,7 @@ dependencies = [
  "mc-account-keys",
  "mc-crypto-hashes",
  "mc-crypto-keys",
+ "mc-crypto-memo-mac",
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-validation",
  "mc-fog-report-validation-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@ cargo-features = ["named-profiles"]
 
 [workspace]
 members = [
+    "abstract-account-keys",
     "account-keys",
     "account-keys/slip10",
     "account-keys/types",
@@ -39,6 +40,7 @@ members = [
     "crypto/digestible/signature",
     "crypto/digestible/test-utils",
     "crypto/keys",
+    "crypto/memo-mac",
     "crypto/message-cipher",
     "crypto/multisig",
     "crypto/noise",

--- a/abstract-account-keys/Cargo.toml
+++ b/abstract-account-keys/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+authors = ["MobileCoin"]
+edition = "2021"
+readme = "README.md"
+
+[dependencies]
+# External dependencies
+displaydoc = { version = "0.2", default-features = false }
+rand_core = { version = "0.6", default-features = false }
+serde = { version = "1", default-features = false }
+subtle = { version = "2", default-features = false }
+zeroize = { version = "1", default-features = false }
+
+# MobileCoin dependencies
+mc-crypto-keys = { path = "../crypto/keys", default-features = false }
+mc-crypto-ring-signature = { path = "../crypto/ring-signature", default-features = false }
+mc-transaction-types = { path = "../transaction/types", default-features = false }

--- a/abstract-account-keys/README.md
+++ b/abstract-account-keys/README.md
@@ -1,0 +1,8 @@
+mc-abstract-account-keys
+===============
+
+This crate defines *traits* that abstract the functionality of a MobileCoin AccountKeys
+object. The abstraction is meant to lend itself to the situation of hardware wallets,
+where the spend key must remain on the hardware device. 
+
+This crate must be maximally portable so that it can meet the needs of hardware wallets.

--- a/abstract-account-keys/src/error.rs
+++ b/abstract-account-keys/src/error.rs
@@ -1,0 +1,34 @@
+use alloc::string::String;
+use displaydoc::Display;
+use mc_crypto_keys::KeyError;
+use mc_crypto_ring_signature::{Error as RingSignatureError};
+use serde::{Deserialize, Serialize};
+
+/// An error that can occur when using an abstract account keys object
+#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub enum Error {
+    /// True input not owned by this subaddress
+    TrueInputNotOwned,
+    /// Connection failed: {0}
+    ConnectionFailed(String),
+    /// Invalid Ristretto key in TxOut: {0}
+    Keys(KeyError),
+    /// Real input index out of bounds
+    RealInputIndexOutOfBounds,
+    /// Ring Signature: {0}
+    RingSignature(RingSignatureError),
+    /// No path to spend key (logic error)
+    NoPathToSpendKey,
+}
+
+impl From<KeyError> for Error {
+    fn from(src: KeyError) -> Self {
+        Self::Keys(src)
+    }
+}
+
+impl From<RingSignatureError> for Error {
+    fn from(src: RingSignatureError) -> Self {
+        Self::RingSignature(src)
+    }
+}

--- a/abstract-account-keys/src/error.rs
+++ b/abstract-account-keys/src/error.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 use displaydoc::Display;
 use mc_crypto_keys::KeyError;
-use mc_crypto_ring_signature::{Error as RingSignatureError};
+use mc_crypto_ring_signature::Error as RingSignatureError;
 use serde::{Deserialize, Serialize};
 
 /// An error that can occur when using an abstract account keys object

--- a/abstract-account-keys/src/key_image_computer.rs
+++ b/abstract-account-keys/src/key_image_computer.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use crate::Error;
+use mc_crypto_keys::{CompressedRistrettoPublic};
+use mc_crypto_ring_signature::KeyImage;
+
+/// An object that can compute the key image of a TxOut, given a subset of its data and the subaddress index.
+/// This generally requires the subaddress spend private key.
+pub trait KeyImageComputer {
+    /// Compute the key image of a TxOut given its public key, and the subaddress index on which this account owns it.
+    fn compute_key_image(&self, tx_out_public_key: &CompressedRistrettoPublic, subaddress_index: u64) -> Result<KeyImage, Error>;
+}

--- a/abstract-account-keys/src/key_image_computer.rs
+++ b/abstract-account-keys/src/key_image_computer.rs
@@ -1,12 +1,18 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use crate::Error;
-use mc_crypto_keys::{CompressedRistrettoPublic};
+use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_crypto_ring_signature::KeyImage;
 
-/// An object that can compute the key image of a TxOut, given a subset of its data and the subaddress index.
-/// This generally requires the subaddress spend private key.
+/// An object that can compute the key image of a TxOut, given a subset of its
+/// data and the subaddress index. This generally requires the subaddress spend
+/// private key.
 pub trait KeyImageComputer {
-    /// Compute the key image of a TxOut given its public key, and the subaddress index on which this account owns it.
-    fn compute_key_image(&self, tx_out_public_key: &CompressedRistrettoPublic, subaddress_index: u64) -> Result<KeyImage, Error>;
+    /// Compute the key image of a TxOut given its public key, and the
+    /// subaddress index on which this account owns it.
+    fn compute_key_image(
+        &self,
+        tx_out_public_key: &CompressedRistrettoPublic,
+        subaddress_index: u64,
+    ) -> Result<KeyImage, Error>;
 }

--- a/abstract-account-keys/src/lib.rs
+++ b/abstract-account-keys/src/lib.rs
@@ -1,8 +1,9 @@
 #![no_std]
 #![deny(missing_docs)]
 
-//! This crate provides traits that either AccountKeys objects or Hardware Wallets
-//! objects can implement to support signing a Tx, checking balance, etc.
+//! This crate provides traits that either AccountKeys objects or Hardware
+//! Wallets objects can implement to support signing a Tx, checking balance,
+//! etc.
 
 // FIXME
 extern crate alloc;
@@ -13,9 +14,9 @@ mod memo_hmac_signer;
 mod ring_signer;
 
 pub use error::Error;
-pub use key_image_computer::{KeyImageComputer};
-pub use memo_hmac_signer::{MemoHmacSigner};
-pub use ring_signer::{RingSigner, SignableInputRing, OneTimeKeyDeriveData, InputSecret};
+pub use key_image_computer::KeyImageComputer;
+pub use memo_hmac_signer::MemoHmacSigner;
+pub use ring_signer::{InputSecret, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 
 /// A trait which captures all the functionality of a set of account keys needed
 /// to check ones balance and sign transactions.
@@ -23,8 +24,8 @@ pub use ring_signer::{RingSigner, SignableInputRing, OneTimeKeyDeriveData, Input
 /// This is meant to be generic over, a locally stored set of account keys, and
 /// a connection to a hardware wallet.
 ///
-/// Note: We still should add more functionality around computation of public address,
-/// computation of view private key, subaddress view private key. At the moment,
-/// this is difficult because public address is part of mc-account-keys and this
-/// creates a circular dependency.
+/// Note: We still should add more functionality around computation of public
+/// address, computation of view private key, subaddress view private key. At
+/// the moment, this is difficult because public address is part of
+/// mc-account-keys and this creates a circular dependency.
 pub trait AbstractAccountKeys: KeyImageComputer + MemoHmacSigner + RingSigner {}

--- a/abstract-account-keys/src/lib.rs
+++ b/abstract-account-keys/src/lib.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![deny(missing_docs)]
+
+//! This crate provides traits that either AccountKeys objects or Hardware Wallets
+//! objects can implement to support signing a Tx, checking balance, etc.
+
+// FIXME
+extern crate alloc;
+
+mod error;
+mod key_image_computer;
+mod memo_hmac_signer;
+mod ring_signer;
+
+pub use error::Error;
+pub use key_image_computer::{KeyImageComputer};
+pub use memo_hmac_signer::{MemoHmacSigner};
+pub use ring_signer::{RingSigner, SignableInputRing, OneTimeKeyDeriveData, InputSecret};
+
+/// A trait which captures all the functionality of a set of account keys needed
+/// to check ones balance and sign transactions.
+///
+/// This is meant to be generic over, a locally stored set of account keys, and
+/// a connection to a hardware wallet.
+///
+/// Note: We still should add more functionality around computation of public address,
+/// computation of view private key, subaddress view private key. At the moment,
+/// this is difficult because public address is part of mc-account-keys and this
+/// creates a circular dependency.
+pub trait AbstractAccountKeys: KeyImageComputer + MemoHmacSigner + RingSigner {}

--- a/abstract-account-keys/src/memo_hmac_signer.rs
+++ b/abstract-account-keys/src/memo_hmac_signer.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use crate::Error;
+use mc_crypto_keys::{CompressedRistrettoPublic};
+
+/// An object that can compute the appropriate hmac of a MCIP #4-style Authenticated Sender memo,
+/// for spend keys which have been abstracted.
+/// This generally requires the subaddress spend private key.
+pub trait MemoHmacSigner {
+    /// Compute the hmac which "signs" a given MCIP #4 Authenticated sender memo
+    fn compute_memo_hmac_sig(&self, receiving_subaddress_view_public: &CompressedRistrettoPublic, tx_out_public_key: &CompressedRistrettoPublic, memo_type: &[u8; 2], memo_data_sans_hmac: &[u8; 48]) -> Result<[u8; 16], Error>;
+}

--- a/abstract-account-keys/src/memo_hmac_signer.rs
+++ b/abstract-account-keys/src/memo_hmac_signer.rs
@@ -1,12 +1,18 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use crate::Error;
-use mc_crypto_keys::{CompressedRistrettoPublic};
+use mc_crypto_keys::CompressedRistrettoPublic;
 
-/// An object that can compute the appropriate hmac of a MCIP #4-style Authenticated Sender memo,
-/// for spend keys which have been abstracted.
+/// An object that can compute the appropriate hmac of a MCIP #4-style
+/// Authenticated Sender memo, for spend keys which have been abstracted.
 /// This generally requires the subaddress spend private key.
 pub trait MemoHmacSigner {
     /// Compute the hmac which "signs" a given MCIP #4 Authenticated sender memo
-    fn compute_memo_hmac_sig(&self, receiving_subaddress_view_public: &CompressedRistrettoPublic, tx_out_public_key: &CompressedRistrettoPublic, memo_type: &[u8; 2], memo_data_sans_hmac: &[u8; 48]) -> Result<[u8; 16], Error>;
+    fn compute_memo_hmac_sig(
+        &self,
+        receiving_subaddress_view_public: &CompressedRistrettoPublic,
+        tx_out_public_key: &CompressedRistrettoPublic,
+        memo_type: &[u8; 2],
+        memo_data_sans_hmac: &[u8; 48],
+    ) -> Result<[u8; 16], Error>;
 }

--- a/abstract-account-keys/src/ring_signer.rs
+++ b/abstract-account-keys/src/ring_signer.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use alloc::{string::String, vec::Vec};
-use displaydoc::Display;
-use mc_crypto_keys::{KeyError, RistrettoPrivate};
+use crate::Error;
+use alloc::{vec::Vec};
+use mc_crypto_keys::{RistrettoPrivate};
 use mc_crypto_ring_signature::{
-    CryptoRngCore, Error as RingSignatureError, ReducedTxOut, RingMLSAG, Scalar,
+    CryptoRngCore, ReducedTxOut, RingMLSAG, Scalar,
 };
 use mc_transaction_types::Amount;
 use serde::{Deserialize, Serialize};
@@ -115,34 +115,5 @@ impl<S: RingSigner> RingSigner for &S {
         rng: &mut dyn CryptoRngCore,
     ) -> Result<RingMLSAG, Error> {
         (*self).sign(message, signable_ring, output_blinding, rng)
-    }
-}
-
-/// An error that can occur when using an abstract RingSigner
-#[derive(Clone, Debug, Deserialize, Display, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-pub enum Error {
-    /// True input not owned by this subaddress
-    TrueInputNotOwned,
-    /// Connection failed: {0}
-    ConnectionFailed(String),
-    /// Invalid Ristretto key in TxOut: {0}
-    Keys(KeyError),
-    /// Real input index out of bounds
-    RealInputIndexOutOfBounds,
-    /// Ring Signature: {0}
-    RingSignature(RingSignatureError),
-    /// No path to spend key (logic error)
-    NoPathToSpendKey,
-}
-
-impl From<KeyError> for Error {
-    fn from(src: KeyError) -> Self {
-        Self::Keys(src)
-    }
-}
-
-impl From<RingSignatureError> for Error {
-    fn from(src: RingSignatureError) -> Self {
-        Self::RingSignature(src)
     }
 }

--- a/abstract-account-keys/src/ring_signer.rs
+++ b/abstract-account-keys/src/ring_signer.rs
@@ -1,11 +1,9 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use crate::Error;
-use alloc::{vec::Vec};
-use mc_crypto_keys::{RistrettoPrivate};
-use mc_crypto_ring_signature::{
-    CryptoRngCore, ReducedTxOut, RingMLSAG, Scalar,
-};
+use alloc::vec::Vec;
+use mc_crypto_keys::RistrettoPrivate;
+use mc_crypto_ring_signature::{CryptoRngCore, ReducedTxOut, RingMLSAG, Scalar};
 use mc_transaction_types::Amount;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;

--- a/account-keys/src/impls.rs
+++ b/account-keys/src/impls.rs
@@ -1,0 +1,89 @@
+//! Implement mc-abstract-account-keys traits for concrete AccountKeys
+
+use crate::{AccountKeys};
+use curve25519_dalek::scalar::Scalar;
+use mc_abstract_account_keys::{RingSigner, MemoHmacSigner, KeyImageComputer, Error};
+use mc_crypto_ring_signature::{KeyImage,SignableInputRing, onetime_keys::recover_onetime_private_key};
+
+// Note: We should delete `LocalRingSigner` and just use `AccountKeys` where we were using that.
+impl RingSinger for AccountKeys {
+    fn sign(
+        &self,
+        message: &[u8],
+        ring: &SignableInputRing,
+        pseudo_output_blinding: Scalar,
+        rng: &mut dyn CryptoRngCore,
+    ) -> Result<RingMLSAG, Error> {
+        let real_input = ring
+            .members
+            .get(ring.real_input_index)
+            .ok_or(Error::RealInputIndexOutOfBounds)?;
+        let target_key = RistrettoPublic::try_from(&real_input.target_key)?;
+
+        // First, compute the one-time private key
+        let onetime_private_key = match ring.input_secret.onetime_key_derive_data {
+            OneTimeKeyDeriveData::OneTimeKey(key) => key,
+            OneTimeKeyDeriveData::SubaddressIndex(subaddress_index) => {
+                let public_key = RistrettoPublic::try_from(&real_input.public_key)?;
+
+                recover_onetime_private_key(
+                    &public_key,
+                    self.view_private_key(),
+                    &self.subaddress_spend_private(subaddress_index),
+                )
+            }
+        };
+
+        // Check if this is the correct one-time private key
+        if RistrettoPublic::from(&onetime_private_key) != target_key {
+            return Err(Error::TrueInputNotOwned);
+        }
+
+        // Note: Some implementations might be able to cache this generator
+        let generator = generators(*ring.input_secret.amount.token_id);
+
+        // Sign the MLSAG
+        Ok(RingMLSAG::sign(
+            message,
+            &ring.members,
+            ring.real_input_index,
+            &onetime_private_key,
+            ring.input_secret.amount.value,
+            &ring.input_secret.blinding,
+            &pseudo_output_blinding,
+            &generator,
+            rng,
+        )?)
+    }
+}
+
+impl MemoHmacSigner for AccountKeys {
+    fn compute_memo_hmac_sig(&self, receiving_subaddress_view_public: &CompressedRistrettoPublic, tx_out_public_key: &CompressedRistrettoPublic, memo_type: &[u8; 2], memo_data_sans_hmac: &[u8; 48]) -> Result<[u8; 16], Error> {
+
+        let shared_secret = self
+            .subaddress_spend_private_key(DEFAULT_SUBADDRESS_INDEX)
+            .key_exchange(receiving_subaddress_view_public_key);
+
+        let hmac_value = compute_category1_hmac(
+            shared_secret.as_ref(),
+            tx_out_public_key,
+            Self::MEMO_TYPE_BYTES,
+            &memo_data_sans_hmac,
+        );
+
+        Ok(hmac_value)
+    }        
+}
+
+impl KeyImageComputer for AccountKeys {
+    fn compute_key_image(&self, tx_out_public_key: &CompressedRistrettoPublic, subaddress_index: u64) -> Result<KeyImage, Error> {
+        let decompressed_tx_pub = RistrettoPublic::try_from(tx_out_public_key)?;
+
+        let onetime_private_key = recover_onetime_private_key(
+            &decompressed_tx_pub,
+            self.view_private_key(),
+            &self.subaddress_spend_private(subaddress_index),
+        );
+        Ok(KeyImage::from(&onetime_private_key));
+    }
+}

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -687,6 +687,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+dependencies = [
+ "displaydoc",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "rand_core",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-account-keys"
 version = "2.0.0"
 dependencies = [
@@ -1170,6 +1184,7 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "mc-abstract-account-keys",
  "mc-account-keys",
  "mc-crypto-dalek",
  "mc-crypto-keys",

--- a/crypto/memo-mac/Cargo.toml
+++ b/crypto/memo-mac/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mc-crypto-memo-mac"
+version = "2.0.0"
+authors = ["MobileCoin"]
+edition = "2021"
+
+[features]
+test-only = []
+
+[dependencies]
+# External dependencies
+hmac = "0.12"
+sha2 = { version = "0.10", default-features = false }
+
+# MobileCoin dependencies
+mc-crypto-keys = { path = "../../crypto/keys", default-features = false }

--- a/crypto/memo-mac/README.md
+++ b/crypto/memo-mac/README.md
@@ -1,0 +1,7 @@
+mc-crypto-memo-mac
+==================
+
+This crate contains details for computing the RTH memo hmac value. This is in it's
+own crate for ease of implementing the functionality on hardware wallet devices.
+
+

--- a/crypto/memo-mac/src/lib.rs
+++ b/crypto/memo-mac/src/lib.rs
@@ -1,0 +1,44 @@
+#![no_std]
+
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! HMAC code shared by all category 0x01 memos.
+//!
+//! This validation scheme was proposed for standardization in
+//! mobilecoinfoundation/mcips/pull/4
+
+use hmac::{Hmac, Mac};
+use mc_crypto_keys::{CompressedRistrettoPublic};
+use sha2::Sha512;
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// Shared code for memo types in category 0x01, whose last 16 bytes is an HMAC
+/// This HMAC key is always first the 32 bytes of a shared secret, then the 32
+/// bytes of the TxOut public key, then all the bytes of the decrypted memo,
+/// omitting the last 16 which are the HMAC.
+///
+/// Arguments:
+/// * shared_secret, produced in some way between sender and recipient.
+/// * tx_out_public_key, from the TxOut associated to this memo
+/// * memo_data_sans_hmac. This is 64 bytes minus the 16 at the end for hmac.
+pub fn compute_category1_hmac(
+    shared_secret: &[u8; 32],
+    tx_out_public_key: &CompressedRistrettoPublic,
+    memo_type_bytes: [u8; 2],
+    memo_data_sans_mac: &[u8; 48],
+) -> [u8; 16] {
+    let mut mac = HmacSha512::new_from_slice(shared_secret.as_ref())
+        .expect("hmac can take a key of any size");
+    // First add domain separation
+    mac.update(b"mc-memo-mac");
+    // Next add tx_out_public_key, binding this mac to a paritcular TxOut
+    mac.update(tx_out_public_key.as_ref());
+    // Next add memo type bytes (2)
+    mac.update(&memo_type_bytes);
+    // Next add all the memo data bytes, except for the last 16 (which are the mac)
+    mac.update(memo_data_sans_mac);
+    let mut result = [0u8; 16];
+    result.copy_from_slice(&mac.finalize().into_bytes()[0..16]);
+    result
+}

--- a/crypto/memo-mac/src/lib.rs
+++ b/crypto/memo-mac/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! HMAC code shared by all category 0x01 memos.
@@ -8,7 +7,7 @@
 //! mobilecoinfoundation/mcips/pull/4
 
 use hmac::{Hmac, Mac};
-use mc_crypto_keys::{CompressedRistrettoPublic};
+use mc_crypto_keys::CompressedRistrettoPublic;
 use sha2::Sha512;
 
 type HmacSha512 = Hmac<Sha512>;

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -17,6 +17,7 @@ subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }
 
 # MobileCoin dependencies
+mc-abstract-account-keys = { path = "../../../abstract-account-keys" }
 mc-account-keys = { path = "../../../account-keys", default-features = false }
 mc-crypto-dalek = { path = "../../dalek" }
 mc-crypto-keys = { path = "../../keys", default-features = false }

--- a/crypto/ring-signature/signer/src/lib.rs
+++ b/crypto/ring-signature/signer/src/lib.rs
@@ -13,5 +13,5 @@ pub use no_keys_ring_signer::NoKeysRingSigner;
 mod local_signer;
 pub use local_signer::LocalRingSigner;
 
-mod traits;
-pub use traits::{Error, InputSecret, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
+// For now, re-export these
+pub use mc_abstract_account_keys::{Error, RingSigner, InputSecret, OneTimeKeyDeriveData, SignableInputRing};

--- a/crypto/ring-signature/signer/src/lib.rs
+++ b/crypto/ring-signature/signer/src/lib.rs
@@ -14,4 +14,6 @@ mod local_signer;
 pub use local_signer::LocalRingSigner;
 
 // For now, re-export these
-pub use mc_abstract_account_keys::{Error, RingSigner, InputSecret, OneTimeKeyDeriveData, SignableInputRing};
+pub use mc_abstract_account_keys::{
+    Error, InputSecret, OneTimeKeyDeriveData, RingSigner, SignableInputRing,
+};

--- a/crypto/ring-signature/signer/src/local_signer.rs
+++ b/crypto/ring-signature/signer/src/local_signer.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
+use mc_abstract_account_keys::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use mc_account_keys::AccountKey;
 use mc_crypto_keys::RistrettoPublic;
 use mc_crypto_ring_signature::{

--- a/crypto/ring-signature/signer/src/no_keys_ring_signer.rs
+++ b/crypto/ring-signature/signer/src/no_keys_ring_signer.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use super::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
+use mc_abstract_account_keys::{Error, OneTimeKeyDeriveData, RingSigner, SignableInputRing};
 use mc_crypto_keys::RistrettoPublic;
 use mc_crypto_ring_signature::{generators, CryptoRngCore, RingMLSAG, Scalar};
 

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -705,6 +705,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+dependencies = [
+ "displaydoc",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "rand_core",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-account-keys"
 version = "2.0.0"
 dependencies = [
@@ -1082,6 +1096,7 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "mc-abstract-account-keys",
  "mc-account-keys",
  "mc-crypto-dalek",
  "mc-crypto-keys",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -709,6 +709,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+dependencies = [
+ "displaydoc",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "rand_core",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-account-keys"
 version = "2.0.0"
 dependencies = [
@@ -1051,6 +1065,7 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "mc-abstract-account-keys",
  "mc-account-keys",
  "mc-crypto-dalek",
  "mc-crypto-keys",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -717,6 +717,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-abstract-account-keys"
+version = "2.0.0"
+dependencies = [
+ "displaydoc",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-types",
+ "rand_core",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-account-keys"
 version = "2.0.0"
 dependencies = [
@@ -1094,6 +1108,7 @@ dependencies = [
  "displaydoc",
  "generic-array",
  "hex_fmt",
+ "mc-abstract-account-keys",
  "mc-account-keys",
  "mc-crypto-dalek",
  "mc-crypto-keys",

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -24,6 +24,7 @@ zeroize = "1"
 mc-account-keys = { path = "../../account-keys" }
 mc-crypto-hashes = { path = "../../crypto/hashes" }
 mc-crypto-keys = { path = "../../crypto/keys", default-features = false }
+mc-crypto-memo-mac = { path = "../../crypto/memo-mac" }
 mc-crypto-ring-signature-signer = { path = "../../crypto/ring-signature/signer", default-features = false }
 mc-fog-report-validation = { path = "../../fog/report/validation" }
 mc-transaction-core = { path = "../../transaction/core" }

--- a/transaction/std/src/memo/authenticated_common.rs
+++ b/transaction/std/src/memo/authenticated_common.rs
@@ -5,43 +5,10 @@
 //! This validation scheme was proposed for standardization in
 //! mobilecoinfoundation/mcips/pull/4
 
-use hmac::{Hmac, Mac};
 use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_crypto_keys::{CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate};
-use sha2::Sha512;
+use mc_crypto_memo_mac::compute_category1_hmac;
 use subtle::{Choice, ConstantTimeEq};
-
-type HmacSha512 = Hmac<Sha512>;
-
-/// Shared code for memo types in category 0x01, whose last 16 bytes is an HMAC
-/// This HMAC key is always first the 32 bytes of a shared secret, then the 32
-/// bytes of the TxOut public key, then all the bytes of the decrypted memo,
-/// omitting the last 16 which are the HMAC.
-///
-/// Arguments:
-/// * shared_secret, produced in some way between sender and recipient.
-/// * tx_out_public_key, from the TxOut associated to this memo
-/// * memo_data. The last 16 bytes of this slice will be ignored.
-pub fn compute_category1_hmac(
-    shared_secret: &[u8; 32],
-    tx_out_public_key: &CompressedRistrettoPublic,
-    memo_type_bytes: [u8; 2],
-    memo_data: &[u8; 64],
-) -> [u8; 16] {
-    let mut mac = HmacSha512::new_from_slice(shared_secret.as_ref())
-        .expect("hmac can take a key of any size");
-    // First add domain separation
-    mac.update(b"mc-memo-mac");
-    // Next add tx_out_public_key, binding this mac to a paritcular TxOut
-    mac.update(tx_out_public_key.as_ref());
-    // Next add memo type bytes (2)
-    mac.update(&memo_type_bytes);
-    // Next add all the memo data bytes, except for the last 16 (which are the mac)
-    mac.update(&memo_data[..(64 - 16)]);
-    let mut result = [0u8; 16];
-    result.copy_from_slice(&mac.finalize().into_bytes()[0..16]);
-    result
-}
 
 /// Shared code for validation of 0x0100 and 0x0101 memos
 pub fn validate_authenticated_sender(
@@ -64,7 +31,7 @@ pub fn validate_authenticated_sender(
         shared_secret.as_ref(),
         tx_out_public_key,
         memo_type_bytes,
-        memo_data,
+        memo_data[..48].try_into().unwrap(),
     );
     let found_hmac: [u8; 16] = memo_data[(64 - 16)..].try_into().unwrap();
     result &= expected_hmac.ct_eq(&found_hmac);

--- a/transaction/std/src/memo/authenticated_sender.rs
+++ b/transaction/std/src/memo/authenticated_sender.rs
@@ -5,7 +5,7 @@
 //! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
 
 use super::{
-    authenticated_common::{compute_category1_hmac, validate_authenticated_sender},
+    authenticated_common::{validate_authenticated_sender},
     credential::SenderMemoCredential,
     RegisteredMemoType,
 };
@@ -14,6 +14,7 @@ use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_crypto_keys::{
     CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate, RistrettoPublic,
 };
+use mc_crypto_memo_mac::{compute_category1_hmac};
 use subtle::Choice;
 
 /// A memo that the sender writes to convey their identity in an authenticated
@@ -67,7 +68,7 @@ impl AuthenticatedSenderMemo {
             shared_secret.as_ref(),
             tx_out_public_key,
             Self::MEMO_TYPE_BYTES,
-            &memo_data,
+            &memo_data[..48].try_into().unwrap(),
         );
         memo_data[48..].copy_from_slice(&hmac_value);
 

--- a/transaction/std/src/memo/authenticated_sender.rs
+++ b/transaction/std/src/memo/authenticated_sender.rs
@@ -5,8 +5,7 @@
 //! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
 
 use super::{
-    authenticated_common::{validate_authenticated_sender},
-    credential::SenderMemoCredential,
+    authenticated_common::validate_authenticated_sender, credential::SenderMemoCredential,
     RegisteredMemoType,
 };
 use crate::impl_memo_type_conversions;
@@ -14,7 +13,7 @@ use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_crypto_keys::{
     CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate, RistrettoPublic,
 };
-use mc_crypto_memo_mac::{compute_category1_hmac};
+use mc_crypto_memo_mac::compute_category1_hmac;
 use subtle::Choice;
 
 /// A memo that the sender writes to convey their identity in an authenticated

--- a/transaction/std/src/memo/authenticated_sender_with_payment_request_id.rs
+++ b/transaction/std/src/memo/authenticated_sender_with_payment_request_id.rs
@@ -5,7 +5,7 @@
 //! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
 
 use super::{
-    authenticated_common::{compute_category1_hmac, validate_authenticated_sender},
+    authenticated_common::{validate_authenticated_sender},
     credential::SenderMemoCredential,
     RegisteredMemoType,
 };
@@ -14,6 +14,7 @@ use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_crypto_keys::{
     CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate, RistrettoPublic,
 };
+use mc_crypto_memo_mac::{compute_category1_hmac};
 use subtle::Choice;
 
 /// A memo that the sender writes to convey their identity in an authenticated
@@ -72,7 +73,7 @@ impl AuthenticatedSenderWithPaymentRequestIdMemo {
             shared_secret.as_ref(),
             tx_out_public_key,
             Self::MEMO_TYPE_BYTES,
-            &memo_data,
+            &memo_data[..48].try_into().unwrap(),
         );
         memo_data[48..].copy_from_slice(&hmac_value);
 

--- a/transaction/std/src/memo/authenticated_sender_with_payment_request_id.rs
+++ b/transaction/std/src/memo/authenticated_sender_with_payment_request_id.rs
@@ -5,8 +5,7 @@
 //! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
 
 use super::{
-    authenticated_common::{validate_authenticated_sender},
-    credential::SenderMemoCredential,
+    authenticated_common::validate_authenticated_sender, credential::SenderMemoCredential,
     RegisteredMemoType,
 };
 use crate::impl_memo_type_conversions;
@@ -14,7 +13,7 @@ use mc_account_keys::{PublicAddress, ShortAddressHash};
 use mc_crypto_keys::{
     CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate, RistrettoPublic,
 };
-use mc_crypto_memo_mac::{compute_category1_hmac};
+use mc_crypto_memo_mac::compute_category1_hmac;
 use subtle::Choice;
 
 /// A memo that the sender writes to convey their identity in an authenticated

--- a/transaction/std/src/memo/mod.rs
+++ b/transaction/std/src/memo/mod.rs
@@ -44,7 +44,6 @@
 //! | 0x0202          | Gift Code Cancellation Memo                       |
 
 pub use self::{
-    authenticated_common::compute_category1_hmac,
     authenticated_sender::AuthenticatedSenderMemo,
     authenticated_sender_with_payment_request_id::AuthenticatedSenderWithPaymentRequestIdMemo,
     burn_redemption::BurnRedemptionMemo,


### PR DESCRIPTION
In order to make progress on the hardware wallets project, we need to start adding abstractions for more of the functionality of account keys beyond just signing rings.

One of the main asks is also, the memo signing part. In this commit we also threw in the key images.

We couldn't throw in Public Address computations yet because it causes circular dependencies, unless we do more refactoring. We decided to hold off before this PR gets too large.

Without public addresses, we can't easily compute the short address hash of the source address, which is needed for the memo computations. So we can't make the transaction builder part generic over this new memo trait just yet either.

Nevertheless, committing to this API can help enable further progress on the hardware wallet side.

One thing I'm anticipating is, if the memo builder contains a reference to "handle to hardware wallet", and the ring signer is also "handle to hardware wallet", then we may want to have an `Rc`-wrapper in there to allow it to be in "two places at once". This shouldn't pose a problem on the desktop/transaction builder side.

One thing I'm unsure about is if I'm making a mistake making traits like `RingSigner` take `&self` instead of `&mut self`. We could probably easily correct course if we have to though. It seems likely that whatever handle to the hardware wallet we obtain, it may not be perfectly thread-safe, so maybe `&mut self` is better. OTOH I'd kind of like to avoid complicating the transaction builder, and using either `Mutex` or `Rc` or something to resolve the mutability issue.