### PR TITLE
improve fog ingest logging when unique constraint is violated

### DIFF
--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -625,10 +625,13 @@ impl SqlRecoveryDb {
             // errors.
             Err(Error::Orm(diesel::result::Error::DatabaseError(
                 diesel::result::DatabaseErrorKind::UniqueViolation,
-                _,
-            ))) => Ok(AddBlockDataStatus {
-                block_already_scanned_with_this_key: true,
-            }),
+                details,
+            ))) => {
+                log::info!(self.logger, "Unique constraint violated when adding block {} for ingest invocation id {}: {:?}", block.index, ingest_invocation_id, details);
+                Ok(AddBlockDataStatus {
+                    block_already_scanned_with_this_key: true,
+                })
+            }
             Err(err) => Err(err),
         }
     }


### PR DESCRIPTION
this doesn't happen very often, but when it did happen in testnet, we couldn't figure out why very easily and went database spelunking. we still don't know why, and in the future we want these details logged.