### PR TITLE
Make mc_ledger_db::Error implement Debug by forwarding to Display

### DIFF
--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -96,10 +96,10 @@ pub enum Error {
 //
 // This is somewhat unusual, but the main reason is, lmdb::error::Other(c_int)
 // is very opaque in the Debug output, and displays a nice human readable string
-// in the Display output. The debug output often occurs when we call LedgerDb::open
-// and it fails because of an OS issue, and this error is unwrapped, which is very
-// typical. This change will make it show e.g "file not found" or "permission denied"
-// instead of obscure errno codes.
+// in the Display output. The debug output often occurs when we call
+// LedgerDb::open and it fails because of an OS issue, and this error is
+// unwrapped, which is very typical. This change will make it show e.g "file not
+// found" or "permission denied" instead of obscure errno codes.
 impl core::fmt::Debug for Error {
     fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         <Self as core::fmt::Display>::fmt(self, formatter)

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -6,7 +6,7 @@ use mc_transaction_core::membership_proofs::RangeError;
 use mc_util_lmdb::MetadataStoreError;
 
 /// A Ledger error kind.
-#[derive(Debug, Eq, PartialEq, Clone, Display)]
+#[derive(Clone, Display, Eq, PartialEq)]
 pub enum Error {
     /// Record not found
     NotFound,
@@ -90,6 +90,20 @@ pub enum Error {
 
     /// Missing masked amonut
     MissingMaskedAmount,
+}
+
+// Implement Debug by forwarding to Display
+//
+// This is somewhat unusual, but the main reason is, lmdb::error::Other(c_int)
+// is very opaque in the Debug output, and displays a nice human readable string
+// in the Display output. The debug output often occurs when we call LedgerDb::open
+// and it fails because of an OS issue, and this error is unwrapped, which is very
+// typical. This change will make it show e.g "file not found" or "permission denied"
+// instead of obscure errno codes.
+impl core::fmt::Debug for Error {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        <Self as core::fmt::Display>::fmt(self, formatter)
+    }
 }
 
 impl From<lmdb::Error> for Error {

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
     /// Too few outputs
     TooFewOutputs,
 
-    /// LMDB error, may mean database is opened multiple times in a process.
+    /// BadRslot, may mean database is opened multiple times in a process.
     BadRslot,
 
     /// Capacity exceeded


### PR DESCRIPTION
This may be controversial, but I think this may be a good change to make in this particular case.

The goal is to fix #2666.

A lot of our code takes a path to a `LedgerDb` as a command line argument. Then it calls `LedgerDb::open` on that path and unwraps any errors.

LMDB is a C library, and if it encounters any libc errors these get returned as `lmdb::Error::Other(c_int)`.

If we Display this error, it will call `mdb_strerror`:

https://docs.rs/lmdb-rkv/latest/src/lmdb/error.rs.html#127

http://www.lmdb.tech/doc/group__mdb.html#ga569e66c1e3edc1a6016b86719ee3d098

Which will decide if it is an lmdb error or a libc error, and in the latter case call `strerror` and in the former case do something appropriate for the lmdb error.

If we print this error as `Debug`, it will do none of that, it just gives us the `c_int`, and many developers aren't sure what to make of `Lmdb(Other(2))` or `Lmdb(Other(13))`.

Sometimes they will start trying to match these numbers to this list:

https://docs.rs/lmdb-rkv/latest/lmdb/enum.Error.html

which is reasonable but will lead them totally down the wrong path.

The problem is that `unwrap` and `expect` both use the `Debug` output for the error instead of the `Display` output.

We could try to rewrite all the unwraps of `LedgerDb` errors, but
(1) there a lot of them
(2) since the derived `Debug` output is so much worse than the `Display` output, it seems like it might be better not derive `Debug` and make `Debug` forward to `Display`.

It's hard for me to see a downside to that except that it's somewhat unusual, and I see significant upside in this particular case.
I don't think there's a way to accomplish this goal with a smaller code change -- another option might be wrapping `lmdb::Error` with a newtype wrapper that customizes it's `Debug` output only for the `Other` case. That route will introduce a lot of boilerplate for the newtype in many places, and I'm not sure that the formatting changes that would lead to are actually noticeably different or preferable compared to this approach.