### PR TITLE
Add TxSummary object and incorporate it into MLSAG signing digest

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -612,9 +612,16 @@ message UnsignedTx {
 /// A structure that contains all the data required to sign a transaction that
 /// does not rely on having the spend private key.
 message SigningData {
-    /// The message extended with the range proof and pseudo_output_commitments.
-    /// This ensures that they are signed by each RingMLSAG.
-    bytes extended_message_digest = 1;
+    /// The bytes actually signed by MLSAG signatures.
+    /// This is different depending on what block version we are in.
+    /// * In the oldest block versions, this is a large number of bytes called the
+    ///   "extended message", which includes a tx prefix as well as the pseudo output commitments.
+    /// * In block version 2, this is instead 32 bytes called the "extended message digest".
+    /// * In block version 3, this is instead 32 bytes called the "extended-message-and-tx-summary digest".
+    ///
+    /// Note that SCI's are the exception to this, they sign the digest based on their TxIn instead,
+    /// see MCIP #31 for more on that. Everything that isn't an SCI signs this.
+    bytes mlsag_signing_digest = 1;
 
     /// The actual pseudo output commitments use the blindings from
     /// `pseudo_output_blinding` and not the original true input.

--- a/api/src/convert/signing_data.rs
+++ b/api/src/convert/signing_data.rs
@@ -107,7 +107,7 @@ mod tests {
                 .build_unsigned::<StdRng, DefaultTxOutputsOrdering>()
                 .unwrap();
 
-            let signing_data = unsigned_tx.get_signing_data(&mut rng).unwrap();
+            let (signing_data, _, _) = unsigned_tx.get_signing_data(&mut rng).unwrap();
 
             // Converting mc_transaction_core::ring_ct::SigningData -> external::SigningData
             // -> mc_transaction_core::ring_ct::SigningData should be the identity

--- a/api/src/convert/signing_data.rs
+++ b/api/src/convert/signing_data.rs
@@ -8,7 +8,7 @@ use mc_transaction_core::ring_ct::SigningData;
 impl From<&SigningData> for external::SigningData {
     fn from(src: &SigningData) -> Self {
         let mut signing_data = external::SigningData::new();
-        signing_data.set_extended_message_digest(src.extended_message_digest.clone());
+        signing_data.set_mlsag_signing_digest(src.mlsag_signing_digest.clone());
         signing_data.set_pseudo_output_blindings(
             src.pseudo_output_blindings
                 .iter()
@@ -44,7 +44,7 @@ impl TryFrom<&external::SigningData> for SigningData {
             .map(|commitment| commitment.try_into())
             .collect::<Result<Vec<_>, _>>()?;
         Ok(SigningData {
-            extended_message_digest: src.extended_message_digest.clone(),
+            mlsag_signing_digest: src.mlsag_signing_digest.clone(),
             pseudo_output_blindings,
             pseudo_output_commitments,
             range_proof_bytes: src.range_proof_bytes.clone(),

--- a/transaction/core/src/domain_separators.rs
+++ b/transaction/core/src/domain_separators.rs
@@ -44,6 +44,9 @@ pub const TXOUT_MERKLE_NIL_DOMAIN_TAG: &str = "mc_tx_out_merkle_nil";
 /// Domain separator for computing the extended message digest
 pub const EXTENDED_MESSAGE_DOMAIN_TAG: &str = "mc_extended_message";
 
+/// Domain separator for computing the extended message and tx summary digest
+pub const EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG: &str = "mc_extended_message_and_tx_summary";
+
 /// Domain separator for hashing MintConfigTxPrefixs
 pub const MINT_CONFIG_TX_PREFIX_DOMAIN_TAG: &str = "mc_mint_config_tx_prefix";
 

--- a/transaction/core/src/input_rules.rs
+++ b/transaction/core/src/input_rules.rs
@@ -13,7 +13,7 @@ use crate::{
     tx::{Tx, TxOut},
     BlockVersion, RevealedTxOut, RevealedTxOutError,
 };
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::{collections::BTreeMap, vec::Vec};
 use displaydoc::Display;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::CompressedRistrettoPublic;
@@ -70,17 +70,17 @@ pub struct InputRules {
 }
 
 impl InputRules {
-    /// Get all tx target keys associated to outputs appearing in these rules
-    pub fn associated_tx_target_keys(&self) -> BTreeSet<CompressedRistrettoPublic> {
-        let mut result = BTreeSet::default();
+    /// Get all TxOut's appearing in these rules, keyed by public key
+    pub fn associated_tx_outs(&self) -> BTreeMap<CompressedRistrettoPublic, TxOut> {
+        let mut result = BTreeMap::default();
         for output in self.required_outputs.iter() {
-            result.insert(output.target_key);
+            result.insert(output.public_key, output.clone());
         }
         for output in self.partial_fill_outputs.iter() {
-            result.insert(output.tx_out.target_key);
+            result.insert(output.tx_out.public_key, output.tx_out.clone());
         }
         for output in self.partial_fill_change.iter() {
-            result.insert(output.tx_out.target_key);
+            result.insert(output.tx_out.public_key, output.tx_out.clone());
         }
         result
     }

--- a/transaction/core/src/input_rules.rs
+++ b/transaction/core/src/input_rules.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 The MobileCoin Foundation
+// Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! Input rules, described in MCIP #31, specify any additional criteria that the
 //! Tx must satisfy to be valid.
@@ -18,13 +18,14 @@ use displaydoc::Display;
 use mc_crypto_digestible::Digestible;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// A representation of rules on a transaction, imposed by the signer of some
 /// input in the transaction.
 ///
 /// Any rule could conceivably be added here if it can be evaluated against a
 /// `Tx`.
-#[derive(Clone, Digestible, PartialEq, Eq, Message, Serialize, Deserialize)]
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
 pub struct InputRules {
     /// Outputs that are required to appear in the Tx prefix for the transaction
     /// to be valid

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -44,7 +44,7 @@ pub use revealed_tx_out::{try_reveal_amount, RevealedTxOut, RevealedTxOutError};
 pub use token::{tokens, Token};
 pub use tx::MemoContext;
 pub use tx_error::{NewMemoError, NewTxError, TxOutConversionError, ViewKeyMatchError};
-pub use tx_summary::{TxOutSummary, TxSummary};
+pub use tx_summary::{TxInSummary, TxOutSummary, TxSummary};
 
 // Re-export from transaction-types, and some from RingSignature crate.
 pub use mc_crypto_ring_signature::{Commitment, CompressedCommitment};

--- a/transaction/core/src/lib.rs
+++ b/transaction/core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod mint;
 pub mod range_proofs;
 pub mod ring_ct;
 pub mod tx;
+pub mod tx_summary;
 pub mod validation;
 
 #[cfg(test)]
@@ -43,6 +44,7 @@ pub use revealed_tx_out::{try_reveal_amount, RevealedTxOut, RevealedTxOutError};
 pub use token::{tokens, Token};
 pub use tx::MemoContext;
 pub use tx_error::{NewMemoError, NewTxError, TxOutConversionError, ViewKeyMatchError};
+pub use tx_summary::{TxOutSummary, TxSummary};
 
 // Re-export from transaction-types, and some from RingSignature crate.
 pub use mc_crypto_ring_signature::{Commitment, CompressedCommitment};

--- a/transaction/core/src/revealed_tx_out.rs
+++ b/transaction/core/src/revealed_tx_out.rs
@@ -7,10 +7,11 @@ use mc_crypto_digestible::Digestible;
 use mc_crypto_ring_signature::Scalar;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// A TxOut together with its amount shared secret, which can be used to reveal
 /// the amount and token id and check them against the commitment data
-#[derive(Clone, Digestible, PartialEq, Eq, Message, Serialize, Deserialize)]
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
 pub struct RevealedTxOut {
     /// The TxOut which is being revealed
     #[prost(message, required, tag = "1")]

--- a/transaction/core/src/ring_ct/mod.rs
+++ b/transaction/core/src/ring_ct/mod.rs
@@ -5,6 +5,7 @@
 mod error;
 mod generator_cache;
 mod rct_bulletproofs;
+mod signing_digest;
 
 pub use self::{
     error::Error,
@@ -13,4 +14,5 @@ pub use self::{
         InputRing, OutputSecret, PresignedInputRing, SignatureRctBulletproofs, SignedInputRing,
         SigningData,
     },
+    signing_digest::{compute_mlsag_signing_digest, ExtendedMessageDigest, MLSAGSigningDigest},
 };

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -1045,7 +1045,7 @@ mod rct_bulletproofs_tests {
         ring_signature::{
             generators, Error as RingSignatureError, KeyImage, PedersenGens, ReducedTxOut,
         },
-        tx::TxPrefix,
+        tx::{TxIn, TxPrefix},
         CompressedCommitment, TokenId,
     };
     use alloc::vec::Vec;
@@ -1171,6 +1171,11 @@ mod rct_bulletproofs_tests {
                         blinding,
                     },
                 });
+
+                // This is janky, but needed so that the compute_mlsag_signing_digest
+                // code can find one `TxIn` for each input ring, and determine that
+                // there are no InputRules associated to any of them.
+                tx_prefix.inputs.push(TxIn::default());
             }
 
             // Create one output with the same value as each input.

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -29,10 +29,11 @@ use zeroize::Zeroize;
 
 use crate::{
     constants::FEE_BLINDING,
-    domain_separators::EXTENDED_MESSAGE_DOMAIN_TAG,
+    domain_separators::{EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG, EXTENDED_MESSAGE_DOMAIN_TAG},
     range_proofs::{check_range_proofs, generate_range_proofs},
     ring_ct::{Error, GeneratorCache},
-    Amount, BlockVersion,
+    tx::TxPrefix,
+    Amount, BlockVersion, TxSummary,
 };
 
 /// A presigned RingMLSAG and ancillary data needed to incorporate it into a
@@ -104,8 +105,19 @@ pub struct SignedInputRing {
 /// key and uses that to generate a fully signed transaction.
 #[derive(Clone, Debug, Deserialize, Digestible, Eq, PartialEq, Serialize)]
 pub struct SigningData {
-    /// Transaction extended message.
-    pub extended_message_digest: Vec<u8>,
+    /// The bytes actually signed by MLSAG signatures.
+    /// This is different depending on what block version we are in.
+    /// * In the oldest block versions, this is a large number of bytes called
+    ///   the "extended message".
+    /// * In block version 2, this is instead 32 bytes called the "extended
+    ///   message digest".
+    /// * In block version 3, this is instead 32 bytes called the
+    ///   "extended-message-and-tx-summary digest".
+    ///
+    /// Note that SCI's are the exception to this, they sign the digest based on
+    /// their TxIn instead, see MCIP #31 for more on that. Everything that
+    /// isn't an SCI signs this.
+    pub mlsag_signing_digest: Vec<u8>,
 
     /// Pseudo output blindings.
     pub pseudo_output_blindings: Vec<Scalar>,
@@ -139,7 +151,9 @@ impl SigningData {
     /// # Arguments
     /// * `block_version` - Block version of transaction being signed. This may
     ///   influence details of the signature.
-    /// * `message` - The messages to be signed, e.g. Hash(TxPrefix).
+    /// * `tx_prefix` - This is used to generate the "message" as
+    ///   tx_prefix.hash(), and to generate the TxSummary, which also becomes
+    ///   part of the Digest which MLSAGs sign.
     /// * `rings` - Input rings, each one describing a single input to the
     ///   transaction.
     /// * `output_secrets` - Outputs secret (amount and commitment) for the
@@ -150,7 +164,7 @@ impl SigningData {
     /// * `rng` - randomness
     pub fn new<CSPRNG: RngCore + CryptoRng>(
         block_version: BlockVersion,
-        message: &[u8; 32],
+        tx_prefix: &TxPrefix,
         rings: &[InputRing],
         output_secrets: &[OutputSecret],
         fee: Amount,
@@ -353,11 +367,11 @@ impl SigningData {
             .map(|point| CompressedCommitment::from(&point.compress()))
             .collect();
 
-        // Extend the message with the range proof and pseudo_output_commitments.
-        // This ensures that they are signed by each RingMLSAG.
-        let extended_message_digest = compute_extended_message_either_version(
+        // Compute the mlsag_signing_digest in whatever way is appropriate for this
+        // block version.
+        let mlsag_signing_digest = compute_mlsag_signing_digest(
             block_version,
-            message,
+            tx_prefix,
             &pseudo_output_commitments,
             &range_proof,
             &range_proofs,
@@ -381,7 +395,7 @@ impl SigningData {
         }
 
         Ok(Self {
-            extended_message_digest,
+            mlsag_signing_digest,
             pseudo_output_blindings,
             pseudo_output_commitments,
             range_proof_bytes: range_proof,
@@ -437,7 +451,7 @@ impl SignatureRctBulletproofs {
     ///
     /// # Arguments
     /// * `block_version` - This may influence details of the signature
-    /// * `message` - The messages to be signed, e.g. Hash(TxPrefix).
+    /// * `tx_prefix` - The TxPrefix to be signed
     /// * `rings` - One or more rings of one-time addresses and amount
     ///   commitments.
     /// * `real_input_indices` - The index of the real input in each ring.
@@ -449,7 +463,7 @@ impl SignatureRctBulletproofs {
     /// * `token id` - This determines the pedersen generator for commitments
     pub fn sign<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
         block_version: BlockVersion,
-        message: &[u8; 32],
+        tx_prefix: &TxPrefix,
         input_rings: &[InputRing],
         output_secrets: &[OutputSecret],
         fee: Amount,
@@ -458,7 +472,7 @@ impl SignatureRctBulletproofs {
     ) -> Result<Self, Error> {
         sign_with_balance_check(
             block_version,
-            message,
+            tx_prefix,
             input_rings,
             output_secrets,
             fee,
@@ -472,7 +486,7 @@ impl SignatureRctBulletproofs {
     ///
     /// # Arguments
     /// * `block_version` - This may influence details of the signature
-    /// * `message` - The message which was signed
+    /// * `tx_prefix` - The TxPrefix which was signed over
     /// * `rings` - One or more rings which were signed to create this signature
     /// * `output_commitments` - Output amount commitments.
     /// * `fee` - Amount of the implicit fee output. commitment
@@ -480,7 +494,7 @@ impl SignatureRctBulletproofs {
     pub fn verify<CSPRNG: RngCore + CryptoRng>(
         &self,
         block_version: BlockVersion,
-        message: &[u8; 32],
+        tx_prefix: &TxPrefix,
         rings: &[SignedInputRing],
         output_commitments: &[CompressedCommitment],
         fee: Amount,
@@ -702,9 +716,9 @@ impl SignatureRctBulletproofs {
         }
 
         // Extend the message with the range proof and pseudo_output_commitments.
-        let extended_message_digest = compute_extended_message_either_version(
+        let mlsag_signing_digest = compute_mlsag_signing_digest(
             block_version,
-            message,
+            tx_prefix,
             &self.pseudo_output_commitments,
             &self.range_proof_bytes,
             &self.range_proofs,
@@ -718,7 +732,7 @@ impl SignatureRctBulletproofs {
             let this_was_signed: &[u8] = if let Some(signed_digest) = ring.signed_digest.as_ref() {
                 &signed_digest[..]
             } else {
-                &extended_message_digest
+                &mlsag_signing_digest
             };
 
             let ring_signature = &self.ring_signatures[i];
@@ -753,7 +767,7 @@ impl SignatureRctBulletproofs {
 /// * `rng` - randomness
 fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
     block_version: BlockVersion,
-    message: &[u8; 32],
+    tx_prefix: &TxPrefix,
     rings: &[InputRing],
     output_secrets: &[OutputSecret],
     fee: Amount,
@@ -762,7 +776,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
     rng: &mut CSPRNG,
 ) -> Result<SignatureRctBulletproofs, Error> {
     let SigningData {
-        extended_message_digest,
+        mlsag_signing_digest,
         pseudo_output_blindings,
         pseudo_output_commitments,
         range_proofs,
@@ -772,7 +786,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
         ..
     } = SigningData::new(
         block_version,
-        message,
+        tx_prefix,
         rings,
         output_secrets,
         fee,
@@ -789,7 +803,7 @@ fn sign_with_balance_check<CSPRNG: RngCore + CryptoRng, S: RingSigner + ?Sized>(
             |(ring, pseudo_output_blinding)| -> Result<RingMLSAG, Error> {
                 Ok(match ring {
                     InputRing::Signable(ring) => {
-                        signer.sign(&extended_message_digest, ring, pseudo_output_blinding, rng)?
+                        signer.sign(&mlsag_signing_digest, ring, pseudo_output_blinding, rng)?
                     }
                     InputRing::Presigned(ring) => ring.mlsag.clone(),
                 })
@@ -877,7 +891,59 @@ fn compute_pseudo_output_blindings<CSPRNG: RngCore + CryptoRng>(
         .collect())
 }
 
+/// Compute the digest that mlsags should actually sign, depending on the block
+/// version.
+///
+/// TODO: When support for block version < 2 is deprecated,
+/// we can make this return `[u8; 32]` instead, which is nicer for the hardware
+/// wallet implementation.
+fn compute_mlsag_signing_digest(
+    block_version: BlockVersion,
+    tx_prefix: &TxPrefix,
+    pseudo_output_commitments: &[CompressedCommitment],
+    range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
+) -> Vec<u8> {
+    // The historical "message" is the tx_prefix hash
+    let message = tx_prefix.hash();
+    // The historical extended message
+    let extended_message = compute_extended_message_either_version(
+        block_version,
+        &message,
+        pseudo_output_commitments,
+        range_proof_bytes,
+        range_proofs,
+    );
+
+    // When the tx summary is also supposed to be part of the digest (to support
+    // hardware wallets, we do another round of merlin using the previous digest
+    // as the starting point, and then digest the TxSummary.
+    // The TxSummary is much smaller than the entire Tx, so this last digest
+    // can be reproduced on the hardware wallet with relative ease, compared to
+    // trying to reproduce the entire extended message digest.
+    if block_version.mlsags_sign_extended_message_and_tx_summary_digest() {
+        let mut transcript =
+            MerlinTranscript::new(EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG.as_bytes());
+        extended_message.append_to_transcript(b"extended_message", &mut transcript);
+
+        // Make the TxSummary
+        let tx_summary = TxSummary::new(tx_prefix, pseudo_output_commitments);
+        tx_summary.append_to_transcript(b"tx_summary", &mut transcript);
+
+        // Extract digest
+        let mut output = [0u8; 32];
+        transcript.extract_digest(&mut output);
+        return output.to_vec();
+    } else {
+        return extended_message;
+    }
+}
+
 /// Toggles between old-style and new-style extended message
+///
+/// TODO: When support for block version < 2 is deprecated,
+/// we can make this return `[u8; 32]` instead, which is nicer for the hardware
+/// wallet implementation.
 fn compute_extended_message_either_version(
     block_version: BlockVersion,
     message: &[u8],
@@ -953,6 +1019,7 @@ mod rct_bulletproofs_tests {
         ring_signature::{
             generators, Error as RingSignatureError, KeyImage, PedersenGens, ReducedTxOut,
         },
+        tx::TxPrefix,
         CompressedCommitment, TokenId,
     };
     use alloc::vec::Vec;
@@ -970,8 +1037,12 @@ mod rct_bulletproofs_tests {
     extern crate std;
 
     struct SignatureParams {
-        /// Message to be signed.
-        message: [u8; 32],
+        /// TxPrefix to be signed.
+        /// Note that the TxPrefix is only hashed in this computation,
+        /// and its set of inputs and outputs are ignored.
+        ///
+        /// It is only actually used in this test to record the fee amount.
+        tx_prefix: TxPrefix,
 
         /// Rings of input onetime addresses and amount commitments.
         rings: Vec<SignableInputRing>,
@@ -981,14 +1052,11 @@ mod rct_bulletproofs_tests {
 
         /// Block Version
         block_version: BlockVersion,
-
-        /// Token id
-        fee_token_id: TokenId,
     }
 
     impl SignatureParams {
         fn generator(&self) -> PedersenGens {
-            generators(*self.fee_token_id)
+            generators(self.tx_prefix.fee_token_id)
         }
 
         fn random<RNG: RngCore + CryptoRng>(
@@ -1007,8 +1075,7 @@ mod rct_bulletproofs_tests {
             num_token_ids: usize,
             rng: &mut RNG,
         ) -> Self {
-            let mut message = [0u8; 32];
-            rng.fill_bytes(&mut message);
+            let mut tx_prefix = TxPrefix::default();
 
             if !block_version.mixed_transactions_are_supported() && num_token_ids != 1 {
                 panic!("more than one token id not supported at this block version");
@@ -1021,7 +1088,7 @@ mod rct_bulletproofs_tests {
             }
 
             // First token id is the fee
-            let fee_token_id = TokenId::from(token_ids[0]);
+            tx_prefix.fee_token_id = token_ids[0];
 
             let mut generator_cache = GeneratorCache::default();
 
@@ -1033,7 +1100,7 @@ mod rct_bulletproofs_tests {
                 for _i in 0..num_mixins {
                     let public_key = CompressedRistrettoPublic::from_random(rng);
                     let target_key = CompressedRistrettoPublic::from_random(rng);
-                    let generator = generator_cache.get(fee_token_id);
+                    let generator = generator_cache.get(tx_prefix.fee_token_id.into());
                     let commitment = {
                         let value = rng.next_u64();
                         let blinding = Scalar::random(rng);
@@ -1093,11 +1160,10 @@ mod rct_bulletproofs_tests {
                 .collect();
 
             SignatureParams {
-                message,
+                tx_prefix,
                 rings,
                 output_secrets,
                 block_version,
-                fee_token_id,
             }
         }
 
@@ -1126,17 +1192,28 @@ mod rct_bulletproofs_tests {
                 .collect()
         }
 
+        fn get_fee_amount(&self) -> Amount {
+            Amount::new(
+                self.tx_prefix.fee,
+                TokenId::from(self.tx_prefix.fee_token_id),
+            )
+        }
+
+        fn set_fee_amount(&mut self, amount: Amount) {
+            self.tx_prefix.fee = amount.value;
+            self.tx_prefix.fee_token_id = *amount.token_id;
+        }
+
         fn sign<RNG: RngCore + CryptoRng>(
             &self,
-            fee: u64,
             rng: &mut RNG,
         ) -> Result<SignatureRctBulletproofs, Error> {
             SignatureRctBulletproofs::sign(
                 self.block_version,
-                &self.message,
+                &self.tx_prefix,
                 &self.get_input_rings(),
                 &self.output_secrets,
-                Amount::new(fee, self.fee_token_id),
+                self.get_fee_amount(),
                 &NoKeysRingSigner {},
                 rng,
             )
@@ -1144,15 +1221,14 @@ mod rct_bulletproofs_tests {
 
         fn sign_without_balance_check<RNG: RngCore + CryptoRng>(
             &self,
-            fee: u64,
             rng: &mut RNG,
         ) -> Result<SignatureRctBulletproofs, Error> {
             sign_with_balance_check(
                 self.block_version,
-                &self.message,
+                &self.tx_prefix,
                 &self.get_input_rings(),
                 &self.output_secrets,
-                Amount::new(fee, self.fee_token_id),
+                self.get_fee_amount(),
                 false,
                 &NoKeysRingSigner {},
                 rng,
@@ -1176,7 +1252,7 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
             params.rings = Vec::new();
 
-            let result = params.sign(0, &mut rng);
+            let result = params.sign(&mut rng);
 
             match result {
                 Err(Error::NoInputs) => {} // OK,
@@ -1198,7 +1274,7 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
             params.rings[0].members = Vec::new();
 
-            let result = params.sign(0, &mut rng);
+            let result = params.sign(&mut rng);
 
             match result {
                 Err(Error::InvalidRingSize(0)) => {} // OK,
@@ -1217,7 +1293,7 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let signature = params.sign(0, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             // The signature must contain one ring signature per input.
             assert_eq!(signature.ring_signatures.len(), num_inputs);
@@ -1242,15 +1318,14 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
             result.unwrap();
@@ -1268,15 +1343,14 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random_mixed(block_version, num_inputs, num_mixins, num_token_ids, &mut rng);
-            let fee = 0;
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
             result.unwrap();
@@ -1293,9 +1367,8 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
 
-            let mut signature = params.sign(fee, &mut rng).unwrap();
+            let mut signature = params.sign(&mut rng).unwrap();
 
             // Modify an MLSAG ring signature
             let index = rng.next_u64() as usize % (num_inputs);
@@ -1303,10 +1376,10 @@ mod rct_bulletproofs_tests {
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1324,7 +1397,6 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
             // Modify an output value
             {
                 let index = rng.next_u64() as usize % (num_inputs);
@@ -1332,14 +1404,14 @@ mod rct_bulletproofs_tests {
             }
 
             // Sign, without checking that value is preserved.
-            let invalid_signature = params.sign_without_balance_check(fee, &mut rng).unwrap();
+            let invalid_signature = params.sign_without_balance_check(&mut rng).unwrap();
 
             let result = invalid_signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1357,8 +1429,7 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
-            let mut signature = params.sign(fee, &mut rng).unwrap();
+            let mut signature = params.sign(&mut rng).unwrap();
 
             // Modify the range proof
             let wrong_range_proof = {
@@ -1376,10 +1447,10 @@ mod rct_bulletproofs_tests {
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1397,8 +1468,7 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
-            let mut signature = params.sign(fee, &mut rng).unwrap();
+            let mut signature = params.sign(&mut rng).unwrap();
 
             // Modify the range proof
             let wrong_range_proof = {
@@ -1416,10 +1486,10 @@ mod rct_bulletproofs_tests {
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1438,21 +1508,20 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
 
             // Duplicate one of the rings.
             params.rings[2] = params.rings[3].clone();
             // Duplicate the corresponding output also, so we don't get "value not conserved" error
             params.output_secrets[2].amount = params.output_secrets[3].amount;
 
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1470,8 +1539,7 @@ mod rct_bulletproofs_tests {
             let block_version: BlockVersion = block_version.try_into().unwrap();
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
-            let fee = 0;
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             use mc_util_serial::prost::Message;
 
@@ -1497,28 +1565,28 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(block_version, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let popped_secret = params.output_secrets.pop().unwrap();
-            let fee = popped_secret.amount.value;
+            params.set_fee_amount(popped_secret.amount);
 
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
             result.unwrap();
 
             // Verify should fail if the signature disagrees with the fee.
-            let wrong_fee = fee + 1;
+            let wrong_fee = params.tx_prefix.fee + 1;
             match signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(wrong_fee, params.fee_token_id),
+                Amount::new(wrong_fee, params.tx_prefix.fee_token_id.into()),
                 &mut rng,
             ) {
                 Err(Error::ValueNotConserved) => {} // Expected
@@ -1540,16 +1608,16 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let popped_secret = params.output_secrets.pop().unwrap();
-            let fee = popped_secret.amount.value;
+            params.set_fee_amount(popped_secret.amount);
 
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 BlockVersion::TWO,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
             assert!(result.is_err());
@@ -1566,16 +1634,16 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let popped_secret = params.output_secrets.pop().unwrap();
-            let fee = popped_secret.amount.value;
+            params.set_fee_amount(popped_secret.amount);
 
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             let result = signature.verify(
                 BlockVersion::ONE,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
             assert!(result.is_err());
@@ -1592,26 +1660,26 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(BlockVersion::TWO, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let popped_secret = params.output_secrets.pop().unwrap();
-            let fee = popped_secret.amount.value;
+            params.set_fee_amount(popped_secret.amount);
 
-            let signature = params.sign(fee, &mut rng).unwrap();
+            let signature = params.sign(&mut rng).unwrap();
 
             signature.verify(
                 BlockVersion::TWO,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             ).unwrap();
 
 
             let result = signature.verify(
                 BlockVersion::TWO,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, TokenId::from(*params.fee_token_id + 1)),
+                Amount::new(params.tx_prefix.fee, TokenId::from(params.tx_prefix.fee_token_id + 1)),
                 &mut rng,
             );
 
@@ -1629,11 +1697,11 @@ mod rct_bulletproofs_tests {
             let mut params = SignatureParams::random(BlockVersion::ONE, num_inputs, num_mixins, &mut rng);
             // Remove one of the outputs, and use its value as the fee. This conserves value.
             let popped_secret = params.output_secrets.pop().unwrap();
-            let fee = popped_secret.amount.value;
+            params.set_fee_amount(popped_secret.amount);
 
-            params.fee_token_id = 1.into();
+            params.tx_prefix.fee_token_id = 1;
 
-            assert_eq!(params.sign(fee, &mut rng), Err(Error::TokenIdNotAllowed));
+            assert_eq!(params.sign(&mut rng), Err(Error::TokenIdNotAllowed));
         }
 
         #[test]
@@ -1649,15 +1717,14 @@ mod rct_bulletproofs_tests {
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random_mixed(block_version, num_inputs, num_mixins,num_token_ids, &mut rng);
 
-            let fee = 0;
-            let mut signature = params.sign(fee, &mut rng).unwrap();
+            let mut signature = params.sign(&mut rng).unwrap();
 
             signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             ).unwrap();
 
@@ -1665,10 +1732,10 @@ mod rct_bulletproofs_tests {
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 
@@ -1688,15 +1755,14 @@ mod rct_bulletproofs_tests {
             let mut rng: RngType = SeedableRng::from_seed(seed);
             let params = SignatureParams::random_mixed(block_version, num_inputs, num_mixins, num_token_ids, &mut rng);
 
-            let fee = 0;
-            let mut signature = params.sign(fee, &mut rng).unwrap();
+            let mut signature = params.sign(&mut rng).unwrap();
 
             signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             ).unwrap();
 
@@ -1704,10 +1770,10 @@ mod rct_bulletproofs_tests {
 
             let result = signature.verify(
                 block_version,
-                &params.message,
+                &params.tx_prefix,
                 &params.get_signed_input_rings(),
                 &params.get_output_commitments(),
-                Amount::new(fee, params.fee_token_id),
+                params.get_fee_amount(),
                 &mut rng,
             );
 

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -33,7 +33,7 @@ use crate::{
     range_proofs::{check_range_proofs, generate_range_proofs},
     ring_ct::{Error, GeneratorCache},
     tx::TxPrefix,
-    Amount, BlockVersion, TxInSummary, TxSummary,
+    Amount, BlockVersion, TxSummary,
 };
 
 /// A presigned RingMLSAG and ancillary data needed to incorporate it into a
@@ -934,15 +934,7 @@ fn compute_mlsag_signing_digest(
     );
 
     // Make the TxSummary
-    let tx_in_summaries: Vec<TxInSummary> =
-        zip_exact(tx_prefix.inputs.iter(), pseudo_output_commitments.iter())?
-            .map(|(tx_in, commitment)| TxInSummary {
-                pseudo_output_commitment: *commitment,
-                input_rules: tx_in.input_rules.clone(),
-            })
-            .collect();
-
-    let tx_summary = TxSummary::new(tx_prefix, tx_in_summaries);
+    let tx_summary = TxSummary::new(tx_prefix, pseudo_output_commitments)?;
 
     // When the tx summary is also supposed to be part of the digest (to support
     // hardware wallets, we do another round of merlin using the previous digest

--- a/transaction/core/src/ring_ct/signing_digest.rs
+++ b/transaction/core/src/ring_ct/signing_digest.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use crate::{
+    domain_separators::{EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG, EXTENDED_MESSAGE_DOMAIN_TAG},
+    tx::TxPrefix,
+    BlockVersion, CompressedCommitment, TxSummary,
+};
+use alloc::vec::Vec;
+use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
+use mc_util_zip_exact::ZipExactError;
+
+/// The MLSAG signing digest is the digest that MLSAGs actually sign
+pub struct MLSAGSigningDigest(pub Vec<u8>);
+
+/// The extended message digest (or, before block version 2, the extended
+/// message)
+pub struct ExtendedMessageDigest(pub Vec<u8>);
+
+impl From<MLSAGSigningDigest> for Vec<u8> {
+    fn from(src: MLSAGSigningDigest) -> Self {
+        src.0
+    }
+}
+
+impl From<ExtendedMessageDigest> for Vec<u8> {
+    fn from(src: ExtendedMessageDigest) -> Self {
+        src.0
+    }
+}
+
+/// Compute the digest that mlsags should actually sign, depending on the block
+/// version.
+///
+/// Returns:
+/// * The MLSAG Signing Digest
+/// * The TxSummary
+/// * The extended_message_digest.
+///
+/// TODO: When support for block version < 2 is deprecated,
+/// we can make this return `[u8; 32]` instead of Vec<u8>, which is nicer for
+/// the hardware wallet implementation.
+pub fn compute_mlsag_signing_digest(
+    block_version: BlockVersion,
+    tx_prefix: &TxPrefix,
+    pseudo_output_commitments: &[CompressedCommitment],
+    range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
+) -> Result<(MLSAGSigningDigest, TxSummary, ExtendedMessageDigest), ZipExactError> {
+    // The historical "message" is the tx_prefix hash
+    let message = tx_prefix.hash();
+    // The historical extended message
+    let extended_message = compute_extended_message_either_version(
+        block_version,
+        &message,
+        pseudo_output_commitments,
+        range_proof_bytes,
+        range_proofs,
+    );
+
+    // Make the TxSummary
+    let tx_summary = TxSummary::new(tx_prefix, pseudo_output_commitments)?;
+
+    // When the tx summary is also supposed to be part of the digest (to support
+    // hardware wallets, we do another round of merlin using the previous digest
+    // as the starting point, and then digest the TxSummary.
+    // The TxSummary is much smaller than the entire Tx, so this last digest
+    // can be reproduced on the hardware wallet with relative ease, compared to
+    // trying to reproduce the entire extended message digest.
+    let mlsag_signing_digest = if block_version.mlsags_sign_extended_message_and_tx_summary_digest()
+    {
+        let mut transcript =
+            MerlinTranscript::new(EXTENDED_MESSAGE_AND_TX_SUMMARY_DOMAIN_TAG.as_bytes());
+        extended_message
+            .0
+            .append_to_transcript(b"extended_message", &mut transcript);
+        tx_summary.append_to_transcript(b"tx_summary", &mut transcript);
+
+        // Extract digest
+        let mut output = [0u8; 32];
+        transcript.extract_digest(&mut output);
+        MLSAGSigningDigest(output.to_vec())
+    } else {
+        // Bfore the extended_message_and_tx_summary_digest, mlsags sign the extended
+        // message digest
+        MLSAGSigningDigest(extended_message.0.clone())
+    };
+
+    Ok((mlsag_signing_digest, tx_summary, extended_message))
+}
+
+/// Toggles between old-style and new-style extended message
+///
+/// TODO: When support for block version < 2 is deprecated,
+/// we can make this return `[u8; 32]` instead, which is nicer for the hardware
+/// wallet implementation.
+fn compute_extended_message_either_version(
+    block_version: BlockVersion,
+    message: &[u8],
+    pseudo_output_commitments: &[CompressedCommitment],
+    range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
+) -> ExtendedMessageDigest {
+    ExtendedMessageDigest(if block_version.mlsags_sign_extended_message_digest() {
+        // New-style extended message using merlin
+        digest_extended_message(
+            message,
+            pseudo_output_commitments,
+            range_proof_bytes,
+            range_proofs,
+        )
+        .to_vec()
+    } else {
+        // Old-style extended message
+        extend_message(message, pseudo_output_commitments, range_proof_bytes)
+    })
+}
+
+/// Computes a merlin digest of message, pseudo_output_commitments, range proof
+fn digest_extended_message(
+    message: &[u8],
+    pseudo_output_commitments: &[CompressedCommitment],
+    range_proof_bytes: &[u8],
+    range_proofs: &[Vec<u8>],
+) -> [u8; 32] {
+    let mut transcript = MerlinTranscript::new(EXTENDED_MESSAGE_DOMAIN_TAG.as_bytes());
+    message.append_to_transcript(b"message", &mut transcript);
+    pseudo_output_commitments.append_to_transcript(b"pseudo_output_commitments", &mut transcript);
+    range_proof_bytes.append_to_transcript_allow_omit(b"range_proof_bytes", &mut transcript);
+    range_proofs.append_to_transcript_allow_omit(b"range_proofs", &mut transcript);
+
+    let mut output = [0u8; 32];
+    transcript.extract_digest(&mut output);
+    output
+}
+
+/// Concatenates [message || pseudo_output_commitments || range_proof].
+/// (Used before block version two)
+fn extend_message(
+    message: &[u8],
+    pseudo_output_commitments: &[CompressedCommitment],
+    range_proof_bytes: &[u8],
+) -> Vec<u8> {
+    let mut extended_message: Vec<u8> = Vec::with_capacity(
+        message.len() + pseudo_output_commitments.len() * 32 + range_proof_bytes.len(),
+    );
+    extended_message.extend_from_slice(message);
+    for commitment in pseudo_output_commitments {
+        extended_message.extend_from_slice(commitment.as_ref());
+    }
+    extended_message.extend_from_slice(range_proof_bytes);
+    extended_message
+}

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -149,6 +149,9 @@ impl Tx {
 
 /// TxPrefix is the Tx struct without the signature.  It is used to
 /// calculate the prefix hash for signing and verifying.
+///
+/// Note: If you add something here, consider if it should be added to the
+/// TxSummary also for hardware wallet visibility.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize, Message, Digestible)]
 pub struct TxPrefix {
     /// List of inputs to the transaction.

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -101,7 +101,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
-/// A subset of the data in a Tx which enables efficient verification (by e.g. a
+/// A subset of the data in a Tx which enables efficient verification (e.g. by a
 /// HW wallet) of the inputs and outputs of a transaction being signed.
 #[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
 pub struct TxSummary {

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -178,19 +178,20 @@ impl TxSummary {
 #[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
 pub struct TxOutSummary {
     /// The amount being sent.
-    #[prost(oneof = "MaskedAmount", tags = "1, 2")]
+    // Note: These tags must match those of MaskedAmount enum in transaction-core
+    #[prost(oneof = "MaskedAmount", tags = "1, 6")]
     pub masked_amount: Option<MaskedAmount>,
 
     /// The one-time public address of this output.
-    #[prost(message, required, tag = "3")]
+    #[prost(message, required, tag = "2")]
     pub target_key: CompressedRistrettoPublic,
 
     /// The per output tx public key
-    #[prost(message, required, tag = "4")]
+    #[prost(message, required, tag = "3")]
     pub public_key: CompressedRistrettoPublic,
 
     /// Whether or not this output is associated to an input with rules
-    #[prost(bool, tag = "5")]
+    #[prost(bool, tag = "4")]
     pub associated_to_input_rules: bool,
 }
 

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -8,7 +8,7 @@
 //!   requires sending about 1kb of data and can be fast even on a slow
 //!   connection and slow device.
 //! * However, if they want to be able to display to the user what it is that
-//!   they are signing, i.e. how much money is being transfered to who, and
+//!   they are signing, i.e. how much money is being transferred to who, and
 //!   verify that this is correct on the device, then they have to be able to
 //!   trace the "extended message digest" back to the TxPrefix.outputs list and
 //!   see where these inputs they are signing away are going to.

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -74,7 +74,7 @@
 //! Tx. So it could completely account for the transfer of value caused by the
 //! Tx, it could identify change outputs, and it could display b58 encodings of
 //! the public addresses for outbound transfers. This should only require
-//! sending a few kb in the worst case.
+//! sending a few KB in the worst case.
 //!
 //! It's reasonable to ask, what if the computer lies to the device in the
 //! TxSummary. What if, the TxPrefix actually says one thing, and the TxSummary

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! The TxSummary is meant to reduce the complexity of implementing a hardware
+//! wallet.
+//!
+//! Hardware wallets have the following issue:
+//! * The main function they want to perform is signing RingMLSAG. This only
+//!   requires sending about 1kb of data and can be fast even on a slow
+//!   connection and slow device.
+//! * However, if they want to be able to display to the user what it is that
+//!   they are signing, i.e. how much money is being transfered to who, and
+//!   verify that this is correct on the device, then they have to be able to
+//!   trace the "extended message digest" back to the TxPrefix.outputs list and
+//!   see where these inputs they are signing away are going to.
+//! * Unfortunately, computing the extended message digest is very annoying,
+//!   because it depends on essentially the entire TxPrefix. A Tx may have as
+//!   many as 16 TxIn's. Each TxIn has 11 mixins. Each mixin may contain a
+//!   merkle proof with say 30 merkle proof elements. Each merkle proof element
+//!   is 40 bytes. So suddenly, we have a need to stream > 100 kb of data to the
+//!   device so that it can compute this digest, and if any piece of data is
+//!   skipped, then the digest will be wrong and cannot be verified.
+//!
+//! The point of the TxSummary is to avoid the need for them to have to stream
+//! all of this data to be confident about what is the balance of the Tx that
+//! they are signing.
+//!
+//! The idea is similar to merkle proof verification. You don't have to see the
+//! entire data set to be convinced that the piece you care about is part of the
+//! hash, you can be supplied with hashes for the branches of the tree that you
+//! aren't specifically interested in, and then be convinced that the data you
+//! are interested is part of the root hash.
+//!
+//! So, we:
+//! * Take the existing extended message digest (32 bytes)
+//! * Use that to start a new Merlin transcript
+//! * Martial the TxSummary into this new Merlin transcript
+//! * A 32 byte digest resulting from that is new "extended message with tx
+//!   summary digest", and this is what the MLSAG actually sign.
+//!
+//! We propose that the TxSummary contains:
+//! * For each output in TxPrefix.outputs, the public key, target key, and
+//!   masked amount.
+//! * The list of pseudo output commitments.
+//!
+//! These data can be produced easily during Tx validation without major
+//! changes. They don't contain any secrets that the enclave isn't supposed to
+//! have.
+//!
+//! For the hardware wallet, what we can do is:
+//! * When we want to start signing MLSAGs, we send the 32 byte extended message
+//!   digest, and the TxSummary. The device can compute the "extended message
+//!   with tx summary digest" and sign MLSAGs over that.
+//! * For each output in the summary, the device expects the computer to
+//!   ADDITONALLY supply this subset of the arguments to TxOut::new:
+//!   * block_version,
+//!   * amount,
+//!   * recipient,
+//!   * tx_private_key,
+//! * These are not part of the TxSummary (because the enclave can't know them)
+//!   but they can be part of a TxSummaryVerificationData or some such thing.
+//! * For a given public key, target key, and masked amount, it is intractable
+//!   to find a different amount, recipient, and tx private key that leads to
+//!   the same data (discrete log hard). So the device can be convinced that
+//!   these are the amounts and destinations of each such TxOut.
+//! * For each pseudo output commitment, either this corresponds to an MLSAG
+//!   that the device will actually sign, or it is coming from an SCI, which the
+//!   device will not actually sign. For anything which the device will not
+//!   actually sign, the TxSummaryVerification data can include the amount and
+//!   blinding factor. The computer actually has this for all of the pseudo
+//!   output commitments anyways.
+//!
+//! At this point, the device would then know the amount (value and token id) of
+//! every input in the Tx, and the amount and recipient of every output in the
+//! Tx. So it could completely account for the transfer of value caused by the
+//! Tx, it could identify change outputs, and it could display b58 encodings of
+//! the public addresses for outbound transfers. This should only require
+//! sending a few kb in the worst case.
+//!
+//! It's reasonable to ask, what if the computer lies to the device in the
+//! TxSummary. What if, the TxPrefix actually says one thing, and the TxSummary
+//! it gives to the device says another. The device cannot detect this if it
+//! doesn't have insight into the extended message digest. However, in this
+//! case, the transaction will simply be invalid when it is submitted, because
+//! the consensus enclave will derive a different value for the TxSummary when
+//! it attempts to validate the transaction, and that value will actually be
+//! based on the TxPrefix. So the computer can gain no advantage by lying to the
+//! device in this way.
+//!
+//! In this module we only attempt to define the TxSummary and how it is
+//! digested. We do not attempt to define the TxSummaryVerificationData, that is
+//! thought of as part of the hardware device protocol.
+//!
+//! In the future we might want that in this crate though to help hardware
+//! wallets standardize, and ensure test coverage as the Tx format evolves, I'm
+//! not sure.
+
+use crate::{
+    tx::{TxOut, TxPrefix},
+    CompressedCommitment, MaskedAmount,
+};
+use alloc::vec::Vec;
+use mc_crypto_digestible::Digestible;
+use mc_crypto_keys::CompressedRistrettoPublic;
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+/// A subset of the data in a Tx which enables efficient verification (by e.g. a
+/// HW wallet) of the inputs and outputs of a transaction being signed.
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
+pub struct TxSummary {
+    /// The outputs which will be added to the blockchain as a result of this
+    /// transaction
+    #[prost(message, repeated, tag = "1")]
+    pub outputs: Vec<TxOutSummary>,
+
+    /// Commitments of value equal to each real input.
+    #[prost(message, repeated, tag = "2")]
+    pub pseudo_output_commitments: Vec<CompressedCommitment>,
+
+    /// Fee paid to the foundation for this transaction
+    #[prost(uint64, tag = "3")]
+    pub fee: u64,
+
+    /// Token id for the fee output of this transaction
+    #[prost(uint64, tag = "4")]
+    pub fee_token_id: u64,
+
+    /// The block index at which this transaction is no longer valid.
+    #[prost(uint64, tag = "5")]
+    pub tombstone_block: u64,
+}
+
+impl TxSummary {
+    /// Make a TxSummary for a given TxPrefix and pseudo output commitments
+    pub fn new(tx_prefix: &TxPrefix, pseudo_output_commitments: &[CompressedCommitment]) -> Self {
+        Self {
+            outputs: tx_prefix.outputs.iter().map(Into::into).collect(),
+            pseudo_output_commitments: pseudo_output_commitments.to_vec(),
+            fee: tx_prefix.fee,
+            fee_token_id: tx_prefix.fee_token_id,
+            tombstone_block: tx_prefix.tombstone_block,
+        }
+    }
+}
+
+/// A subset of the data of a TxOut.
+///
+/// Fog hint and memo are omitted to reduce size and complexity on HW device,
+/// which can't really do much with those and isn't very interested in them
+/// anyways.
+#[derive(Clone, Deserialize, Digestible, Eq, Hash, Message, PartialEq, Serialize, Zeroize)]
+pub struct TxOutSummary {
+    /// The amount being sent.
+    #[prost(oneof = "MaskedAmount", tags = "1, 6")]
+    #[digestible(name = "amount")]
+    pub masked_amount: Option<MaskedAmount>,
+
+    /// The one-time public address of this output.
+    #[prost(message, required, tag = "2")]
+    pub target_key: CompressedRistrettoPublic,
+
+    /// The per output tx public key
+    #[prost(message, required, tag = "3")]
+    pub public_key: CompressedRistrettoPublic,
+}
+
+impl From<&TxOut> for TxOutSummary {
+    fn from(src: &TxOut) -> Self {
+        Self {
+            masked_amount: src.masked_amount.clone(),
+            target_key: src.target_key.clone(),
+            public_key: src.public_key.clone(),
+        }
+    }
+}

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -50,7 +50,7 @@
 //! * When we want to start signing MLSAGs, we send the 32 byte extended message
 //!   digest, and the TxSummary. The device can compute the "extended message
 //!   with tx summary digest" and sign MLSAGs over that.
-//! * For each output in the summary, the device expects the computer to
+//! * For each output in the summary, the device expects the host computer to
 //!   ADDITONALLY supply this subset of the arguments to TxOut::new:
 //!   * block_version,
 //!   * amount,

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -37,7 +37,7 @@
 //! * A 32 byte digest resulting from that is new "extended message with tx
 //!   summary digest", and this is what the MLSAG actually sign.
 //!
-//! We propose that the TxSummary contains:
+//! The TxSummary contains:
 //! * For each output in TxPrefix.outputs, the public key, target key, and
 //!   masked amount.
 //! * The list of pseudo output commitments.

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -136,7 +136,7 @@ impl TxSummary {
             zip_exact(tx_prefix.inputs.iter(), pseudo_output_commitments.iter())?
                 .map(|(input, commitment)| {
                     let mut result = TxInSummary {
-                        pseudo_output_commitment: commitment.clone(),
+                        pseudo_output_commitment: *commitment,
                         ..Default::default()
                     };
                     if let Some(rules) = &input.input_rules {

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 //! The TxSummary is meant to reduce the complexity of implementing a hardware
-//! wallet. (See MCIP 52 also.)
+//! wallet. (See MCIP 52)
 //!
 //! Hardware wallets have the following issue:
 //! * The main function they want to perform is signing RingMLSAG. This only

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -302,13 +302,10 @@ pub fn validate_signature<R: RngCore + CryptoRng>(
         .cloned()
         .collect::<Vec<_>>();
 
-    let tx_prefix_hash = tx.prefix.hash();
-    let message = tx_prefix_hash.as_bytes();
-
     tx.signature
         .verify(
             block_version,
-            message,
+            &tx.prefix,
             &rings,
             &output_commitments,
             Amount::new(tx.prefix.fee, TokenId::from(tx.prefix.fee_token_id)),

--- a/transaction/extra/src/unsigned_tx.rs
+++ b/transaction/extra/src/unsigned_tx.rs
@@ -43,10 +43,9 @@ impl UnsignedTx {
         rng: &mut RNG,
     ) -> Result<Tx, RingCtError> {
         let prefix = self.tx_prefix.clone();
-        let message = prefix.hash().0;
         let signature = SignatureRctBulletproofs::sign(
             self.block_version,
-            &message,
+            &prefix,
             self.rings.as_slice(),
             self.output_secrets.as_slice(),
             Amount::new(prefix.fee, TokenId::from(prefix.fee_token_id)),
@@ -62,14 +61,13 @@ impl UnsignedTx {
         &self,
         rng: &mut RNG,
     ) -> Result<SigningData, RingCtError> {
-        let message = self.tx_prefix.hash().0;
         let fee_amount = Amount::new(
             self.tx_prefix.fee,
             TokenId::from(self.tx_prefix.fee_token_id),
         );
         SigningData::new(
             self.block_version,
-            &message,
+            &self.tx_prefix,
             &self.rings,
             &self.output_secrets,
             fee_amount,

--- a/transaction/extra/src/unsigned_tx.rs
+++ b/transaction/extra/src/unsigned_tx.rs
@@ -4,7 +4,8 @@ use alloc::vec::Vec;
 use mc_crypto_ring_signature_signer::RingSigner;
 use mc_transaction_core::{
     ring_ct::{
-        Error as RingCtError, InputRing, OutputSecret, SignatureRctBulletproofs, SigningData,
+        Error as RingCtError, ExtendedMessageDigest, InputRing, OutputSecret,
+        SignatureRctBulletproofs, SigningData,
     },
     tx::{Tx, TxPrefix},
     TxSummary,
@@ -57,16 +58,17 @@ impl UnsignedTx {
         Ok(Tx { prefix, signature })
     }
 
-    /// Get extraneous signing data
+    /// Get prepared (but unsigned) ringct bulletproofs which can be signed
+    /// later. Also gets the TxSummary and related digests.
     pub fn get_signing_data<RNG: CryptoRng + RngCore>(
         &self,
         rng: &mut RNG,
-    ) -> Result<(SigningData, TxSummary, Vec<u8>), RingCtError> {
+    ) -> Result<(SigningData, TxSummary, ExtendedMessageDigest), RingCtError> {
         let fee_amount = Amount::new(
             self.tx_prefix.fee,
             TokenId::from(self.tx_prefix.fee_token_id),
         );
-        SigningData::new(
+        SigningData::new_with_summary(
             self.block_version,
             &self.tx_prefix,
             &self.rings,

--- a/transaction/extra/src/unsigned_tx.rs
+++ b/transaction/extra/src/unsigned_tx.rs
@@ -6,7 +6,7 @@ use mc_transaction_core::{
     ring_ct::{
         Error as RingCtError, InputRing, OutputSecret, SignatureRctBulletproofs, SigningData,
     },
-    tx::{Tx, TxPrefix},
+    tx::{Tx, TxPrefix}, TxSummary,
 };
 use mc_transaction_types::{Amount, BlockVersion, TokenId};
 use rand_core::{CryptoRng, RngCore};
@@ -60,7 +60,7 @@ impl UnsignedTx {
     pub fn get_signing_data<RNG: CryptoRng + RngCore>(
         &self,
         rng: &mut RNG,
-    ) -> Result<SigningData, RingCtError> {
+    ) -> Result<(SigningData, TxSummary, Vec<u8>), RingCtError> {
         let fee_amount = Amount::new(
             self.tx_prefix.fee,
             TokenId::from(self.tx_prefix.fee_token_id),

--- a/transaction/extra/src/unsigned_tx.rs
+++ b/transaction/extra/src/unsigned_tx.rs
@@ -6,7 +6,8 @@ use mc_transaction_core::{
     ring_ct::{
         Error as RingCtError, InputRing, OutputSecret, SignatureRctBulletproofs, SigningData,
     },
-    tx::{Tx, TxPrefix}, TxSummary,
+    tx::{Tx, TxPrefix},
+    TxSummary,
 };
 use mc_transaction_types::{Amount, BlockVersion, TokenId};
 use rand_core::{CryptoRng, RngCore};

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -131,6 +131,12 @@ impl BlockVersion {
     pub fn require_block_metadata(&self) -> bool {
         self.0 >= 3
     }
+
+    /// MLSAGs sign the extended_message_and_tx_summary digest in v3 and up.
+    /// TODO: MCIP
+    pub fn mlsags_sign_extended_message_and_tx_summary_digest(&self) -> bool {
+        self.0 >= 3
+    }
 }
 
 impl Deref for BlockVersion {

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -20,8 +20,7 @@ use serde::{Deserialize, Serialize};
 /// you should try to convert them to BlockVersion.
 /// If that conversion fails, it means that this set of rules
 /// is not understood by your version of `mc-transaction-core`.
-/// This means that your build has reached end-of-life, and the user needs to
-/// update.
+/// This means that your build has reached end-of-life, and needs an update.
 ///
 /// You should not assume that all block versions you will ever see will be
 /// understood by your version of transaction core, otherwise there will be

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -13,9 +13,22 @@ use serde::{Deserialize, Serialize};
 /// the network is not supported, generally by requesting users to upgrade their
 /// software.
 ///
-/// If you need to manipulate block versions that cannot be understood by your
-/// version of `mc-transaction-core`, then you should use u32 to represent
-/// block version numbers.
+/// If you need to manipulate block versions that come from the network, you
+/// should use u32 to represent that.
+///
+/// Then, if you need to e.g. sign a transaction,
+/// you should try to convert them to BlockVersion.
+/// If that conversion fails, it means that this set of rules
+/// is not understood by your version of `mc-transaction-core`.
+/// This means that your build has reached end-of-life, and the user needs to
+/// update.
+///
+/// You should not assume that all block versions you will ever see will be
+/// understood by your version of transaction core, otherwise there will be
+/// no way for your software to help the user to upgrade when you reach EOL.
+///
+/// For example, `BlockVersion::try_from(...).unwrap()` is typically a bug
+/// if it's not in test code.
 #[derive(
     Clone,
     Copy,
@@ -132,8 +145,8 @@ impl BlockVersion {
         self.0 >= 3
     }
 
-    /// MLSAGs sign the extended_message_and_tx_summary digest in v3 and up.
-    /// TODO: MCIP
+    /// MLSAGs sign extended-message-and-tx-summary digest starting from v3.
+    /// [MCIP #52](https://github.com/mobilecoinfoundation/mcips/pull/52)
     pub fn mlsags_sign_extended_message_and_tx_summary_digest(&self) -> bool {
         self.0 >= 3
     }


### PR DESCRIPTION
The motivation here is that, hardware wallets like Ledger have an expectation that the device can verify what is the balance change that will result from signing a given transaction and who the outbound money will be paid to.

However, currently we have scoped things so that hardware wallets just are responsible for signing the Ring MLSAG, and they don't see large parts of the Tx, including the TxPrefix.

The only way that the set of outputs is connected to the RingMLSAG is that the TxPrefix is hashed into the "message", which is hashed with more things to produce the "extended_message_digest", which is the 32 byte digest that the RingMLSAG actually signs.

For the hardware wallet to really know what it is signing then, it would have to reproduce the entire extended message digest. The problem with this is that the TxPrefix can be > 100kb, which is much larger than the few kb that the hardware device currently has to handle, and is much too big to fit in the device's memory.

Instead, we introduce a `TxSummary` object and add an extra step where it is hashed in just at the very end. The computer can then prove that the hash the MLSAG is signing is connected to a given TxSummary, and provide enough information from there to understand the balance delta and where the money is going. This manages to avoid sending all the merkle proofs for all the mixins and so it can be done sending only a few kb.

The hope is to do this for v3, otherwise this issue may become the long pole for shipping hardware wallet support.

For other clients and servers, this doesn't meaningfully affect the time to sign or verify a Tx.