### PR TITLE
Signature Verification in Mint Client

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -28,11 +28,11 @@ fn main() {
     match config.command {
         Commands::CheckSig {
             signature,
-	    contents,
-	    pubkey,
-	} => {
-	    let result = pubkey.verify(&contents.unwrap(), &signature);
-	    println!("Verification result = {:?}", result);
+            contents,
+            pubkey,
+        } => {
+            let result = pubkey.verify(&contents.unwrap(), &signature);
+            println!("Verification result = {:?}", result);
         }
 
         Commands::GenerateAndSubmitMintConfigTx {

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -28,10 +28,10 @@ fn main() {
     match config.command {
         Commands::CheckSig {
             signature,
-            contents,
+            digest,
             pubkey,
         } => {
-            let result = pubkey.verify(&contents.unwrap(), &signature);
+            let result = pubkey.verify(&digest.unwrap(), &signature);
             println!("Verification result = {:?}", result);
         }
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -31,7 +31,7 @@ fn main() {
             digest,
             pubkey,
         } => {
-            let result = pubkey.verify(&digest.unwrap(), &signature);
+            let result = pubkey.verify(&digest, &signature);
             println!("Verification result = {:?}", result);
         }
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -31,9 +31,8 @@ fn main() {
 	    contents,
 	    pubkey,
 	} => {
-	    println!("\x1b[33m NOW VERIFYING\x1b[0m");
 	    let result = pubkey.verify(&contents.unwrap(), &signature);
-	    println!("\x1b[32m RESULT = {:?}", result);
+	    println!("Verification result = {:?}", result);
         }
 
         Commands::GenerateAndSubmitMintConfigTx {

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -11,7 +11,7 @@ use mc_consensus_api::{
 };
 use mc_consensus_enclave_api::GovernorsSigner;
 use mc_consensus_mint_client::{printers, Commands, Config, TxFile};
-use mc_crypto_keys::{Ed25519Pair, Signer};
+use mc_crypto_keys::{Ed25519Pair, Signer, Verifier};
 use mc_crypto_multisig::MultiSig;
 use mc_transaction_core::{
     constants::MAX_TOMBSTONE_BLOCKS,
@@ -26,6 +26,16 @@ fn main() {
     let config = Config::parse();
 
     match config.command {
+        Commands::CheckSig {
+            signature,
+	    contents,
+	    pubkey,
+	} => {
+	    println!("\x1b[33m NOW VERIFYING\x1b[0m");
+	    let result = pubkey.verify(&contents.unwrap(), &signature);
+	    println!("\x1b[32m RESULT = {:?}", result);
+        }
+
         Commands::GenerateAndSubmitMintConfigTx {
             node,
             params,

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -230,8 +230,10 @@ impl MintTxParams {
 }
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Verify whether a signature over given contents verifies with the provided pubkey.
     #[clap(arg_required_else_help = true)]
     CheckSig {
+        /// The signature to verify.
         #[clap(
             long = "signature",
             use_value_delimiter = true,
@@ -239,13 +241,14 @@ pub enum Commands {
         )]
         signature: Ed25519Signature,
 
+	/// The contents that were signed.
         #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_CONTENTS")]
         contents: Option<[u8; 32]>,
 
+	/// The public key to verify with the signature.
         #[clap(long = "public-key", parse(try_from_str = load_pub_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
          pubkey: Ed25519Public,
     },
-
 
     /// Generate and submit a MintConfigTx transaction.
     #[clap(arg_required_else_help = true)]

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -252,7 +252,7 @@ pub enum Commands {
 
         /// The public key to verify with the signature.
 	///
-	/// This pemfile is created with `ledger-agent -e ed25519 --pemout <outfile>.pub <key_identifier>`
+	/// This pemfile can be created with `ledger-agent -e ed25519 --pemout <outfile>.pub <key_identifier>`
         #[clap(long = "public-key", parse(try_from_str = load_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
         pubkey: Ed25519Public,
     },

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -235,6 +235,8 @@ pub enum Commands {
     #[clap(arg_required_else_help = true)]
     CheckSig {
         /// The signature to verify.
+	///
+	/// This signature is created with `ledger-agent -e ed25519 --sign-blob <hash> <key_identifier>`
         #[clap(
             long = "signature",
             use_value_delimiter = true,
@@ -242,11 +244,15 @@ pub enum Commands {
         )]
         signature: Ed25519Signature,
 
-        /// The contents that were signed.
-        #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_CONTENTS")]
-        contents: Option<[u8; 32]>,
+        /// The digest (hash of the tokens.toml) that was signed.
+	///
+	/// This digest is created with `mint-client hash-tx-file --tx-file mintconfig.json`
+        #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_DIGEST")]
+        digest: Option<[u8; 32]>,
 
         /// The public key to verify with the signature.
+	///
+	/// This pemfile is created with `ledger-agent -e ed25519 --pemout <outfile>.pub <key_identifier>`
         #[clap(long = "public-key", parse(try_from_str = load_pub_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
         pubkey: Ed25519Public,
     },

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -230,7 +230,8 @@ impl MintTxParams {
 }
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Verify whether a signature over given contents verifies with the provided pubkey.
+    /// Verify whether a signature over given contents verifies with the
+    /// provided pubkey.
     #[clap(arg_required_else_help = true)]
     CheckSig {
         /// The signature to verify.
@@ -241,13 +242,13 @@ pub enum Commands {
         )]
         signature: Ed25519Signature,
 
-	/// The contents that were signed.
+        /// The contents that were signed.
         #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_CONTENTS")]
         contents: Option<[u8; 32]>,
 
-	/// The public key to verify with the signature.
+        /// The public key to verify with the signature.
         #[clap(long = "public-key", parse(try_from_str = load_pub_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
-         pubkey: Ed25519Public,
+        pubkey: Ed25519Public,
     },
 
     /// Generate and submit a MintConfigTx transaction.

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -244,9 +244,9 @@ pub enum Commands {
         )]
         signature: Ed25519Signature,
 
-        /// The digest (hash of the tokens.toml) that was signed.
+        /// The digest that was signed.
 	///
-	/// This digest is created with `mint-client hash-tx-file --tx-file mintconfig.json`
+	/// An example digest may be created with `mint-client hash-tx-file --tx-file mintconfig.json`
         #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_DIGEST")]
         digest: [u8; 32],
 

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -248,7 +248,7 @@ pub enum Commands {
 	///
 	/// This digest is created with `mint-client hash-tx-file --tx-file mintconfig.json`
         #[clap(long, parse(try_from_str = FromHex::from_hex), env = "MC_MINTING_DIGEST")]
-        digest: Option<[u8; 32]>,
+        digest: [u8; 32],
 
         /// The public key to verify with the signature.
 	///

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -253,7 +253,7 @@ pub enum Commands {
         /// The public key to verify with the signature.
 	///
 	/// This pemfile is created with `ledger-agent -e ed25519 --pemout <outfile>.pub <key_identifier>`
-        #[clap(long = "public-key", parse(try_from_str = load_pub_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
+        #[clap(long = "public-key", parse(try_from_str = load_key_from_pem), env = "MC_MINTING_PUBLIC_KEY")]
         pubkey: Ed25519Public,
     },
 
@@ -437,25 +437,14 @@ pub struct Config {
     pub command: Commands,
 }
 
-pub fn load_pub_key_from_pem(filename: &str) -> Result<Ed25519Public, String> {
+pub fn load_key_from_pem<K: DistinguishedEncoding>(filename: &str) -> Result<K, String> {
     let bytes =
         fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
 
     let parsed_pem = pem::parse(&bytes)
         .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
 
-    Ed25519Public::try_from_der(&parsed_pem.contents[..])
-        .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))
-}
-
-pub fn load_key_from_pem(filename: &str) -> Result<Ed25519Private, String> {
-    let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
-
-    let parsed_pem = pem::parse(&bytes)
-        .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
-
-    Ed25519Private::try_from_der(&parsed_pem.contents[..])
+    K::try_from_der(&parsed_pem.contents[..])
         .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))
 }
 

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -236,7 +236,7 @@ pub enum Commands {
     CheckSig {
         /// The signature to verify.
 	///
-	/// This signature is created with `ledger-agent -e ed25519 --sign-blob <hash> <key_identifier>`
+	/// This signature can be created with `ledger-agent -e ed25519 --sign-blob <hash> <key_identifier>`
         #[clap(
             long = "signature",
             use_value_delimiter = true,


### PR DESCRIPTION
### Motivation

The users of the mint client will need to verify signatures if there is an issue with any of the steps in the process. 

Example usage:

```
RUST_LOG=warn ./target/release/mc-consensus-mint-client check-sig --signature ee8a35ce960dd392b6c5894fe2717f6b4c87c991c5fbf12df210b5c55952a40f658ee505714755185b796a710649797ea8e16fe11f47dc7bf994380e969f8ada --digest b3b5255e08383972386303ca0a963f6c3edad5df3819c210d36fd378c9d9a43e --public-key key.pub
```

