### PR TITLE
Add block range to MVQ response

### DIFF
--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -79,6 +79,11 @@ message MultiViewStoreQueryResponse {
 
     /// Status that gets returned when the Fog View Store services a MultiViewStoreQueryRequest.
     MultiViewStoreQueryResponseStatus status = 3;
+
+    /// The block range that this view store is responsible for based on the store's sharding strategy. Note that this
+    /// doesn't mean the block ranges that this store has processed. Rather, this is the range of blocks that this
+    /// store should process once they become available.
+    fog_common.BlockRange block_range = 4;
 }
 
 /// Fulfills requests sent directly by a Fog client, e.g. a mobile phone using the SDK.

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -82,7 +82,7 @@ message MultiViewStoreQueryResponse {
 
     /// The block range that this view store is responsible for based on the store's sharding strategy. Note that this
     /// doesn't mean the block ranges that this store has processed. Rather, this is the range of blocks that this
-    /// store should process once they become available.
+    /// store is configured to serve once they become available.
     fog_common.BlockRange block_range = 4;
 }
 

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -9,6 +9,7 @@ use grpcio::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
 use mc_attest_api::attest;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
+    fog_common::BlockRange,
     view::{
         MultiViewStoreQueryRequest, MultiViewStoreQueryResponse, MultiViewStoreQueryResponseStatus,
     },
@@ -243,6 +244,8 @@ where
     ) -> MultiViewStoreQueryResponse {
         let mut response = MultiViewStoreQueryResponse::new();
         response.set_fog_view_store_uri(fog_view_store_uri.url().to_string());
+        let block_range = BlockRange::from(&self.sharding_strategy.get_block_range());
+        response.set_block_range(block_range);
         for query in queries.into_iter() {
             let result = self.query_nonce_impl(query);
             // Only one of the query messages in an MVSQR is intended for this store

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -21,6 +21,9 @@ pub trait ShardingStrategy {
     /// Different sharding strategies might be ready to serve TxOuts when
     /// different conditions have been met.
     fn is_ready_to_serve_tx_outs(&self, processed_block_count: BlockCount) -> bool;
+
+    /// Returns the block range that this sharding strategy is responsible for.
+    fn get_block_range(&self) -> BlockRange;
 }
 
 /// Determines whether or not to process a block's TxOuts based on the "epoch"
@@ -43,6 +46,10 @@ impl ShardingStrategy for EpochShardingStrategy {
 
     fn is_ready_to_serve_tx_outs(&self, processed_block_count: BlockCount) -> bool {
         self.have_enough_blocks_been_processed(processed_block_count)
+    }
+
+    fn get_block_range(&self) -> BlockRange {
+        self.epoch_block_range.clone()
     }
 }
 


### PR DESCRIPTION
### Motivation
The highest processed block range was being calculated incorrectly previously. The router's enclave was using the minimum highest processed block from all the stores as the highest processed block that it returned to the client. The stores calculated their highest processed block based on its enclave block tracker that only incremented its processed block count when it added a block to it's enclave. 

This resulted in unexpected behavior because each store returned the highest block that it added to its enclave RATHER than the highest block that it observed (the expected behavior). The new paradigm is as follows: each store will continue returning this number and will now additionally add it's block range. The router will then look at each block range, and find the first time a store hasn't processed all of it's block range. This will be returned to the client as the highest processed block range. 

This PR makes the small change of adding a new `block_range` field to the MVQ proto. The next PRs will implement the rest of the logic.