### PR TITLE
Implement nonce based auth for Fog View Store

### DIFF
--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -568,8 +568,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
             .map(|(_, encryptor)| {
                 let aad = sealed_client_message.aad.clone();
                 let (data, nonce) = encryptor.encrypt_with_nonce(&aad, &client_query_bytes)?;
-                let channel_id =
-                    NonceSession::new(sealed_client_message.channel_id.clone().into(), nonce);
+                let channel_id = NonceSession::new(encryptor.binding().into(), nonce);
                 Ok(EnclaveMessage {
                     aad,
                     channel_id,

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -100,6 +100,8 @@ pub enum ViewEnclaveRequest {
     /// Complete the client connection to a Fog View store that accepted our
     /// client auth request. This is meant to be called after [ViewStoreInit].
     ViewStoreConnect(ResponderId, NonceAuthResponse),
+    /// Accept a connection to a frontend.
+    FrontendAccept(NonceAuthRequest),
     /// Collates shard query responses into a single query response for the
     /// client.
     CollateQueryResponses(
@@ -148,6 +150,10 @@ pub trait ViewEnclaveApi: ReportableEnclave {
     /// Begin a connection to a Fog View Store. The enclave calling this method
     /// will act as a client to the Fog View Store.
     fn view_store_init(&self, view_store_id: ResponderId) -> Result<NonceAuthRequest>;
+
+    /// Accept a connection to a Fog View Router instance acting as a frontend
+    /// to the Fog View Store.
+    fn frontend_accept(&self, req: NonceAuthRequest) -> Result<(NonceAuthResponse, NonceSession)>;
 
     /// Complete the connection to a Fog View Store that has accepted our
     /// ClientAuthRequest. This is meant to be called after the enclave has

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -254,6 +254,10 @@ where
             .backend_connect(view_store_id, view_store_auth_response)?)
     }
 
+    fn frontend_accept(&self, req: NonceAuthRequest) -> Result<(NonceAuthResponse, NonceSession)> {
+        Ok(self.ake.frontend_accept(req)?)
+    }
+
     fn collate_shard_query_responses(
         &self,
         sealed_query: SealedClientMessage,

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -183,6 +183,12 @@ impl ViewEnclaveApi for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn frontend_accept(&self, req: NonceAuthRequest) -> Result<(NonceAuthResponse, NonceSession)> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::FrontendAccept(req))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn query(
         &self,
         payload: EnclaveMessage<ClientSession>,

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -121,6 +121,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         ViewEnclaveRequest::ViewStoreConnect(view_store_id, msg) => {
             serialize(&ENCLAVE.view_store_connect(view_store_id, msg))
         }
+        ViewEnclaveRequest::FrontendAccept(msg) => serialize(&ENCLAVE.frontend_accept(msg)),
         ViewEnclaveRequest::ClientClose(session) => serialize(&ENCLAVE.client_close(session)),
         ViewEnclaveRequest::Query(req, untrusted_query_response) => {
             serialize(&ENCLAVE.query(req, untrusted_query_response))

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -119,6 +119,36 @@ where
         }
     }
 
+    fn auth_nonce_impl(
+        &mut self,
+        mut request: attest::AuthMessage,
+        logger: &Logger,
+    ) -> Result<attest::AuthMessage, RpcStatus> {
+        // TODO: Use the prost message directly, once available
+        match self.enclave.frontend_accept(request.take_data().into()) {
+            Ok((response, _)) => {
+                let mut result = attest::AuthMessage::new();
+                result.set_data(response.into());
+                Ok(result)
+            }
+            Err(client_error) => {
+                // This is debug because there's no requirement on the remote party to trigger
+                // it.
+                log::debug!(
+                    logger,
+                    "ViewEnclaveApi::frontend_accept failed: {}",
+                    client_error
+                );
+                let rpc_permissions_error = rpc_permissions_error(
+                    "client_auth",
+                    format!("Permission denied: {}", client_error),
+                    logger,
+                );
+                Err(rpc_permissions_error)
+            }
+        }
+    }
+
     pub fn create_untrusted_query_response(
         &mut self,
         aad: &[u8],
@@ -321,7 +351,7 @@ where
                 return send_result(ctx, sink, err.into(), logger);
             }
 
-            send_result(ctx, sink, self.auth_impl(request, logger), logger);
+            send_result(ctx, sink, self.auth_nonce_impl(request, logger), logger);
         })
     }
 

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -89,7 +89,7 @@ where
         }
     }
 
-    fn auth_impl(
+    fn client_auth(
         &mut self,
         mut request: attest::AuthMessage,
         logger: &Logger,
@@ -119,7 +119,7 @@ where
         }
     }
 
-    fn auth_nonce_impl(
+    fn frontend_auth(
         &mut self,
         mut request: attest::AuthMessage,
         logger: &Logger,
@@ -131,17 +131,17 @@ where
                 result.set_data(response.into());
                 Ok(result)
             }
-            Err(client_error) => {
+            Err(frontend_error) => {
                 // This is debug because there's no requirement on the remote party to trigger
                 // it.
                 log::debug!(
                     logger,
                     "ViewEnclaveApi::frontend_accept failed: {}",
-                    client_error
+                    frontend_error
                 );
                 let rpc_permissions_error = rpc_permissions_error(
-                    "client_auth",
-                    format!("Permission denied: {}", client_error),
+                    "fontend_accept",
+                    format!("Permission denied: {}", frontend_error),
                     logger,
                 );
                 Err(rpc_permissions_error)
@@ -307,7 +307,7 @@ where
                 return send_result(ctx, sink, err.into(), logger);
             }
 
-            send_result(ctx, sink, self.auth_impl(request, logger), logger);
+            send_result(ctx, sink, self.client_auth(request, logger), logger);
         })
     }
 
@@ -351,7 +351,7 @@ where
                 return send_result(ctx, sink, err.into(), logger);
             }
 
-            send_result(ctx, sink, self.auth_nonce_impl(request, logger), logger);
+            send_result(ctx, sink, self.frontend_auth(request, logger), logger);
         })
     }
 


### PR DESCRIPTION
### Motivation
This PR updates Fog View stores to implement nonce based auth that serves as the foundation for FVR <-> Fog View Store communication. 
