### PR TITLE
Add SignerSet::is_valid

### DIFF
--- a/consensus/service/config/src/error.rs
+++ b/consensus/service/config/src/error.rs
@@ -27,16 +27,8 @@ pub enum Error {
     /// Mint configuration is not allowed for token id {0}
     MintConfigNotAllowed(TokenId),
 
-    /**
-     * Invalid mint configuration for token id {0}: must have at least one
-     * signer
-     */
-    NoSigners(TokenId),
-
-    /** Invalid mint configuration for token id {0}: signer set threshold
-     * exceeds number of signers
-     */
-    SignerSetThresholdExceedsSigners(TokenId),
+    /// Invalid signer set for token id {0}
+    InvalidSignerSet(TokenId),
 
     /// Cannot figure out file extension
     PathExtension,

--- a/consensus/service/config/src/tokens.rs
+++ b/consensus/service/config/src/tokens.rs
@@ -177,13 +177,9 @@ impl TokenConfig {
                 return Err(Error::MintConfigNotAllowed(self.token_id));
             }
 
-            // We must have at least one governor.
-            if governors.signers().is_empty() || governors.threshold() == 0 {
-                return Err(Error::NoSigners(self.token_id));
-            }
-
-            if governors.threshold() as usize > governors.signers().len() {
-                return Err(Error::SignerSetThresholdExceedsSigners(self.token_id));
+            // Signer set must be valid.
+            if !governors.is_valid() {
+                return Err(Error::InvalidSignerSet(self.token_id));
             }
         }
 
@@ -837,7 +833,9 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert!(matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == 2));
+        assert!(
+            matches!(tokens.validate(), Err(Error::InvalidSignerSet(token_id)) if token_id == 2)
+        );
     }
 
     #[test]
@@ -859,7 +857,9 @@ mod tests {
 
         let tokens: TokensConfig = toml::from_str(input_toml).expect("failed parsing toml");
 
-        assert!(matches!(tokens.validate(), Err(Error::NoSigners(token_id)) if token_id == 2));
+        assert!(
+            matches!(tokens.validate(), Err(Error::InvalidSignerSet(token_id)) if token_id == 2)
+        );
     }
 
     #[test]

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -100,6 +100,13 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
         self.threshold
     }
 
+    /// Check if this signer set is valid.
+    /// A signer set is considered valid if it has a threshold of at least one,
+    /// and the number of signers is greater than or equal to the threshold.
+    pub fn is_valid(&self) -> bool {
+        self.threshold > 0 && self.threshold as usize <= self.signers.len()
+    }
+
     /// Verify a message against a multi-signature, returning the list of
     /// signers that signed it.
     pub fn verify<
@@ -122,6 +129,11 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
     where
         P: Verifier<S>,
     {
+        // Refuse to validate anything if we have an invalid signer set.
+        if !self.is_valid() {
+            return Err(SignatureError::new());
+        }
+
         // If the signature contains less than the threshold number of signers or more
         // than the hardcoded limit, there's no point in trying.
         if multi_sig.signatures.len() < self.threshold as usize
@@ -489,5 +501,46 @@ mod test {
             multi_sig,
             mc_util_serial::decode(&mc_util_serial::encode(&multi_sig)).unwrap(),
         );
+    }
+
+    #[test]
+    fn test_is_valid() {
+        let mut rng = Hc128Rng::from_seed([1u8; 32]);
+        let signer1 = Ed25519Pair::from_random(&mut rng);
+        let signer2 = Ed25519Pair::from_random(&mut rng);
+        let signer3 = Ed25519Pair::from_random(&mut rng);
+
+        // Signer set with threshold = 0 is invalid
+        assert!(!SignerSet::new(
+            vec![
+                signer1.public_key(),
+                signer2.public_key(),
+                signer3.public_key(),
+            ],
+            0,
+        )
+        .is_valid());
+
+        // Signer set with threshold > number of signers is invalid
+        assert!(!SignerSet::new(
+            vec![
+                signer1.public_key(),
+                signer2.public_key(),
+                signer3.public_key(),
+            ],
+            4,
+        )
+        .is_valid());
+
+        // Signer set with threshol
+        assert!(SignerSet::new(
+            vec![
+                signer1.public_key(),
+                signer2.public_key(),
+                signer3.public_key(),
+            ],
+            3,
+        )
+        .is_valid());
     }
 }

--- a/crypto/multisig/src/lib.rs
+++ b/crypto/multisig/src/lib.rs
@@ -104,7 +104,7 @@ impl<P: Default + PublicKey + Message> SignerSet<P> {
     /// A signer set is considered valid if it has a threshold of at least one,
     /// and the number of signers is greater than or equal to the threshold.
     pub fn is_valid(&self) -> bool {
-        self.threshold > 0 && self.threshold as usize <= self.signers.len()
+        0 < self.threshold && self.threshold as usize <= self.signers.len()
     }
 
     /// Verify a message against a multi-signature, returning the list of

--- a/transaction/core/src/mint/validation/config.rs
+++ b/transaction/core/src/mint/validation/config.rs
@@ -66,8 +66,7 @@ fn validate_configs(token_id: TokenId, configs: &[MintConfig]) -> Result<(), Err
             return Err(Error::InvalidTokenId(config.token_id.into()));
         }
 
-        let num_signers = config.signer_set.signers().len();
-        if num_signers == 0 || num_signers < config.signer_set.threshold() as usize {
+        if !config.signer_set.is_valid() {
             return Err(Error::InvalidSignerSet);
         }
     }


### PR DESCRIPTION
### Motivation

While working on the nested signer set PRs I learned that there will be a need to a method to check that a `SignerSet` satisfies some basic sanity tests. I want to add that method to the existing `SignerSet`, so that when `SignerSetV2` is introduced and the code starts having match statements to operate on either a V1 or V2 signerset, I could do something like this:
```
match signer_set {
    V1(signer_set) => signer_set.is_valid(),
    V2(signer_set) => signer_set.is_valid(),
}
```

The V2 implementation already has this, and it will be helpful to have this ready on the current implementaiton (and reduce the size of the V2 PR that touches this).