### PR TITLE
make `tools/local-network/local-network.py` not do ip checks

### DIFF
--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/bin/main.rs"
 [features]
 default = ["ip-check"]
 ip-check = []
+bypass-ip-check = []
 
 [dependencies]
 mc-account-keys = { path = "../account-keys" }

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -15,7 +15,7 @@ use mc_mobilecoind_api::MobilecoindUri;
 use mc_sgx_css::Signature;
 use mc_util_parse::{load_css_file, parse_duration_in_seconds};
 use mc_util_uri::{ConnectionUri, ConsensusClientUri, FogUri};
-#[cfg(feature = "ip-check")]
+#[cfg(all(feature = "ip-check", not(feature = "bypass-ip-check")))]
 use reqwest::{
     blocking::Client,
     header::{HeaderMap, HeaderValue, InvalidHeaderValue, AUTHORIZATION, CONTENT_TYPE},
@@ -132,7 +132,7 @@ pub enum ConfigError {
     DataMissing(String),
 
     /// Invalid header: {0}
-    #[cfg(feature = "ip-check")]
+    #[cfg(all(feature = "ip-check", not(feature = "bypass-ip-check")))]
     InvalidHeader(InvalidHeaderValue),
 }
 
@@ -148,7 +148,7 @@ impl From<reqwest::Error> for ConfigError {
     }
 }
 
-#[cfg(feature = "ip-check")]
+#[cfg(all(feature = "ip-check", not(feature = "bypass-ip-check")))]
 impl From<InvalidHeaderValue> for ConfigError {
     fn from(e: InvalidHeaderValue) -> Self {
         Self::InvalidHeader(e)
@@ -231,7 +231,7 @@ impl Config {
     ///
     /// Note, both of these services are free tier and rate-limited. A longer
     /// term solution would be to filter on the consensus server.
-    #[cfg(feature = "ip-check")]
+    #[cfg(all(feature = "ip-check", not(feature = "bypass-ip-check")))]
     pub fn validate_host(&self) -> Result<(), ConfigError> {
         let client = Client::builder().gzip(true).use_rustls_tls().build()?;
         let mut json_headers = HeaderMap::new();
@@ -276,7 +276,7 @@ impl Config {
     /// Ensure local IP address is valid
     ///
     /// This does nothing when ip-check is disabled.
-    #[cfg(not(feature = "ip-check"))]
+    #[cfg(not(all(feature = "ip-check", not(feature = "bypass-ip-check"))))]
     pub fn validate_host(&self) -> Result<(), ConfigError> {
         Ok(())
     }

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -469,6 +469,7 @@ class Network:
 
         # Note: bypass-ip-check feature of mobilecoind is used here,
         # because ip-check is sometimes problematic for devs or CI machines.
+        # If the service rate limits you then mobilecoind fails to start.
         subprocess.run(
             f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen --feature mc-mobilecoind/bypass-ip-check {CARGO_FLAGS}',
             shell=True,

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -470,8 +470,9 @@ class Network:
         # Note: no-default-features is set here to avoid the ip_check feature
         # of mc-mobilecoind, which is sometimes problematic for devs or CI machines.
         # If service rate limits you then you can't start mobilecoind.
+        # None of the other crates here have a default feature.
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build --no-default-features -p mc-consensus-service/default -p mc-ledger-distribution/default -p mc-admin-http-gateway/default -p mc-util-grpc-admin-tool/default -p mc-mobilecoind -p mc-crypto-x509-test-vectors/default -p mc-consensus-mint-client/default -p mc-util-seeded-ed25519-key-gen/default {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build --no-default-features -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen {CARGO_FLAGS}',
             shell=True,
             check=True,
         )

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -471,7 +471,7 @@ class Network:
         # because ip-check is sometimes problematic for devs or CI machines.
         # If the service rate limits you then mobilecoind fails to start.
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen --feature mc-mobilecoind/bypass-ip-check {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen --features mc-mobilecoind/bypass-ip-check {CARGO_FLAGS}',
             shell=True,
             check=True,
         )

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -467,12 +467,10 @@ class Network:
                 check=True,
             )
 
-        # Note: no-default-features is set here to avoid the ip_check feature
-        # of mc-mobilecoind, which is sometimes problematic for devs or CI machines.
-        # If service rate limits you then you can't start mobilecoind.
-        # None of the other crates here have a default feature.
+        # Note: bypass-ip-check feature of mobilecoind is used here,
+        # because ip-check is sometimes problematic for devs or CI machines.
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build --no-default-features -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen --feature mc-mobilecoind/bypass-ip-check {CARGO_FLAGS}',
             shell=True,
             check=True,
         )

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -467,8 +467,11 @@ class Network:
                 check=True,
             )
 
+        # Note: no-default-features is set here to avoid the ip_check feature
+        # of mc-mobilecoind, which is sometimes problematic for devs or CI machines.
+        # If service rate limits you then you can't start mobilecoind.
         subprocess.run(
-            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build -p mc-consensus-service -p mc-ledger-distribution -p mc-admin-http-gateway -p mc-util-grpc-admin-tool -p mc-mobilecoind -p mc-crypto-x509-test-vectors -p mc-consensus-mint-client -p mc-util-seeded-ed25519-key-gen {CARGO_FLAGS}',
+            f'cd {PROJECT_DIR} && CONSENSUS_ENCLAVE_PRIVKEY="{enclave_pem}" cargo build --no-default-features -p mc-consensus-service/default -p mc-ledger-distribution/default -p mc-admin-http-gateway/default -p mc-util-grpc-admin-tool/default -p mc-mobilecoind -p mc-crypto-x509-test-vectors/default -p mc-consensus-mint-client/default -p mc-util-seeded-ed25519-key-gen/default {CARGO_FLAGS}',
             shell=True,
             check=True,
         )


### PR DESCRIPTION
This was the simplest way I could see to turn off default-features only on mobilecoind (thanks Nick!)