### PR TITLE
Fix an incorrect comparison

### DIFF
--- a/.internal-ci/test/minting-config-tx-test.sh
+++ b/.internal-ci/test/minting-config-tx-test.sh
@@ -70,7 +70,7 @@ echo "-- sleep and wait for tx/blocks to sync"
 new_block_count=0
 echo "-- Waiting for mint config tx to commit to the block chain"
 
-while [[ $block_count -le $new_block_count ]]
+while [[ $block_count -ge $new_block_count ]]
 do
     sleep 15
     new_block_count=$(get_block_count)


### PR DESCRIPTION
What this `while` loop is trying to achieve is waiting for a new block to show up.`$block_count` is the current number of blocks, and `$new_block_count` is the new block count. We want to wait as long as  `new_block_count <= block_count`, right now the loop is waiting while 'block_count <= new_block_count', so it actually never waits (since `new_block_count` is initialized to 0).