### PR TITLE
use Blake2b instead of Sha-512 for amount shared secret derivation

### DIFF
--- a/transaction/core/src/amount/v2.rs
+++ b/transaction/core/src/amount/v2.rs
@@ -17,7 +17,7 @@ use core::convert::TryInto;
 use crc::Crc;
 use hkdf::Hkdf;
 use mc_crypto_digestible::Digestible;
-use mc_crypto_hashes::Digest;
+use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::RistrettoPublic;
 use mc_crypto_ring_signature::{generators, CompressedCommitment, Scalar};
 use prost::Message;
@@ -112,10 +112,10 @@ impl MaskedAmountV2 {
 
     /// Get the amount shared secret from the tx out shared secret
     pub fn compute_amount_shared_secret(tx_out_shared_secret: &RistrettoPublic) -> [u8; 32] {
-        let mut hasher = Sha512::new();
+        let mut hasher = Blake2b512::new();
         hasher.update(&AMOUNT_SHARED_SECRET_DOMAIN_TAG);
         hasher.update(&tx_out_shared_secret.to_bytes());
-        // Safety: Sha512 is a 512-bit (64-byte) hash.
+        // Safety: Blake2b is a 512-bit (64-byte) hash.
         hasher.finalize()[0..32].try_into().unwrap()
     }
 


### PR DESCRIPTION
We decided to do this because we generally use Blake2b for key derivations when it's a one-off hash like this, and we use Sha512 only when we want to use `HKDF`. This brings this more in line with our existing code. MCIP 42 has been updated to reflect this.