### PR TITLE
Implement debug for Fog View Router client error

### DIFF
--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -204,6 +204,7 @@ impl Drop for FogViewRouterGrpcClient {
 }
 
 /// Errors related to the Fog View Router Client.
+#[derive(Debug)]
 pub enum Error {
     /// Decode errors.
     Decode(DecodeError),


### PR DESCRIPTION
<!-- List changes here -->

### Motivation
The FVR integration tests unwraps a result with the `mc_fog_view_connection::Error`, and this requires that it implement `Debug`.
