### PR TITLE
fixup cargo toml

### DIFF
--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -30,7 +30,7 @@ mc-util-serial = { path = "../../util/serial" }
 # Enable all default features not known to break code coverage builds
 proptest = { version = "1.0", default-features = false, features = ["default-code-coverage"], optional = true }
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 subtle = { version = "2.4.1", default-features = false, features = ["i128"] }
 zeroize = { version = "1", default-features = false }


### PR DESCRIPTION
 https://github.com/mobilecoinfoundation/mobilecoin/commit/bf4216551790b05c70a29321e248a8a58b1739b4

In referenced commit, we started using features from rand-core 0.6.4, after dependabot had bumped us to that version.

However, this can break downstream, because we only had 0.6 in the Cargo.toml, so cargo could potentially select 0.6.3 still.

Thanks to Davey for reporting the build breakage.