### PR TITLE
Make fog-view load blocks from postgres in batches

### DIFF
--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -273,7 +273,7 @@ pub trait RecoveryDb {
         &self,
         ingress_key: CompressedRistrettoPublic,
         block_index: u64,
-        block_count: u64,
+        block_count: usize,
     ) -> Result<Vec<Vec<ETxOutRecord>>, Self::Error>;
 
     /// Get the invocation id that published this block with this key.

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -256,6 +256,26 @@ pub trait RecoveryDb {
         block_index: u64,
     ) -> Result<Option<Vec<ETxOutRecord>>, Self::Error>;
 
+    /// Get ETxOutRecords for a given ingress key from a block, and subsequent
+    /// blocks, up to some limit. (This is like a batch call to
+    /// get_tx_outs_by_block_and_key_retriable with lookahead, and makes
+    /// sense if there is high network latency.)
+    ///
+    /// Arguments:
+    /// * ingress_key: The ingress key we need ETxOutRecords from
+    /// * block_index: The first block we need ETxOutRecords from
+    /// * block_count: How many subsequent blocks to also request data for.
+    ///
+    /// Returns:
+    /// * The sequence of ETxOutRecord's, from consequecutive blocks starting
+    ///   from block_index. Empty if not even the block_index'th block exists.
+    fn get_tx_outs_by_block_range_and_key(
+        &self,
+        ingress_key: CompressedRistrettoPublic,
+        block_index: u64,
+        block_count: u64,
+    ) -> Result<Vec<Vec<ETxOutRecord>>, Self::Error>;
+
     /// Get the invocation id that published this block with this key.
     ///
     /// Note: This is only used by TESTS right now, but it is important to be

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -977,7 +977,7 @@ impl SqlRecoveryDb {
         // We will get one row for each hit in the table we found
         let rows: Vec<(i64, Vec<u8>)> = query.load::<(i64, Vec<u8>)>(&conn)?;
 
-        if rows.len() > block_count as usize {
+        if rows.len() > block_count {
             log::warn!(
                 self.logger,
                 "When querying, more responses than expected: {} > {}",

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -964,20 +964,27 @@ impl SqlRecoveryDb {
         //
         // This ensures that we can detect any gaps in the data
         let key_bytes: &[u8] = ingress_key.as_ref();
-        let query = schema::ingested_blocks::dsl::ingested_blocks
-            .filter(schema::ingested_blocks::dsl::ingress_public_key.eq(key_bytes))
-            .filter(schema::ingested_blocks::dsl::block_number.ge(block_index as i64))
-            .filter(
-                schema::ingested_blocks::dsl::block_number.lt((block_index + block_count) as i64),
-            )
-            .select((
-                schema::ingested_blocks::dsl::block_number,
-                schema::ingested_blocks::dsl::proto_ingested_block_data,
-            ))
-            .order(schema::ingested_blocks::dsl::block_number.asc());
+        let query = {
+            use schema::ingested_blocks::dsl;
+            dsl::ingested_blocks
+                .filter(dsl::ingress_public_key.eq(key_bytes))
+                .filter(dsl::block_number.ge(block_index as i64))
+                .limit(block_count as i64)
+                .select((dsl::block_number, dsl::proto_ingested_block_data))
+                .order(dsl::block_number.asc())
+        };
 
         // We will get one row for each hit in the table we found
         let rows: Vec<(i64, Vec<u8>)> = query.load::<(i64, Vec<u8>)>(&conn)?;
+
+        if rows.len() > block_count as usize {
+            log::warn!(
+                self.logger,
+                "When querying, more responses than expected: {} > {}",
+                rows.len(),
+                block_count
+            );
+        }
 
         // We want to iterate over the rows we got, make sure there are no gaps in block
         // indices, and decode the TxOut's and return them. If there are gaps,
@@ -2376,6 +2383,100 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(tx_outs, records2);
+    }
+
+    #[test_with_logger]
+    fn test_get_tx_outs_by_block_range_and_key(logger: Logger) {
+        let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
+        let db = db_test_context.get_db_instance();
+
+        let ingress_key = CompressedRistrettoPublic::from(RistrettoPublic::from_random(&mut rng));
+        db.new_ingress_key(&ingress_key, 122).unwrap();
+
+        let invoc_id1 = db
+            .new_ingest_invocation(None, &ingress_key, &random_kex_rng_pubkey(&mut rng), 122)
+            .unwrap();
+
+        let invoc_id2 = db
+            .new_ingest_invocation(None, &ingress_key, &random_kex_rng_pubkey(&mut rng), 123)
+            .unwrap();
+
+        let (block1, records1) = random_block(&mut rng, 122, 10);
+        db.add_block_data(&invoc_id1, &block1, 0, &records1)
+            .unwrap();
+
+        let (block2, records2) = random_block(&mut rng, 123, 10);
+        db.add_block_data(&invoc_id2, &block2, 0, &records2)
+            .unwrap();
+
+        // Get tx outs for a key we're not aware of or a block id we're not aware of
+        // should return empty vec
+        let batch_result = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, 124, 2)
+            .unwrap();
+        assert_eq!(batch_result.len(), 0);
+
+        let batch_result = db
+            .get_tx_outs_by_block_range_and_key(
+                CompressedRistrettoPublic::from_random(&mut rng),
+                123,
+                2,
+            )
+            .unwrap();
+        assert_eq!(batch_result.len(), 0);
+
+        // Getting tx outs in a batch should work as expected when requesting things
+        // that exist
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block1.index, 1)
+            .unwrap();
+        assert_eq!(batch_results.len(), 1);
+        assert_eq!(batch_results[0], records1);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block2.index, 1)
+            .unwrap();
+        assert_eq!(batch_results.len(), 1);
+        assert_eq!(batch_results[0], records2);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block1.index, 2)
+            .unwrap();
+        assert_eq!(batch_results.len(), 2);
+        assert_eq!(batch_results[0], records1);
+        assert_eq!(batch_results[1], records2);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block2.index, 2)
+            .unwrap();
+        assert_eq!(batch_results.len(), 1);
+        assert_eq!(batch_results[0], records2);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block1.index, 3)
+            .unwrap();
+        assert_eq!(batch_results.len(), 2);
+        assert_eq!(batch_results[0], records1);
+        assert_eq!(batch_results[1], records2);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block2.index, 3)
+            .unwrap();
+        assert_eq!(batch_results.len(), 1);
+        assert_eq!(batch_results[0], records2);
+
+        // When there is a gap in the data, the gap should suppress any further results
+        // even if there are hits later in the range.
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block1.index - 1, 2)
+            .unwrap();
+        assert_eq!(batch_results.len(), 0);
+
+        let batch_results = db
+            .get_tx_outs_by_block_range_and_key(ingress_key, block1.index - 2, 3)
+            .unwrap();
+        assert_eq!(batch_results.len(), 0);
     }
 
     #[test_with_logger]

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -935,6 +935,71 @@ impl SqlRecoveryDb {
         }
     }
 
+    /// Get ETxOutRecords for a given ingress key from a block, and subsequent
+    /// blocks, up to some limit. (This is like a batch call to
+    /// get_tx_outs_by_block_and_key_retriable with lookahead, and makes
+    /// sense if there is high network latency.)
+    ///
+    /// Arguments:
+    /// * ingress_key: The ingress key we need ETxOutRecords from
+    /// * block_index: The first block we need ETxOutRecords from
+    /// * block_count: How many subsequent blocks to also request data for.
+    ///
+    /// Returns:
+    /// * The sequence of ETxOutRecord's, from consequecutive blocks starting
+    ///   from block_index. Empty if not even the block_index'th block exists.
+    fn get_tx_outs_by_block_range_and_key_retriable(
+        &self,
+        ingress_key: CompressedRistrettoPublic,
+        block_index: u64,
+        block_count: u64,
+    ) -> Result<Vec<Vec<ETxOutRecord>>, Error> {
+        let conn = self.pool.get()?;
+
+        // The idea is:
+        // Similar to get_tx_outs_by_block_and_key_retriable, but now
+        // * we have a range of admissible block indices
+        // * we order by the block number
+        // * we also select over the block number so that sql gives us the block number
+        //
+        // This ensures that we can detect any gaps in the data
+        let key_bytes: &[u8] = ingress_key.as_ref();
+        let query = schema::ingested_blocks::dsl::ingested_blocks
+            .filter(schema::ingested_blocks::dsl::ingress_public_key.eq(key_bytes))
+            .filter(schema::ingested_blocks::dsl::block_number.ge(block_index as i64))
+            .filter(
+                schema::ingested_blocks::dsl::block_number.lt((block_index + block_count) as i64),
+            )
+            .select((
+                schema::ingested_blocks::dsl::block_number,
+                schema::ingested_blocks::dsl::proto_ingested_block_data,
+            ))
+            .order(schema::ingested_blocks::dsl::block_number.asc());
+
+        // We will get one row for each hit in the table we found
+        let rows: Vec<(i64, Vec<u8>)> = query.load::<(i64, Vec<u8>)>(&conn)?;
+
+        // We want to iterate over the rows we got, make sure there are no gaps in block
+        // indices, and decode the TxOut's and return them. If there are gaps,
+        // we log at warn level, and short-circuit out of this, returning only
+        // whatever we managed to get. That will discard data that we got from
+        // the DB and we will request it again later, but there is no reason for
+        // there to be gaps, that's not how the system works, so it isn't
+        // important to optimize for that case.
+
+        let mut result = Vec::new();
+        for (idx, (block_number, proto)) in rows.into_iter().enumerate() {
+            if block_index + idx as u64 == block_number as u64 {
+                let proto = ProtoIngestedBlockData::decode(&*proto)?;
+                result.push(proto.e_tx_out_records);
+            } else {
+                log::warn!(self.logger, "When querying for block index {} and up to {} blocks on, the {}'th response has block_number {} which is not expected. Gaps in the data?", block_index, block_count, idx, block_number);
+                break;
+            }
+        }
+        Ok(result)
+    }
+
     /// Get iid that produced data for given ingress key and a given block
     /// index.
     fn get_invocation_id_by_block_and_key_retriable(
@@ -1346,6 +1411,30 @@ impl RecoveryDb for SqlRecoveryDb {
     ) -> Result<Option<Vec<ETxOutRecord>>, Self::Error> {
         our_retry(self.get_retries(), || {
             self.get_tx_outs_by_block_and_key_retriable(ingress_key, block_index)
+        })
+    }
+
+    /// Get ETxOutRecords for a given ingress key from a block, and subsequent
+    /// blocks, up to some limit. (This is like a batch call to
+    /// get_tx_outs_by_block_and_key with lookahead, and makes sense if
+    /// there is high network latency.)
+    ///
+    /// Arguments:
+    /// * ingress_key: The ingress key we need ETxOutRecords from
+    /// * block_index: The first block we need ETxOutRecords from
+    /// * block_count: How many subsequent blocks to also request data for.
+    ///
+    /// Returns:
+    /// * The sequence of ETxOutRecord's, from consequecutive blocks starting
+    ///   from block_index. Empty if not even the block_index'th block exists.
+    fn get_tx_outs_by_block_range_and_key(
+        &self,
+        ingress_key: CompressedRistrettoPublic,
+        block_index: u64,
+        block_count: u64,
+    ) -> Result<Vec<Vec<ETxOutRecord>>, Self::Error> {
+        our_retry(self.get_retries(), || {
+            self.get_tx_outs_by_block_range_and_key_retriable(ingress_key, block_index, block_count)
         })
     }
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -952,7 +952,7 @@ impl SqlRecoveryDb {
         &self,
         ingress_key: CompressedRistrettoPublic,
         block_index: u64,
-        block_count: u64,
+        block_count: usize,
     ) -> Result<Vec<Vec<ETxOutRecord>>, Error> {
         let conn = self.pool.get()?;
 
@@ -1438,7 +1438,7 @@ impl RecoveryDb for SqlRecoveryDb {
         &self,
         ingress_key: CompressedRistrettoPublic,
         block_index: u64,
-        block_count: u64,
+        block_count: usize,
     ) -> Result<Vec<Vec<ETxOutRecord>>, Self::Error> {
         our_retry(self.get_retries(), || {
             self.get_tx_outs_by_block_range_and_key_retriable(ingress_key, block_index, block_count)

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -75,6 +75,6 @@ pub struct MobileAcctViewConfig {
     /// How many blocks to request at once when requesting blocks from postgres
     /// Increasing this may help if there is high network latency with postgres,
     /// and should not much harm performance otherwise when loading the DB.
-    #[clap(long, default_value = "100", env = "MC_BLOCK_BATCH_REQUEST_SIZE")]
-    pub block_batch_request_size: usize,
+    #[clap(long, default_value = "1000", env = "MC_BLOCK_QUERY_BATCH_SIZE")]
+    pub block_query_batch_size: usize,
 }

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -71,4 +71,10 @@ pub struct MobileAcctViewConfig {
     /// Postgres config
     #[clap(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+
+    /// How many blocks to request at once when requesting blocks from postgres
+    /// Increasing this may help if there is high network latency with postgres,
+    /// and should not much harm performance otherwise when loading the DB.
+    #[clap(long, default_value = "100", env = "MC_BLOCK_BATCH_REQUEST_SIZE")]
+    pub block_batch_request_size: usize,
 }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -294,7 +294,7 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
                 self.db.get_tx_outs_by_block_range_and_key(
                     ingress_key,
                     block_index,
-                    self.block_batch_request_size as u64,
+                    self.block_batch_request_size,
                 )
             };
 

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -394,7 +394,7 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
         let db = db_test_context.get_db_instance();
-        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), logger);
+        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), 1, logger);
 
         // Initially, our database starts empty.
         let ingress_keys = db_fetcher.get_highest_processed_block_context();
@@ -624,7 +624,7 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
         let db = db_test_context.get_db_instance();
-        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), logger);
+        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), 1, logger);
 
         // Register two ingress keys that have some overlap:
         // key_id1 starts at block 0, key2 starts at block 5.
@@ -681,7 +681,7 @@ mod tests {
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let db_test_context = SqlRecoveryDbTestContext::new(logger.clone());
         let db = db_test_context.get_db_instance();
-        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), logger);
+        let db_fetcher = DbFetcher::new(db.clone(), Default::default(), 1, logger);
 
         // Register two ingress keys that have some overlap:
         // invoc_id1 starts at block 0, invoc_id2 starts at block 50.

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -78,6 +78,7 @@ impl DbFetcher {
     pub fn new<DB: RecoveryDb + Clone + Send + Sync + 'static>(
         db: DB,
         readiness_indicator: ReadinessIndicator,
+        block_batch_request_size: usize,
         logger: Logger,
     ) -> Self {
         let stop_requested = Arc::new(AtomicBool::new(false));
@@ -102,6 +103,7 @@ impl DbFetcher {
                         thread_shared_state,
                         thread_num_queued_records_limiter,
                         readiness_indicator,
+                        block_batch_request_size,
                         logger,
                     )
                 })
@@ -172,6 +174,7 @@ struct DbFetcherThread<DB: RecoveryDb + Clone + Send + Sync + 'static> {
     block_tracker: BlockTracker,
     num_queued_records_limiter: Arc<(Mutex<usize>, Condvar)>,
     readiness_indicator: ReadinessIndicator,
+    block_batch_request_size: usize,
     logger: Logger,
 }
 
@@ -184,8 +187,13 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
         shared_state: Arc<Mutex<DbFetcherSharedState>>,
         num_queued_records_limiter: Arc<(Mutex<usize>, Condvar)>,
         readiness_indicator: ReadinessIndicator,
+        block_batch_request_size: usize,
         logger: Logger,
     ) {
+        assert!(
+            block_batch_request_size > 0,
+            "Block batch request size cannot be 0, this is a configuration error"
+        );
         let thread = Self {
             db,
             stop_requested,
@@ -193,6 +201,7 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
             block_tracker: BlockTracker::new(logger.clone()),
             num_queued_records_limiter,
             readiness_indicator,
+            block_batch_request_size,
             logger,
         };
         thread.run();
@@ -282,64 +291,67 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
             // Attempt to load data for the next block.
             let get_tx_outs_by_block_result = {
                 let _metrics_timer = counters::GET_TX_OUTS_BY_BLOCK_TIME.start_timer();
-                self.db
-                    .get_tx_outs_by_block_and_key(ingress_key, block_index)
+                self.db.get_tx_outs_by_block_range_and_key(
+                    ingress_key,
+                    block_index,
+                    self.block_batch_request_size as u64,
+                )
             };
 
             match get_tx_outs_by_block_result {
-                Ok(Some(tx_outs)) => {
-                    let num_tx_outs = tx_outs.len();
-
-                    // Log
-                    log::info!(
-                        self.logger,
-                        "ingress_key {:?} fetched {} tx outs for block {}",
-                        ingress_key,
-                        num_tx_outs,
-                        block_index,
-                    );
-
-                    // Ingest has produced data for this block, we'd like to keep trying the
-                    // next block on the next loop iteration.
-                    may_have_more_work = true;
-
-                    // Mark that we are done fetching data for this block.
-                    self.block_tracker.block_processed(ingress_key, block_index);
-
-                    // Store the fetched records so that they could be consumed by the enclave
-                    // when its ready.
-                    {
-                        let mut state = self.shared_state();
-                        state.fetched_records.push(FetchedRecords {
+                Ok(block_results) => {
+                    if !block_results.is_empty() {
+                        // Log
+                        log::info!(
+                            self.logger,
+                            "ingress_key {:?} fetched {} blocks starting with block {}",
                             ingress_key,
+                            block_results.len(),
                             block_index,
-                            records: tx_outs,
-                        });
+                        );
+
+                        if block_results.len() == self.block_batch_request_size {
+                            // Ingest has produced as much block data as we asked for,
+                            // we'd like to keep trying to download in the next loop iteration.
+                            may_have_more_work = true;
+                        }
+
+                        for (idx, tx_outs) in block_results.into_iter().enumerate() {
+                            let idx = idx as u64;
+                            let num_tx_outs = tx_outs.len();
+
+                            // Mark that we are done fetching data for this block.
+                            self.block_tracker
+                                .block_processed(ingress_key, block_index + idx);
+
+                            // Store the fetched records so that they could be consumed by the
+                            // enclave when its ready.
+                            {
+                                let mut state = self.shared_state();
+                                state.fetched_records.push(FetchedRecords {
+                                    ingress_key,
+                                    block_index: block_index + idx,
+                                    records: tx_outs,
+                                });
+                            }
+
+                            // Update metrics.
+                            counters::BLOCKS_FETCHED_COUNT.inc();
+                            counters::TXOS_FETCHED_COUNT.inc_by(num_tx_outs as u64);
+
+                            // Block if we have queued up enough records for now.
+                            // (Until the enclave thread drains the queue).
+                            let (lock, condvar) = &*self.num_queued_records_limiter;
+                            let mut num_queued_records = condvar
+                                .wait_while(lock.lock().unwrap(), |num_queued_records| {
+                                    *num_queued_records > MAX_QUEUED_RECORDS
+                                })
+                                .expect("condvar wait failed");
+                            *num_queued_records += num_tx_outs;
+
+                            counters::DB_FETCHER_NUM_QUEUED_RECORDS.set(*num_queued_records as i64);
+                        }
                     }
-
-                    // Update metrics.
-                    counters::BLOCKS_FETCHED_COUNT.inc();
-                    counters::TXOS_FETCHED_COUNT.inc_by(num_tx_outs as u64);
-
-                    // Block if we have queued up enough records for now.
-                    // (Until the enclave thread drains the queue).
-                    let (lock, condvar) = &*self.num_queued_records_limiter;
-                    let mut num_queued_records = condvar
-                        .wait_while(lock.lock().unwrap(), |num_queued_records| {
-                            *num_queued_records > MAX_QUEUED_RECORDS
-                        })
-                        .expect("condvar wait failed");
-                    *num_queued_records += num_tx_outs;
-
-                    counters::DB_FETCHER_NUM_QUEUED_RECORDS.set(*num_queued_records as i64);
-                }
-                Ok(None) => {
-                    log::trace!(
-                        self.logger,
-                        "ingress_key {:?} block {} query missed, no new data yet",
-                        ingress_key,
-                        block_index
-                    );
                 }
                 Err(err) => {
                     log::warn!(
@@ -351,6 +363,8 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
                     );
                     // We might have more work to do, we aren't sure because of the error
                     may_have_more_work = true;
+                    // Let's back off for one interval when there is an error
+                    sleep(DB_POLL_INTERNAL);
                 }
             }
         }

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -71,6 +71,7 @@ where
         let readiness_indicator = ReadinessIndicator::default();
 
         let db_poll_thread = DbPollThread::new(
+            config.clone(),
             enclave.clone(),
             recovery_db.clone(),
             readiness_indicator.clone(),
@@ -210,6 +211,9 @@ where
     E: ViewEnclaveProxy,
     DB: RecoveryDb + Clone + Send + Sync + 'static,
 {
+    /// Config
+    config: MobileAcctViewConfig,
+
     /// Enclave.
     enclave: E,
 
@@ -247,6 +251,7 @@ where
 
     /// Initialize a new DbPollThread object.
     pub fn new(
+        config: MobileAcctViewConfig,
         enclave: E,
         db: DB,
         readiness_indicator: ReadinessIndicator,
@@ -256,6 +261,7 @@ where
         let shared_state = Arc::new(Mutex::new(DbPollSharedState::default()));
 
         Self {
+            config,
             enclave,
             db,
             join_handle: None,
@@ -275,6 +281,7 @@ where
             *shared_state = DbPollSharedState::default();
         }
 
+        let thread_config = self.config.clone();
         let thread_enclave = self.enclave.clone();
         let thread_db = self.db.clone();
         let thread_stop_requested = self.stop_requested.clone();
@@ -287,6 +294,7 @@ where
                 .name(format!("DbPoll-{}", std::any::type_name::<E>()))
                 .spawn(move || {
                     Self::thread_entrypoint(
+                        thread_config,
                         thread_enclave,
                         thread_db,
                         thread_stop_requested,
@@ -310,6 +318,7 @@ where
     }
 
     fn thread_entrypoint(
+        config: MobileAcctViewConfig,
         enclave: E,
         db: DB,
         stop_requested: Arc<AtomicBool>,
@@ -320,6 +329,7 @@ where
         log::debug!(logger, "Db poll thread started");
 
         let mut worker = DbPollThreadWorker::new(
+            config,
             stop_requested,
             enclave,
             db,
@@ -402,6 +412,7 @@ where
     DB: RecoveryDb + Clone + Send + Sync + 'static,
 {
     pub fn new(
+        config: MobileAcctViewConfig,
         stop_requested: Arc<AtomicBool>,
         enclave: E,
         db: DB,
@@ -414,7 +425,12 @@ where
             enclave,
             db: db.clone(),
             shared_state,
-            db_fetcher: DbFetcher::new(db, readiness_indicator, logger.clone()),
+            db_fetcher: DbFetcher::new(
+                db,
+                readiness_indicator,
+                config.block_batch_request_size,
+                logger.clone(),
+            ),
             enclave_block_tracker: BlockTracker::new(logger.clone()),
             last_unblocked_at: Instant::now(),
             logger,

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -428,7 +428,7 @@ where
             db_fetcher: DbFetcher::new(
                 db,
                 readiness_indicator,
-                config.block_batch_request_size,
+                config.block_query_batch_size,
                 logger.clone(),
             ),
             enclave_block_tracker: BlockTracker::new(logger.clone()),

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -77,6 +77,7 @@ fn get_test_environment(
             admin_listen_uri: Default::default(),
             client_auth_token_max_lifetime: Default::default(),
             postgres_config: Default::default(),
+            block_batch_request_size: 10,
         };
 
         let enclave = SgxViewEnclave::new(

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -77,7 +77,7 @@ fn get_test_environment(
             admin_listen_uri: Default::default(),
             client_auth_token_max_lifetime: Default::default(),
             postgres_config: Default::default(),
-            block_batch_request_size: 10,
+            block_query_batch_size: 2,
         };
 
         let enclave = SgxViewEnclave::new(


### PR DESCRIPTION
These batches have a size which is configurable as a command line parameter.

---

The point of this is that we have been having issues where the network latency to get from fog-view to postgres has been high enough that it becomes the bottleneck for fog-view loading all the data into ORAM, and begins to significantly negatively impact the time to restart fog view. We can make the server more tolerant of that by making it try to load more data at once.

Thanks to James for suggested approach here