### PR TITLE
release/v2 - CI/CD - change testing token to 8192

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -206,7 +206,7 @@ jobs:
       env:
         MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.MINTING_TRUST_ROOT_PRIVATE }}
       run: |
-        .internal-ci/util/generate_minting_keys.sh
+        .internal-ci/util/generate_minting_keys.sh --token-id 8192
 
     - name: Login to DockerHub
       if: inputs.minting_config_enabled == 'true'

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -255,7 +255,7 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/minting-config-tx-test.sh \
-            --token-id 1
+            --token-id 8192
 
     - name: Test - Minting tx
       if: inputs.testing_1_2 == 'true'
@@ -270,7 +270,7 @@ jobs:
         command: |
           /test/minting-tx-test.sh \
             --key-dir ${{ env.DST_KEYS_DIR }} \
-            --token-id 1
+            --token-id 8192
 
     - name: Test - mobilecoind-json integration
       if: inputs.testing_1_2 == 'true'
@@ -298,7 +298,7 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/mint-auditor-test.sh \
-            --token-id 1
+            --token-id 8192
 
     - name: Test - use drain_accounts to transfer id 1 balances to fog keys
       if: inputs.testing_1_2 == 'true'
@@ -315,7 +315,7 @@ jobs:
             --src ${{ env.DST_KEYS_DIR }} \
             --dst ${{ env.DST_FOG_KEYS_DIR }} \
             --fee 1024 \
-            --token-id 1
+            --token-id 8192
 
     - name: Test - fog-test-client token id 0
       if: inputs.testing_1_2 == 'true'
@@ -345,4 +345,4 @@ jobs:
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.DST_FOG_KEYS_DIR }} \
-            --token-id 1
+            --token-id 8192

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -90,7 +90,7 @@ jobs:
       env:
         MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.MINTING_TRUST_ROOT_PRIVATE }}
       run: |
-        .internal-ci/util/generate_minting_keys.sh
+        .internal-ci/util/generate_minting_keys.sh --token-id 8192
 
     - name: Login to DockerHub
       if: inputs.minting_config_enabled == 'true'

--- a/.internal-ci/test/mint-auditor-test.sh
+++ b/.internal-ci/test/mint-auditor-test.sh
@@ -10,6 +10,7 @@ usage()
 {
     echo "Usage --token-id <num>"
     echo "    --token-id - token id to test"
+    echo "    --token-fee - fee for token id"
 }
 
 is_set()
@@ -30,8 +31,12 @@ do
             usage
             exit 0
             ;;
-        --token-id )
+        --token-id)
             token_id="${2}"
+            shift 2
+            ;;
+        --token-fee)
+            token_fee="${2}"
             shift 2
             ;;
         *)
@@ -43,6 +48,7 @@ do
 done
 
 is_set token_id
+is_set token_fee
 is_set NAMESPACE
 
 
@@ -94,6 +100,8 @@ python3 integration_test.py \
     --mint-auditor-addr "mobilecoind-mint-auditor:7774" \
     --mint-client-bin /usr/local/bin/mc-consensus-mint-client \
     --node-url "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
-    --mint-signing-key "${token_signer_key}"
+    --mint-signing-key "${token_signer_key}" \
+    --token-id "${token_id}" \
+    --token-fee "${token_fee}"
 
 popd >/dev/null || exit 1

--- a/.internal-ci/test/minting-config-tx-test.sh
+++ b/.internal-ci/test/minting-config-tx-test.sh
@@ -53,7 +53,7 @@ mc-consensus-mint-client generate-and-submit-mint-config-tx \
     --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
     --signing-key "${governor_signer_key}" \
     --token-id "${token_id}" \
-    --config "1000000000:${token_id}:${token_signer_key}" \
+    --config "1000000000:1:${token_signer_key}" \
     --total-mint-limit 10000000000
 
 echo "-- sleep and wait for tx/blocks to sync"

--- a/.internal-ci/util/generate_minting_keys.sh
+++ b/.internal-ci/util/generate_minting_keys.sh
@@ -9,35 +9,72 @@ set -e
 
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+usage()
+{
+    echo "Usage:"
+    echo "${0} --token-id 8192"
+    echo "    --token-id - id to generate keys for"
+}
+
+is_set()
+{
+    var_name="${1}"
+    if [ -z "${!var_name}" ]
+    then
+        echo "${var_name} is not set."
+        usage
+        exit 1
+    fi
+}
+
+while (( "$#" ))
+do
+    case "${1}" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        --token-id )
+            token_id="${2}"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+is_set token_id
+
 BASE_PATH="${BASE_PATH:-.tmp/seeds/minting}"
 mkdir -p "${BASE_PATH}"
 
-# Token 1 governor keys
+# Token governor keys
 # This key pair is used to validate MintConfigTxs
-if [[ ! -f "${BASE_PATH}/minter1_governor.private.pem" ]]
+if [[ ! -f "${BASE_PATH}/minter${token_id}_governor.private.pem" ]]
 then
     "${location}/generate_ed25519_keys.sh" \
-        --public-out "${BASE_PATH}/minter1_governor.public.pem" \
-        --private-out "${BASE_PATH}/minter1_governor.private.pem"
+        --public-out "${BASE_PATH}/minter${token_id}_governor.public.pem" \
+        --private-out "${BASE_PATH}/minter${token_id}_governor.private.pem"
 else
-    echo "minter1_governor keys already exist"
+    echo "minter${token_id}_governor keys already exist"
 fi
-sha256sum "${BASE_PATH}/minter1_governor.private.pem"
-sha256sum "${BASE_PATH}/minter1_governor.public.pem"
+sha256sum "${BASE_PATH}/minter${token_id}_governor.private.pem"
+sha256sum "${BASE_PATH}/minter${token_id}_governor.public.pem"
 
-# Token 1 signer keys
+# Token signer keys
 # This key pair is used to validate MintTX
 if [[ ! -f "${BASE_PATH}/token_signer.private.pem" ]]
 then
-    echo "Writing token1_signer keys"
+    echo "Writing token${token_id}_signer keys"
     "${location}/generate_ed25519_keys.sh" \
-        --public-out "${BASE_PATH}/token1_signer.public.pem" \
-        --private-out "${BASE_PATH}/token1_signer.private.pem"
+        --public-out "${BASE_PATH}/token${token_id}_signer.public.pem" \
+        --private-out "${BASE_PATH}/token${token_id}_signer.private.pem"
 else
-    echo "token1_signer keys already exist"
+    echo "token${token_id}_signer keys already exist"
 fi
-sha256sum "${BASE_PATH}/token1_signer.private.pem"
-sha256sum "${BASE_PATH}/token1_signer.public.pem"
+sha256sum "${BASE_PATH}/token${token_id}_signer.private.pem"
+sha256sum "${BASE_PATH}/token${token_id}_signer.public.pem"
 
 # Write minting trust root private key if its defined.
 if [[ -n "${MINTING_TRUST_ROOT_PRIVATE}" ]]

--- a/.internal-ci/util/generate_tokens_config.sh
+++ b/.internal-ci/util/generate_tokens_config.sh
@@ -32,8 +32,8 @@ json=$(cat "${location}/tokens.base.json")
 
 # Set minter1 pub keys and threshold
 minter1_governor=$(cat "${minting_path}/minter1_governor.public.pem")
-json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 1) | .governors.signers) |= \"${minter1_governor}\"")
-json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 1) | .governors.threshold) |= 1")
+json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 8192) | .governors.signers) |= \"${minter1_governor}\"")
+json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 8192) | .governors.threshold) |= 1")
 
 #output unsigned tokens
 echo "$json" | jq . > .tmp/tokens.json

--- a/.internal-ci/util/generate_tokens_config.sh
+++ b/.internal-ci/util/generate_tokens_config.sh
@@ -21,25 +21,41 @@ minting_path="${BASE_PATH}/seeds/minting"
 # check for required files
 exists "${location}/tokens.base.json"
 
-exists "${minting_path}/minter1_governor.public.pem"
-sha256sum "${minting_path}/minter1_governor.public.pem"
+# Grab base json
+json=$(cat "${location}/tokens.base.json")
+token_ids=$(echo "${json}" | jq -r '.tokens[].token_id')
 
+for id in ${token_ids}
+do
+    if [[ ${id} -eq 0 ]]
+    then
+        echo "Found token_id 0 - nothing to do."
+        continue
+    fi
+
+    echo "Token ID: ${id} - Checking for governor ed25519 keys"
+    exists "${minting_path}/minter${id}_governor.public.pem"
+    sha256sum "${minting_path}/minter8192_governor.public.pem"
+
+    echo "Token ID: ${id} - Add governor signer pub keys and threshold to json"
+    minter_governor=$(cat "${minting_path}/minter${id}_governor.public.pem")
+
+    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.signers) |= \"${minter_governor}\"")
+
+    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.threshold) |= 1")
+done
+
+#output unsigned tokens
+echo "$json" | jq . > "${BASE_PATH}/tokens.json"
+
+echo "Checking for minting_trust_root ed25519 keys"
 exists "${minting_path}/minting_trust_root.private.pem"
 sha256sum "${minting_path}/minting_trust_root.private.pem"
 
-# Grab base json
-json=$(cat "${location}/tokens.base.json")
-
-# Set minter1 pub keys and threshold
-minter1_governor=$(cat "${minting_path}/minter1_governor.public.pem")
-json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 8192) | .governors.signers) |= \"${minter1_governor}\"")
-json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == 8192) | .governors.threshold) |= 1")
-
-#output unsigned tokens
-echo "$json" | jq . > .tmp/tokens.json
-
 # Sign tokens file
-echo "Signing tokens file"
+echo "Signing the tokens file"
 mc-consensus-mint-client sign-governors --tokens "${BASE_PATH}/tokens.json" \
     --signing-key "${minting_path}/minting_trust_root.private.pem" \
     --output-json "${BASE_PATH}/tokens.signed.json"  >/dev/null
+
+cat "${BASE_PATH}/tokens.signed.json"

--- a/.internal-ci/util/tokens.base.json
+++ b/.internal-ci/util/tokens.base.json
@@ -6,7 +6,7 @@
             "minimum_fee": 400000000
         },
         {
-            "token_id": 1,
+            "token_id": 8192,
             "minimum_fee": 1024,
             "governors": {
                 "signers": "",

--- a/mint-auditor/tests/integration_test.py
+++ b/mint-auditor/tests/integration_test.py
@@ -150,7 +150,7 @@ class MintAuditorTest:
         try:
             b58_addr = self.mobilecoind_client.get_b58_public_address(monitor_id)
             logging.info(f"Minting to {b58_addr}")
-            token_id = 1
+            token_id = self.args.token_id
             mint_amount = 10000
 
             # Get the network block height and wait for the mint auditor to catch up
@@ -180,7 +180,7 @@ class MintAuditorTest:
 
             # Burn 300 tokens
             burn_amount = 300
-            fee_amount = 1024
+            fee_amount = self.args.token_fee
             utxos = self.mobilecoind_client.get_utxos(monitor_id, token_id)
             tx_proposal = self.mobilecoind_client.generate_burn_redemption_tx(
                 monitor_id,
@@ -265,6 +265,12 @@ if __name__ == '__main__':
     parser.add_argument("--mint-signing-key",
                         type=str,
                         help="path to the mint signing private key file")
+    parser.add_argument("--token-id",
+                        type=int,
+                        help="token id to mint")
+    parser.add_argument("--token-fee",
+                        type=int,
+                        help="fee for specified token id")
 
     args = parser.parse_args()
     MintAuditorTest(args).run()


### PR DESCRIPTION
### Motivation
Change the CD integrations alternate token from 1 to 8192 so we don't conflict with the main/test token id 1 in future testing.
