### PR TITLE
upgrade to serde_with 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1862,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -5424,6 +5465,7 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_cbor",
+ "serde_json",
  "serde_with",
 ]
 
@@ -7283,11 +7325,24 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
 dependencies = [
  "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -17,4 +17,7 @@ prost = { version = "0.11", default-features = false, features = ["prost-derive"
 protobuf = { version = "2.27", optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"] }
-serde_with = { version = "1.14", default-features = false, optional = true }
+serde_with = { version = "2.0", default-features = false, features = ["macros"], optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
### Motivation
I added `serde_with` to another crate as part of my work on multisig stuff and noticed there is a newer version with breaking API changes, so I used that as an opportunity to move us to the newer version.

I also added a test case to ensure this is behaving is expected, since the macro order matters (quoting the [manual](https://docs.rs/serde_with/2.0.1/serde_with/guide/serde_as/index.html), `place the #[serde_as] attribute before the #[derive] attribute`).