### PR TITLE
Initial work on supporting nested multi-sigs

### DIFF
--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -5,8 +5,8 @@
 //! produce a joint signature on a common message. The simplest multi-signature
 //! of a message is just a set of signatures containing one signature over the
 //! message from each member of the signing group. We say that a multi-signature
-//! is an M-of-N threshold signature if only M valid signatures are required from
-//! a signing group of size N.
+//! is an M-of-N threshold signature if only M valid signatures are required
+//! from a signing group of size N.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -15,7 +15,7 @@ extern crate alloc;
 
 mod v2;
 
-pub use v2::{Signer, SignerContainer, SignerEntity, SignerSetV2};
+pub use v2::{SignerContainer, SignerEntity, SignerIdentity, SignerSetV2};
 
 use alloc::vec::Vec;
 use core::hash::Hash;

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -5,8 +5,8 @@
 //! produce a joint signature on a common message. The simplest multi-signature
 //! of a message is just a set of signatures containing one signature over the
 //! message from each member of the signing group. We say that a multi-signature
-//! is a m-of-n threshold signature if only m valid signatures are required from
-//! a signing group of size n.
+//! is an M-of-N threshold signature if only M valid signatures are required from
+//! a signing group of size N.
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -5,18 +5,17 @@
 //! produce a joint signature on a common message. The simplest multi-signature
 //! of a message is just a set of signatures containing one signature over the
 //! message from each member of the signing group. We say that a multi-signature
-//! is a m-of-n threshold signature if only k valid signatures are required from
+//! is a m-of-n threshold signature if only m valid signatures are required from
 //! a signing group of size n.
 
 #![cfg_attr(not(test), no_std)]
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 
 extern crate alloc;
 
 mod v2;
 
-// TODO
-pub use v2::*;
+pub use v2::{Signer, SignerContainer, SignerEntity, SignerSetV2};
 
 use alloc::vec::Vec;
 use core::hash::Hash;

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -145,7 +145,7 @@ impl<S: SignerIdentity> SignerSetV2<S> {
         // list of signatures since it is cheap to do, and a reasonable defensive
         // programming measure.
         let mut signatures = multi_sig.signatures().to_vec();
-        signatures.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
+        signatures.sort();
         signatures.dedup();
 
         // Verify signatures.

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -516,7 +516,7 @@ mod test_nested_multisigs {
         // The top-level multisig requires 1-of-2 signatures
         let signer_set = SignerSetV2::new(vec![org1_signerset.into(), org2_signerset.into()], 1);
 
-        // With not signatures, the multisig should not verify.
+        // With no signatures, the multisig should not verify.
         let multi_sig = MultiSig::new(vec![]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
@@ -591,7 +591,6 @@ mod test_nested_multisigs {
             org1_signer3_sig,
             org2_signer1_sig,
             org2_signer2_sig,
-            org2_signer2_sig,
         ]);
         let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
         assert_eq_ignore_order(
@@ -657,7 +656,7 @@ mod test_nested_multisigs {
                 org1_signer2_sig,
                 org2_signer2_sig,
                 org2_signer3_sig,
-            ], // TODO check sig2 for org1
+            ],
         );
         let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
         assert_eq_ignore_order(
@@ -799,7 +798,7 @@ mod test_nested_multisigs {
 
         // Using the common signer as part of the org1 signer set results in only org1
         // being matched.
-        let multi_sig = MultiSig::new(vec![common_signer_sig, org1_signer1_sig, org1_signer2_sig]);
+        let multi_sig = MultiSig::new(vec![common_signer_sig, org1_signer1_sig]);
         let signers = signer_set
             .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)
             .unwrap();
@@ -808,7 +807,6 @@ mod test_nested_multisigs {
             vec![
                 common_signer.public_key(),
                 org1_signer1.public_key(),
-                org1_signer2.public_key(),
             ],
         );
 
@@ -827,56 +825,6 @@ mod test_nested_multisigs {
             ],
         );
 
-        // Using the common signer as part of both orgs results in both being matched.
-        let multi_sig = MultiSig::new(vec![
-            common_signer_sig,
-            org1_signer1_sig,
-            org1_signer2_sig,
-            org2_signer1_sig,
-            org2_signer2_sig,
-            org2_signer3_sig,
-        ]);
-        let signers = signer_set
-            .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)
-            .unwrap();
-
-        assert_eq_ignore_order(
-            signers,
-            vec![
-                common_signer.public_key(),
-                org1_signer1.public_key(),
-                org1_signer2.public_key(),
-                org2_signer1.public_key(),
-                org2_signer2.public_key(),
-                org2_signer3.public_key(),
-            ],
-        );
-
-        // Adding a third signer to org1 causes it to be added into the list of matches.
-        let multi_sig = MultiSig::new(vec![
-            common_signer_sig,
-            org1_signer1_sig,
-            org1_signer2_sig,
-            org1_signer3_sig,
-            org2_signer1_sig,
-            org2_signer2_sig,
-            org2_signer3_sig,
-        ]);
-        let signers = signer_set
-            .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)
-            .unwrap();
-
-        assert_eq_ignore_order(
-            signers,
-            vec![
-                common_signer.public_key(),
-                org1_signer1.public_key(),
-                org1_signer2.public_key(),
-                org1_signer3.public_key(),
-                org2_signer1.public_key(),
-                org2_signer2.public_key(),
-                org2_signer3.public_key(),
-            ],
         );
     }
 
@@ -935,22 +883,12 @@ mod test_nested_multisigs {
         ]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
-        let multi_sig = MultiSig::new(vec![
-            // Valid org1 signature
-            org1_signer1_sig,
-            org1_signer2_sig,
-            org1_signer3_sig,
-            // A valid single signer
-            single_signer1_sig,
-        ]);
-        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
-
         // Providing 3 valid signatures verifies.
         let multi_sig = MultiSig::new(vec![
             // Valid org1 signature
             org1_signer1_sig,
             org1_signer2_sig,
-            // Two valid singler signers
+            // Two valid single signers
             single_signer1_sig,
             single_signer2_sig,
             // Partial but invalid org2 signature

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -31,7 +31,7 @@ pub enum SignerEntity<S: SignerIdentity> {
     #[prost(message, tag = "1")]
     Single(S),
 
-    /// A m-out-of-n group of signers
+    /// An M-out-of-N group of signers
     #[prost(message, tag = "2")]
     Multi(SignerSetV2<S>),
 }

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -130,24 +130,13 @@ impl<S: SignerIdentity> SignerSetV2<S> {
     /// means the rules for verifying a single signer set and a nested one
     /// are the same, and easier to follow. The example above simply shows a
     /// poorly specified signer set.
-    pub fn verify<
-        SIG: Clone
-            + Default
-            + Digestible
-            + Eq
-            + Hash
-            + Message
-            + Ord
-            + PartialEq
-            + PartialOrd
-            + Serialize
-            + Signature,
-    >(
+    pub fn verify<SIG>(
         &self,
         message: &[u8],
-        multi_sig: &MultiSig<SIG>,
+        multi_sig: &MultiSig<SIG>
     ) -> Result<Vec<S>, SignatureError>
     where
+        SIG: Clone + Digestible + Eq + Hash + Message + Ord + Serialize + Signature,
         S: Verifier<SIG>,
     {
         if multi_sig.signatures().len() > MAX_SIGNATURES {

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -73,17 +73,13 @@ impl<S: SignerIdentity> From<SignerEntity<S>> for SignerContainer<S> {
 
 impl<S: SignerIdentity> From<S> for SignerContainer<S> {
     fn from(signer: S) -> Self {
-        Self {
-            entity: Some(SignerEntity::Single(signer)),
-        }
+        SignerEntity::from(signer).into()
     }
 }
 
-impl<S: SignerIdentity> From<SignerSetV2<S>> for SignerContainer<S> {
+impl<S: Signer> From<SignerSetV2<S>> for SignerContainer<S> {
     fn from(signer_set: SignerSetV2<S>) -> Self {
-        Self {
-            entity: Some(SignerEntity::Multi(signer_set)),
-        }
+        SignerEntity::from(signer_set)).into()
     }
 }
 

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -144,7 +144,7 @@ impl<S: SignerIdentity> SignerSetV2<S> {
         }
 
         // Sort and dedup the list of signatures. Even though we match signers to
-        // signatures (and not the other way around), we still deuplicate the
+        // signatures (and not the other way around), we still deduplicate the
         // list of signatures since it is cheap to do, and a reasonable defensive
         // programming measure.
         let mut signatures = multi_sig.signatures().to_vec();

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -6,7 +6,7 @@ use super::MultiSig;
 use alloc::vec::Vec;
 use core::hash::Hash;
 use mc_crypto_digestible::Digestible;
-use mc_crypto_keys::{PublicKey, Signature, SignatureError, Verifier};
+use mc_crypto_keys::{Signature, SignatureError, Verifier};
 use prost::{Message, Oneof};
 use serde::{Deserialize, Serialize};
 
@@ -124,6 +124,10 @@ impl<S: Signer> SignerSetV2<S> {
     where
         S: Verifier<SIG>,
     {
+        if multi_sig.signatures().len() > MAX_SIGNATURES {
+            return Err(SignatureError::new());
+        }
+
         // Sort and dedup the list of signers.
         let mut signatures = multi_sig.signatures.clone();
         signatures.sort_by(|a, b| a.as_ref().cmp(b.as_ref()));
@@ -163,6 +167,12 @@ impl<S: Signer> SignerSetV2<S> {
         signers.sort();
         signers.dedup();
 
+        println!("verify_helper ---------------------------------");
+        println!("signer set: {:#?}", signers);
+        println!("threshold: {}", self.threshold);
+        println!("signatures: {:?}", signatures);
+        println!("seen_signers: {:?}", seen_signers);
+
         // See which signers are satisfied by which signatures.
         let mut matched_signers = Vec::new();
         let mut num_matched_entities = 0;
@@ -172,6 +182,9 @@ impl<S: Signer> SignerSetV2<S> {
                 Some(SignerEntity::Single(ref s)) => {
                     // If we already encountered this signer, we cannot use it again.
                     if seen_signers.contains(s) {
+                        continue;
+                    }
+                    if matched_signers.contains(s) {
                         continue;
                     }
 
@@ -184,13 +197,12 @@ impl<S: Signer> SignerSetV2<S> {
                     }
                 }
                 Some(SignerEntity::Multi(ref s)) => {
-                    let mut seen_signers = seen_signers.to_vec();
-                    seen_signers.extend(matched_signers.clone());
+                    let mut ignore_signers = seen_signers.to_vec();
+                    ignore_signers.extend(matched_signers.clone());
 
-                    if let Ok(signers) = s.verify_helper(message, signatures, &seen_signers) {
-                        seen_signers.extend(signers);
+                    if let Ok(signers) = s.verify_helper(message, signatures, &ignore_signers) {
+                        matched_signers.extend(signers);
                         num_matched_entities += 1;
-                        break;
                     }
                 }
                 None => {}
@@ -199,16 +211,23 @@ impl<S: Signer> SignerSetV2<S> {
 
         // Did we pass the threshold of verified signatures?
         if num_matched_entities < self.threshold as usize {
+            println!(
+                "no match ---------- {} {}",
+                num_matched_entities, self.threshold
+            );
             return Err(SignatureError::new());
         }
 
-        matched_signers.extend(seen_signers.to_vec());
+        println!(
+            "---- match {} {} {:?}",
+            num_matched_entities, self.threshold, matched_signers
+        );
         Ok(matched_signers.to_vec())
     }
 }
 
 #[cfg(test)]
-mod test {
+mod test_single_level {
     use super::*;
     use alloc::vec;
     use mc_crypto_keys::{Ed25519Pair, Ed25519Public, Signer};
@@ -531,6 +550,426 @@ mod test {
         assert_eq!(
             multi_sig,
             mc_util_serial::decode(&mc_util_serial::encode(&multi_sig)).unwrap(),
+        );
+    }
+}
+
+/// Tests for nested k-out-of-n multisigs
+#[cfg(test)]
+mod test_nested_multisigs {
+    use super::*;
+    use alloc::vec;
+    use mc_crypto_keys::{Ed25519Pair, Ed25519Public, Ed25519Signature, Signer};
+    use mc_util_from_random::FromRandom;
+    use rand_core::SeedableRng;
+    use rand_hc::Hc128Rng;
+
+    /// Helper method for comparing two signers list.
+    /// In other places in the code we might convert to a HashSet first and then
+    /// compare, but that would hide duplicate elements and we want to catch
+    /// that.
+    #[track_caller]
+    fn assert_eq_ignore_order(mut a: Vec<Ed25519Public>, mut b: Vec<Ed25519Public>) {
+        a.sort();
+        b.sort();
+
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn ed25519_verify_signers_sanity_one_of_two_orgs() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let message = b"this is a test";
+
+        // Org 1 requires 2-of-3 signatures
+        let org1_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org1_signerset = SignerSetV2::new(
+            vec![
+                org1_signer1.public_key().into(),
+                org1_signer2.public_key().into(),
+                org1_signer3.public_key().into(),
+            ],
+            2,
+        );
+
+        // Org 2 requires 3-of-3 signatures
+        let org2_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org2_signerset = SignerSetV2::new(
+            vec![
+                org2_signer1.public_key().into(),
+                org2_signer2.public_key().into(),
+                org2_signer3.public_key().into(),
+            ],
+            3,
+        );
+
+        // Sign the message with all of our signers.
+        let org1_signer1_sig = org1_signer1.try_sign(message.as_ref()).unwrap();
+        let org1_signer2_sig = org1_signer2.try_sign(message.as_ref()).unwrap();
+        let org1_signer3_sig = org1_signer3.try_sign(message.as_ref()).unwrap();
+
+        let org2_signer1_sig = org2_signer1.try_sign(message.as_ref()).unwrap();
+        let org2_signer2_sig = org2_signer2.try_sign(message.as_ref()).unwrap();
+        let org2_signer3_sig = org2_signer3.try_sign(message.as_ref()).unwrap();
+
+        // The top-level multisig requires 1-of-2 signatures
+        let signer_set = SignerSetV2::new(vec![org1_signerset.into(), org2_signerset.into()], 1);
+
+        // With not signatures, the multisig should not verify.
+        let multi_sig = MultiSig::new(vec![]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Org1 satisfies the threshold, no org2 signatures.
+        let multi_sig: MultiSig<Ed25519Signature> =
+            MultiSig::new(vec![org1_signer1_sig, org1_signer3_sig]);
+        let signers = signer_set
+            .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)
+            .unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![org1_signer1.public_key(), org1_signer3.public_key()],
+        );
+
+        // Org2 satisfies the threshold, no org1 signatures.
+        let multi_sig = MultiSig::new(vec![org2_signer1_sig, org2_signer2_sig, org2_signer3_sig]);
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+
+        // Both orgs satisfy the threshold.
+        let multi_sig = MultiSig::new(vec![
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
+            org1_signer1_sig,
+            org1_signer3_sig,
+        ]);
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org1_signer1.public_key(),
+                org1_signer3.public_key(),
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+
+        // Both orgs satisfy the threshold (org1 exceeds it)
+        let multi_sig = MultiSig::new(vec![
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
+            org1_signer1_sig,
+            org1_signer3_sig,
+            org1_signer2_sig,
+        ]);
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org1_signer1.public_key(),
+                org1_signer2.public_key(),
+                org1_signer3.public_key(),
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+
+        // One org satisfies the threshold and one org does not.
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer3_sig,
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer2_sig,
+        ]);
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![org1_signer1.public_key(), org1_signer3.public_key()],
+        );
+
+        // Neither orgs provides a valid signature
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer1_sig,
+            org2_signer1_sig,
+            org2_signer1_sig,
+            org2_signer1_sig,
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+    }
+
+    #[test]
+    fn ed25519_verify_signers_sanity_two_of_two_orgs() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let message = b"this is a test";
+
+        // Org 1 requires 2-of-3 signatures
+        let org1_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org1_signerset = SignerSetV2::new(
+            vec![
+                org1_signer1.public_key().into(),
+                org1_signer2.public_key().into(),
+                org1_signer3.public_key().into(),
+            ],
+            2,
+        );
+
+        // Org 2 requires 3-of-3 signatures
+        let org2_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org2_signerset = SignerSetV2::new(
+            vec![
+                org2_signer1.public_key().into(),
+                org2_signer2.public_key().into(),
+                org2_signer3.public_key().into(),
+            ],
+            3,
+        );
+
+        // Sign the message with all of our signers.
+        let org1_signer1_sig = org1_signer1.try_sign(message.as_ref()).unwrap();
+        let org1_signer2_sig = org1_signer2.try_sign(message.as_ref()).unwrap();
+        let org1_signer3_sig = org1_signer3.try_sign(message.as_ref()).unwrap();
+
+        let org2_signer1_sig = org2_signer1.try_sign(message.as_ref()).unwrap();
+        let org2_signer2_sig = org2_signer2.try_sign(message.as_ref()).unwrap();
+        let org2_signer3_sig = org2_signer3.try_sign(message.as_ref()).unwrap();
+
+        // The top-level multisig requires 2-of-2 signatures
+        let signer_set = SignerSetV2::new(vec![org1_signerset.into(), org2_signerset.into()], 2);
+
+        // With no signatures, the multisig should not verify.
+        let multi_sig = MultiSig::new(vec![]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Org1 satisfies the threshold, no org2 signatures.
+        let multi_sig = MultiSig::new(vec![org1_signer2_sig, org1_signer3_sig]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Org2 satisfies the threshold, no org1 signatures.
+        let multi_sig = MultiSig::new(vec![org2_signer1_sig, org2_signer2_sig, org2_signer3_sig]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        // Both orgs satisfy the threshold.
+        let multi_sig = MultiSig::new(
+            vec![
+                org1_signer1_sig,
+                org2_signer1_sig,
+                org1_signer2_sig,
+                org2_signer2_sig,
+                org2_signer3_sig,
+            ], // TODO check sig2 for org1
+        );
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org1_signer1.public_key(),
+                org1_signer2.public_key(),
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+
+        // Org1 exceeds the threshold, org2 satisfies it.
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org2_signer1_sig,
+            org1_signer2_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
+            org1_signer3_sig,
+        ]);
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org1_signer1.public_key(),
+                org1_signer2.public_key(),
+                org1_signer3.public_key(),
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+
+        println!("A");
+        // One org satisfies the threshold and one org does not.
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer2_sig,
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer1_sig,
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        println!("B");
+        // Neither orgs provides a valid signature
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer1_sig,
+            org2_signer1_sig,
+            org2_signer1_sig,
+            org2_signer2_sig,
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+        println!("C");
+        // Trying to pass the same org twice doesn't get us to the threshold
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer2_sig,
+            org1_signer3_sig,
+            org1_signer1_sig,
+            org1_signer2_sig,
+            org1_signer3_sig,
+        ]);
+        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
+
+        println!("D");
+        // Passing multiple valid signatures only matches them once.
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org1_signer3_sig,
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
+            org2_signer2_sig,
+            org1_signer1_sig,
+            org1_signer3_sig,
+        ]);
+        println!("E");
+        let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
+        assert_eq_ignore_order(
+            signers,
+            vec![
+                org1_signer1.public_key(),
+                org1_signer3.public_key(),
+                org2_signer1.public_key(),
+                org2_signer2.public_key(),
+                org2_signer3.public_key(),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_serde_works() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+
+        let org1_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org1_signerset = SignerSetV2::new(
+            vec![
+                org1_signer1.public_key().into(),
+                org1_signer2.public_key().into(),
+                org1_signer3.public_key().into(),
+            ],
+            2,
+        );
+
+        // Org 2 requires 3-of-3 signatures
+        let org2_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org2_signerset = SignerSetV2::new(
+            vec![
+                org2_signer1.public_key().into(),
+                org2_signer2.public_key().into(),
+                org2_signer3.public_key().into(),
+            ],
+            3,
+        );
+
+        assert_eq!(
+            org1_signerset,
+            mc_util_serial::deserialize(&mc_util_serial::serialize(&org1_signerset).unwrap())
+                .unwrap(),
+        );
+        assert_eq!(
+            org2_signerset,
+            mc_util_serial::deserialize(&mc_util_serial::serialize(&org2_signerset).unwrap())
+                .unwrap(),
+        );
+
+        // Combined signer set
+        let signer_set = SignerSetV2::<Ed25519Public>::new(
+            vec![org1_signerset.into(), org2_signerset.into()],
+            2,
+        );
+
+        assert_eq!(
+            signer_set,
+            mc_util_serial::deserialize(&mc_util_serial::serialize(&signer_set).unwrap()).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_prost_works() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+
+        let org1_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org1_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org1_signerset = SignerSetV2::new(
+            vec![
+                org1_signer1.public_key().into(),
+                org1_signer2.public_key().into(),
+                org1_signer3.public_key().into(),
+            ],
+            2,
+        );
+
+        // Org 2 requires 3-of-3 signatures
+        let org2_signer1 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer2 = Ed25519Pair::from_random(&mut rng);
+        let org2_signer3 = Ed25519Pair::from_random(&mut rng);
+        let org2_signerset = SignerSetV2::new(
+            vec![
+                org2_signer1.public_key().into(),
+                org2_signer2.public_key().into(),
+                org2_signer3.public_key().into(),
+            ],
+            3,
+        );
+
+        assert_eq!(
+            org1_signerset,
+            mc_util_serial::decode(&mc_util_serial::encode(&org1_signerset)).unwrap(),
+        );
+        assert_eq!(
+            org2_signerset,
+            mc_util_serial::decode(&mc_util_serial::encode(&org2_signerset)).unwrap(),
+        );
+
+        // Combined signer set
+        let signer_set = SignerSetV2::<Ed25519Public>::new(
+            vec![org1_signerset.into(), org2_signerset.into()],
+            2,
+        );
+
+        assert_eq!(
+            signer_set,
+            mc_util_serial::decode(&mc_util_serial::encode(&signer_set)).unwrap(),
         );
     }
 }

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -1080,36 +1080,36 @@ mod test_nested_multisigs {
         // Signing with less than the threshold doesn't verify.
         let multi_sig = MultiSig::new(vec![
             // Valid org1 signature
-            org1_signer1_sig.clone(),
-            org1_signer2_sig.clone(),
+            org1_signer1_sig,
+            org1_signer2_sig,
             // Invalid org2 signature
-            org2_signer1_sig.clone(),
-            org2_signer2_sig.clone(),
+            org2_signer1_sig,
+            org2_signer2_sig,
             // One of the single signers
-            single_signer1_sig.clone(),
+            single_signer1_sig,
         ]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
         let multi_sig = MultiSig::new(vec![
             // Valid org1 signature
-            org1_signer1_sig.clone(),
-            org1_signer2_sig.clone(),
-            org1_signer3_sig.clone(),
+            org1_signer1_sig,
+            org1_signer2_sig,
+            org1_signer3_sig,
             // A valid single signer
-            single_signer1_sig.clone(),
+            single_signer1_sig,
         ]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
         // Providing 3 valid signatures verifies.
         let multi_sig = MultiSig::new(vec![
             // Valid org1 signature
-            org1_signer1_sig.clone(),
-            org1_signer2_sig.clone(),
+            org1_signer1_sig,
+            org1_signer2_sig,
             // Two valid singler signers
-            single_signer1_sig.clone(),
-            single_signer2_sig.clone(),
+            single_signer1_sig,
+            single_signer2_sig,
             // Partial but invalid org2 signature
-            org2_signer1_sig.clone(),
+            org2_signer1_sig,
         ]);
         let signers = signer_set
             .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)
@@ -1128,15 +1128,15 @@ mod test_nested_multisigs {
         // Providing 4 valid signatures verifies.
         let multi_sig = MultiSig::new(vec![
             // Valid org1 signature
-            org1_signer1_sig.clone(),
-            org1_signer2_sig.clone(),
+            org1_signer1_sig,
+            org1_signer2_sig,
             // Two valid singler signers
-            single_signer1_sig.clone(),
-            single_signer2_sig.clone(),
+            single_signer1_sig,
+            single_signer2_sig,
             // Valid org2 signature
-            org2_signer1_sig.clone(),
-            org2_signer2_sig.clone(),
-            org2_signer3_sig.clone(),
+            org2_signer1_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
         ]);
         let signers = signer_set
             .verify::<Ed25519Signature>(message.as_ref(), &multi_sig)

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -434,45 +434,6 @@ mod test_single_level {
         );
         let message = b"this is a test";
 
-        // Try with just no valid signatures, we should fail to verify.
-        let multi_sig = MultiSig::new(vec![signer4.try_sign(message.as_ref()).unwrap()]);
-        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
-
-        let multi_sig = MultiSig::new(vec![
-            signer4.try_sign(message.as_ref()).unwrap(),
-            signer4.try_sign(message.as_ref()).unwrap(),
-        ]);
-        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
-
-        let multi_sig = MultiSig::new(vec![
-            signer4.try_sign(message.as_ref()).unwrap(),
-            signer5.try_sign(message.as_ref()).unwrap(),
-        ]);
-        assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
-
-        // Add a valid signer, we should now verify successfully.
-        let multi_sig = MultiSig::new(vec![
-            signer4.try_sign(message.as_ref()).unwrap(),
-            signer5.try_sign(message.as_ref()).unwrap(),
-            signer1.try_sign(message.as_ref()).unwrap(),
-        ]);
-        assert_eq_ignore_order(
-            signer_set.verify(message.as_ref(), &multi_sig).unwrap(),
-            vec![signer1.public_key()],
-        );
-
-        // With two valid signers we should get both back.
-        let multi_sig = MultiSig::new(vec![
-            signer4.try_sign(message.as_ref()).unwrap(),
-            signer5.try_sign(message.as_ref()).unwrap(),
-            signer1.try_sign(message.as_ref()).unwrap(),
-            signer2.try_sign(message.as_ref()).unwrap(),
-        ]);
-        assert_eq_ignore_order(
-            signer_set.verify(message.as_ref(), &multi_sig).unwrap(),
-            vec![signer1.public_key(), signer2.public_key()],
-        );
-
         // Add the same valid signers, they should not be returned twice.
         let multi_sig = MultiSig::new(vec![
             signer1.try_sign(message.as_ref()).unwrap(),

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -434,7 +434,7 @@ mod test_single_level {
         );
         let message = b"this is a test";
 
-        // Add the same valid signers, they should not be returned twice.
+        // Add the same valid signers, they should only be returned once.
         let multi_sig = MultiSig::new(vec![
             signer1.try_sign(message.as_ref()).unwrap(),
             signer2.try_sign(message.as_ref()).unwrap(),

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -160,24 +160,13 @@ impl<S: SignerIdentity> SignerSetV2<S> {
     // The code that does the actual signature verification. We separate it from the
     // public `verify` method so that we do not keep re-sorting an already
     // sorted signers/signatures list.
-    fn verify_helper<
-        SIG: Clone
-            + Default
-            + Digestible
-            + Eq
-            + Hash
-            + Message
-            + Ord
-            + PartialEq
-            + PartialOrd
-            + Serialize
-            + Signature,
-    >(
+    fn verify_helper<SIG>(
         &self,
         message: &[u8],
         signatures: &[SIG],
     ) -> Result<Vec<S>, SignatureError>
     where
+        SIG: Clone + Default + Digestible + Eq + Hash + Message + Ord + Serialize + Signature,
         S: Verifier<SIG>,
     {
         // Sort and dedup the list of signers.

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -13,7 +13,7 @@ use mc_crypto_keys::{PublicKey, Signature, SignatureError, Verifier};
 use prost::{Message, Oneof};
 use serde::{Deserialize, Serialize};
 
-/// A marker traint for indicating that a type is able to produce signatures.
+/// A marker trait for indicating that a type is able to produce signatures.
 /// While we do not strictly have to limit ourselves to `PublicKey`, it makes it
 /// more obvious what the intent of this trait is.
 pub trait SignerIdentity: Default + Message + PublicKey {}

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -132,9 +132,9 @@ impl<S: Signer> SignerSetV2<S> {
     /// 1) A, B, C (threshold 2)
     /// 2) A, D, E (threshold 3)
     /// If we are passed signatures A, B, C, D, E we could in theory satisfy the
-    /// threshold of both groups but since A gets "consumed" when matching the first group,
-    /// leaving the second group with only D and E, it will not be
-    /// considered a match. We say we could match all 5 signatures
+    /// threshold of both groups but since A gets "consumed" when matching the
+    /// first group, leaving the second group with only D and E, it will not
+    /// be considered a match. We say we could match all 5 signatures
     /// in theory, because if we ignored A for the first set, it could still be
     /// used to match the 2nd set. Such algorithm would require a more
     /// complex (and slower) implementation, and is not currently supported.

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -320,7 +320,7 @@ mod test_single_level {
         ]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
-        // Using an unknown signer does not get in the way of verifiying a valid set.
+        // Using an unknown signer does not get in the way of verifying a valid set.
         let multi_sig = MultiSig::new(vec![
             signer1.try_sign(message.as_ref()).unwrap(),
             signer3.try_sign(message.as_ref()).unwrap(),

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! A multi-signature implementations that perment nesting.
+//! A multi-signature implementations that supports nesting.
 //! This allows us to accommodate a requirement, where for example we want to
 //! have 2-out-of-3 organizations signing a transaction, and having each
 //! organization require 2-out-of-3 members to sign.

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -312,7 +312,7 @@ mod test_single_level {
         ]);
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
-        // Using an unknown signer should not allow us to verify is we are under the
+        // Using an unknown signer should not allow us to verify if we are under the
         // threshold
         let multi_sig = MultiSig::new(vec![
             signer1.try_sign(message.as_ref()).unwrap(),

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -188,8 +188,9 @@ impl<S: SignerIdentity> SignerSetV2<S> {
             match signer.entity {
                 Some(SignerEntity::Single(ref single_signer)) => {
                     // See if any of the signatures match this signer.
-                    // Note that we do not need to check if we already encounted this signer, since
-                    // we de-duped the list of signers before entering the outer loop.
+                    // Note that we do not need to check if we already encountered this signer,
+                    // since we de-duped the list of signers before entering the
+                    // outer loop.
                     if signatures
                         .iter()
                         .any(|sig| single_signer.verify(message, sig).is_ok())

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -677,15 +677,13 @@ mod test_nested_multisigs {
         assert!(signer_set.verify(message.as_ref(), &multi_sig).is_err());
 
         // Both orgs satisfy the threshold.
-        let multi_sig = MultiSig::new(
-            vec![
-                org1_signer1_sig,
-                org2_signer1_sig,
-                org1_signer2_sig,
-                org2_signer2_sig,
-                org2_signer3_sig,
-            ],
-        );
+        let multi_sig = MultiSig::new(vec![
+            org1_signer1_sig,
+            org2_signer1_sig,
+            org1_signer2_sig,
+            org2_signer2_sig,
+            org2_signer3_sig,
+        ]);
         let signers = signer_set.verify(message.as_ref(), &multi_sig).unwrap();
         assert_eq_ignore_order(
             signers,
@@ -814,12 +812,9 @@ mod test_nested_multisigs {
         let common_signer_sig = common_signer.try_sign(message).unwrap();
 
         let org1_signer1_sig = org1_signer1.try_sign(message.as_ref()).unwrap();
-        let org1_signer2_sig = org1_signer2.try_sign(message.as_ref()).unwrap();
-        let org1_signer3_sig = org1_signer3.try_sign(message.as_ref()).unwrap();
 
         let org2_signer1_sig = org2_signer1.try_sign(message.as_ref()).unwrap();
         let org2_signer2_sig = org2_signer2.try_sign(message.as_ref()).unwrap();
-        let org2_signer3_sig = org2_signer3.try_sign(message.as_ref()).unwrap();
 
         // The top-level multisig requires 1-of-2 signatures
         let signer_set = SignerSetV2::new(vec![org1_signerset.into(), org2_signerset.into()], 1);
@@ -832,10 +827,7 @@ mod test_nested_multisigs {
             .unwrap();
         assert_eq_ignore_order(
             signers,
-            vec![
-                common_signer.public_key(),
-                org1_signer1.public_key(),
-            ],
+            vec![common_signer.public_key(), org1_signer1.public_key()],
         );
 
         // Using the common signer as part of the org2 signer set results in only org2
@@ -851,8 +843,6 @@ mod test_nested_multisigs {
                 org2_signer1.public_key(),
                 org2_signer2.public_key(),
             ],
-        );
-
         );
     }
 
@@ -919,8 +909,7 @@ mod test_nested_multisigs {
 
         // Org 1 requires 2-of-3 signatures
         let (org1_signerset, org1_signers) = make_signer_set(2, 3, &mut rng);
-        let (org1_signer1, org1_signer2, org1_signer3) =
-            (&org1_signers[0], &org1_signers[1], &org1_signers[2]);
+        let (org1_signer1, org1_signer2) = (&org1_signers[0], &org1_signers[1]);
 
         // Org 2 requires 3-of-3 signatures
         let (org2_signerset, org2_signers) = make_signer_set(3, 3, &mut rng);
@@ -934,7 +923,6 @@ mod test_nested_multisigs {
         // Sign the message with all of our signers.
         let org1_signer1_sig = org1_signer1.try_sign(message.as_ref()).unwrap();
         let org1_signer2_sig = org1_signer2.try_sign(message.as_ref()).unwrap();
-        let org1_signer3_sig = org1_signer3.try_sign(message.as_ref()).unwrap();
 
         let org2_signer1_sig = org2_signer1.try_sign(message.as_ref()).unwrap();
         let org2_signer2_sig = org2_signer2.try_sign(message.as_ref()).unwrap();

--- a/crypto/multisig/src/v2.rs
+++ b/crypto/multisig/src/v2.rs
@@ -119,9 +119,12 @@ impl<S: SignerIdentity> SignerSetV2<S> {
     ///
     /// Note that a signer is allowed to appear in multiple signer sets. For
     /// example, assume a signer set that requires 2 out of 2 signers, each
-    /// being its own signer set: 1) SignerSet1: SignerA, SignerB (1 out of
-    /// 2) 2) SignerSet2: SignerA, SignerC (1 out of 2)
-    /// 3) SignerSetX: SignerSet1, SignerSet (2 out of 2)
+    /// being its own signer set:
+    ///
+    /// 1) SignerSet1: SignerA, SignerB (1 out of 2)
+    /// 2) SignerSet2: SignerA, SignerC (1 out of 2)
+    /// 3) SignerSetX: SignerSet1, SignerSet2 (2 out of 2)
+    ///
     /// When validating SignerSetX, providing just a signature from SignerA will
     /// be enough to satisfy all thresholds. This is acceptable because it
     /// means the rules for verifying a single signer set and a nested one


### PR DESCRIPTION
## Update: This is likely going to get closed in favor of https://github.com/mobilecoinfoundation/mobilecoin/pull/2732 (and whatever followup PRs build on top of it)

### Motivation

We would like to support nested multi-sigs. Right now a multisig follows
an m-out-of-n scheme, and is used in authorizing mints and minting
configuration changes.
The original thinking behind it is that we would require, for example,
2 out of 3 organizations to approve a mint and in this setup each
organization has a single signing key.
A requirement recently was introduced to allow individual organizations
to each support a multi-sig - e.g. make it possible for each organization
to have an m-out-of-n signature scheme for itself, and then require m-out-of-n
organizations to approve mints.
To accommodate this, we need to change the multisig crate to support nested
multisigs.

### Future Work
- Change protobuf definitions to support the V2 nested Ed25519 multisig
- Change ledger to support that
- Change tokens.toml and associated data structures to support a nested
  configuration
- Move existing `SignerSet` into a v1 file, rename to `SignerSetV1`,
  move `MultiSig` into its own file, etc. Didn't do these in this PR to
keep the focus on reviewing the new code.
