### PR TITLE
fixup to partial fills -- input rules check for zero partial fill change

### DIFF
--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -76,6 +76,7 @@ impl From<InputRuleError> for ProposeTxResult {
             | InputRuleError::MissingFractionalChangeOutput
             | InputRuleError::MissingFractionalOutput
             | InputRuleError::FractionalOutputTokenIdMismatch
+            | InputRuleError::ZeroPartialFillChange
             | InputRuleError::MinPartialFillValueExceedsPartialFillChange
             | InputRuleError::FractionalOutputAmountDoesNotRespectFillFraction
             | InputRuleError::FractionalChangeOutputAmountExceedsLimit => {

--- a/transaction/core/tests/input_rules.rs
+++ b/transaction/core/tests/input_rules.rs
@@ -214,6 +214,40 @@ fn test_input_rules_verify_min_partial_fill_value() {
     );
 }
 
+// Test that invalid amount shared secrets cause invalid transactions
+#[test]
+fn test_input_rules_verify_nonzero_partial_fill_change() {
+    let block_version = BlockVersion::THREE;
+    let (mut tx, revealed_tx_outs) = get_input_rules_test_tx(block_version);
+    get_first_rules(&tx).verify(block_version, &tx).unwrap();
+
+    // Add a partial fill output, by doubling one of the revealed tx outs.
+    get_first_rules_mut(&mut tx)
+        .partial_fill_outputs
+        .push(change_committed_amount(
+            &revealed_tx_outs[1],
+            Amount::new(2000, 0.into()),
+        ));
+    // Add a partial fill change, also by doubling one of the revealed tx outs.
+    // This means the fill fraction is 1/2, which we are satisfying.
+    get_first_rules_mut(&mut tx).partial_fill_change = Some(change_committed_amount(
+        &revealed_tx_outs[0],
+        Amount::new(2000, 0.into()),
+    ));
+    get_first_rules(&tx).verify(block_version, &tx).unwrap();
+
+    // Change the partial fill change to zero. This should result in an error.
+    get_first_rules_mut(&mut tx).partial_fill_change = Some(change_committed_amount(
+        &revealed_tx_outs[0],
+        Amount::new(0, 0.into()),
+    ));
+
+    assert_matches!(
+        get_first_rules(&tx).verify(block_version, &tx),
+        Err(InputRuleError::ZeroPartialFillChange)
+    );
+}
+
 // Test that partial fill outputs and change without matching real outputs cause
 // invalid transactions
 #[test]


### PR DESCRIPTION
this was suggested in review of the mcip, and brings the implementation in line with the spec. Previously this was only checked in the SCI validate routine.

It doesn't create a bug in the enclave to omit
this check, but it also simplifies review if we just have one spec for everywhere and enforce it everywhere.