### PR TITLE
Create query_backend enclave methods

### DIFF
--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -216,7 +216,6 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
     }
 
     pub fn frontend_decrypt(&self, msg: EnclaveMessage<NonceSession>) -> Result<Vec<u8>> {
-        // Ensure lock gets released as soon as we're done decrypting.
         let mut frontends = self.frontends.lock()?;
         frontends
             .get_mut(&msg.channel_id)

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -83,6 +83,9 @@ pub enum ViewEnclaveRequest {
     /// An encrypted fog_types::view::QueryRequest
     /// Respond with fog_types::view::QueryResponse
     Query(EnclaveMessage<ClientSession>, UntrustedQueryResponse),
+    /// An encrypted fog_types::view::QueryRequest
+    /// Respond with fog_types::view::QueryResponse.
+    QueryBackend(EnclaveMessage<NonceSession>, UntrustedQueryResponse),
     /// Request from untrusted to add encrypted tx out records to ORAM
     AddRecords(Vec<ETxOutRecord>),
     /// Takes a client query message and returns a SealedClientMessage
@@ -161,6 +164,13 @@ pub trait ViewEnclaveApi: ReportableEnclave {
         payload: EnclaveMessage<ClientSession>,
         untrusted_query_response: UntrustedQueryResponse,
     ) -> Result<Vec<u8>>;
+
+    /// Service a query response from a frontend.
+    fn query_backend(
+        &self,
+        payload: EnclaveMessage<NonceSession>,
+        untrusted_query_response: UntrustedQueryResponse,
+    ) -> Result<(Vec<u8>, u64)>;
 
     /// SERVER-FACING
 

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -85,7 +85,7 @@ pub enum ViewEnclaveRequest {
     Query(EnclaveMessage<ClientSession>, UntrustedQueryResponse),
     /// An encrypted fog_types::view::QueryRequest
     /// Respond with fog_types::view::QueryResponse.
-    QueryBackend(EnclaveMessage<NonceSession>, UntrustedQueryResponse),
+    QueryStore(EnclaveMessage<NonceSession>, UntrustedQueryResponse),
     /// Request from untrusted to add encrypted tx out records to ORAM
     AddRecords(Vec<ETxOutRecord>),
     /// Takes a client query message and returns a SealedClientMessage

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -165,12 +165,13 @@ pub trait ViewEnclaveApi: ReportableEnclave {
         untrusted_query_response: UntrustedQueryResponse,
     ) -> Result<Vec<u8>>;
 
-    /// Service a query response from a frontend.
-    fn query_backend(
+    /// Service a frontend's query request. Intended to be used by a Fog View
+    /// Store.
+    fn query_store(
         &self,
         payload: EnclaveMessage<NonceSession>,
         untrusted_query_response: UntrustedQueryResponse,
-    ) -> Result<(Vec<u8>, u64)>;
+    ) -> Result<EnclaveMessage<NonceSession>>;
 
     /// SERVER-FACING
 

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -61,6 +61,63 @@ where
             logger,
         }
     }
+
+    fn query_impl(
+        &self,
+        plaintext_request: &[u8],
+        untrusted_query_response: UntrustedQueryResponse,
+    ) -> Result<Vec<u8>> {
+        let req: QueryRequest = mc_util_serial::decode(plaintext_request).map_err(|e| {
+            log::error!(self.logger, "Could not decode user request: {}", e);
+            Error::ProstDecode
+        })?;
+
+        // Prepare the untrusted part of the response.
+        let mut missed_block_ranges = Vec::new();
+        let mut rng_records = Vec::new();
+        let mut decommissioned_ingest_invocations = Vec::new();
+
+        for event in untrusted_query_response.user_events.into_iter() {
+            match event {
+                FogUserEvent::NewRngRecord(rng_record) => rng_records.push(rng_record),
+
+                FogUserEvent::DecommissionIngestInvocation(decommissioned_ingest_invocation) => {
+                    decommissioned_ingest_invocations.push(decommissioned_ingest_invocation)
+                }
+
+                FogUserEvent::MissingBlocks(range) => missed_block_ranges.push(range),
+            }
+        }
+
+        let mut resp = QueryResponse {
+            highest_processed_block_count: untrusted_query_response.highest_processed_block_count,
+            highest_processed_block_signature_timestamp: untrusted_query_response
+                .highest_processed_block_signature_timestamp,
+            next_start_from_user_event_id: untrusted_query_response.next_start_from_user_event_id,
+            missed_block_ranges,
+            rng_records,
+            decommissioned_ingest_invocations,
+            tx_out_search_results: Default::default(),
+            last_known_block_count: untrusted_query_response.last_known_block_count,
+            last_known_block_cumulative_txo_count: untrusted_query_response
+                .last_known_block_cumulative_txo_count,
+        };
+
+        // Do the txos part, scope lock of e_tx_out_store
+        {
+            let mut lk = self.e_tx_out_store.lock()?;
+            let store = lk.as_mut().ok_or(Error::EnclaveNotInitialized)?;
+
+            resp.tx_out_search_results = req
+                .get_txos
+                .iter()
+                .map(|key| store.find_record(&key[..]))
+                .collect();
+        }
+
+        let response_plaintext_bytes = mc_util_serial::encode(&resp);
+        Ok(response_plaintext_bytes)
+    }
 }
 
 impl<OSC> ReportableEnclave for ViewEnclave<OSC>
@@ -127,62 +184,29 @@ where
     ) -> Result<Vec<u8>> {
         let channel_id = msg.channel_id.clone();
         let user_plaintext = self.ake.client_decrypt(msg)?;
-
-        let req: QueryRequest = mc_util_serial::decode(&user_plaintext).map_err(|e| {
-            log::error!(self.logger, "Could not decode user request: {}", e);
-            Error::ProstDecode
-        })?;
-
-        // Prepare the untrusted part of the response.
-        let mut missed_block_ranges = Vec::new();
-        let mut rng_records = Vec::new();
-        let mut decommissioned_ingest_invocations = Vec::new();
-
-        for event in untrusted_query_response.user_events.into_iter() {
-            match event {
-                FogUserEvent::NewRngRecord(rng_record) => rng_records.push(rng_record),
-
-                FogUserEvent::DecommissionIngestInvocation(decommissioned_ingest_invocation) => {
-                    decommissioned_ingest_invocations.push(decommissioned_ingest_invocation)
-                }
-
-                FogUserEvent::MissingBlocks(range) => missed_block_ranges.push(range),
-            }
-        }
-
-        let mut resp = QueryResponse {
-            highest_processed_block_count: untrusted_query_response.highest_processed_block_count,
-            highest_processed_block_signature_timestamp: untrusted_query_response
-                .highest_processed_block_signature_timestamp,
-            next_start_from_user_event_id: untrusted_query_response.next_start_from_user_event_id,
-            missed_block_ranges,
-            rng_records,
-            decommissioned_ingest_invocations,
-            tx_out_search_results: Default::default(),
-            last_known_block_count: untrusted_query_response.last_known_block_count,
-            last_known_block_cumulative_txo_count: untrusted_query_response
-                .last_known_block_cumulative_txo_count,
-        };
-
-        // Do the txos part, scope lock of e_tx_out_store
-        {
-            let mut lk = self.e_tx_out_store.lock()?;
-            let store = lk.as_mut().ok_or(Error::EnclaveNotInitialized)?;
-
-            resp.tx_out_search_results = req
-                .get_txos
-                .iter()
-                .map(|key| store.find_record(&key[..]))
-                .collect();
-        }
-
-        let response_plaintext_bytes = mc_util_serial::encode(&resp);
-
+        let response_plaintext_bytes =
+            self.query_impl(&user_plaintext, untrusted_query_response)?;
         let response = self
             .ake
             .client_encrypt(&channel_id, &[], &response_plaintext_bytes)?;
 
         Ok(response.data)
+    }
+
+    fn query_backend(
+        &self,
+        msg: EnclaveMessage<NonceSession>,
+        untrusted_query_response: UntrustedQueryResponse,
+    ) -> Result<(Vec<u8>, u64)> {
+        let channel_id = msg.channel_id.clone();
+        let user_plaintext = self.ake.frontend_decrypt(msg)?;
+        let response_plaintext_bytes =
+            self.query_impl(&user_plaintext, untrusted_query_response)?;
+        let response = self
+            .ake
+            .frontend_encrypt(&channel_id, &[], &response_plaintext_bytes)?;
+
+        Ok((response.data, response.channel_id.nonce()))
     }
 
     fn add_records(&self, records: Vec<ETxOutRecord>) -> Result<()> {

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -193,11 +193,11 @@ where
         Ok(response.data)
     }
 
-    fn query_backend(
+    fn query_store(
         &self,
         msg: EnclaveMessage<NonceSession>,
         untrusted_query_response: UntrustedQueryResponse,
-    ) -> Result<(Vec<u8>, u64)> {
+    ) -> Result<EnclaveMessage<NonceSession>> {
         let channel_id = msg.channel_id.clone();
         let user_plaintext = self.ake.frontend_decrypt(msg)?;
         let response_plaintext_bytes =
@@ -206,7 +206,7 @@ where
             .ake
             .frontend_encrypt(&channel_id, &[], &response_plaintext_bytes)?;
 
-        Ok((response.data, response.channel_id.nonce()))
+        Ok(response)
     }
 
     fn add_records(&self, records: Vec<ETxOutRecord>) -> Result<()> {

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -201,7 +201,7 @@ impl ViewEnclaveApi for SgxViewEnclave {
         payload: EnclaveMessage<NonceSession>,
         untrusted_query_response: UntrustedQueryResponse,
     ) -> Result<EnclaveMessage<NonceSession>> {
-        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::QueryBackend(
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::QueryStore(
             payload,
             untrusted_query_response,
         ))?;

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -196,6 +196,19 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn query_backend(
+        &self,
+        payload: EnclaveMessage<NonceSession>,
+        untrusted_query_response: UntrustedQueryResponse,
+    ) -> Result<(Vec<u8>, u64)> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::QueryBackend(
+            payload,
+            untrusted_query_response,
+        ))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn add_records(&self, records: Vec<ETxOutRecord>) -> Result<()> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::AddRecords(records))?;
         let outbuf = self.enclave_call(&inbuf)?;

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -196,11 +196,11 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn query_backend(
+    fn query_store(
         &self,
         payload: EnclaveMessage<NonceSession>,
         untrusted_query_response: UntrustedQueryResponse,
-    ) -> Result<(Vec<u8>, u64)> {
+    ) -> Result<EnclaveMessage<NonceSession>> {
         let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::QueryBackend(
             payload,
             untrusted_query_response,

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -125,6 +125,9 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         ViewEnclaveRequest::Query(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }
+        ViewEnclaveRequest::QueryBackend(req, untrusted_query_response) => {
+            serialize(&ENCLAVE.query_backend(req, untrusted_query_response))
+        }
         ViewEnclaveRequest::AddRecords(records) => serialize(&ENCLAVE.add_records(records)),
         ViewEnclaveRequest::DecryptAndSealQuery(client_query) => {
             serialize(&ENCLAVE.decrypt_and_seal_query(client_query))

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -126,7 +126,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }
         ViewEnclaveRequest::QueryBackend(req, untrusted_query_response) => {
-            serialize(&ENCLAVE.query_backend(req, untrusted_query_response))
+            serialize(&ENCLAVE.query_store(req, untrusted_query_response))
         }
         ViewEnclaveRequest::AddRecords(records) => serialize(&ENCLAVE.add_records(records)),
         ViewEnclaveRequest::DecryptAndSealQuery(client_query) => {

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -125,7 +125,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         ViewEnclaveRequest::Query(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query(req, untrusted_query_response))
         }
-        ViewEnclaveRequest::QueryBackend(req, untrusted_query_response) => {
+        ViewEnclaveRequest::QueryStore(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query_store(req, untrusted_query_response))
         }
         ViewEnclaveRequest::AddRecords(records) => serialize(&ENCLAVE.add_records(records)),

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -174,14 +174,14 @@ where
         tracer.in_span("query_impl", |_cx| {
             let untrusted_query_response =
                 self.create_untrusted_query_response(request.get_aad(), &tracer)?;
-            let result_blob = tracer.in_span("enclave_query", |_cx| {
+            let data = tracer.in_span("enclave_query", |_cx| {
                 self.enclave
                     .query(request.into(), untrusted_query_response)
                     .map_err(|e| self.enclave_err_to_rpc_status("enclave request", e))
             })?;
 
             let mut resp = attest::Message::new();
-            resp.set_data(result_blob);
+            resp.set_data(data);
             Ok(resp)
         })
     }
@@ -193,15 +193,14 @@ where
     ) -> Result<attest::NonceMessage, RpcStatus> {
         log::trace!(self.logger, "Getting encrypted request");
         let tracer = tracer!();
-
         tracer.in_span("query_nonce_impl", |_cx| {
-            // TODO: Create query_nonce enclave method that does what query currently does
-            // but for NonceMessage. It should produce data and a nonce that is
-            // then set on the nonce_message.
-            let _untrusted_query_response =
+            let untrusted_query_response =
                 self.create_untrusted_query_response(request.get_aad(), &tracer)?;
-            let data = vec![0; 0];
-            let nonce = 0;
+            let (data, nonce) = tracer.in_span("enclave_query", |_cx| {
+                self.enclave
+                    .query_backend(request.into(), untrusted_query_response)
+                    .map_err(|e| self.enclave_err_to_rpc_status("enclave request", e))
+            })?;
 
             let mut nonce_message = attest::NonceMessage::new();
             nonce_message.set_data(data);

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -196,16 +196,13 @@ where
         tracer.in_span("query_nonce_impl", |_cx| {
             let untrusted_query_response =
                 self.create_untrusted_query_response(request.get_aad(), &tracer)?;
-            let (data, nonce) = tracer.in_span("enclave_query", |_cx| {
+            let enclave_nonce_message = tracer.in_span("enclave_query_store", |_cx| {
                 self.enclave
-                    .query_backend(request.into(), untrusted_query_response)
+                    .query_store(request.into(), untrusted_query_response)
                     .map_err(|e| self.enclave_err_to_rpc_status("enclave request", e))
             })?;
 
-            let mut nonce_message = attest::NonceMessage::new();
-            nonce_message.set_data(data);
-            nonce_message.set_nonce(nonce);
-            Ok(nonce_message)
+            Ok(enclave_nonce_message.into())
         })
     }
 


### PR DESCRIPTION
### Motivation
PR #2617 updated the MVQ request and responses to use `attest::NonceMessage`, and modified the Fog View Store API to accept this new MVQ but didn't implement the logic to actually fulfill this nonce-based query. This PR implements this by providing new enclave methods.  