### PR TITLE
Switch mint governors to SignerSetV2

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -488,7 +488,11 @@ message MintConfigTx {
 /// A mint-config transaction coupled with the data used to validate it.
 message ValidatedMintConfigTx {
     MintConfigTx mint_config_tx = 1;
-    Ed25519SignerSetV1 signer_set = 2;
+
+    oneof signer_set {
+        Ed25519SignerSetV1 signer_set_v1 = 2;
+        Ed25519SignerSetV2 signer_set_v2 = 4;
+    }
 }
 
 // The amount and blinding factor of a TxOut

--- a/api/src/convert/mint_versioned_signer_set.rs
+++ b/api/src/convert/mint_versioned_signer_set.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Convert to/from mc_transaction_core::mint::VersionedSignerSet
+
+use crate::{external, ConversionError};
+use mc_transaction_core::mint::VersionedSignerSet;
+
+impl From<&VersionedSignerSet> for external::ValidatedMintConfigTx_oneof_signer_set {
+    fn from(src: &VersionedSignerSet) -> Self {
+        match src {
+            VersionedSignerSet::V1(signer_set) => Self::signer_set_v1(signer_set.into()),
+
+            VersionedSignerSet::V2(signer_set) => Self::signer_set_v2(signer_set.into()),
+        }
+    }
+}
+
+impl TryFrom<&external::ValidatedMintConfigTx_oneof_signer_set> for VersionedSignerSet {
+    type Error = ConversionError;
+
+    fn try_from(
+        src: &external::ValidatedMintConfigTx_oneof_signer_set,
+    ) -> Result<Self, Self::Error> {
+        match src {
+            external::ValidatedMintConfigTx_oneof_signer_set::signer_set_v1(signer_set) => {
+                Ok(VersionedSignerSet::V1(signer_set.try_into()?))
+            }
+
+            external::ValidatedMintConfigTx_oneof_signer_set::signer_set_v2(signer_set) => {
+                Ok(VersionedSignerSet::V2(signer_set.try_into()?))
+            }
+        }
+    }
+}

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -28,6 +28,7 @@ mod input_secret;
 mod key_image;
 mod mint_config;
 mod mint_tx;
+mod mint_versioned_signer_set;
 mod node;
 mod output_secret;
 mod public_address;

--- a/consensus/api/proto/consensus_config.proto
+++ b/consensus/api/proto/consensus_config.proto
@@ -38,7 +38,7 @@ message TokenConfig {
     uint64 minimum_fee = 2;
 
     // Minting governors (optional, only when minting is configured).
-    external.Ed25519SignerSetV1 governors = 3;
+    external.Ed25519SignerSetV2 governors = 5; // tag 3 used to be the Ed25519SignerSetV1 governors that were deprecated
 
     // Currently active mint configurations for this token (optional, only if a valid MintConfigTx has been previously issued).
     ActiveMintConfigs active_mint_configs = 4;

--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -89,7 +89,7 @@ mod test {
     use super::*;
     use alloc::{string::ToString, vec};
     use mc_crypto_keys::Ed25519Public;
-    use mc_crypto_multisig::SignerSetV1;
+    use mc_crypto_multisig::SignerSetV2;
     use mc_transaction_core::{tokens::Mob, Token, TokenId};
 
     /// Different block_version/fee maps/responder ids should result in
@@ -172,7 +172,7 @@ mod test {
             fee_map: FeeMap::default(),
             governors_map: GovernorsMap::try_from_iter([(
                 TokenId::from(1),
-                SignerSetV1::new(vec![Ed25519Public::default()], 1),
+                SignerSetV2::new(vec![Ed25519Public::default().into()], 1),
             )])
             .unwrap(),
             governors_signature: None,
@@ -183,7 +183,7 @@ mod test {
             fee_map: FeeMap::default(),
             governors_map: GovernorsMap::try_from_iter([(
                 TokenId::from(2),
-                SignerSetV1::new(vec![Ed25519Public::default()], 1),
+                SignerSetV2::new(vec![Ed25519Public::default().into()], 1),
             )])
             .unwrap(),
             governors_signature: None,
@@ -194,7 +194,13 @@ mod test {
             fee_map: FeeMap::default(),
             governors_map: GovernorsMap::try_from_iter([(
                 TokenId::from(2),
-                SignerSetV1::new(vec![Ed25519Public::default(), Ed25519Public::default()], 1),
+                SignerSetV2::new(
+                    vec![
+                        Ed25519Public::default().into(),
+                        Ed25519Public::default().into(),
+                    ],
+                    1,
+                ),
             )])
             .unwrap(),
             governors_signature: None,

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -366,7 +366,7 @@ impl SgxConsensusEnclave {
 
             validated_txs.push(ValidatedMintConfigTx {
                 mint_config_tx: tx,
-                signer_set: governors,
+                signer_set: Some(governors.into()),
             });
         }
 
@@ -1035,7 +1035,7 @@ mod tests {
     use mc_common::{logger::test_with_logger, HashMap, HashSet};
     use mc_consensus_enclave_api::{FeeMap, GovernorsMap, GovernorsSigner};
     use mc_crypto_keys::{Ed25519Private, Ed25519Signature};
-    use mc_crypto_multisig::SignerSetV1;
+    use mc_crypto_multisig::SignerSetV2;
     use mc_ledger_db::{
         test_utils::{add_txos_to_ledger, create_ledger, create_transaction, initialize_ledger},
         Ledger,
@@ -1085,7 +1085,8 @@ mod tests {
         let token_id1 = TokenId::from(1);
         let token_id2 = TokenId::from(2);
         let (_mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
         let governors_map1 =
             GovernorsMap::try_from_iter([(token_id1, signer_set1.clone())]).unwrap();
         let governors_map2 = GovernorsMap::try_from_iter([(token_id2, signer_set1)]).unwrap();
@@ -2233,8 +2234,10 @@ mod tests {
             &mut rng,
         );
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map =
             GovernorsMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
@@ -2368,7 +2371,8 @@ mod tests {
             &mut rng,
         );
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map = GovernorsMap::try_from_iter([(token_id1, signer_set1)]).unwrap();
 
@@ -2452,7 +2456,8 @@ mod tests {
             &mut rng,
         );
 
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map = GovernorsMap::try_from_iter([
             // NOTE: token_id1 is also governed by signer_set2, which means a MintTx signed with a
@@ -2527,8 +2532,10 @@ mod tests {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
         let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map = GovernorsMap::try_from_iter([
             (token_id1, signer_set1.clone()),
@@ -2599,11 +2606,11 @@ mod tests {
                 vec![
                     ValidatedMintConfigTx {
                         mint_config_tx: mint_config_tx1.clone(),
-                        signer_set: signer_set1.clone(),
+                        signer_set: Some(signer_set1.clone().into()),
                     },
                     ValidatedMintConfigTx {
                         mint_config_tx: mint_config_tx2.clone(),
-                        signer_set: signer_set2.clone(),
+                        signer_set: Some(signer_set2.clone().into()),
                     }
                 ]
             );
@@ -2625,7 +2632,8 @@ mod tests {
         let (mint_config_tx1, _signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
         let (_mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
 
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map = GovernorsMap::try_from_iter([(token_id2, signer_set2)]).unwrap();
 
@@ -2688,7 +2696,8 @@ mod tests {
         let (mut mint_config_tx1, signers1) =
             create_mint_config_tx_and_signers(token_id1, &mut rng);
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
 
         // This will invalidate the signature.
         mint_config_tx1.prefix.tombstone_block += 1;
@@ -2752,7 +2761,8 @@ mod tests {
 
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map = GovernorsMap::try_from_iter([(token_id1, signer_set1)]).unwrap();
 
@@ -2832,8 +2842,10 @@ mod tests {
             &mut rng,
         );
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map =
             GovernorsMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])
@@ -3016,8 +3028,10 @@ mod tests {
         let (mint_config_tx1, signers1) = create_mint_config_tx_and_signers(token_id1, &mut rng);
         let (mint_config_tx2, signers2) = create_mint_config_tx_and_signers(token_id2, &mut rng);
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
-        let signer_set2 = SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
+        let signer_set2 =
+            SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1);
 
         let governors_map =
             GovernorsMap::try_from_iter([(token_id1, signer_set1), (token_id2, signer_set2)])

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -310,7 +310,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
             .into_iter()
             .map(|mint_config_tx| ValidatedMintConfigTx {
                 mint_config_tx,
-                signer_set: SignerSetV1::default(),
+                signer_set: Some(SignerSetV1::default().into()),
             })
             .collect();
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -246,7 +246,6 @@ fn main() {
         Commands::SignGovernors {
             signing_key,
             mut tokens,
-            output_toml,
             output_json,
         } => {
             let governors_map = tokens
@@ -259,11 +258,6 @@ fn main() {
             println!("Put this signature in the governors configuration file in the key \"governors_signature\".");
 
             tokens.governors_signature = Some(signature);
-
-            if let Some(path) = output_toml {
-                let toml_str = toml::to_string_pretty(&tokens).expect("failed serializing toml");
-                fs::write(path, toml_str).expect("failed writing output file");
-            }
 
             if let Some(path) = output_json {
                 let json_str =

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -363,7 +363,7 @@ pub enum Commands {
         tx_filenames: Vec<PathBuf>,
     },
 
-    /// Sign governors configuration from a tokens.toml/tokens.json file.
+    /// Sign governors configuration from a tokens.json file.
     SignGovernors {
         /// The key to sign with.
         #[clap(long = "signing-key", value_parser = load_key_from_pem, env = "MC_MINTING_SIGNING_KEY")]

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -373,10 +373,6 @@ pub enum Commands {
         #[clap(long, value_parser = parse_tokens_file, env = "MC_MINTING_TOKENS_CONFIG")]
         tokens: TokensConfig,
 
-        /// Optionally write a new tokens.toml file containing the signature.
-        #[clap(long, env = "MC_MINTING_OUTPUT_TOML")]
-        output_toml: Option<PathBuf>,
-
         /// Optionally write a new tokens.json file containing the signature.
         #[clap(long, env = "MC_MINTING_OUTPUT_JSON")]
         output_json: Option<PathBuf>,

--- a/consensus/service/config/src/error.rs
+++ b/consensus/service/config/src/error.rs
@@ -27,16 +27,8 @@ pub enum Error {
     /// Mint configuration is not allowed for token id {0}
     MintConfigNotAllowed(TokenId),
 
-    /**
-     * Invalid mint configuration for token id {0}: must have at least one
-     * signer
-     */
-    NoSigners(TokenId),
-
-    /** Invalid mint configuration for token id {0}: signer set threshold
-     * exceeds number of signers
-     */
-    SignerSetThresholdExceedsSigners(TokenId),
+    /// Signer set for token id {0} is invalid: {1}
+    SignerSet(TokenId, String),
 
     /// Cannot figure out file extension
     PathExtension,

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -170,8 +170,8 @@ impl ClientApiService {
                 grpc_token_config.set_token_id(*token_config.token_id());
                 grpc_token_config
                     .set_minimum_fee(token_config.minimum_fee_or_default().unwrap_or(0));
-                if let Some(governors) = token_config.governors() {
-                    grpc_token_config.set_governors(governors.into());
+                if let Some(governors) = token_config.governors()? {
+                    grpc_token_config.set_governors((&governors).into());
                 }
 
                 let active_mint_configs = self

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -9,6 +9,7 @@ use mc_consensus_api::{
     consensus_common::{ProposeTxResponse, ProposeTxResult},
 };
 use mc_consensus_enclave::Error as EnclaveError;
+use mc_consensus_service_config::Error as ConfigError;
 use mc_ledger_db::Error as LedgerError;
 use mc_transaction_core::{mint::MintValidationError, validation::TransactionValidationError};
 
@@ -37,6 +38,9 @@ pub enum ConsensusGrpcError {
 
     /// Invalid argument `{0}`
     InvalidArgument(String),
+
+    /// Config error: `{0}`
+    Config(ConfigError),
 
     /// Other error `{0}`
     Other(String),
@@ -92,6 +96,12 @@ impl From<MintTxManagerError> for ConsensusGrpcError {
             MintTxManagerError::MintValidation(err) => Self::from(err),
             MintTxManagerError::LedgerDb(err) => Self::from(err),
         }
+    }
+}
+
+impl From<ConfigError> for ConsensusGrpcError {
+    fn from(src: ConfigError) -> Self {
+        Self::Config(src)
     }
 }
 

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -923,7 +923,7 @@ mod tests {
         slot::SlotMetrics,
         MockScpNode, QuorumSet,
     };
-    use mc_crypto_multisig::SignerSetV1;
+    use mc_crypto_multisig::SignerSetV2;
     use mc_ledger_db::{
         test_utils::{
             add_block_contents_to_ledger, create_ledger, create_transaction, initialize_ledger,
@@ -1660,7 +1660,8 @@ mod tests {
         };
         add_block_contents_to_ledger(&mut ledger, block_version, block_contents, &mut rng).unwrap();
 
-        let signer_set1 = SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1);
+        let signer_set1 =
+            SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1);
         let governors_map = GovernorsMap::try_from_iter([(token_id1, signer_set1)]).unwrap();
         let mint_tx_manager =
             MintTxManagerImpl::new(ledger.clone(), block_version, governors_map, logger.clone());

--- a/consensus/service/src/mint_tx_manager/mod.rs
+++ b/consensus/service/src/mint_tx_manager/mod.rs
@@ -253,7 +253,7 @@ mod mint_config_tx_tests {
     use super::*;
     use mc_blockchain_types::BlockContents;
     use mc_common::logger::test_with_logger;
-    use mc_crypto_multisig::SignerSetV1;
+    use mc_crypto_multisig::SignerSetV2;
     use mc_ledger_db::test_utils::{
         add_block_contents_to_ledger, create_ledger, initialize_ledger,
     };
@@ -281,7 +281,7 @@ mod mint_config_tx_tests {
         let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -313,15 +313,15 @@ mod mint_config_tx_tests {
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![
             (
                 token_id_1,
-                SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_2,
-                SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_3,
-                SignerSetV1::new(signers3.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers3.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
         ])
         .unwrap();
@@ -354,7 +354,7 @@ mod mint_config_tx_tests {
         let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
 
@@ -410,7 +410,7 @@ mod mint_config_tx_tests {
         let (mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -454,7 +454,7 @@ mod mint_config_tx_tests {
         let (_mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -485,7 +485,7 @@ mod mint_config_tx_tests {
         let (mut mint_config_tx, signers) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -519,7 +519,7 @@ mod mint_config_tx_tests {
         let (mint_config_tx4, _) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -578,11 +578,11 @@ mod mint_config_tx_tests {
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![
             (
                 token_id_1,
-                SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_2,
-                SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
         ])
         .unwrap();
@@ -626,7 +626,7 @@ mod mint_config_tx_tests {
         let (mint_config_tx6, _) = create_mint_config_tx_and_signers(token_id_1, &mut rng);
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -670,7 +670,7 @@ mod mint_tx_tests {
     use mc_blockchain_types::BlockContents;
     use mc_common::logger::test_with_logger;
     use mc_crypto_keys::Ed25519Pair;
-    use mc_crypto_multisig::SignerSetV1;
+    use mc_crypto_multisig::SignerSetV2;
     use mc_ledger_db::test_utils::{
         add_block_contents_to_ledger, create_ledger, initialize_ledger,
     };
@@ -707,7 +707,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -753,11 +753,11 @@ mod mint_tx_tests {
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![
             (
                 token_id_1,
-                SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_2,
-                SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
         ])
         .unwrap();
@@ -819,11 +819,11 @@ mod mint_tx_tests {
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![
             (
                 token_id_1,
-                SignerSetV1::new(signers1.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers1.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_2,
-                SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
         ])
         .unwrap();
@@ -901,7 +901,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -991,7 +991,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -1079,7 +1079,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -1140,7 +1140,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -1190,7 +1190,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -1274,7 +1274,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =
@@ -1358,11 +1358,11 @@ mod mint_tx_tests {
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![
             (
                 token_id_1,
-                SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
             (
                 token_id_2,
-                SignerSetV1::new(signers2.iter().map(|s| s.public_key()).collect(), 1),
+                SignerSetV2::new(signers2.iter().map(|s| s.public_key().into()).collect(), 1),
             ),
         ])
         .unwrap();
@@ -1461,7 +1461,7 @@ mod mint_tx_tests {
         // Create MintTxManagerImpl
         let token_id_to_governors = GovernorsMap::try_from_iter(vec![(
             token_id_1,
-            SignerSetV1::new(signers.iter().map(|s| s.public_key()).collect(), 1),
+            SignerSetV2::new(signers.iter().map(|s| s.public_key().into()).collect(), 1),
         )])
         .unwrap();
         let mint_tx_manager =

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -231,17 +231,31 @@ class Node:
                     "token_id": 1,
                     "minimum_fee": 1024,
                     "governors": {
-                        "signers": open(os.path.join(MINTING_KEYS_DIR, 'governor1.pub')).read(),
-                        "threshold": 1
-                    }
+                        "signer_identities": {
+                            "governor1": open(os.path.join(MINTING_KEYS_DIR, 'governor1.pub')).read(),
+                        },
+                        "signer_set": {
+                            "threshold": 1,
+                            "signers": [
+                                {"type": "Single", "identity": "governor1" },
+                            ],
+                        },
+                    },
                 },
                 {
                     "token_id": 2,
                     "minimum_fee": 1024,
                     "governors": {
-                        "signers": open(os.path.join(MINTING_KEYS_DIR, 'governor2.pub')).read(),
-                        "threshold": 1
-                    }
+                        "signer_identities": {
+                            "governor2": open(os.path.join(MINTING_KEYS_DIR, 'governor2.pub')).read(),
+                        },
+                        "signer_set": {
+                            "threshold": 1,
+                            "signers": [
+                                {"type": "Single", "identity": "governor2" },
+                            ],
+                        },
+                    },
                 },
              ],
         }
@@ -455,7 +469,7 @@ class Network:
             shutil.rmtree(WORK_DIR)
         except FileNotFoundError:
             pass
-        os.mkdir(WORK_DIR)
+        os.makedirs(WORK_DIR)
 
     def build_binaries(self):
         print('Building binaries...')

--- a/transaction/core/src/mint/mod.rs
+++ b/transaction/core/src/mint/mod.rs
@@ -8,7 +8,9 @@ mod validation;
 
 pub mod constants;
 
-pub use config::{MintConfig, MintConfigTx, MintConfigTxPrefix, ValidatedMintConfigTx};
+pub use config::{
+    MintConfig, MintConfigTx, MintConfigTxPrefix, ValidatedMintConfigTx, VersionedSignerSet,
+};
 pub use tx::{MintTx, MintTxPrefix};
 pub use validation::{
     config::validate_mint_config_tx, error::Error as MintValidationError, tx::validate_mint_tx,

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -15,7 +15,7 @@ use crate::{
     BlockVersion, TokenId,
 };
 use mc_crypto_keys::Ed25519Public;
-use mc_crypto_multisig::SignerSetV1;
+use mc_crypto_multisig::SignerSetV2;
 
 /// Determines if the transaction is valid, with respect to the provided
 /// context.
@@ -34,7 +34,7 @@ pub fn validate_mint_config_tx(
     tx: &MintConfigTx,
     current_block_index: Option<u64>,
     block_version: BlockVersion,
-    governors: &SignerSetV1<Ed25519Public>,
+    governors: &SignerSetV2<Ed25519Public>,
 ) -> Result<(), Error> {
     validate_block_version(block_version)?;
 
@@ -79,10 +79,10 @@ fn validate_configs(token_id: TokenId, configs: &[MintConfig]) -> Result<(), Err
 ///
 /// # Arguments
 /// * `tx` - A pending transaction that is being validated.
-/// * `signer_set` - The signer set that is permitted to sign the transaction.
+/// * `governors` - The signer set that is permitted to sign the transaction.
 fn validate_signature(
     tx: &MintConfigTx,
-    governors: &SignerSetV1<Ed25519Public>,
+    governors: &SignerSetV2<Ed25519Public>,
 ) -> Result<(), Error> {
     let message = tx.prefix.hash();
 
@@ -100,7 +100,7 @@ mod tests {
         TokenId,
     };
     use mc_crypto_keys::{Ed25519Pair, Signer};
-    use mc_crypto_multisig::MultiSig;
+    use mc_crypto_multisig::{MultiSig, SignerSetV1};
     use mc_util_from_random::FromRandom;
     use mc_util_test_helper::get_seeded_rng;
 
@@ -246,11 +246,11 @@ mod tests {
         };
         assert!(validate_signature(
             &tx,
-            &SignerSetV1::new(
+            &SignerSetV2::new(
                 vec![
-                    governor_1.public_key(),
-                    governor_2.public_key(),
-                    governor_3.public_key()
+                    governor_1.public_key().into(),
+                    governor_2.public_key().into(),
+                    governor_3.public_key().into(),
                 ],
                 1
             )
@@ -268,11 +268,11 @@ mod tests {
         };
         assert!(validate_signature(
             &tx,
-            &SignerSetV1::new(
+            &SignerSetV2::new(
                 vec![
-                    governor_1.public_key(),
-                    governor_2.public_key(),
-                    governor_3.public_key()
+                    governor_1.public_key().into(),
+                    governor_2.public_key().into(),
+                    governor_3.public_key().into(),
                 ],
                 2
             )
@@ -290,11 +290,11 @@ mod tests {
         };
         assert!(validate_signature(
             &tx,
-            &SignerSetV1::new(
+            &SignerSetV2::new(
                 vec![
-                    governor_1.public_key(),
-                    governor_2.public_key(),
-                    governor_3.public_key()
+                    governor_1.public_key().into(),
+                    governor_2.public_key().into(),
+                    governor_3.public_key().into(),
                 ],
                 2
             )
@@ -310,11 +310,11 @@ mod tests {
         let tx = MintConfigTx { prefix, signature };
         assert!(validate_signature(
             &tx,
-            &SignerSetV1::new(
+            &SignerSetV2::new(
                 vec![
-                    governor_1.public_key(),
-                    governor_2.public_key(),
-                    governor_3.public_key()
+                    governor_1.public_key().into(),
+                    governor_2.public_key().into(),
+                    governor_3.public_key().into(),
                 ],
                 3
             )
@@ -365,11 +365,11 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(
+                &SignerSetV2::new(
                     vec![
-                        governor_1.public_key(),
-                        governor_2.public_key(),
-                        governor_3.public_key()
+                        governor_1.public_key().into(),
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into(),
                     ],
                     1
                 )
@@ -384,11 +384,11 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(
+                &SignerSetV2::new(
                     vec![
-                        governor_1.public_key(),
-                        governor_2.public_key(),
-                        governor_3.public_key()
+                        governor_1.public_key().into(),
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into(),
                     ],
                     1
                 )
@@ -439,11 +439,11 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(
+                &SignerSetV2::new(
                     vec![
-                        governor_1.public_key(),
-                        governor_2.public_key(),
-                        governor_3.public_key()
+                        governor_1.public_key().into(),
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into(),
                     ],
                     2
                 )
@@ -460,7 +460,13 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(vec![governor_2.public_key(), governor_3.public_key()], 1)
+                &SignerSetV2::new(
+                    vec![
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into()
+                    ],
+                    1
+                )
             ),
             Err(Error::InvalidSignature)
         );
@@ -474,7 +480,13 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(vec![governor_2.public_key(), governor_3.public_key()], 2)
+                &SignerSetV2::new(
+                    vec![
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into()
+                    ],
+                    2
+                )
             ),
             Err(Error::InvalidSignature)
         );
@@ -522,11 +534,11 @@ mod tests {
         assert_eq!(
             validate_signature(
                 &tx,
-                &SignerSetV1::new(
+                &SignerSetV2::new(
                     vec![
-                        governor_1.public_key(),
-                        governor_2.public_key(),
-                        governor_3.public_key()
+                        governor_1.public_key().into(),
+                        governor_2.public_key().into(),
+                        governor_3.public_key().into(),
                     ],
                     2
                 )

--- a/transaction/core/test-utils/src/mint.rs
+++ b/transaction/core/test-utils/src/mint.rs
@@ -94,7 +94,7 @@ pub fn create_mint_config_tx(
 pub fn mint_config_tx_to_validated(mint_config_tx: &MintConfigTx) -> ValidatedMintConfigTx {
     ValidatedMintConfigTx {
         mint_config_tx: mint_config_tx.clone(),
-        signer_set: SignerSetV1::default(),
+        signer_set: Some(SignerSetV1::default().into()),
     }
 }
 

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -7,7 +7,7 @@ use alloc::vec::Vec;
 
 pub extern crate prost;
 
-pub use prost::{DecodeError, EncodeError, Message};
+pub use prost::{DecodeError, EncodeError, Message, Oneof};
 use serde::{Deserialize, Serialize};
 
 // We put a new-type around serde_cbor::Error in `mod decode` and `mod encode`,


### PR DESCRIPTION
## Update: This is likely going to get closed in favor of https://github.com/mobilecoinfoundation/mobilecoin/pull/2732 (and whatever followup PRs build on top of it)


Switch the mint governors configuration to use the nested-multisig
SignerSetV2.

TODO:
This still needs local network and deployment fixes.