### PR TITLE
Remove `get_nonce` from NonceSession, rename `peek_nonce`->`nonce`

### DIFF
--- a/attest/api/src/conversions.rs
+++ b/attest/api/src/conversions.rs
@@ -126,7 +126,7 @@ impl From<EnclaveMessage<NonceSession>> for NonceMessage {
         retval.set_aad(src.aad);
         // it doesn't matter if we don't bump the nonce when retrieving it,
         // src.channel_id will be discarded anyways.
-        retval.set_nonce(src.channel_id.peek_nonce());
+        retval.set_nonce(src.channel_id.nonce());
         retval.set_channel_id(src.channel_id.into());
         retval.set_data(src.data);
         retval

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -161,15 +161,8 @@ impl NonceSession {
     }
 
     /// Retrieves the nonce for this session
-    pub fn peek_nonce(&self) -> u64 {
+    pub fn nonce(&self) -> u64 {
         self.nonce
-    }
-
-    /// Retrieves a copy of the nonce, and increments it for the next time.
-    pub fn get_nonce(&mut self) -> u64 {
-        let retval = self.nonce;
-        self.nonce += 1;
-        retval
     }
 }
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["MobileCoin"]
 edition = "2021"
 
 [dependencies]
+
+aes-gcm = "0.9.4"
+cookie = "0.16"
+displaydoc = "0.2"
+grpcio = "0.11.0"
 mc-attest-ake = { path = "../attest/ake" }
 mc-attest-api = { path = "../attest/api" }
 mc-attest-core = { path = "../attest/core" }
@@ -19,11 +24,6 @@ mc-transaction-core = { path = "../transaction/core" }
 mc-util-grpc = { path = "../util/grpc" }
 mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
-
-aes-gcm = "0.9.4"
-cookie = "0.16"
-displaydoc = "0.2"
-grpcio = "0.11.0"
 retry = "1.3"
 secrecy = "0.8"
 sha2 = "0.10"

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -7,10 +7,10 @@ description = "Digestible Signatures"
 readme = "README.md"
 
 [features]
-alloc = [ "mc-crypto-digestible/alloc" ]
-dalek = [ "mc-crypto-digestible/dalek" ]
-derive = [ "mc-crypto-digestible/derive" ]
-default = [ "alloc", "derive", "dalek" ]
+alloc = ["mc-crypto-digestible/alloc"]
+dalek = ["mc-crypto-digestible/dalek"]
+derive = ["mc-crypto-digestible/derive"]
+default = ["alloc", "derive", "dalek"]
 
 [dependencies]
 mc-crypto-digestible = { path = "..", default_features = false }

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -26,7 +26,6 @@ mc-util-serial = { path = "../../../util/serial" }
 
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
 
-
 [dev-dependencies]
 mc-crypto-digestible-test-utils = { path = "../../digestible/test-utils" }
 mc-crypto-rand = { path = "../../rand" }

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -30,8 +30,8 @@ mc-fog-view-protocol = { path = "../protocol" }
 
 # third-party
 aes-gcm = "0.9.4"
-grpcio = "0.11.0"
 futures = "0.3"
+grpcio = "0.11.0"
 retry = "1.3"
 sha2 = { version = "0.10", default-features = false }
 tokio = { version = "1.19.2", features = ["full"] }


### PR DESCRIPTION
Also sort Cargo.toml files due to precommit hook.

### Motivation

There's no reason to expose `get_nonce`, and it could cause some issues, so it's being removed. Without `get_nonce` to contrast against, there's no reason not to call `peek_nonce` just `nonce`.