### PR TITLE
Helper struct for ser/deserializing SignerSetV2s in a more human-friendly fashion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.6",
  "subtle",
- "time 0.3.9",
+ "time 0.3.15",
  "version_check",
 ]
 
@@ -978,13 +978,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.3",
+ "hashbrown",
  "lock_api",
  "parking_lot_core 0.9.3",
 ]
@@ -1650,12 +1685,6 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1829,6 +1858,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,12 +1895,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
  "serde",
 ]
 
@@ -2492,7 +2527,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "displaydoc",
- "hashbrown 0.12.3",
+ "hashbrown",
  "hex",
  "hex_fmt",
  "hostname",
@@ -2884,6 +2919,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
+ "serde_with 2.0.1",
  "toml",
 ]
 
@@ -5424,7 +5460,7 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_cbor",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -6751,7 +6787,7 @@ dependencies = [
  "serde_json",
  "state",
  "tempfile",
- "time 0.3.9",
+ "time 0.3.15",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -6798,7 +6834,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.3.9",
+ "time 0.3.15",
  "tokio",
  "uncased",
 ]
@@ -7205,7 +7241,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.15",
  "url",
  "uuid",
 ]
@@ -7288,6 +7324,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.15",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7510,7 +7574,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.9",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -7545,7 +7609,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.9",
+ "time 0.3.15",
 ]
 
 [[package]]
@@ -7796,13 +7860,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
  "itoa 1.0.1",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -25,4 +25,5 @@ hex = "0.4"
 pem = "1.1"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"
+serde_with = "2.0"
 toml = "0.5"

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -5,10 +5,12 @@
 
 mod error;
 mod network;
-mod tokens;
 mod signer_set;
+mod tokens;
 
-pub use crate::{error::Error, network::NetworkConfig, tokens::TokensConfig};
+pub use crate::{
+    error::Error, network::NetworkConfig, signer_set::SignerSetConfig, tokens::TokensConfig,
+};
 
 use clap::Parser;
 use mc_attest_core::ProviderId;

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -6,6 +6,7 @@
 mod error;
 mod network;
 mod tokens;
+mod signer_set;
 
 pub use crate::{error::Error, network::NetworkConfig, tokens::TokensConfig};
 

--- a/consensus/service/config/src/signer_set.rs
+++ b/consensus/service/config/src/signer_set.rs
@@ -292,6 +292,9 @@ mod tests {
         "#;
 
         let err = serde_json::from_str::<SignerSetConfig>(invalid_config_json).unwrap_err();
-        assert_eq!(err.to_string(), "Failed to parse PEM: malformedframing at line 4 column 145");
+        assert_eq!(
+            err.to_string(),
+            "Failed to parse PEM: malformedframing at line 4 column 145"
+        );
     }
 }

--- a/consensus/service/config/src/signer_set.rs
+++ b/consensus/service/config/src/signer_set.rs
@@ -1,0 +1,296 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Data types for representing a `SignerSetV2` in a configuration file.
+//! We do not deserialize a `SignerSetV2` directly, because it is too hard
+//! to maintain by a human operator.
+
+use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+use std::{collections::HashMap, fmt, str::FromStr};
+
+/// A helper struct for serializing/deserializing an Ed25519Public key that is
+/// PEM-DER-encoded.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct PemEd25519Public(pub Ed25519Public);
+
+impl FromStr for PemEd25519Public {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pem = pem::parse(s).map_err(|e| format!("Failed to parse PEM: {}", e))?;
+        let public_key = Ed25519Public::try_from_der(&pem.contents)
+            .map_err(|e| format!("Failed to parse public key {:?}: {}", s, e))?;
+        Ok(PemEd25519Public(public_key))
+    }
+}
+
+impl fmt::Display for PemEd25519Public {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let pem = pem::Pem {
+            tag: "PUBLIC KEY".to_string(),
+            contents: self.0.to_der().to_vec(),
+        };
+        write!(f, "{}", pem::encode(&pem).replace('\r', ""))
+    }
+}
+
+impl From<Ed25519Public> for PemEd25519Public {
+    fn from(public_key: Ed25519Public) -> Self {
+        PemEd25519Public(public_key)
+    }
+}
+
+impl From<PemEd25519Public> for mc_crypto_multisig::SignerContainer<Ed25519Public> {
+    fn from(pem_public_key: PemEd25519Public) -> Self {
+        pem_public_key.0.into()
+    }
+}
+
+/// Wrapper around `mc_crypto_multisig::SignerEntity` that allows us specifying
+/// singers via a string as opposed to an Ed25519Public key.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "type", content = "identity")]
+enum Signer {
+    Single(String),
+    Multi(SignerSet),
+}
+
+/// Wrapper around `mc_crypto_multisig::SignerSet` that allows us specifying
+/// singers via a string name
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+struct SignerSet {
+    threshold: u32,
+    signers: Vec<Signer>,
+}
+
+impl SignerSet {
+    /// Given a map of signer names to public keys, return a
+    /// `mc_crypto_multisig::SignerSet` that represents the same signing
+    /// structure that is described by this `SignerSet`.
+    pub fn resolve(
+        &self,
+        signer_identities: &HashMap<String, PemEd25519Public>,
+    ) -> Result<mc_crypto_multisig::SignerSetV2<Ed25519Public>, String> {
+        let signers = self
+            .signers
+            .iter()
+            .map(|signer| match signer {
+                Signer::Single(identity) => signer_identities
+                    .get(identity)
+                    .ok_or_else(|| format!("Unknown identity: {}", identity))
+                    .cloned()
+                    .map(Into::into),
+                Signer::Multi(signer_set) => signer_set
+                    .resolve(signer_identities)
+                    .map(|signer_set| signer_set.into()),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(mc_crypto_multisig::SignerSetV2::new(
+            signers,
+            self.threshold,
+        ))
+    }
+}
+
+/// Signer set configuration, structured in a way that makes it a bit more sane
+/// for humans to review and edit.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct SignerSetConfig {
+    /// A map of human readable name to a PEM-encoded public key, representing a
+    /// single signing identity.
+    #[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")]
+    signer_identities: HashMap<String, PemEd25519Public>,
+
+    /// Signer set configuration.
+    signer_set: SignerSet,
+}
+
+impl TryFrom<&SignerSetConfig> for mc_crypto_multisig::SignerSetV2<Ed25519Public> {
+    type Error = String;
+
+    fn try_from(signer_set_config: &SignerSetConfig) -> Result<Self, Self::Error> {
+        signer_set_config
+            .signer_set
+            .resolve(&signer_set_config.signer_identities)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_happy_flow() {
+        // Keys randomly generated using `openssl genpkey -algorithm ED25519 | openssl
+        // pkey -pubout`
+        let key_mobilecoin = PemEd25519Public::from_str("-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAl3XVo/DeiTjHn8dYQuEtBjQrEWNQSKpfzw3X9dewSVY=\n-----END PUBLIC KEY-----\n").unwrap().0;
+        let key_lp1 = PemEd25519Public::from_str(
+            "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAf2gGDJ2c18AJtpYg7C3CpFaFJ8Y6ytVDweKHkmitu2Q=\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap()
+        .0;
+        let key_lp2 = PemEd25519Public::from_str(
+            "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAeUw6FyG1H4ZXAkzTJnyW/fY7eDHzjuztcWnoMOtx+cU=\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap()
+        .0;
+        let key_lp3a = PemEd25519Public::from_str(
+            "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoqh+PBcDGtLCbVNiNV8F3k/FdNw9xq6ql8x/54qXnpA=\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap()
+        .0;
+        let key_lp3b = PemEd25519Public::from_str(
+            "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEArQ2apgrrQili3wfZ+SAABnq69CU2ZT1kBT12HMF4fTo=\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap()
+        .0;
+        let key_some_org = PemEd25519Public::from_str(
+            "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnpD/7uFovy/ABkoM13Pz/wvQ1yu2WL9yzEjjNkNWuBc=\n-----END PUBLIC KEY-----\n",
+        )
+        .unwrap()
+        .0;
+
+        let valid_json = r#"
+        {
+            "signer_identities": {
+              "MobileCoin": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAl3XVo/DeiTjHn8dYQuEtBjQrEWNQSKpfzw3X9dewSVY=\n-----END PUBLIC KEY-----\n",
+              "LP-1": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAf2gGDJ2c18AJtpYg7C3CpFaFJ8Y6ytVDweKHkmitu2Q=\n-----END PUBLIC KEY-----\n",
+              "LP-2": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAeUw6FyG1H4ZXAkzTJnyW/fY7eDHzjuztcWnoMOtx+cU=\n-----END PUBLIC KEY-----\n",
+              "LP-3A": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAoqh+PBcDGtLCbVNiNV8F3k/FdNw9xq6ql8x/54qXnpA=\n-----END PUBLIC KEY-----\n",
+              "LP-3B": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEArQ2apgrrQili3wfZ+SAABnq69CU2ZT1kBT12HMF4fTo=\n-----END PUBLIC KEY-----\n",
+              "SomeOrg": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAnpD/7uFovy/ABkoM13Pz/wvQ1yu2WL9yzEjjNkNWuBc=\n-----END PUBLIC KEY-----\n"
+            },
+            "signer_set": {
+              "threshold": 3,
+              "signers": [
+                {
+                  "type": "Single",
+                  "identity": "MobileCoin"
+                },
+                {
+                  "type": "Single",
+                  "identity": "SomeOrg"
+                },
+                {
+                  "type": "Multi",
+                  "identity": {
+                    "threshold": 2,
+                    "signers": [
+                      {
+                        "type": "Single",
+                        "identity": "LP-1"
+                      },
+                      {
+                        "type": "Single",
+                        "identity": "LP-2"
+                      },
+                      {
+                        "type": "Multi",
+                        "identity": {
+                          "threshold": 2,
+                          "signers": [
+                             {
+                              "type": "Single",
+                              "identity": "LP-3A"
+                             },
+                             {
+                              "type": "Single",
+                              "identity": "LP-3B"
+                             },
+                             {
+                              "type": "Single",
+                              "identity": "MobileCoin"
+                             }
+                         ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        "#;
+
+        let signer_set_config: SignerSetConfig = serde_json::from_str(valid_json).unwrap();
+
+        let signer_set: mc_crypto_multisig::SignerSetV2<Ed25519Public> =
+            (&signer_set_config).try_into().unwrap();
+
+        let expected_signer_set = mc_crypto_multisig::SignerSetV2::new(
+            vec![
+                key_mobilecoin.into(),
+                key_some_org.into(),
+                mc_crypto_multisig::SignerSetV2::new(
+                    vec![
+                        key_lp1.into(),
+                        key_lp2.into(),
+                        mc_crypto_multisig::SignerSetV2::new(
+                            vec![key_lp3a.into(), key_lp3b.into(), key_mobilecoin.into()],
+                            2,
+                        )
+                        .into(),
+                    ],
+                    2,
+                )
+                .into(),
+            ],
+            3,
+        );
+
+        assert_eq!(signer_set, expected_signer_set);
+    }
+
+    #[test]
+    fn unknown_identity_fails_to_parse() {
+        let invalid_config_json = r#"
+        {
+            "signer_identities": {
+              "MobileCoin": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAl3XVo/DeiTjHn8dYQuEtBjQrEWNQSKpfzw3X9dewSVY=\n-----END PUBLIC KEY-----\n"
+            },
+            "signer_set": {
+              "threshold": 3,
+              "signers": [
+                {
+                  "type": "Single",
+                  "identity": "Nope"
+                }
+              ]
+            }
+          }
+        "#;
+
+        let signer_set_config: SignerSetConfig = serde_json::from_str(invalid_config_json).unwrap();
+        let signer_set: Result<mc_crypto_multisig::SignerSetV2<_>, _> =
+            (&signer_set_config).try_into();
+
+        assert_eq!(signer_set, Err("Unknown identity: Nope".into()));
+    }
+
+    #[test]
+    fn invalid_pem_fails_to_parse() {
+        // This PEM is missing a dash
+        let invalid_config_json = r#"
+        {
+            "signer_identities": {
+              "MobileCoin": "----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAl3XVo/DeiTjHn8dYQuEtBjQrEWNQSKpfzw3X9dewSVY=\n-----END PUBLIC KEY-----\n"
+            },
+            "signer_set": {
+              "threshold": 3,
+              "signers": [
+                {
+                  "type": "Single",
+                  "identity": "MobileCoin"
+                }
+              ]
+            }
+          }
+        "#;
+
+        let err = serde_json::from_str::<SignerSetConfig>(invalid_config_json).unwrap_err();
+        assert_eq!(err.to_string(), "Failed to parse PEM: malformedframing at line 4 column 145");
+    }
+}

--- a/consensus/service/config/src/signer_set.rs
+++ b/consensus/service/config/src/signer_set.rs
@@ -96,10 +96,11 @@ impl SignerSet {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(mc_crypto_multisig::SignerSetV2::new(
-            signers,
-            self.threshold,
-        ))
+        let signer_set = mc_crypto_multisig::SignerSetV2::new(signers, self.threshold);
+        if !signer_set.is_valid() {
+            return Err("SignerSet is invalid".into());
+        }
+        Ok(signer_set)
     }
 }
 
@@ -329,7 +330,10 @@ mod tests {
         let signer_set: Result<mc_crypto_multisig::SignerSetV2<_>, _> =
             (&signer_set_config).try_into();
 
-        assert_eq!(signer_set, Err("SignerSet contains invalid threshold of 0/1".into()));
+        assert_eq!(
+            signer_set,
+            Err("SignerSet contains invalid threshold of 0/1".into())
+        );
     }
 
     #[test]
@@ -355,6 +359,9 @@ mod tests {
         let signer_set: Result<mc_crypto_multisig::SignerSetV2<_>, _> =
             (&signer_set_config).try_into();
 
-        assert_eq!(signer_set, Err("SignerSet contains invalid threshold of 2/1".into()));
+        assert_eq!(
+            signer_set,
+            Err("SignerSet contains invalid threshold of 2/1".into())
+        );
     }
 }

--- a/consensus/service/config/src/signer_set.rs
+++ b/consensus/service/config/src/signer_set.rs
@@ -3,6 +3,7 @@
 //! Data types for representing a `SignerSetV2` in a configuration file.
 //! We do not deserialize a `SignerSetV2` directly, because it is too hard
 //! to maintain by a human operator.
+//! See tests below for an example of the file format.
 
 use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Update: This is likely going to get closed in favor of https://github.com/mobilecoinfoundation/mobilecoin/pull/2732 (and whatever followup PRs build on top of it)



### Motivation

`SignerSetV2`s are going to be stored inside JSON configuration files
suck as `tokens.json` or files used when constructing `MintConfigTx`s
(once the mint client starts supporting the revised multisig scheme).

The current representation of `SignerSetV1` inside JSON files has caused
some headaches:
1. It is not possible to tell which entity stands behind which public
   key. Separately, it would be nice to refer to a public key by name when declaring a signer set.
2. There is currently a known bug in `pem::parse_many` - turns out it
   will silently ignore data that is not properly surrounded by the
dashed markers. The format being proposed here parses each PEM
individually, so it bypasses this annoyance.

Basically the idea is to create a slightly more human-friendly
serialized representation of signer sets.
