### PR TITLE
Mitigate tob-5 by making a v2 of client_propose_tx endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,26 +2590,38 @@ dependencies = [
 name = "mc-consensus-enclave"
 version = "2.1.0-pre0"
 dependencies = [
+ "aes-gcm",
  "cargo-emit",
+ "lazy_static",
+ "mc-attest-ake",
+ "mc-attest-api",
  "mc-attest-core",
  "mc-attest-enclave-api",
+ "mc-attest-net",
  "mc-attest-verifier",
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-enclave-api",
  "mc-consensus-enclave-edl",
  "mc-crypto-keys",
+ "mc-crypto-rand",
  "mc-enclave-boundary",
+ "mc-fog-test-infra",
+ "mc-ledger-db",
  "mc-sgx-panic-edl",
  "mc-sgx-report-cache-api",
+ "mc-sgx-report-cache-untrusted",
  "mc-sgx-slog-edl",
  "mc-sgx-types",
  "mc-sgx-urts",
  "mc-transaction-core",
+ "mc-transaction-core-test-utils",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "mc-util-metrics",
  "mc-util-serial",
  "pkg-config",
+ "sha2 0.10.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,10 +2647,13 @@ dependencies = [
 name = "mc-consensus-enclave-impl"
 version = "2.1.0-pre0"
 dependencies = [
+ "aes-gcm",
  "cargo-emit",
  "hex",
  "mbedtls",
  "mc-account-keys",
+ "mc-attest-ake",
+ "mc-attest-api",
  "mc-attest-core",
  "mc-attest-enclave-api",
  "mc-attest-trusted",
@@ -2677,6 +2680,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_hc 0.3.1",
+ "sha2 0.10.6",
  "subtle",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "mc-connection",
  "mc-consensus-api",
  "mc-consensus-enclave",
+ "mc-consensus-enclave-api",
  "mc-consensus-enclave-mock",
  "mc-consensus-scp",
  "mc-consensus-service-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,32 +663,22 @@ version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
+ "atty",
  "bitflags",
- "clap_lex 0.2.2",
+ "clap_derive",
+ "clap_lex",
  "indexmap",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
  "textwrap 0.15.1",
 ]
 
 [[package]]
-name = "clap"
-version = "4.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive",
- "clap_lex 0.3.0",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
-]
-
-[[package]]
 name = "clap_derive"
-version = "4.0.13"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -702,15 +692,6 @@ name = "clap_lex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1305,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.8.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1566,9 +1547,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
@@ -1944,9 +1925,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1980,9 +1961,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -2146,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2175,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2192,16 +2173,16 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -2214,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2233,8 +2214,8 @@ dependencies = [
  "mc-crypto-x509-test-vectors",
  "mc-fog-report-validation-test-utils",
  "mc-test-vectors-b58-encodings",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-from-random",
@@ -2255,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2280,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2298,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "bincode",
@@ -2332,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2345,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2365,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2376,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2386,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2412,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2426,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2440,7 +2421,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2467,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2485,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2523,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2536,6 +2517,7 @@ dependencies = [
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-api",
+ "mc-consensus-enclave-api",
  "mc-crypto-keys",
  "mc-crypto-noise",
  "mc-crypto-rand",
@@ -2554,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2566,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2587,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2613,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2630,12 +2612,13 @@ dependencies = [
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",
+ "prost",
  "serde",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2643,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2680,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2693,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2716,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "grpcio",
  "hex",
@@ -2745,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2769,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "mc-common",
  "mc-consensus-scp",
  "mc-transaction-core",
@@ -2781,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2797,11 +2780,11 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "chrono",
- "clap 4.0.15",
+ "clap 3.2.22",
  "curve25519-dalek",
  "displaydoc",
  "fs_extra",
@@ -2834,9 +2817,9 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -2862,10 +2845,10 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "hex",
  "mc-attest-core",
@@ -2890,7 +2873,7 @@ dependencies = [
 name = "mc-consensus-tool"
 version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "mc-common",
  "mc-connection",
@@ -2902,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "digest 0.10.5",
@@ -2922,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "digest 0.10.5",
@@ -2938,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2947,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2960,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2969,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -2977,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2986,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -2994,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -3003,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3039,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3053,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3067,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3088,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3097,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3125,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3152,10 +3135,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.15",
+ "clap 3.2.22",
  "mc-crypto-keys",
  "mc-util-build-script",
  "pem",
@@ -3164,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3175,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3186,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3218,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "crossbeam-channel",
  "curve25519-dalek",
  "grpcio",
@@ -3237,8 +3220,8 @@ dependencies = [
  "mc-fog-report-connection",
  "mc-fog-report-resolver",
  "mc-ledger-db",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
@@ -3251,7 +3234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3275,10 +3258,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "assert_cmd",
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "grpcio",
  "hex",
@@ -3314,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3349,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3366,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3374,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3407,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3420,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3432,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "dirs",
  "displaydoc",
  "futures",
@@ -3490,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3515,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3531,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3553,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3582,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3600,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3608,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3631,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3644,12 +3627,13 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
+ "hex",
  "lazy_static",
  "mc-account-keys",
  "mc-api",
@@ -3699,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3716,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "mc-account-keys",
  "mc-blockchain-test-utils",
@@ -3744,14 +3728,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3762,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3779,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -3787,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "grpcio",
  "lazy_static",
@@ -3826,7 +3810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -3842,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3861,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3870,10 +3854,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "hex",
  "mc-account-keys",
@@ -3894,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3911,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -3926,9 +3910,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
@@ -3962,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3972,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3985,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3993,10 +3977,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4027,9 +4011,9 @@ dependencies = [
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
  "mc-sgx-css",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-grpc",
@@ -4044,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4065,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4076,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4091,10 +4075,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "chrono",
- "clap 4.0.15",
+ "clap 3.2.22",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
@@ -4125,10 +4109,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "chrono",
- "clap 4.0.15",
+ "clap 3.2.22",
  "mc-common",
  "mc-fog-recovery-db-iface",
  "mc-fog-sql-recovery-db",
@@ -4137,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "grpcio",
  "hex_fmt",
@@ -4152,8 +4136,8 @@ dependencies = [
  "mc-fog-sample-paykit",
  "mc-fog-uri",
  "mc-sgx-css",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
@@ -4171,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "digest 0.10.5",
  "hex",
  "mc-account-keys",
@@ -4193,7 +4177,6 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
- "mc-util-parse",
  "mc-watcher",
  "mc-watcher-api",
  "rand_core 0.6.4",
@@ -4205,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4225,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4233,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4253,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4288,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4306,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4314,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4336,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4349,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4368,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4391,12 +4374,13 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
+ "hex",
  "lazy_static",
  "mc-attest-api",
  "mc-attest-core",
@@ -4442,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4454,9 +4438,9 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-rand",
- "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-lmdb",
  "mc-util-metrics",
@@ -4471,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "dirs",
  "displaydoc",
  "mc-api",
@@ -4494,9 +4478,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "mc-api",
  "mc-common",
  "mc-ledger-db",
@@ -4505,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "lmdb-rkv",
  "mc-common",
  "mc-ledger-db",
@@ -4518,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4552,10 +4536,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
- "clap 4.0.15",
+ "clap 3.2.22",
  "crossbeam-channel",
  "displaydoc",
  "grpcio",
@@ -4591,8 +4575,8 @@ dependencies = [
  "mc-ledger-sync",
  "mc-mobilecoind-api",
  "mc-sgx-css",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
@@ -4621,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4630,7 +4614,7 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-consensus-api",
- "mc-transaction-builder",
+ "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
@@ -4640,10 +4624,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "async-channel",
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "grpcio",
  "hex",
@@ -4656,8 +4640,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-resolver",
  "mc-mobilecoind-api",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-serial",
@@ -4672,9 +4656,9 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "hex",
  "mc-api",
@@ -4748,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4781,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "grpcio",
  "hex",
@@ -4805,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -4815,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -4823,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -4832,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -4840,30 +4824,30 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "hex_fmt",
  "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4874,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4890,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -4900,18 +4884,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -4922,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4934,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -4944,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -4953,13 +4937,13 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-test-vectors-definitions",
- "mc-transaction-builder",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -4968,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4980,8 +4964,8 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-oblivious-traits",
  "mc-test-vectors-definitions",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -4989,8 +4973,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-builder"
-version = "2.1.0-pre0"
+name = "mc-transaction-core"
+version = "2.0.0"
+dependencies = [
+ "aes",
+ "assert_matches",
+ "bulletproofs-og",
+ "crc",
+ "curve25519-dalek",
+ "displaydoc",
+ "generic-array",
+ "hex_fmt",
+ "hkdf",
+ "lazy_static",
+ "mc-account-keys",
+ "mc-common",
+ "mc-crypto-box",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-test-utils",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation-test-utils",
+ "mc-ledger-db",
+ "mc-transaction-core-test-utils",
+ "mc-transaction-std",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-test-helper",
+ "mc-util-zip-exact",
+ "merlin",
+ "proptest",
+ "prost",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "subtle",
+ "tempdir",
+ "zeroize",
+]
+
+[[package]]
+name = "mc-transaction-core-test-utils"
+version = "2.0.0"
+dependencies = [
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-rand",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation-test-utils",
+ "mc-transaction-core",
+ "mc-util-from-random",
+ "mc-util-serial",
+]
+
+[[package]]
+name = "mc-transaction-std"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5020,69 +5065,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-core"
-version = "2.1.0-pre0"
-dependencies = [
- "aes",
- "assert_matches",
- "bulletproofs-og",
- "crc",
- "curve25519-dalek",
- "displaydoc",
- "generic-array",
- "hex_fmt",
- "hkdf",
- "lazy_static",
- "mc-account-keys",
- "mc-common",
- "mc-crypto-box",
- "mc-crypto-digestible",
- "mc-crypto-digestible-test-utils",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation-test-utils",
- "mc-ledger-db",
- "mc-transaction-builder",
- "mc-transaction-core-test-utils",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-test-helper",
- "mc-util-zip-exact",
- "merlin",
- "proptest",
- "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.6",
- "subtle",
- "tempdir",
- "zeroize",
-]
-
-[[package]]
-name = "mc-transaction-core-test-utils"
-version = "2.1.0-pre0"
-dependencies = [
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-rand",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation-test-utils",
- "mc-transaction-core",
- "mc-util-from-random",
- "mc-util-serial",
-]
-
-[[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5093,16 +5077,16 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "hex",
  "mc-api",
 ]
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.0",
@@ -5118,7 +5102,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5126,7 +5110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5134,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5145,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5156,17 +5140,17 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "mc-util-build-info",
 ]
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "mc-blockchain-types",
  "mc-common",
@@ -5177,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5188,20 +5172,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
+ "hex",
  "mc-account-keys",
  "mc-blockchain-test-utils",
  "mc-common",
@@ -5210,7 +5195,6 @@ dependencies = [
  "mc-util-build-info",
  "mc-util-from-random",
  "mc-util-keyfile",
- "mc-util-parse",
  "rand 0.8.5",
  "rand_hc 0.3.1",
  "tempfile",
@@ -5218,10 +5202,10 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
- "clap 4.0.15",
+ "clap 3.2.22",
  "cookie",
  "displaydoc",
  "futures",
@@ -5252,9 +5236,9 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -5263,25 +5247,25 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
+ "hex",
  "mc-common",
  "mc-util-grpc",
- "mc-util-parse",
  "percent-encoding",
 ]
 
 [[package]]
 name = "mc-util-host-cert"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "hex",
  "mc-account-keys",
@@ -5290,7 +5274,6 @@ dependencies = [
  "mc-crypto-rand",
  "mc-crypto-x509-test-vectors",
  "mc-util-from-random",
- "mc-util-parse",
  "mc-util-serial",
  "mc-util-test-helper",
  "pem",
@@ -5307,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5317,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5326,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5334,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5347,16 +5330,15 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "hex",
  "itertools",
  "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5367,12 +5349,12 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
+ "hex",
  "mc-crypto-keys",
  "mc-util-from-random",
- "mc-util-parse",
  "pem",
  "rand 0.8.5",
  "rand_hc 0.3.1",
@@ -5380,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5391,7 +5373,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5402,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "itertools",
  "lazy_static",
  "mc-account-keys",
@@ -5415,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5423,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5432,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5450,21 +5432,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "getrandom 0.2.7",
  "mc-account-keys",
  "mc-api",
  "mc-crypto-keys",
- "mc-transaction-builder",
  "mc-transaction-core",
+ "mc-transaction-std",
  "rand 0.8.5",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -5472,9 +5454,9 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
- "clap 4.0.15",
+ "clap 3.2.22",
  "displaydoc",
  "futures",
  "grpcio",
@@ -5516,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -5663,9 +5645,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
+checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 
 [[package]]
 name = "multer"
@@ -6176,9 +6158,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -6655,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "retry"
-version = "2.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
+checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -7222,9 +7204,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -7593,9 +7575,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8215,9 +8197,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8256,9 +8238,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "513df541345bb9fcc07417775f3d51bbb677daf307d8035c0afafd87dc2e6599"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -8270,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "6150d36a03e90a3cf6c12650be10626a9902d70c5270fd47d7a47e5389a10d56"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,22 +663,32 @@ version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.2",
  "indexmap",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
  "textwrap 0.15.1",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -692,6 +702,15 @@ name = "clap_lex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1286,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1547,9 +1566,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
@@ -2127,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2156,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-slip10"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2173,16 +2192,16 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -2195,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2214,8 +2233,8 @@ dependencies = [
  "mc-crypto-x509-test-vectors",
  "mc-fog-report-validation-test-utils",
  "mc-test-vectors-b58-encodings",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-from-random",
@@ -2236,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2261,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2279,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bincode",
@@ -2313,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2326,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2346,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2357,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2367,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2393,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2407,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2421,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2448,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2466,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2504,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2536,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2548,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2569,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2595,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2618,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2626,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2663,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2676,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2699,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "grpcio",
  "hex",
@@ -2728,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2752,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "mc-common",
  "mc-consensus-scp",
  "mc-transaction-core",
@@ -2764,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2780,11 +2799,11 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.15",
  "curve25519-dalek",
  "displaydoc",
  "fs_extra",
@@ -2818,9 +2837,9 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-report-cache-api",
  "mc-sgx-report-cache-untrusted",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-util-cli",
  "mc-util-from-random",
  "mc-util-grpc",
@@ -2846,10 +2865,10 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "hex",
  "mc-attest-core",
@@ -2874,7 +2893,7 @@ dependencies = [
 name = "mc-consensus-tool"
 version = "2.0.0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "mc-common",
  "mc-connection",
@@ -2886,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest 0.10.5",
@@ -2906,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest 0.10.5",
@@ -2922,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2931,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -2944,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2953,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -2961,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2970,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -2978,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -2987,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3023,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3037,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3051,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3072,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3081,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3109,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3136,10 +3155,10 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 3.2.22",
+ "clap 4.0.15",
  "mc-crypto-keys",
  "mc-util-build-script",
  "pem",
@@ -3148,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3159,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3170,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3202,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "crossbeam-channel",
  "curve25519-dalek",
  "grpcio",
@@ -3221,8 +3240,8 @@ dependencies = [
  "mc-fog-report-connection",
  "mc-fog-report-resolver",
  "mc-ledger-db",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-cli",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
@@ -3235,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3259,10 +3278,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "assert_cmd",
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "grpcio",
  "hex",
@@ -3298,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3333,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3350,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3358,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3391,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3404,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3416,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "dirs",
  "displaydoc",
  "futures",
@@ -3474,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3499,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3515,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3537,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3566,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3584,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3592,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3615,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3628,13 +3647,12 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
- "hex",
  "lazy_static",
  "mc-account-keys",
  "mc-api",
@@ -3684,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3701,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "mc-account-keys",
  "mc-blockchain-test-utils",
@@ -3729,14 +3747,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3747,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3764,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -3772,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "grpcio",
  "lazy_static",
@@ -3811,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -3827,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -3846,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -3855,10 +3873,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "hex",
  "mc-account-keys",
@@ -3879,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3896,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -3911,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
@@ -3947,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -3957,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -3970,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -3978,10 +3996,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
@@ -4012,9 +4030,9 @@ dependencies = [
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
  "mc-sgx-css",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-grpc",
@@ -4029,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4050,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4061,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4076,10 +4094,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.15",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",
@@ -4110,10 +4128,10 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
- "clap 3.2.22",
+ "clap 4.0.15",
  "mc-common",
  "mc-fog-recovery-db-iface",
  "mc-fog-sql-recovery-db",
@@ -4122,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "grpcio",
  "hex_fmt",
@@ -4137,8 +4155,8 @@ dependencies = [
  "mc-fog-sample-paykit",
  "mc-fog-uri",
  "mc-sgx-css",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-cli",
  "mc-util-grpc",
  "mc-util-keyfile",
@@ -4156,9 +4174,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "digest 0.10.5",
  "hex",
  "mc-account-keys",
@@ -4178,6 +4196,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-generate-sample-ledger",
  "mc-util-keyfile",
+ "mc-util-parse",
  "mc-watcher",
  "mc-watcher-api",
  "rand_core 0.6.4",
@@ -4189,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4209,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4217,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4237,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4272,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4290,7 +4309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4298,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4320,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4333,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4352,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4375,13 +4394,12 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
- "hex",
  "lazy_static",
  "mc-attest-api",
  "mc-attest-core",
@@ -4427,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4439,9 +4457,9 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-multisig",
  "mc-crypto-rand",
+ "mc-transaction-builder",
  "mc-transaction-core",
  "mc-transaction-core-test-utils",
- "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-lmdb",
  "mc-util-metrics",
@@ -4456,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "dirs",
  "displaydoc",
  "mc-api",
@@ -4479,9 +4497,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "mc-api",
  "mc-common",
  "mc-ledger-db",
@@ -4490,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "lmdb-rkv",
  "mc-common",
  "mc-ledger-db",
@@ -4503,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4537,10 +4555,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
- "clap 3.2.22",
+ "clap 4.0.15",
  "crossbeam-channel",
  "displaydoc",
  "grpcio",
@@ -4576,8 +4594,8 @@ dependencies = [
  "mc-ledger-sync",
  "mc-mobilecoind-api",
  "mc-sgx-css",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
@@ -4606,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4615,7 +4633,7 @@ dependencies = [
  "mc-api",
  "mc-common",
  "mc-consensus-api",
- "mc-transaction-std",
+ "mc-transaction-builder",
  "mc-util-build-grpc",
  "mc-util-build-script",
  "mc-util-uri",
@@ -4625,10 +4643,10 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "async-channel",
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "grpcio",
  "hex",
@@ -4641,8 +4659,8 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-fog-report-resolver",
  "mc-mobilecoind-api",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-grpc",
  "mc-util-keyfile",
  "mc-util-serial",
@@ -4657,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "hex",
  "mc-api",
@@ -4733,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4766,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "grpcio",
  "hex",
@@ -4790,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -4800,7 +4818,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -4808,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -4817,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -4825,30 +4843,30 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "hex_fmt",
  "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4859,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4875,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -4885,18 +4903,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -4907,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4919,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -4929,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -4938,13 +4956,13 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
  "mc-crypto-keys",
  "mc-test-vectors-definitions",
- "mc-transaction-std",
+ "mc-transaction-builder",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -4953,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -4965,8 +4983,8 @@ dependencies = [
  "mc-fog-view-protocol",
  "mc-oblivious-traits",
  "mc-test-vectors-definitions",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "mc-util-from-random",
  "mc-util-serial",
  "mc-util-test-vector",
@@ -4974,69 +4992,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-transaction-core"
-version = "2.0.0"
-dependencies = [
- "aes",
- "assert_matches",
- "bulletproofs-og",
- "crc",
- "curve25519-dalek",
- "displaydoc",
- "generic-array",
- "hex_fmt",
- "hkdf",
- "lazy_static",
- "mc-account-keys",
- "mc-common",
- "mc-crypto-box",
- "mc-crypto-digestible",
- "mc-crypto-digestible-test-utils",
- "mc-crypto-hashes",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-ring-signature",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation-test-utils",
- "mc-ledger-db",
- "mc-transaction-core-test-utils",
- "mc-transaction-std",
- "mc-transaction-types",
- "mc-util-from-random",
- "mc-util-repr-bytes",
- "mc-util-serial",
- "mc-util-test-helper",
- "mc-util-zip-exact",
- "merlin",
- "proptest",
- "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.6",
- "subtle",
- "tempdir",
- "zeroize",
-]
-
-[[package]]
-name = "mc-transaction-core-test-utils"
-version = "2.0.0"
-dependencies = [
- "mc-account-keys",
- "mc-crypto-keys",
- "mc-crypto-multisig",
- "mc-crypto-rand",
- "mc-crypto-ring-signature-signer",
- "mc-fog-report-validation-test-utils",
- "mc-transaction-core",
- "mc-util-from-random",
- "mc-util-serial",
-]
-
-[[package]]
-name = "mc-transaction-std"
-version = "2.0.0"
+name = "mc-transaction-builder"
+version = "2.1.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5066,8 +5023,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-transaction-core"
+version = "2.1.0-pre0"
+dependencies = [
+ "aes",
+ "assert_matches",
+ "bulletproofs-og",
+ "crc",
+ "curve25519-dalek",
+ "displaydoc",
+ "generic-array",
+ "hex_fmt",
+ "hkdf",
+ "lazy_static",
+ "mc-account-keys",
+ "mc-common",
+ "mc-crypto-box",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-test-utils",
+ "mc-crypto-hashes",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation-test-utils",
+ "mc-ledger-db",
+ "mc-transaction-builder",
+ "mc-transaction-core-test-utils",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-util-test-helper",
+ "mc-util-zip-exact",
+ "merlin",
+ "proptest",
+ "prost",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.6",
+ "subtle",
+ "tempdir",
+ "zeroize",
+]
+
+[[package]]
+name = "mc-transaction-core-test-utils"
+version = "2.1.0-pre0"
+dependencies = [
+ "mc-account-keys",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-rand",
+ "mc-crypto-ring-signature-signer",
+ "mc-fog-report-validation-test-utils",
+ "mc-transaction-core",
+ "mc-util-from-random",
+ "mc-util-serial",
+]
+
+[[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5078,16 +5096,16 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "hex",
  "mc-api",
 ]
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.0",
@@ -5103,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5111,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5119,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5130,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5141,17 +5159,17 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "mc-util-build-info",
 ]
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "mc-blockchain-types",
  "mc-common",
@@ -5162,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5173,21 +5191,20 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
- "hex",
+ "clap 4.0.15",
  "mc-account-keys",
  "mc-blockchain-test-utils",
  "mc-common",
@@ -5196,6 +5213,7 @@ dependencies = [
  "mc-util-build-info",
  "mc-util-from-random",
  "mc-util-keyfile",
+ "mc-util-parse",
  "rand 0.8.5",
  "rand_hc 0.3.1",
  "tempfile",
@@ -5203,10 +5221,10 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 3.2.22",
+ "clap 4.0.15",
  "cookie",
  "displaydoc",
  "futures",
@@ -5237,9 +5255,9 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "grpcio",
  "mc-common",
  "mc-util-grpc",
@@ -5248,25 +5266,25 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
- "hex",
+ "clap 4.0.15",
  "mc-common",
  "mc-util-grpc",
+ "mc-util-parse",
  "percent-encoding",
 ]
 
 [[package]]
 name = "mc-util-host-cert"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "hex",
  "mc-account-keys",
@@ -5275,6 +5293,7 @@ dependencies = [
  "mc-crypto-rand",
  "mc-crypto-x509-test-vectors",
  "mc-util-from-random",
+ "mc-util-parse",
  "mc-util-serial",
  "mc-util-test-helper",
  "pem",
@@ -5291,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5301,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5310,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5318,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5331,15 +5350,16 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
+ "hex",
  "itertools",
  "mc-sgx-css",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5350,12 +5370,12 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
- "hex",
+ "clap 4.0.15",
  "mc-crypto-keys",
  "mc-util-from-random",
+ "mc-util-parse",
  "pem",
  "rand 0.8.5",
  "rand_hc 0.3.1",
@@ -5363,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5374,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5385,9 +5405,9 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "itertools",
  "lazy_static",
  "mc-account-keys",
@@ -5398,7 +5418,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5406,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5415,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5433,21 +5453,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "getrandom 0.2.7",
  "mc-account-keys",
  "mc-api",
  "mc-crypto-keys",
+ "mc-transaction-builder",
  "mc-transaction-core",
- "mc-transaction-std",
  "rand 0.8.5",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -5455,9 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
- "clap 3.2.22",
+ "clap 4.0.15",
  "displaydoc",
  "futures",
  "grpcio",
@@ -5499,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",
@@ -6159,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -6638,9 +6658,9 @@ dependencies = [
 
 [[package]]
 name = "retry"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
+checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
 dependencies = [
  "rand 0.8.5",
 ]

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -12,6 +12,7 @@ mc-attest-verifier = { path = "../attest/verifier" }
 mc-blockchain-types = { path = "../blockchain/types" }
 mc-common = { path = "../common" }
 mc-consensus-api = { path = "../consensus/api" }
+mc-consensus-enclave-api = { path = "../consensus/enclave/api" }
 mc-crypto-keys = { path = "../crypto/keys" }
 mc-crypto-noise = { path = "../crypto/noise" }
 mc-crypto-rand = { path = "../crypto/rand" }

--- a/connection/src/lib.rs
+++ b/connection/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::{
     thick::{ThickClient, ThickClientAttestationError},
     traits::{
         AttestationError, AttestedConnection, BlockInfo, BlockchainConnection, Connection,
-        RetryableBlockchainConnection, RetryableUserTxConnection, UserTxConnection, TxOkData,
+        RetryableBlockchainConnection, RetryableUserTxConnection, TxOkData, UserTxConnection,
     },
 };
 

--- a/connection/src/lib.rs
+++ b/connection/src/lib.rs
@@ -20,10 +20,11 @@ pub use crate::{
     thick::{ThickClient, ThickClientAttestationError},
     traits::{
         AttestationError, AttestedConnection, BlockInfo, BlockchainConnection, Connection,
-        RetryableBlockchainConnection, RetryableUserTxConnection, UserTxConnection,
+        RetryableBlockchainConnection, RetryableUserTxConnection, UserTxConnection, TxOkData,
     },
 };
 
 pub use mc_common::trace_time as _trace_time;
 pub use mc_consensus_api::consensus_common::ProposeTxResult;
+pub use mc_consensus_enclave_api::{FeeMap, FeeMapError};
 pub use retry as _retry;

--- a/connection/src/sync.rs
+++ b/connection/src/sync.rs
@@ -6,12 +6,13 @@ use crate::{
     error::RetryResult,
     traits::{
         BlockInfo, BlockchainConnection, Connection, RetryableBlockchainConnection,
-        RetryableUserTxConnection, UserTxConnection,
+        RetryableUserTxConnection, UserTxConnection, TxOkData,
     },
 };
 use mc_blockchain_types::{Block, BlockID, BlockIndex};
 use mc_common::logger::Logger;
-use mc_transaction_core::tx::Tx;
+use mc_consensus_enclave_api::FeeMap;
+use mc_transaction_core::{tx::Tx};
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -236,5 +237,14 @@ impl<UTC: UserTxConnection> RetryableUserTxConnection for SyncConnection<UTC> {
         retry_iterator: impl IntoIterator<Item = Duration>,
     ) -> RetryResult<BlockIndex> {
         impl_sync_connection_retry!(self.write(), self.logger, propose_tx, retry_iterator, tx)
+    }
+
+    fn propose_tx_v2(
+        &self,
+        tx: &Tx,
+        fee_map: &FeeMap,
+        retry_iterator: impl IntoIterator<Item = Duration>,
+    ) -> RetryResult<TxOkData> {
+        impl_sync_connection_retry!(self.write(), self.logger, propose_tx_v2, retry_iterator, tx, fee_map)
     }
 }

--- a/connection/src/sync.rs
+++ b/connection/src/sync.rs
@@ -6,13 +6,13 @@ use crate::{
     error::RetryResult,
     traits::{
         BlockInfo, BlockchainConnection, Connection, RetryableBlockchainConnection,
-        RetryableUserTxConnection, UserTxConnection, TxOkData,
+        RetryableUserTxConnection, TxOkData, UserTxConnection,
     },
 };
 use mc_blockchain_types::{Block, BlockID, BlockIndex};
 use mc_common::logger::Logger;
 use mc_consensus_enclave_api::FeeMap;
-use mc_transaction_core::{tx::Tx};
+use mc_transaction_core::tx::Tx;
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter, Result as FmtResult},
@@ -245,6 +245,13 @@ impl<UTC: UserTxConnection> RetryableUserTxConnection for SyncConnection<UTC> {
         fee_map: &FeeMap,
         retry_iterator: impl IntoIterator<Item = Duration>,
     ) -> RetryResult<TxOkData> {
-        impl_sync_connection_retry!(self.write(), self.logger, propose_tx_v2, retry_iterator, tx, fee_map)
+        impl_sync_connection_retry!(
+            self.write(),
+            self.logger,
+            propose_tx_v2,
+            retry_iterator,
+            tx,
+            fee_map
+        )
     }
 }

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -35,7 +35,7 @@ use mc_consensus_api::{
     consensus_common_grpc::BlockchainApiClient,
     empty::Empty,
 };
-use mc_consensus_enclave_api::{FeeMap, ClientProposeTxRequest};
+use mc_consensus_enclave_api::{FeeMap, ClientProposeTxRequestV2};
 use mc_crypto_keys::X25519;
 use mc_crypto_noise::CipherError;
 use mc_crypto_rand::McRng;
@@ -449,7 +449,7 @@ impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
             .as_mut()
             .expect("no enclave_connection even though attest succeeded");
 
-        let req = ClientProposeTxRequest {
+        let req = ClientProposeTxRequestV2 {
             tx: tx.clone(),
             fee_map_digest: fee_map.canonical_digest().to_vec()
         };
@@ -465,7 +465,7 @@ impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
 
         let resp = self.authenticated_attested_call(|this, call_option| {
             this.consensus_client_api_client
-                .client_tx_propose_async_opt(&msg, call_option)
+                .client_tx_propose_v2_async_opt(&msg, call_option)
         })?;
 
         if resp.get_result() == ProposeTxResult::Ok {

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -8,7 +8,7 @@ use crate::{
     error::{Error, Result},
     traits::{
         AttestationError, AttestedConnection, BlockInfo, BlockchainConnection, Connection,
-        UserTxConnection, TxOkData
+        TxOkData, UserTxConnection,
     },
 };
 use aes_gcm::Aes256Gcm;
@@ -35,11 +35,11 @@ use mc_consensus_api::{
     consensus_common_grpc::BlockchainApiClient,
     empty::Empty,
 };
-use mc_consensus_enclave_api::{FeeMap, ClientProposeTxRequestV2};
+use mc_consensus_enclave_api::{ClientProposeTxRequestV2, FeeMap};
 use mc_crypto_keys::X25519;
 use mc_crypto_noise::CipherError;
 use mc_crypto_rand::McRng;
-use mc_transaction_core::{tx::Tx};
+use mc_transaction_core::tx::Tx;
 use mc_util_grpc::{ConnectionUriGrpcioChannel, GrpcCookieStore, CHAIN_ID_GRPC_HEADER};
 use mc_util_serial::encode;
 use mc_util_uri::{ConnectionUri, ConsensusClientUri as ClientUri, UriConversionError};
@@ -451,7 +451,7 @@ impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
 
         let req = ClientProposeTxRequestV2 {
             tx: tx.clone(),
-            fee_map_digest: fee_map.canonical_digest().to_vec()
+            fee_map_digest: fee_map.canonical_digest().to_vec(),
         };
 
         let mut msg = Message::new();
@@ -480,7 +480,6 @@ impl<CP: CredentialsProvider> UserTxConnection for ThickClient<CP> {
             ))
         }
     }
-
 }
 
 impl<CP: CredentialsProvider> Display for ThickClient<CP> {

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -171,8 +171,9 @@ pub trait UserTxConnection: Connection {
 
     /// Propose a transaction over the encrypted channel (v2 API).
     /// The user makes an assertion about what the current state of the minimum
-    /// fee map is, which the enclave checks and rejects the Tx if it is different.
-    /// This prevents an information leak identified in TOB-MCCT-5
+    /// fee map is, which the enclave checks and rejects the Tx if it is
+    /// different. This prevents an information leak identified in
+    /// TOB-MCCT-5
     fn propose_tx_v2(&mut self, tx: &Tx, minimum_fee_map: &FeeMap) -> Result<TxOkData>;
 }
 

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -5,7 +5,7 @@
 use mc_blockchain_types::{Block, BlockID, BlockIndex, BlockVersion};
 use mc_connection::{
     BlockInfo, BlockchainConnection, Connection, Error as ConnectionError,
-    Result as ConnectionResult, UserTxConnection, TxOkData
+    Result as ConnectionResult, TxOkData, UserTxConnection,
 };
 use mc_consensus_enclave_api::FeeMap;
 use mc_ledger_db::Ledger;

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -5,7 +5,7 @@
 use mc_blockchain_types::{Block, BlockID, BlockIndex, BlockVersion};
 use mc_connection::{
     BlockInfo, BlockchainConnection, Connection, Error as ConnectionError,
-    Result as ConnectionResult, UserTxConnection,
+    Result as ConnectionResult, UserTxConnection, TxOkData
 };
 use mc_consensus_enclave_api::FeeMap;
 use mc_ledger_db::Ledger;
@@ -132,6 +132,14 @@ impl<L: Ledger + Sync> UserTxConnection for MockBlockchainConnection<L> {
     fn propose_tx(&mut self, tx: &Tx) -> ConnectionResult<BlockIndex> {
         self.proposed_txs.push(tx.clone());
         Ok(self.ledger.num_blocks().unwrap())
+    }
+
+    fn propose_tx_v2(&mut self, tx: &Tx, _fee_map: &FeeMap) -> ConnectionResult<TxOkData> {
+        self.proposed_txs.push(tx.clone());
+        Ok(TxOkData {
+            block_count: self.ledger.num_blocks().unwrap(),
+            block_version: 0,   
+        })
     }
 }
 

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -136,9 +136,12 @@ impl<L: Ledger + Sync> UserTxConnection for MockBlockchainConnection<L> {
 
     fn propose_tx_v2(&mut self, tx: &Tx, _fee_map: &FeeMap) -> ConnectionResult<TxOkData> {
         self.proposed_txs.push(tx.clone());
+
+        let block_count = self.ledger.num_blocks().unwrap();
+        let block_version = self.ledger.get_block(block_count - 1).unwrap().version;
         Ok(TxOkData {
-            block_count: self.ledger.num_blocks().unwrap(),
-            block_version: 0,   
+            block_count,
+            block_version,
         })
     }
 }

--- a/connection/test-utils/src/user_tx.rs
+++ b/connection/test-utils/src/user_tx.rs
@@ -3,7 +3,8 @@
 //! User Transaction Connection Mock
 
 use mc_blockchain_types::BlockIndex;
-use mc_connection::{Connection, Result as ConnectionResult, UserTxConnection};
+use mc_connection::{Connection, Result as ConnectionResult, UserTxConnection, TxOkData};
+use mc_consensus_enclave_api::FeeMap;
 use mc_transaction_core::tx::Tx;
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};
 use std::{
@@ -71,5 +72,13 @@ impl UserTxConnection for MockUserTxConnection {
     fn propose_tx(&mut self, tx: &Tx) -> ConnectionResult<BlockIndex> {
         self.submitted_txs.push(tx.clone());
         Ok(1)
+    }
+
+    fn propose_tx_v2(&mut self, tx: &Tx, _fee_map: &FeeMap) -> ConnectionResult<TxOkData> {
+        self.submitted_txs.push(tx.clone());
+        Ok(TxOkData {
+            block_count: 1,
+            block_version: 0,
+        })
     }
 }

--- a/connection/test-utils/src/user_tx.rs
+++ b/connection/test-utils/src/user_tx.rs
@@ -3,7 +3,7 @@
 //! User Transaction Connection Mock
 
 use mc_blockchain_types::BlockIndex;
-use mc_connection::{Connection, Result as ConnectionResult, UserTxConnection, TxOkData};
+use mc_connection::{Connection, Result as ConnectionResult, TxOkData, UserTxConnection};
 use mc_consensus_enclave_api::FeeMap;
 use mc_transaction_core::tx::Tx;
 use mc_util_uri::{ConnectionUri, ConsensusClientUri};

--- a/consensus/api/proto/consensus_client.proto
+++ b/consensus/api/proto/consensus_client.proto
@@ -68,7 +68,7 @@ message ProposeMintTxResponse {
 }
 
 /// Request which is encrypted when calling client_tx_propose_v2 endpoint
-message ClientProposeTxRequest {
+message ClientProposeTxRequestV2 {
     /// The tx being proposed
     external.Tx tx = 1;
 

--- a/consensus/api/proto/consensus_client.proto
+++ b/consensus/api/proto/consensus_client.proto
@@ -67,10 +67,29 @@ message ProposeMintTxResponse {
     uint32 block_version = 3;
 }
 
+/// Request which is encrypted when calling client_tx_propose_v2 endpoint
+message ClientProposeTxRequest {
+    /// The tx being proposed
+    external.Tx tx = 1;
+
+    /// Client's belief about the minimum fee map, expressed as a merlin digest.
+    ///
+    /// The enclave must reject the proposal if this doesn't match the enclave's
+    /// belief, to protect the client from information disclosure attacks.
+    /// (This is TOB-MCCT-5)
+    bytes fee_map_digest = 2;
+}
+
 service ConsensusClientAPI {
     /// This API call is made with an encrypted payload for the enclave,
     /// indicating a new value to be acted upon.
+    /// The attest.Message should be encrypting a Tx protobuf.
     rpc ClientTxPropose(attest.Message) returns (consensus_common.ProposeTxResponse);
+
+    /// This API call is made with an encrypted payload for the enclave,
+    /// indicating a new value to be acted upon.
+    /// The attest.Message should be encrypting a ClientProposeTxRequest protobuf.
+    rpc ClientTxProposeV2(attest.Message) returns (consensus_common.ProposeTxResponse);
 
     /// Propose a new MintConfigTx.
     rpc ProposeMintConfigTx(external.MintConfigTx) returns (ProposeMintConfigTxResponse);

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -97,6 +97,7 @@ enum ProposeTxResult {
     InputRuleInvalidAmountSharedSecret = 51;
     InputRuleTxOutConversion = 52;
     InputRuleAmount = 53;
+    FeeMapDigestMismatch = 54;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -29,3 +29,18 @@ mc-util-build-sgx = { path = "../../util/build/sgx" }
 
 cargo-emit = "0.2.1"
 pkg-config = "0.3"
+
+[dev-dependencies]
+mc-attest-ake = { path = "../../attest/ake" }
+mc-attest-api = { path = "../../attest/api" }
+mc-attest-net = { path = "../../attest/net" }
+mc-crypto-rand = { path = "../../crypto/rand" }
+mc-fog-test-infra = { path = "../../fog/test_infra" }
+mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
+mc-sgx-report-cache-untrusted = { path = "../../sgx/report-cache/untrusted" }
+mc-transaction-core-test-utils = { path = "../../transaction/core/test-utils" }
+mc-util-metrics = { path = "../../util/metrics" }
+
+aes-gcm = "0.9.4"
+lazy_static = "1"
+sha2 = "0.10"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -34,4 +34,5 @@ mc-util-serial = { path = "../../../util/serial", default-features = false }
 
 displaydoc = { version = "0.2", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
+prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -46,15 +46,18 @@ impl Default for BlockchainConfig {
 pub struct BlockchainConfigWithDigest {
     config: BlockchainConfig,
     cached_digest: String,
+    fee_map_digest: [u8; 32],
 }
 
 impl From<BlockchainConfig> for BlockchainConfigWithDigest {
     fn from(config: BlockchainConfig) -> Self {
         let digest = config.digest32::<MerlinTranscript>(b"mc-blockchain-config");
         let cached_digest = hex::encode(digest);
+        let fee_map_digest = config.fee_map.canonical_digest();
         Self {
             config,
             cached_digest,
+            fee_map_digest,
         }
     }
 }
@@ -76,6 +79,11 @@ impl BlockchainConfigWithDigest {
     /// responder id that is unique to the current fee configuration.
     pub fn responder_id(&self, responder_id: &ResponderId) -> ResponderId {
         ResponderId(format!("{}-{}", responder_id.0, self.cached_digest))
+    }
+
+    /// Get canonical fee map digest
+    pub fn canonical_fee_map_digest(&self) -> &[u8; 32] {
+        &self.fee_map_digest
     }
 
     /// Get the config (non mutably)

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -76,6 +76,9 @@ pub enum Error {
 
     /// Failed parsing minting trust root public key
     ParseMintingTrustRootPublicKey(KeyError),
+
+    /// Fee Map Digest Mismatch
+    FeeMapDigestMismatch,
 }
 
 impl From<ParseSealedError> for Error {

--- a/consensus/enclave/api/src/fee_map.rs
+++ b/consensus/enclave/api/src/fee_map.rs
@@ -4,7 +4,7 @@
 
 use alloc::collections::BTreeMap;
 use displaydoc::Display;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_transaction_core::{tokens::Mob, Token, TokenId};
 use serde::{Deserialize, Serialize};
 
@@ -140,6 +140,11 @@ impl FeeMap {
         let mut map = BTreeMap::new();
         map.insert(Mob::ID, Mob::MINIMUM_FEE);
         map
+    }
+
+    /// Get a canonical digest of the minimum fee map
+    pub fn canonical_digest(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(b"mc-fee-map")
     }
 }
 

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -334,8 +334,8 @@ pub trait ConsensusEnclave: ReportableEnclave {
     /// * An EnclaveMessage which encrypts a `Tx` protobuf
     ///
     /// Returns:
-    /// * A Tx context including "locally encrypted" version of Tx and some extracted
-    ///   metadata or,
+    /// * A Tx context including "locally encrypted" version of Tx and some
+    ///   extracted metadata or,
     /// * A serialization / cryptography error.
     fn client_tx_propose(&self, msg: EnclaveMessage<ClientSession>) -> Result<TxContext>;
 
@@ -345,10 +345,10 @@ pub trait ConsensusEnclave: ReportableEnclave {
     /// * An EnclaveMessage which encrypts a `ClientProposeTxRequest` protobuf
     ///
     /// Returns:
-    /// * A Tx context including "locally encrypted" version of Tx and some extracted
-    ///   metadata, or
-    /// * A serialization / cryptography error, or another mismatch error
-    ///   e.g. minimum_fee_map_hash or (some-day) chain-id error
+    /// * A Tx context including "locally encrypted" version of Tx and some
+    ///   extracted metadata, or
+    /// * A serialization / cryptography error, or another mismatch error e.g.
+    ///   minimum_fee_map_hash or (some-day) chain-id error
     fn client_tx_propose_v2(&self, msg: EnclaveMessage<ClientSession>) -> Result<TxContext>;
 
     /// Performs the first steps in accepting transactions from a remote peer:

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -249,7 +249,7 @@ pub struct FormBlockInputs {
 
 /// The schema expected to be encrypted for client_tx_propose_v2
 #[derive(Clone, Message)]
-pub struct ClientProposeTxRequest {
+pub struct ClientProposeTxRequestV2 {
     /// The tx being proposed
     #[prost(message, required, tag = 1)]
     pub tx: Tx,

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -112,6 +112,12 @@ pub enum EnclaveCall {
     /// client.
     ClientTxPropose(EnclaveMessage<ClientSession>),
 
+    /// The [ConsensusEnclave::client_tx_propose_v2()] method.
+    ///
+    /// Start a new transaction proposal given the encrypted message from a
+    /// client.
+    ClientTxProposeV2(EnclaveMessage<ClientSession>),
+
     /// The [ConsensusEnclave::client_discard_message()] method.
     ///
     /// Decrypts an incoming message and discard the data.

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -50,13 +50,17 @@ rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.4", default-features = false, features = ["i128"] }
 
 [dev-dependencies]
+mc-attest-ake = { path = "../../../attest/ake" }
+mc-attest-api = { path = "../../../attest/api" }
 mc-common = { path = "../../../common", features = ["loggers"] }
 mc-crypto-multisig = { path = "../../../crypto/multisig" }
 mc-ledger-db = { path = "../../../ledger/db", features = ["test_utils"] }
 mc-transaction-core-test-utils = { path = "../../../transaction/core/test-utils" }
 
+aes-gcm = "0.9.4"
 rand = "0.8"
 rand_hc = "0.3"
+sha2 = "0.10"
 
 [build-dependencies]
 mc-crypto-keys = { path = "../../../crypto/keys" }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -46,10 +46,10 @@ use mc_common::{
     ResponderId,
 };
 use mc_consensus_enclave_api::{
-    BlockchainConfig, BlockchainConfigWithDigest, ConsensusEnclave, Error, FeeMap, FeePublicKey,
-    FormBlockInputs, GovernorsVerifier, LocallyEncryptedTx, Result, SealedBlockSigningKey,
-    TxContext, WellFormedEncryptedTx, WellFormedTxContext, SMALLEST_MINIMUM_FEE_LOG2,
-    ClientProposeTxRequestV2,
+    BlockchainConfig, BlockchainConfigWithDigest, ClientProposeTxRequestV2, ConsensusEnclave,
+    Error, FeeMap, FeePublicKey, FormBlockInputs, GovernorsVerifier, LocallyEncryptedTx, Result,
+    SealedBlockSigningKey, TxContext, WellFormedEncryptedTx, WellFormedTxContext,
+    SMALLEST_MINIMUM_FEE_LOG2,
 };
 use mc_crypto_ake_enclave::AkeEnclaveState;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
@@ -647,11 +647,14 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Try and deserialize.
         let req: ClientProposeTxRequestV2 = mc_util_serial::decode(&req_bytes)?;
 
-        if &req.fee_map_digest[..] != &self
-            .blockchain_config
-            .get()
-            .ok_or(Error::NotInitialized)?.canonical_fee_map_digest()[..] {
-            return Err(Error::FeeMapDigestMismatch);   
+        if &req.fee_map_digest[..]
+            != &self
+                .blockchain_config
+                .get()
+                .ok_or(Error::NotInitialized)?
+                .canonical_fee_map_digest()[..]
+        {
+            return Err(Error::FeeMapDigestMismatch);
         }
 
         self.client_tx_propose_common(req.tx)

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1058,13 +1058,10 @@ fn mint_output<T: Digestible>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aes_gcm::Aes256Gcm;
     use alloc::vec;
-    use mc_attest_ake::{AuthResponseInput, ClientInitiate, Start, Transition};
-    use mc_attest_api::attest::{AuthMessage, Message};
     use mc_common::{logger::test_with_logger, HashMap, HashSet};
     use mc_consensus_enclave_api::{FeeMap, GovernorsMap, GovernorsSigner};
-    use mc_crypto_keys::{Ed25519Private, Ed25519Signature, X25519};
+    use mc_crypto_keys::{Ed25519Private, Ed25519Signature};
     use mc_crypto_multisig::SignerSet;
     use mc_ledger_db::{
         test_utils::{add_txos_to_ledger, create_ledger, create_transaction, initialize_ledger},
@@ -1080,10 +1077,8 @@ mod tests {
         create_mint_config_tx_and_signers, create_mint_tx_to_recipient, AccountKey,
     };
     use mc_util_from_random::FromRandom;
-    use mc_util_serial::encode;
     use rand_core::SeedableRng;
     use rand_hc::Hc128Rng;
-    use sha2::Sha512;
 
     // The private keys here are only used by tests. They do not need to be
     // specified for main net. The public keys associated with this private keys
@@ -1157,97 +1152,6 @@ mod tests {
             ),
             Err(Error::InvalidGovernorsSignature)
         );
-    }
-
-    #[test_with_logger]
-    fn test_client_tx_propose_works(logger: Logger) {
-        let mut rng = Hc128Rng::from_seed([1u8; 32]);
-
-        let block_version = BlockVersion::MAX;
-        let responder_id = Default::default();
-        let fee_map = FeeMap::default();
-
-        let enclave = SgxConsensusEnclave::new(logger.clone());
-        let blockchain_config = BlockchainConfig {
-            block_version,
-            fee_map: fee_map.clone(),
-            ..Default::default()
-        };
-        enclave
-            .enclave_init(&responder_id, &responder_id, &None, blockchain_config)
-            .unwrap();
-
-        // First, create an encrypted connection from a client
-        let initiator = Start::new(responder_id.to_string());
-        let init_input = ClientInitiate::<X25519, Aes256Gcm, Sha512>::default();
-        let (initiator, auth_request_output) = initiator.try_next(&mut rng, init_input).unwrap();
-
-        let auth_request_msg = AuthMessage::from(auth_request_output);
-        let (auth_response_msg, _client_session) =
-            enclave.client_accept(auth_request_msg.into()).unwrap();
-        let auth_response_msg = AuthMessage::from(auth_response_msg);
-
-        // Now the client should have a working cipher state
-        let verifier = Default::default();
-        let auth_response_event = AuthResponseInput::new(auth_response_msg.into(), verifier);
-        let (mut initiator, _verification_report) =
-            initiator.try_next(&mut rng, auth_response_event).unwrap();
-
-        // Create a valid test transaction.
-        let sender = AccountKey::random(&mut rng);
-        let recipient = AccountKey::random(&mut rng);
-
-        let mut ledger = create_ledger();
-        let n_blocks = 3;
-        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
-
-        // Choose a TxOut to spend. Only the TxOut in the last block is unspent.
-        let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
-        let tx_out = block_contents.outputs[0].clone();
-
-        let tx = create_transaction(
-            block_version,
-            &mut ledger,
-            &tx_out,
-            &sender,
-            &recipient.default_subaddress(),
-            n_blocks + 1,
-            &mut rng,
-        );
-
-        // Try to propose the Tx
-        let mut fee_map_digest = fee_map.canonical_digest().to_vec();
-        let req = ClientProposeTxRequestV2 {
-            tx: tx.clone(),
-            fee_map_digest: fee_map_digest.clone(),
-        };
-
-        let ciphertext = initiator.encrypt(&[], &encode(&req)).unwrap();
-
-        let mut msg = Message::new();
-        msg.set_channel_id(Vec::from(initiator.binding()));
-        msg.set_data(ciphertext);
-
-        enclave
-            .client_tx_propose_v2(msg.into())
-            .expect("unexpected failure to propose tx");
-
-        // Now, let's screw with the fee_map_digest
-        fee_map_digest[0] = !fee_map_digest[0];
-
-        let req = ClientProposeTxRequestV2 {
-            tx: tx.clone(),
-            fee_map_digest,
-        };
-
-        let tx_ciphertext = initiator.encrypt(&[], &encode(&req)).unwrap();
-
-        let mut msg = Message::new();
-        msg.set_channel_id(Vec::from(initiator.binding()));
-        msg.set_data(tx_ciphertext);
-
-        let result = enclave.client_tx_propose_v2(msg.into());
-        assert!(result.is_err(), "unexpected success with bad fee map");
     }
 
     #[test_with_logger]

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -49,7 +49,7 @@ use mc_consensus_enclave_api::{
     BlockchainConfig, BlockchainConfigWithDigest, ConsensusEnclave, Error, FeeMap, FeePublicKey,
     FormBlockInputs, GovernorsVerifier, LocallyEncryptedTx, Result, SealedBlockSigningKey,
     TxContext, WellFormedEncryptedTx, WellFormedTxContext, SMALLEST_MINIMUM_FEE_LOG2,
-    ClientProposeTxRequest,
+    ClientProposeTxRequestV2,
 };
 use mc_crypto_ake_enclave::AkeEnclaveState;
 use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
@@ -645,7 +645,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let req_bytes = self.ake.client_decrypt(msg)?;
 
         // Try and deserialize.
-        let req: ClientProposeTxRequest = mc_util_serial::decode(&req_bytes)?;
+        let req: ClientProposeTxRequestV2 = mc_util_serial::decode(&req_bytes)?;
 
         if &req.fee_map_digest[..] != &self
             .blockchain_config

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -647,8 +647,8 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Try and deserialize.
         let req: ClientProposeTxRequestV2 = mc_util_serial::decode(&req_bytes)?;
 
-        if &req.fee_map_digest[..]
-            != &self
+        if req.fee_map_digest[..]
+            != self
                 .blockchain_config
                 .get()
                 .ok_or(Error::NotInitialized)?

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -201,6 +201,10 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         Ok(TxContext::default())
     }
 
+    fn client_tx_propose_v2(&self, _msg: EnclaveMessage<ClientSession>) -> Result<TxContext> {
+        Ok(TxContext::default())
+    }
+
     fn peer_tx_propose(&self, _msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>> {
         Ok(Vec::default())
     }

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -63,6 +63,8 @@ mock! {
 
         fn client_tx_propose(&self, msg: EnclaveMessage<ClientSession>) -> ConsensusEnclaveResult<TxContext>;
 
+        fn client_tx_propose_v2(&self, msg: EnclaveMessage<ClientSession>) -> ConsensusEnclaveResult<TxContext>;
+
         fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> ConsensusEnclaveResult<Vec<TxContext>>;
 
         fn tx_is_well_formed(

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -219,6 +219,12 @@ impl ConsensusEnclave for ConsensusServiceSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
+    fn client_tx_propose_v2(&self, msg: EnclaveMessage<ClientSession>) -> Result<TxContext> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::ClientTxProposeV2(msg))?;
+        let outbuf = self.enclave_call(&inbuf)?;
+        mc_util_serial::deserialize(&outbuf[..])?
+    }
+
     fn peer_tx_propose(&self, msg: EnclaveMessage<PeerSession>) -> Result<Vec<TxContext>> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::PeerTxPropose(msg))?;
         let outbuf = self.enclave_call(&inbuf)?;

--- a/consensus/enclave/tests/enclave_api_tests.rs
+++ b/consensus/enclave/tests/enclave_api_tests.rs
@@ -1,0 +1,141 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use aes_gcm::Aes256Gcm;
+use mc_attest_ake::{AuthResponseInput, ClientInitiate, Start, Transition};
+use mc_attest_api::attest::{AuthMessage, Message};
+use mc_attest_net::{Client, RaClient};
+use mc_common::{
+    logger::{test_with_logger, Logger},
+    ResponderId,
+};
+use mc_consensus_enclave::{ConsensusEnclave, ConsensusServiceSgxEnclave, ENCLAVE_FILE};
+use mc_consensus_enclave_api::{BlockchainConfig, ClientProposeTxRequestV2, FeeMap};
+use mc_crypto_keys::X25519;
+use mc_crypto_rand::McRng;
+use mc_fog_test_infra::get_enclave_path;
+use mc_ledger_db::{
+    test_utils::{create_ledger, create_transaction, initialize_ledger},
+    Ledger,
+};
+use mc_sgx_report_cache_untrusted::ReportCache;
+use mc_transaction_core::{AccountKey, BlockVersion};
+use mc_util_metrics::IntGauge;
+use mc_util_serial::encode;
+use sha2::Sha512;
+use std::str::FromStr;
+
+lazy_static::lazy_static! {
+    pub static ref DUMMY_INT_GAUGE: IntGauge = IntGauge::new("foo".to_string(), "bar".to_string()).unwrap();
+}
+
+/// Test that we can exercise client_tx_propose_v2 and that it passes and fails
+/// as expected.
+#[test_with_logger]
+fn consensus_enclave_client_tx_propose_v2(logger: Logger) {
+    let mut rng = McRng::default();
+
+    let responder_id = ResponderId::from_str("127.0.0.1:3000").unwrap();
+    let block_version = BlockVersion::MAX;
+    let fee_map = FeeMap::default();
+
+    let blockchain_config = BlockchainConfig {
+        block_version,
+        fee_map: fee_map.clone(),
+        ..Default::default()
+    };
+
+    let (enclave, _, _) = ConsensusServiceSgxEnclave::new(
+        get_enclave_path(ENCLAVE_FILE),
+        &responder_id,
+        &responder_id,
+        &None,
+        blockchain_config,
+    );
+
+    // Update enclave report cache, using SIM or HW-mode RA client as appropriate
+    let ias_spid = Default::default();
+    let ias_api_key = core::str::from_utf8(&[0u8; 64]).unwrap();
+    let ias_client = Client::new(&ias_api_key).expect("Could not create IAS client");
+
+    let report_cache = ReportCache::new(
+        enclave.clone(),
+        ias_client,
+        ias_spid,
+        &DUMMY_INT_GAUGE,
+        logger,
+    );
+    report_cache.start_report_cache().unwrap();
+    report_cache.update_enclave_report_cache().unwrap();
+
+    // First, create an encrypted connection from a client
+    let initiator = Start::new(responder_id.to_string());
+    let init_input = ClientInitiate::<X25519, Aes256Gcm, Sha512>::default();
+    let (initiator, auth_request_output) = initiator.try_next(&mut rng, init_input).unwrap();
+
+    let auth_request_msg = AuthMessage::from(auth_request_output);
+    let (auth_response_msg, _client_session) =
+        enclave.client_accept(auth_request_msg.into()).unwrap();
+    let auth_response_msg = AuthMessage::from(auth_response_msg);
+
+    // Now the client should have a working cipher state
+    let verifier = Default::default();
+    let auth_response_event = AuthResponseInput::new(auth_response_msg.into(), verifier);
+    let (mut initiator, _verification_report) =
+        initiator.try_next(&mut rng, auth_response_event).unwrap();
+
+    // Create a valid test transaction.
+    let sender = AccountKey::random(&mut rng);
+    let recipient = AccountKey::random(&mut rng);
+
+    let mut ledger = create_ledger();
+    let n_blocks = 3;
+    initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+
+    // Choose a TxOut to spend. Only the TxOut in the last block is unspent.
+    let block_contents = ledger.get_block_contents(n_blocks - 1).unwrap();
+    let tx_out = block_contents.outputs[0].clone();
+
+    let tx = create_transaction(
+        block_version,
+        &mut ledger,
+        &tx_out,
+        &sender,
+        &recipient.default_subaddress(),
+        n_blocks + 1,
+        &mut rng,
+    );
+
+    // Try to propose the Tx
+    let mut fee_map_digest = fee_map.canonical_digest().to_vec();
+    let req = ClientProposeTxRequestV2 {
+        tx: tx.clone(),
+        fee_map_digest: fee_map_digest.clone(),
+    };
+
+    let ciphertext = initiator.encrypt(&[], &encode(&req)).unwrap();
+
+    let mut msg = Message::new();
+    msg.set_channel_id(Vec::from(initiator.binding()));
+    msg.set_data(ciphertext);
+
+    enclave
+        .client_tx_propose_v2(msg.into())
+        .expect("unexpected failure to propose tx");
+
+    // Now, let's screw with the fee_map_digest
+    fee_map_digest[0] = !fee_map_digest[0];
+
+    let req = ClientProposeTxRequestV2 {
+        tx: tx.clone(),
+        fee_map_digest,
+    };
+
+    let tx_ciphertext = initiator.encrypt(&[], &encode(&req)).unwrap();
+
+    let mut msg = Message::new();
+    msg.set_channel_id(Vec::from(initiator.binding()));
+    msg.set_data(tx_ciphertext);
+
+    let result = enclave.client_tx_propose_v2(msg.into());
+    assert!(result.is_err(), "unexpected success with bad fee map");
+}

--- a/consensus/enclave/tests/enclave_api_tests.rs
+++ b/consensus/enclave/tests/enclave_api_tests.rs
@@ -55,7 +55,7 @@ fn consensus_enclave_client_tx_propose_v2(logger: Logger) {
     // Update enclave report cache, using SIM or HW-mode RA client as appropriate
     let ias_spid = Default::default();
     let ias_api_key = core::str::from_utf8(&[0u8; 64]).unwrap();
-    let ias_client = Client::new(&ias_api_key).expect("Could not create IAS client");
+    let ias_client = Client::new(ias_api_key).expect("Could not create IAS client");
 
     let report_cache = ReportCache::new(
         enclave.clone(),
@@ -125,10 +125,7 @@ fn consensus_enclave_client_tx_propose_v2(logger: Logger) {
     // Now, let's screw with the fee_map_digest
     fee_map_digest[0] = !fee_map_digest[0];
 
-    let req = ClientProposeTxRequestV2 {
-        tx: tx.clone(),
-        fee_map_digest,
-    };
+    let req = ClientProposeTxRequestV2 { tx, fee_map_digest };
 
     let tx_ciphertext = initiator.encrypt(&[], &encode(&req)).unwrap();
 

--- a/consensus/enclave/tests/graceful_teardown.rs
+++ b/consensus/enclave/tests/graceful_teardown.rs
@@ -29,7 +29,7 @@ fn consensus_enclave_graceful_teardown(logger: Logger) {
 
     let blockchain_config = BlockchainConfig {
         block_version,
-        fee_map: fee_map.clone(),
+        fee_map,
         ..Default::default()
     };
 
@@ -46,7 +46,7 @@ fn consensus_enclave_graceful_teardown(logger: Logger) {
         // Update enclave report cache, using SIM or HW-mode RA client as appropriate
         let ias_spid = Default::default();
         let ias_api_key = core::str::from_utf8(&[0u8; 64]).unwrap();
-        let ias_client = Client::new(&ias_api_key).expect("Could not create IAS client");
+        let ias_client = Client::new(ias_api_key).expect("Could not create IAS client");
 
         let report_cache = ReportCache::new(
             enclave.clone(),

--- a/consensus/enclave/tests/graceful_teardown.rs
+++ b/consensus/enclave/tests/graceful_teardown.rs
@@ -1,0 +1,39 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use mc_common::{
+    logger::{log, test_with_logger, Logger},
+    ResponderId,
+};
+use mc_consensus_enclave::{ConsensusServiceSgxEnclave, ENCLAVE_FILE};
+use mc_fog_test_infra::get_enclave_path;
+use std::str::FromStr;
+
+const NUM_TRIALS: usize = 3;
+
+/// Test that we can create and destroy the consensus enclave repeatedly without
+/// crashing
+#[test_with_logger]
+fn consensus_enclave_graceful_teardown(logger: Logger) {
+    let responder_id = ResponderId::from_str("127.0.0.1:3000").unwrap();
+    let block_version = BlockVersion::MAX;
+    let fee_map = FeeMap::default();
+
+    let blockchain_config = BlockchainConfig {
+        block_version,
+        fee_map: fee_map.clone(),
+        ..Default::default()
+    };
+
+    for reps in 0..NUM_TRIALS {
+        log::info!(logger, "Trial {}/{}", reps + 1, NUM_TRIALS);
+        let _enclave = ConsensusServiceSgxEnclave::new(
+            get_enclave_path(ENCLAVE_FILE),
+            &responder_id,
+            &responder_id,
+            None,
+            blockchain_config,
+            &logger,
+        )
+        .expect("could not initialize enclave");
+    }
+}

--- a/consensus/enclave/tests/graceful_teardown.rs
+++ b/consensus/enclave/tests/graceful_teardown.rs
@@ -1,17 +1,26 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
+use mc_attest_net::{Client, RaClient};
 use mc_common::{
     logger::{log, test_with_logger, Logger},
     ResponderId,
 };
 use mc_consensus_enclave::{ConsensusServiceSgxEnclave, ENCLAVE_FILE};
+use mc_consensus_enclave_api::{BlockchainConfig, FeeMap};
 use mc_fog_test_infra::get_enclave_path;
+use mc_sgx_report_cache_untrusted::ReportCache;
+use mc_transaction_core::BlockVersion;
+use mc_util_metrics::IntGauge;
 use std::str::FromStr;
 
 const NUM_TRIALS: usize = 3;
 
+lazy_static::lazy_static! {
+    pub static ref DUMMY_INT_GAUGE: IntGauge = IntGauge::new("foo".to_string(), "bar".to_string()).unwrap();
+}
+
 /// Test that we can create and destroy the consensus enclave repeatedly without
-/// crashing
+/// crashing. Given the amount of unsafe C code involved, this is worth testing.
 #[test_with_logger]
 fn consensus_enclave_graceful_teardown(logger: Logger) {
     let responder_id = ResponderId::from_str("127.0.0.1:3000").unwrap();
@@ -26,14 +35,27 @@ fn consensus_enclave_graceful_teardown(logger: Logger) {
 
     for reps in 0..NUM_TRIALS {
         log::info!(logger, "Trial {}/{}", reps + 1, NUM_TRIALS);
-        let _enclave = ConsensusServiceSgxEnclave::new(
+        let (enclave, _, _) = ConsensusServiceSgxEnclave::new(
             get_enclave_path(ENCLAVE_FILE),
             &responder_id,
             &responder_id,
-            None,
-            blockchain_config,
-            &logger,
-        )
-        .expect("could not initialize enclave");
+            &None,
+            blockchain_config.clone(),
+        );
+
+        // Update enclave report cache, using SIM or HW-mode RA client as appropriate
+        let ias_spid = Default::default();
+        let ias_api_key = core::str::from_utf8(&[0u8; 64]).unwrap();
+        let ias_client = Client::new(&ias_api_key).expect("Could not create IAS client");
+
+        let report_cache = ReportCache::new(
+            enclave.clone(),
+            ias_client,
+            ias_spid,
+            &DUMMY_INT_GAUGE,
+            logger.clone(),
+        );
+        report_cache.start_report_cache().unwrap();
+        report_cache.update_enclave_report_cache().unwrap();
     }
 }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -707,14 +707,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1218,11 +1218,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1253,29 +1253,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1304,14 +1304,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1319,11 +1319,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1359,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1403,14 +1403,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.0.0"
+version = "2.1.0-pre0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -707,14 +707,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "bitflags",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -886,12 +886,13 @@ dependencies = [
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",
+ "prost",
  "serde",
 ]
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -899,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -931,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -962,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -974,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -994,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "digest",
@@ -1008,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1017,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1030,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1039,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1048,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1057,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1086,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1099,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1109,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1129,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1138,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1162,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1183,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1194,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1217,11 +1218,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1231,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1244,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1252,29 +1253,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1285,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1293,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1303,14 +1304,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1318,11 +1319,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1358,7 +1359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1369,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1380,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1391,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1402,14 +1403,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1419,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -1428,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "2.0.0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -68,6 +68,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
         // Transactions
         EnclaveCall::ClientTxPropose(msg) => serialize(&ENCLAVE.client_tx_propose(msg)),
+        EnclaveCall::ClientTxProposeV2(msg) => serialize(&ENCLAVE.client_tx_propose_v2(msg)),
         EnclaveCall::PeerTxPropose(msg) => serialize(&ENCLAVE.peer_tx_propose(msg)),
         EnclaveCall::TxIsWellFormed(locally_encrypted_tx, block_index, proofs) => {
             serialize(&ENCLAVE.tx_is_well_formed(locally_encrypted_tx, block_index, proofs))

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -22,6 +22,7 @@ mc-common = { path = "../../common", features = ["log"] }
 mc-connection = { path = "../../connection" }
 mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-enclave = { path = "../../consensus/enclave" }
+mc-consensus-enclave-api = { path = "../../consensus/enclave/api" }
 mc-consensus-scp = { path = "../../consensus/scp" }
 mc-consensus-service-config = { path = "config" }
 mc-crypto-digestible = { path = "../../crypto/digestible" }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -20,6 +20,7 @@ use mc_consensus_api::{
     empty::Empty,
 };
 use mc_consensus_enclave::ConsensusEnclave;
+use mc_consensus_enclave_api::Error as EnclaveError;
 use mc_consensus_service_config::Config;
 use mc_ledger_db::Ledger;
 use mc_peers::ConsensusValue;
@@ -83,15 +84,11 @@ impl ClientApiService {
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
         let tx_context = self.enclave.client_tx_propose(msg.into())?;
-        let mut response = ProposeTxResponse::new();
 
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {
             if let TxManagerError::TransactionValidation(cause) = &err {
                 counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
-                let result = ProposeTxResult::from(cause.clone());
-                response.set_result(result);
-                response.set_err_msg(cause.to_string());
             }
             err
         })?;
@@ -104,6 +101,8 @@ impl ClientApiService {
         // The transaction can be considered by the network.
         (*self.propose_tx_callback)(ConsensusValue::TxHash(tx_hash), None, None);
         counters::ADD_TX.inc();
+
+        let response = ProposeTxResponse::new();
         Ok(response)
     }
 
@@ -117,16 +116,23 @@ impl ClientApiService {
         msg: Message,
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
-        let tx_context = self.enclave.client_tx_propose_v2(msg.into())?;
-        let mut response = ProposeTxResponse::new();
+        let tx_context = match self.enclave.client_tx_propose_v2(msg.into()) {
+            Ok(tx_context) => tx_context,
+            Err(EnclaveError::FeeMapDigestMismatch) => {
+                let mut response = ProposeTxResponse::new();
+                response.set_result(ProposeTxResult::FeeMapDigestMismatch);
+                response.set_err_msg(EnclaveError::FeeMapDigestMismatch.to_string());
+                return Ok(response);
+            }
+            Err(err) => {
+                return Err(err.into());
+            }
+        };
 
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {
             if let TxManagerError::TransactionValidation(cause) = &err {
                 counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
-                let result = ProposeTxResult::from(cause.clone());
-                response.set_result(result);
-                response.set_err_msg(cause.to_string());
             }
             err
         })?;
@@ -139,6 +145,8 @@ impl ClientApiService {
         // The transaction can be considered by the network.
         (*self.propose_tx_callback)(ConsensusValue::TxHash(tx_hash), None, None);
         counters::ADD_TX.inc();
+
+        let response = ProposeTxResponse::new();
         Ok(response)
     }
 

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -139,6 +139,7 @@ impl From<ConsensusGrpcError> for Result<ProposeTxResponse, RpcStatus> {
         match src {
             ConsensusGrpcError::TransactionValidation(err) => {
                 let mut resp = ProposeTxResponse::new();
+                resp.set_err_msg(err.to_string());
                 resp.set_result(ProposeTxResult::from(err));
                 Ok(resp)
             }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -924,7 +924,6 @@ impl Client {
         // told us the block version has increased.
         if let Some(block_info_cache) = self.block_info_cache.as_ref() {
             if block_info_cache.network_block_version != self.tx_data.get_latest_block_version() {
-                drop(block_info_cache);
                 self.block_info_cache = None;
             }
         }

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -148,7 +148,7 @@ pub enum Error {
     FogMerkleProof(String),
 
     /// Fee Map: {0}
-    FeeMap(FeeMapError)
+    FeeMap(FeeMapError),
 }
 
 impl From<ConnectionError> for Error {

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -3,7 +3,7 @@
 //! MobileCoin SDK Errors
 
 use displaydoc::Display;
-use mc_connection::{Error as ConnectionError, ProposeTxResult};
+use mc_connection::{Error as ConnectionError, FeeMapError, ProposeTxResult};
 use mc_consensus_api::ConversionError;
 use mc_crypto_keys::KeyError;
 use mc_fog_enclave_connection::Error as EnclaveConnectionError;
@@ -146,6 +146,9 @@ pub enum Error {
 
     /// Fog merkle proof: {0}
     FogMerkleProof(String),
+
+    /// Fee Map: {0}
+    FeeMap(FeeMapError)
 }
 
 impl From<ConnectionError> for Error {
@@ -154,6 +157,12 @@ impl From<ConnectionError> for Error {
             ConnectionError::TransactionValidation(tve, msg) => Error::TxRejected(tve, msg),
             other => Error::ConsensusConnection(other),
         }
+    }
+}
+
+impl From<FeeMapError> for Error {
+    fn from(x: FeeMapError) -> Error {
+        Error::FeeMap(x)
     }
 }
 


### PR DESCRIPTION
TOB-MCCT-5 is about a "token id oracle" described by TOB during review of confidential tokens design. The idea is that the consensus enclave fee map can be changed by the untrusted side, by restarting the node. If the attacker controls a node and is able to get the user to submit their Tx once with one fee map, and once with another, then the priority value leaks information about what the token id of the Tx is.

In principle they could do this without the user knowing -- they would restart the node and it would not be able to attest to the peers after changing the fee map, but it could still accept Tx proposals and see the WellFormedTxContext which conatins the priority number. Then they turn the node back to normal. The user's app retries when their transaction doesn't land, and the same Tx comes back to their node, now with the regular fee map.

This requires having root on a consensus node, but the threat model is that attackers with root on the consensus node should not be able to see the user's token id.

We view this as a time-of-check-vs-time-of-use ([TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)) bug, and we try to fix it a way that those bugs are sometimes fixed. The user, who checked the fee map, also makes an assertion about what the fee-map is when they try to use the system (by submitting a Tx). Before acting on the data (which the attacker has potentially tampered with), the enclave checks if the user's assertion is correct, and rejects the Tx without creating a WellFormedTxContext if the assertion is not correct. (This is sort of like dealing with races when manipulating atomic variables by using compare-and-swap.)

It should be straightforward to add this check, but unfortunately, the status quo `client_propose_tx` has a design flaw. It does not have a `Request` protobuf as the RPC argument, the argument it takes is directly an (encrypted) Tx. So, we cannot add any additional data to that protobuf in a non-breaking way without adding things to `Tx`. And that is untenable in this case because it adds complexity in sensitive areas of the code. We really just want to add this check next to the `Tx`.

To fix this, we introduce a `ClientProposeTxRequest` object, which contains a `Tx`, and the client's minimum fee map digest. We introduce `client_propose_tx_v2` which encrypts this `Request` object instead of a naked `Tx`. This will come in handy if we want to add anything else like this in the future.

Clients will not be able to use `client_propose_tx_v2` until after the V3 service is live, because existing consensus nodes don't have this endpoint. However, in the next release of clients after the v3 release is live, they could all start using `client_propose_tx_v2` and we could deprecate / remove `client_propose_tx`.

I made the fog-sample-paykit exercise the `client_propose_tx_v2` route, since the test client uses that and so we can see that it is working in CD without making `mobilecoind` or anything else use it yet.

I am not sure if this change requires an MCIP. It is a protocol / api change, but not a big one, and users are unlikely to notice. If it does require an MCIP we can write one pretty easily. Let me know what you think.

Also, lmk if you think there's a better approach than the route I took here.