### PR TITLE
Replace client with nonce paradigm for backends

### DIFF
--- a/attest/api/src/conversions.rs
+++ b/attest/api/src/conversions.rs
@@ -5,8 +5,8 @@
 use crate::attest::{AuthMessage, Message, NonceMessage};
 use mc_attest_ake::{AuthRequestOutput, AuthResponseOutput};
 use mc_attest_enclave_api::{
-    ClientAuthRequest, ClientAuthResponse, EnclaveMessage, NonceSession, PeerAuthRequest,
-    PeerAuthResponse, Session,
+    ClientAuthRequest, ClientAuthResponse, EnclaveMessage, NonceAuthRequest, NonceAuthResponse,
+    NonceSession, PeerAuthRequest, PeerAuthResponse, Session,
 };
 use mc_crypto_keys::Kex;
 use mc_crypto_noise::{HandshakePattern, NoiseCipher, NoiseDigest};
@@ -55,6 +55,34 @@ impl From<AuthMessage> for ClientAuthRequest {
 
 impl From<ClientAuthRequest> for AuthMessage {
     fn from(src: ClientAuthRequest) -> AuthMessage {
+        let mut retval = AuthMessage::default();
+        retval.set_data(src.into());
+        retval
+    }
+}
+
+impl From<AuthMessage> for NonceAuthRequest {
+    fn from(src: AuthMessage) -> NonceAuthRequest {
+        src.data.into()
+    }
+}
+
+impl From<NonceAuthRequest> for AuthMessage {
+    fn from(src: NonceAuthRequest) -> AuthMessage {
+        let mut retval = AuthMessage::default();
+        retval.set_data(src.into());
+        retval
+    }
+}
+
+impl From<AuthMessage> for NonceAuthResponse {
+    fn from(src: AuthMessage) -> NonceAuthResponse {
+        src.data.into()
+    }
+}
+
+impl From<NonceAuthResponse> for AuthMessage {
+    fn from(src: NonceAuthResponse) -> AuthMessage {
         let mut retval = AuthMessage::default();
         retval.set_data(src.into());
         retval

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["MobileCoin"]
 edition = "2021"
 
 [dependencies]
+
+aes-gcm = "0.9.4"
+cookie = "0.16"
+displaydoc = "0.2"
+grpcio = "0.11.0"
 mc-attest-ake = { path = "../attest/ake" }
 mc-attest-api = { path = "../attest/api" }
 mc-attest-core = { path = "../attest/core" }
@@ -19,11 +24,6 @@ mc-transaction-core = { path = "../transaction/core" }
 mc-util-grpc = { path = "../util/grpc" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
-
-aes-gcm = "0.9.4"
-cookie = "0.16"
-displaydoc = "0.2"
-grpcio = "0.11.0"
 retry = "1.3"
 secrecy = "0.8"
 sha2 = "0.10"

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -560,7 +560,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         // Ensure lock gets released as soon as we're done decrypting.
         let mut backends = self.backends.lock()?;
         backends
-            .get_mut(&responder_id)
+            .get_mut(responder_id)
             .ok_or(Error::NotFound)
             .and_then(|session| {
                 Ok(session.decrypt_with_nonce(&msg.aad, &msg.data, msg.channel_id.peek_nonce())?)

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -554,8 +554,8 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
 
     pub fn backend_decrypt(
         &self,
-        responder_id: ResponderId,
-        msg: EnclaveMessage<NonceSession>,
+        responder_id: &ResponderId,
+        msg: &EnclaveMessage<NonceSession>,
     ) -> Result<Vec<u8>> {
         // Ensure lock gets released as soon as we're done decrypting.
         let mut backends = self.backends.lock()?;

--- a/fog/api/src/conversions.rs
+++ b/fog/api/src/conversions.rs
@@ -5,26 +5,27 @@
 use crate::{fog_common, ingest_common, view::MultiViewStoreQueryRequest};
 use mc_api::ConversionError;
 use mc_attest_api::attest;
-use mc_attest_enclave_api::{ClientSession, EnclaveMessage};
+use mc_attest_enclave_api::{EnclaveMessage, NonceSession};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_types::common;
 
-impl From<Vec<mc_attest_enclave_api::EnclaveMessage<mc_attest_enclave_api::ClientSession>>>
-    for MultiViewStoreQueryRequest
-{
-    fn from(enclave_messages: Vec<EnclaveMessage<ClientSession>>) -> MultiViewStoreQueryRequest {
+impl From<Vec<EnclaveMessage<NonceSession>>> for MultiViewStoreQueryRequest {
+    fn from(enclave_messages: Vec<EnclaveMessage<NonceSession>>) -> MultiViewStoreQueryRequest {
         enclave_messages
             .into_iter()
             .map(|enclave_message| enclave_message.into())
-            .collect::<Vec<attest::Message>>()
+            .collect::<Vec<attest::NonceMessage>>()
             .into()
     }
 }
 
-impl From<Vec<attest::Message>> for MultiViewStoreQueryRequest {
-    fn from(attested_query_messages: Vec<attest::Message>) -> MultiViewStoreQueryRequest {
+impl From<Vec<attest::NonceMessage>> for MultiViewStoreQueryRequest {
+    fn from(_attested_query_messages: Vec<attest::NonceMessage>) -> MultiViewStoreQueryRequest {
         let mut multi_view_store_query_request = MultiViewStoreQueryRequest::new();
-        multi_view_store_query_request.set_queries(attested_query_messages.into());
+        // TODO: Once MultiViewStoreQueryRequest.queries is modified to be a
+        // Vec<attest::NonceMessage> change this to use the
+        // _attested_query_messages_field.
+        multi_view_store_query_request.set_queries(vec![].into());
 
         multi_view_store_query_request
     }

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -30,8 +30,8 @@ mc-fog-view-protocol = { path = "../protocol" }
 
 # third-party
 aes-gcm = "0.9.4"
-grpcio = "0.11.0"
 futures = "0.3"
+grpcio = "0.11.0"
 retry = "1.3"
 sha2 = { version = "0.10", default-features = false }
 tokio = { version = "1.19.2", features = ["full"] }

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -276,7 +276,7 @@ where
             .expect("Shard query responses must have at least one response.");
         let shard_query_response_plaintext = self
             .ake
-            .backend_decrypt(&shard_query_response.0, shard_query_response.1)?;
+            .backend_decrypt(shard_query_response.0, shard_query_response.1)?;
         let mut shard_query_response: QueryResponse =
             mc_util_serial::decode(&shard_query_response_plaintext).map_err(|e| {
                 log::error!(self.logger, "Could not decode shard query response: {}", e);

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -15,7 +15,8 @@ use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
 use alloc::vec::Vec;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{
-    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, SealedClientMessage,
+    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
+    NonceAuthResponse, NonceSession, SealedClientMessage,
 };
 use mc_common::{
     logger::{log, Logger},
@@ -209,20 +210,20 @@ where
     fn create_multi_view_store_query_data(
         &self,
         sealed_query: SealedClientMessage,
-    ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
+    ) -> Result<Vec<EnclaveMessage<NonceSession>>> {
         Ok(self
             .ake
             .reencrypt_sealed_message_for_backends(&sealed_query)?)
     }
 
-    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<NonceAuthRequest> {
         Ok(self.ake.backend_init(view_store_id)?)
     }
 
     fn view_store_connect(
         &self,
         view_store_id: ResponderId,
-        view_store_auth_response: ClientAuthResponse,
+        view_store_auth_response: NonceAuthResponse,
     ) -> Result<()> {
         Ok(self
             .ake
@@ -232,7 +233,7 @@ where
     fn collate_shard_query_responses(
         &self,
         sealed_query: SealedClientMessage,
-        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<ClientSession>>,
+        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>>,
     ) -> Result<EnclaveMessage<ClientSession>> {
         if shard_query_responses.is_empty() {
             return Ok(EnclaveMessage::default());
@@ -263,15 +264,20 @@ where
     fn create_client_query_response(
         &self,
         client_query_request: QueryRequest,
-        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<ClientSession>>,
+        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>>,
     ) -> Result<QueryResponse> {
-        let encrypted_shard_query_response = shard_query_responses
-            .values()
+        // Choose any shard query response and use it to supply the skeleton values for
+        // the QueryResponse. The tx_out_search_results and
+        // highest_processed_block_count fields will be set based on all of the
+        // shard query responses.
+        let shard_query_response = shard_query_responses
+            .clone()
+            .into_iter()
             .next()
-            .expect("Shard query responses must have at least one response.")
-            .clone();
-        let shard_query_response_plaintext =
-            self.ake.client_decrypt(encrypted_shard_query_response)?;
+            .expect("Shard query responses must have at least one response.");
+        let shard_query_response_plaintext = self
+            .ake
+            .backend_decrypt(shard_query_response.0, shard_query_response.1)?;
         let mut shard_query_response: QueryResponse =
             mc_util_serial::decode(&shard_query_response_plaintext).map_err(|e| {
                 log::error!(self.logger, "Could not decode shard query response: {}", e);

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -271,13 +271,12 @@ where
         // highest_processed_block_count fields will be set based on all of the
         // shard query responses.
         let shard_query_response = shard_query_responses
-            .clone()
-            .into_iter()
+            .iter()
             .next()
             .expect("Shard query responses must have at least one response.");
         let shard_query_response_plaintext = self
             .ake
-            .backend_decrypt(shard_query_response.0, shard_query_response.1)?;
+            .backend_decrypt(&shard_query_response.0, shard_query_response.1)?;
         let mut shard_query_response: QueryResponse =
             mc_util_serial::decode(&shard_query_response_plaintext).map_err(|e| {
                 log::error!(self.logger, "Could not decode shard query response: {}", e);
@@ -287,7 +286,7 @@ where
         let shard_query_responses = shard_query_responses
             .into_iter()
             .map(|(responder_id, enclave_message)| {
-                let plaintext_bytes = self.ake.backend_decrypt(responder_id, enclave_message)?;
+                let plaintext_bytes = self.ake.backend_decrypt(&responder_id, &enclave_message)?;
                 let query_response: QueryResponse = mc_util_serial::decode(&plaintext_bytes)?;
 
                 Ok(query_response)

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -12,7 +12,8 @@ use mc_attest_core::{
     IasNonce, Quote, QuoteNonce, Report, SgxError, TargetInfo, VerificationReport,
 };
 use mc_attest_enclave_api::{
-    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, SealedClientMessage,
+    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
+    NonceAuthResponse, NonceSession, SealedClientMessage,
 };
 use mc_attest_verifier::DEBUG_ENCLAVE;
 use mc_common::{logger::Logger, ResponderId};
@@ -163,7 +164,7 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn view_store_init(&self, view_store_id: ResponderId) -> Result<ClientAuthRequest> {
+    fn view_store_init(&self, view_store_id: ResponderId) -> Result<NonceAuthRequest> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreInit(view_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
@@ -172,7 +173,7 @@ impl ViewEnclaveApi for SgxViewEnclave {
     fn view_store_connect(
         &self,
         view_store_id: ResponderId,
-        view_store_auth_response: ClientAuthResponse,
+        view_store_auth_response: NonceAuthResponse,
     ) -> Result<()> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::ViewStoreConnect(
             view_store_id,
@@ -214,7 +215,7 @@ impl ViewEnclaveApi for SgxViewEnclave {
     fn create_multi_view_store_query_data(
         &self,
         sealed_query: SealedClientMessage,
-    ) -> Result<Vec<EnclaveMessage<ClientSession>>> {
+    ) -> Result<Vec<EnclaveMessage<NonceSession>>> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::CreateMultiViewStoreQuery(
             sealed_query,
         ))?;
@@ -225,7 +226,7 @@ impl ViewEnclaveApi for SgxViewEnclave {
     fn collate_shard_query_responses(
         &self,
         sealed_query: SealedClientMessage,
-        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<ClientSession>>,
+        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>>,
     ) -> Result<EnclaveMessage<ClientSession>> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::CollateQueryResponses(
             sealed_query,

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -20,14 +20,11 @@ ias-dev = [
 ]
 
 [dependencies]
-# fog
-mc-fog-ocall-oram-storage-edl = { path = "../../../ocall_oram_storage/edl" }
-mc-fog-ocall-oram-storage-trusted = { path = "../../../ocall_oram_storage/trusted" }
-mc-fog-recovery-db-iface = { path = "../../../recovery_db_iface" }
-mc-fog-types = { path = "../../../types" }
-mc-fog-view-enclave-api = { path = "../api" }
-mc-fog-view-enclave-edl = { path = "../edl" }
-mc-fog-view-enclave-impl = { path = "../impl" }
+
+# third-party
+lazy_static = { version = "1.4", features = ["spin_no_std"] }
+mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
+mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
 
 # mobilecoin
 mc-attest-core = { path = "../../../../attest/core", default-features = false }
@@ -36,6 +33,14 @@ mc-attest-verifier = { path = "../../../../attest/verifier", default-features = 
 mc-crypto-keys = { path = "../../../../crypto/keys" }
 mc-crypto-rand = { path = "../../../../crypto/rand" }
 mc-enclave-boundary = { path = "../../../../enclave-boundary" }
+# fog
+mc-fog-ocall-oram-storage-edl = { path = "../../../ocall_oram_storage/edl" }
+mc-fog-ocall-oram-storage-trusted = { path = "../../../ocall_oram_storage/trusted" }
+mc-fog-recovery-db-iface = { path = "../../../recovery_db_iface" }
+mc-fog-types = { path = "../../../types" }
+mc-fog-view-enclave-api = { path = "../api" }
+mc-fog-view-enclave-edl = { path = "../edl" }
+mc-fog-view-enclave-impl = { path = "../impl" }
 mc-sgx-compat = { path = "../../../../sgx/compat", features = ["sgx"] }
 mc-sgx-compat-edl = { path = "../../../../sgx/compat-edl" }
 mc-sgx-debug-edl = { path = "../../../../sgx/debug-edl" }
@@ -46,18 +51,13 @@ mc-sgx-slog = { path = "../../../../sgx/slog", features = ["sgx"] }
 mc-sgx-slog-edl = { path = "../../../../sgx/slog-edl" }
 mc-sgx-types = { path = "../../../../sgx/types" }
 mc-util-serial = { path = "../../../../util/serial", default-features = false }
-
-# third-party
-lazy_static = { version = "1.4", features = ["spin_no_std"] }
-mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps", "aesni", "force_aesni_support", "rdrand"] }
-mbedtls-sys-auto = { version = "2.26.1", default-features = false, features = ["custom_threading"] }
 sha2 = { version = "0.10", default-features = false }
 
 [build-dependencies]
-mc-util-build-script = { path = "../../../../util/build/script" }
-mc-util-build-sgx = { path = "../../../../util/build/sgx" }
 
 cargo-emit = "0.2"
+mc-util-build-script = { path = "../../../../util/build/script" }
+mc-util-build-sgx = { path = "../../../../util/build/sgx" }
 pkg-config = "0.3"
 
 [profile.dev]


### PR DESCRIPTION
### Motivation
@jcape created new `Nonce`-based structs that allow Fog View Router (FVR) and Fog VIew Stores to communicate with messages that contain the nonce used in the noise protocol that attests the communication. #2549 added support for inbound frontend messages, and this PR adds the support for outbound "backend" messages. 

Note that this PR stops short of modifying the `MultiviewStoreQueryRequest` and `MultiviewStoreQueryResponse`, and instead supplies a blank `attest::Message` for the conversion that the `router_request_handler` uses. The following PR (#2617) implements this change.

RFC: In the `backend_decrypt` method, I use the `peek_nonce` method rather than the `get_nonce` method to decrypt the message from the backend. See comment for more info but could use confirmation that this is correct.

Note: I included changes to some Cargo.toml files that needed their deps to be sorted.

### Future Work
* #2617: Modify `MultiViewStoreQueryRequest` + `Response` to use `attest::NonceMessage`
* Create a `query_for_nonce` enclave method that fulfills query requests when an `attest::NonceMessage` is used.
* Finish frontend work by using the auth methods in FVR.