### PR TITLE
Create db cleaner executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-fog-sql-recovery-db-cleanup"
+version = "2.0.0"
+dependencies = [
+ "chrono",
+ "clap 3.2.22",
+ "mc-common",
+ "mc-fog-recovery-db-iface",
+ "mc-fog-sql-recovery-db",
+ "serde",
+]
+
+[[package]]
 name = "mc-fog-test-client"
 version = "2.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "fog/sig/authority",
     "fog/sig/report",
     "fog/sql_recovery_db",
+    "fog/sql_recovery_db/cleanup",
     "fog/test-client",
     "fog/test_infra",
     "fog/types",

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mc-fog-sql-recovery-db-cleanup"
+version = "2.0.0"
+authors = ["Mobilecoin"]
+edition = "2021"
+license = "GPL-3.0"
+
+[[bin]]
+name = "mc-fog-sql-recovery-db-cleanup"
+path = "src/main.rs"
+
+[dependencies]
+chrono = "0.4"
+clap = { version = "3.2", features = ["derive", "env"] }
+mc-common = { path = "../../../common", features = ["loggers"] }
+mc-fog-recovery-db-iface = { path = "../../recovery_db_iface" }
+mc-fog-sql-recovery-db = { path = "../../sql_recovery_db" }
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/fog/sql_recovery_db/cleanup/src/config.rs
+++ b/fog/sql_recovery_db/cleanup/src/config.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Specifies configuration for the Fog SQL Recovery DB cleanup binary.
+
+use clap::Parser;
+use serde::Serialize;
+
+/// Configuration parameters for the Fog SQL recovery DB cleanup task.
+#[derive(Clone, Parser, Serialize)]
+#[clap(version)]
+pub struct SqlRecoveryDbCleanupConfig {
+    /// If set to true, performs cleanup task for unused egress keys.
+    #[clap(long)]
+    pub egress_keys: bool,
+
+    /// If set to true, prints out any DB entries that would be cleared by the
+    /// command and doesn't execute the deletion.
+    #[clap(long)]
+    pub dry_run: bool,
+}

--- a/fog/sql_recovery_db/cleanup/src/db_cleaner.rs
+++ b/fog/sql_recovery_db/cleanup/src/db_cleaner.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! A cleanup utility for the Fog SQL DB.
+
+use chrono::{prelude::*, Duration};
+use mc_common::logger::{log, Logger};
+use mc_fog_recovery_db_iface::RecoveryDb;
+use mc_fog_sql_recovery_db::SqlRecoveryDb;
+
+/// Contains helper methods that cleanup the Fog SQL DB.
+pub struct DbCleaner {
+    /// The Fog DB being cleaned up.
+    db: SqlRecoveryDb,
+
+    /// Logger instance.
+    logger: Logger,
+}
+
+impl DbCleaner {
+    pub fn new(db: SqlRecoveryDb, logger: Logger) -> Self {
+        Self { db, logger }
+    }
+
+    /// Identifies expired egress keys and either deletes their associated
+    /// ingest invocations or prints them out.
+    pub fn cleanup_egress_keys(&self, is_dry_run: bool, expiration: Duration) {
+        let expired_date_time = Utc::now()
+            .naive_utc()
+            .checked_sub_signed(expiration)
+            .expect("Expiration should always be in the past");
+
+        let expired_ingest_invocations = self
+            .db
+            .get_expired_invocations(expired_date_time)
+            .expect("Could not retrieve expired ingest invocations.");
+
+        if is_dry_run {
+            log::info!(
+                self.logger,
+                "There are {} expired ingest invocations",
+                expired_ingest_invocations.len()
+            );
+            for (i, expired_ingest_invocation) in expired_ingest_invocations.iter().enumerate() {
+                log::info!(
+                    self.logger,
+                    "Expired Egress key {}\n  ingest_invocation_id: {}\n  egress_public_key: {:?}\n  last_active_at: {:?}",
+                    i + 1,
+                    expired_ingest_invocation.ingest_invocation_id,
+                    expired_ingest_invocation.egress_public_key,
+                    expired_ingest_invocation.last_active_at,
+                );
+            }
+        }
+    }
+}

--- a/fog/sql_recovery_db/cleanup/src/main.rs
+++ b/fog/sql_recovery_db/cleanup/src/main.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Runs a cleanup utility for the Fog Sql Recovery DB.
+
+use crate::{config::SqlRecoveryDbCleanupConfig, db_cleaner::DbCleaner};
+use chrono::Duration;
+use clap::Parser;
+use mc_common::logger::create_app_logger;
+use mc_fog_sql_recovery_db::SqlRecoveryDb;
+use std::env;
+
+mod config;
+mod db_cleaner;
+
+static EXPIRATION_DAYS: i64 = 2;
+
+fn main() {
+    let config = SqlRecoveryDbCleanupConfig::parse();
+    let (logger, _global_logger_guard) = create_app_logger(mc_common::logger::o!());
+
+    let database_url = env::var("DATABASE_URL").expect("Missing DATABASE_URL environment variable");
+    let db = SqlRecoveryDb::new_from_url(&database_url, Default::default(), logger.clone())
+        .expect("failed connecting to database");
+
+    let db_cleaner = DbCleaner::new(db, logger);
+
+    if config.egress_keys {
+        db_cleaner.cleanup_egress_keys(config.dry_run, Duration::days(EXPIRATION_DAYS));
+    }
+}


### PR DESCRIPTION

### Motivation

This PR creates the executable that cleans up the egress keys. Right now, it only implements the dry run functionality, which prints out the keys to the screen. 

### Future Work
* The next PR will handle the non-dry run scenario, which will make changes to the ingest_invocation table.