### PR TITLE
Bump all crate versions to 2.1.0-pre0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,7 +1547,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2173,14 +2173,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "grpcio",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bincode",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2421,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "mc-common",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "chrono",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "clap 3.2.22",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest 0.10.5",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest 0.10.5",
@@ -2919,7 +2919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3020,7 +3020,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 3.2.22",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "crossbeam-channel",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "assert_cmd",
  "clap 3.2.22",
@@ -3295,7 +3295,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3347,7 +3347,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3413,7 +3413,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "dirs",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "grpcio",
@@ -3726,14 +3726,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "clap 3.2.22",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3967,7 +3967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 3.2.22",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4058,7 +4058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "clap 3.2.22",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "clap 3.2.22",
@@ -4119,7 +4119,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "digest 0.10.5",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "grpcio",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "dirs",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "mc-api",
@@ -4487,7 +4487,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "lmdb-rkv",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4534,7 +4534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "clap 3.2.22",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "async-channel",
  "clap 3.2.22",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "grpcio",
@@ -4730,7 +4730,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "grpcio",
  "hex",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "hex_fmt",
@@ -4831,21 +4831,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -4882,18 +4882,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -4926,7 +4926,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "assert_matches",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-std"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "hex",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.0",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5138,7 +5138,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "mc-util-build-info",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5170,18 +5170,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "hex",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "clap 3.2.22",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "grpcio",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "hex",
@@ -5256,11 +5256,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "clap 3.2.22",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "itertools",
  "mc-sgx-css",
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5347,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "hex",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "itertools",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5430,14 +5430,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "getrandom 0.2.7",
  "mc-account-keys",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "clap 3.2.22",
  "displaydoc",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/account-keys/slip10/Cargo.toml
+++ b/account-keys/slip10/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-slip10"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -707,14 +707,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1217,11 +1217,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1252,29 +1252,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1303,14 +1303,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1318,11 +1318,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1402,14 +1402,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "../README.md"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-crypto-dalek"
 description = "MobileCoin Dalek Crypto Configurator Package"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"
@@ -11,7 +11,7 @@ alloc = ["base64/alloc", "ed25519-dalek/alloc", "ed25519-dalek/alloc", "mc-crypt
 serde = ["dep:serde", "ed25519/serde", "ed25519-dalek/serde", "ed25519-dalek/serde", "mc-util-repr-bytes/serde"]
 prost = []
 default = ["alloc", "serde", "prost", "mc-util-repr-bytes/default"]
- 
+
 [dependencies]
 
 base64 = { version = "0.13", default-features = false }

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -727,14 +727,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1208,14 +1208,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1321,11 +1321,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1356,36 +1356,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1414,14 +1414,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1429,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1513,14 +1513,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1539,14 +1539,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -731,14 +731,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if",
  "rand",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1172,14 +1172,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1269,11 +1269,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1304,36 +1304,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1362,14 +1362,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1377,11 +1377,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1461,14 +1461,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1487,14 +1487,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -737,14 +737,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1133,14 +1133,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1331,11 +1331,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1375,36 +1375,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1433,14 +1433,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1448,11 +1448,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1532,14 +1532,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1558,14 +1558,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/std/Cargo.toml
+++ b/transaction/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-std"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 


### PR DESCRIPTION
- Update all crate versions to 2.1.0-pre0 in preparation for alpha testing.

### Motivation

These changes are being made against master first in order to ease the diff between release/v2 and master later. This PR (once merged) will be cherry-picked to the release/v2 branch.

### Future Work
* Update changelog for 2.1.0
