### PR TITLE
Add `--check` option to rust lint.sh script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Run lint script
-        run: ./tools/lint.sh
+        run: ./tools/lint.sh --check
       - name: Check dirty git
         uses: ./.github/actions/check-dirty-git
 

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -4,9 +4,32 @@
 
 set -e  # exit on error
 
-if [[ ! -z "$1" ]]; then
-    cd "$1"
-fi
+CHECK=""
+
+while [ "$1" != "" ]; do
+	case "$1" in
+		--check)
+		  CHECK="--check";;
+		-h | --help)
+			echo "Lints rust files in the repo"
+                        echo "Linters that can fix will fix the files, by default."
+                        echo "Fixing linters include 'cargo sort' and 'cargo fmt'."
+			echo ""
+			echo "Usage: $(basename $0) [--check]"
+			echo ""
+			echo "Args:"
+			echo "        --check  Limit linters that can fix to only check"
+			echo "    -h, --help   Prints help information"
+			exit 0
+			;;
+		*)
+			echo "Unrecognized argument: '$1'"
+                        exit 2
+			;;
+	esac
+
+	shift
+done
 
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
@@ -17,8 +40,8 @@ cargo install cargo-sort
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
-  cargo sort --workspace --grouped --check
-  cargo fmt -- --unstable-features --check
+  cargo sort --workspace --grouped $CHECK
+  cargo fmt -- --unstable-features $CHECK
   cargo clippy --all --all-features
   echo "Linting in $PWD complete."
   popd >/dev/null

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -7,28 +7,28 @@ set -e  # exit on error
 CHECK=""
 
 while [ "$1" != "" ]; do
-	case "$1" in
-		--check)
-		  CHECK="--check";;
-		-h | --help)
-			echo "Lints rust files in the repo"
-                        echo "Linters that can fix will fix the files, by default."
-                        echo "Fixing linters include 'cargo sort' and 'cargo fmt'."
-			echo ""
-			echo "Usage: $(basename $0) [--check]"
-			echo ""
-			echo "Args:"
-			echo "        --check  Limit linters that can fix to only check"
-			echo "    -h, --help   Prints help information"
-			exit 0
-			;;
-		*)
-			echo "Unrecognized argument: '$1'"
-                        exit 2
-			;;
-	esac
-
-	shift
+  case "$1" in
+    --check)
+      CHECK="--check"
+      ;;
+    -h | --help)
+      echo "Lints rust files in the repo"
+      echo "Linters that can fix will fix the files, by default."
+      echo "Fixing linters include 'cargo sort' and 'cargo fmt'."
+      echo ""
+      echo "Usage: $(basename $0) [--check]"
+      echo ""
+      echo "Args:"
+      echo "        --check  Limit linters that can fix to only check"
+      echo "    -h, --help   Prints help information"
+      exit 0
+      ;;
+    *)
+      echo "Unrecognized argument: '$1'"
+      exit 2
+      ;;
+  esac
+  shift
 done
 
 # We want to check with --all-targets since it checks test code, but that flag


### PR DESCRIPTION
Previously the lint.sh script would always check. Now the script will
attempt to fix and will only check if the `--check` flag is provided.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
