### PR TITLE
Scp/more scp logs

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -194,7 +194,7 @@ fn main() {
             TxFile::MintTx(tx) => {
                 println!("{}", hex::encode(&tx.prefix.hash()));
             }
-        }
+        },
 
         Commands::HashMintTx { params } => {
             let tx_prefix = params

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -263,8 +263,8 @@ pub enum Commands {
         params: MintConfigTxPrefixParams,
     },
 
-    /// Produce a hash of a MintConfigTx or MintTx tranasaction from a JSON tx-file.
-    /// This is useful for offline/HSM signing.
+    /// Produce a hash of a MintConfigTx or MintTx tranasaction from a JSON
+    /// tx-file. This is useful for offline/HSM signing.
     HashTxFile {
         /// The file to load
         #[clap(long, parse(try_from_str = load_tx_file_from_path), env = "MC_MINTING_TX_FILE")]

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -133,13 +133,13 @@ impl<V: Value, N: ScpNode<V>> LoggingScpNode<V, N> {
         let data_json = serde_json::to_string_pretty(&data)
             .map_err(|e| format!("failed serialize: {:?}", e))?;
 
-        let mut file_path = slot_out_path.clone();
+        let mut file_path = slot_out_path;
         file_path.push(format!("{:08}.json", self.msg_count));
         self.msg_count += 1;
 
         let mut file = File::create(&file_path)
             .map_err(|e| format!("failed creating {:?}: {:?}", file_path, e))?;
-        file.write_all(&data_json.as_bytes())
+        file.write_all(data_json.as_bytes())
             .map_err(|e| format!("failed writing {:?}: {:?}", file_path, e))?;
 
         Ok(())

--- a/consensus/scp/viewer/templates/slot.html
+++ b/consensus/scp/viewer/templates/slot.html
@@ -83,14 +83,14 @@
                     $('#PN', template).text(t.PN).parent().show();
                     $('#CN', template).text(t.CN).parent().show();
                     $('#HN', template).text(t.HN).parent().show();
-                } else if (msg.topic.Prepare && msg.topic.Nominate) {
+                } else if (msg.topic.NominatePrepare) {
                     $('#topic', template).text("Prepare/Nominate");
 
-                    var t = msg.topic.Nominate;
+                    var t = msg.topic.NominatePrepare[0];
                     $('#X', template).html(format_values(t.X)).parent().show();
                     $('#Y', template).html(format_values(t.Y)).parent().show();
 
-                    var t = msg.topic.Prepare;
+                    var t = msg.topic.NominatePrepare[1];
                     $('#B', template).html(format_ballot(t.B)).parent().show();
                     $('#P', template).html(format_ballot(t.P)).parent().show();
                     $('#PP', template).html(format_ballot(t.PP)).parent().show();
@@ -126,7 +126,7 @@
                 $('#N', template).text(b.N);
                 $('#count', template).text(b.X.length);
                 $.each(b.X, function(idx, val) {
-                    $('#values', template).append($('<li></li>').text(to_hex_str(val).substr(0, 12)));
+                    $('#values', template).append($('<li></li>').text(format_value(val)));
                 })
                 return template;
             }
@@ -135,9 +135,16 @@
                 var template = $($('script[data-template="values"]').text());
                 $('#count', template).text(list.length);
                 $.each(list, function(idx, val) {
-                    $('#values', template).append($('<li></li>').text(to_hex_str(val).substr(0, 12)));
+                    $('#values', template).append($('<li></li>').text(format_value(val)));
                 })
                 return template;
+            }
+
+            function format_value(val) {
+                if (val.TxHash) {
+                    val.TxHash = to_hex_str(val.TxHash).substr(0, 12);
+                }
+                return JSON.stringify(val);
             }
 
             function to_hex_str(byteArray) {
@@ -188,6 +195,14 @@
         Phase: <span id="phase"></span><br>
         Nominate round: <span id="nominate-round"></span><br>
         Max priority peers: <span id="max-priority-peers"></span><br>
+        Message index: {% if msg_index > 0 %}
+            <a href="{{ url_for('slot_node_msg', slot_index=slot_index, node_id=node_id, msg_index=msg_index - 1) }}">&lt;</a>
+        {% endif %}
+        {{ msg_index }} / {{ highest_msg_index }}
+        {% if msg_index < highest_msg_index %}
+            <a href="{{ url_for('slot_node_msg', slot_index=slot_index, node_id=node_id, msg_index=msg_index + 1) }}">&gt;</a>
+        {% endif %}
+        <br>
 
         <h1>M (message map)</h1>
         <div id="M"></div>

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -194,7 +194,7 @@ impl ByzantineLedger {
             match scp_debug_dir {
                 None => Box::new(node),
                 Some(path) => Box::new(
-                    LoggingScpNode::new(node, path, logger.clone())
+                    LoggingScpNode::new(node, path)
                         .expect("Failed creating LoggingScpNode"),
                 ),
             }

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -194,8 +194,7 @@ impl ByzantineLedger {
             match scp_debug_dir {
                 None => Box::new(node),
                 Some(path) => Box::new(
-                    LoggingScpNode::new(node, path)
-                        .expect("Failed creating LoggingScpNode"),
+                    LoggingScpNode::new(node, path).expect("Failed creating LoggingScpNode"),
                 ),
             }
         };

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -465,9 +465,7 @@ class Network:
             )
 
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mint-auditor -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen {CARGO_FLAGS}',
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-mobilecoind --no-default-features {CARGO_FLAGS}',
-
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mint-auditor -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen -p mc-mobilecoind {CARGO_FLAGS}',
             shell=True,
             check=True,
         )


### PR DESCRIPTION
Change the scp debug logs writer to not remove logs from previous slots, and also store the ScpNode state as it was after each message was processed.
