### PR TITLE
Modify MVQ to use NonceMessage

### DIFF
--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -563,7 +563,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
             .get_mut(responder_id)
             .ok_or(Error::NotFound)
             .and_then(|session| {
-                Ok(session.decrypt_with_nonce(&msg.aad, &msg.data, msg.channel_id.peek_nonce())?)
+                Ok(session.decrypt_with_nonce(&msg.aad, &msg.data, msg.channel_id.nonce())?)
             })
     }
 

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -50,7 +50,7 @@ message FogViewRouterResponse {
 
 message MultiViewStoreQueryRequest {
     /// A list of queries encrypted for Fog View Stores.
-    repeated attest.Message queries = 1;
+    repeated attest.NonceMessage queries = 1;
 }
 
 /// The status associated with a MultiViewStoreQueryResponse
@@ -69,7 +69,7 @@ message MultiViewStoreQueryResponse {
     /// Optional field that gets set when the Fog View Store is able to decrypt a query
     /// included in the MultiViewStoreQueryRequest and create a query response for that
     //  query.
-    attest.Message query_response = 1;
+    attest.NonceMessage query_response = 1;
 
     /// The FogViewStoreUri for the specific Fog View Store that
     /// tried to decrypt the MultiViewStoreQueryRequest and failed.

--- a/fog/api/src/conversions.rs
+++ b/fog/api/src/conversions.rs
@@ -20,12 +20,9 @@ impl From<Vec<EnclaveMessage<NonceSession>>> for MultiViewStoreQueryRequest {
 }
 
 impl From<Vec<attest::NonceMessage>> for MultiViewStoreQueryRequest {
-    fn from(_attested_query_messages: Vec<attest::NonceMessage>) -> MultiViewStoreQueryRequest {
+    fn from(attested_query_messages: Vec<attest::NonceMessage>) -> MultiViewStoreQueryRequest {
         let mut multi_view_store_query_request = MultiViewStoreQueryRequest::new();
-        // TODO: Once MultiViewStoreQueryRequest.queries is modified to be a
-        // Vec<attest::NonceMessage> change this to use the
-        // _attested_query_messages_field.
-        multi_view_store_query_request.set_queries(vec![].into());
+        multi_view_store_query_request.set_queries(attested_query_messages.into());
 
         multi_view_store_query_request
     }

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -194,7 +194,7 @@ where
         log::trace!(self.logger, "Getting encrypted request");
         let tracer = tracer!();
 
-        tracer.in_span("query_impl", |_cx| {
+        tracer.in_span("query_nonce_impl", |_cx| {
             // TODO: Create query_nonce enclave method that does what query currently does
             // but for NonceMessage. It should produce data and a nonce that is
             // then set on the nonce_message.

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -24,14 +24,14 @@ pub struct ProcessedShardResponseData {
     pub view_store_uris_for_authentication: Vec<FogViewStoreUri>,
 
     /// New, successfully processed query responses.
-    pub new_query_responses: Vec<(ResponderId, attest::Message)>,
+    pub new_query_responses: Vec<(ResponderId, attest::NonceMessage)>,
 }
 
 impl ProcessedShardResponseData {
     pub fn new(
         shard_clients_for_retry: Vec<Arc<FogViewStoreApiClient>>,
         view_store_uris_for_authentication: Vec<FogViewStoreUri>,
-        new_query_responses: Vec<(ResponderId, attest::Message)>,
+        new_query_responses: Vec<(ResponderId, attest::NonceMessage)>,
     ) -> Self {
         ProcessedShardResponseData {
             shard_clients_for_retry,

--- a/util/telemetry/src/lib.rs
+++ b/util/telemetry/src/lib.rs
@@ -8,10 +8,12 @@ pub use opentelemetry::{
 };
 
 use opentelemetry::{
-    global::{tracer_provider, BoxedTracer},
+    global::tracer_provider,
     trace::{SpanBuilder, TraceId, TracerProvider},
 };
 use std::borrow::Cow;
+
+pub use opentelemetry::global::BoxedTracer;
 
 #[macro_export]
 macro_rules! tracer {


### PR DESCRIPTION
### Motivation
The MultiViewStoreQuery uses `attest::Message` queries but needs to use `attest::NonceMessage` queries now that FVR is using Nonce based sessions.  This PR makes this change but stops short of adding a `query` enclave method that takes a `NonceMessage`. 

NOTE: CI is failing for this PR for reasons that don't seem to be associated with the new functionality. I'm going to investigate this CI failure in parallel, but it shouldn't block this PR. 

### Future Work
- Create a `query` enclave method that takes a `NonceMessage`.