### PR TITLE
Update to SGX 2.17.1, add INTEL-SA-00657 to known advisories list. (#2639)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,6 @@ commands:
           command: |
             command -v rustup >/dev/null \
               || curl https://sh.rustup.rs --tlsv1.2 -sSf | sh -s -- -y --default-toolchain stable
-            # Installs the toolchain specified in `rust-toolchain`
             "$HOME/.cargo/bin/rustup" show active-toolchain
 
   install-ci-deps:
@@ -308,11 +307,10 @@ commands:
       - checkout
       - when:
           condition: { equal: [ << parameters.os >>, macos ] }
-          steps: [ restore-homebrew-cache ]
+          steps: [ restore-homebrew-cache, install-rust ]
       - when:
           condition: { equal: [ << parameters.os >>, linux ] }
           steps: [ enable-postgresql ]
-      - install-rust
       - restore-cargo-cache
       - env_setup
       - install-ci-deps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@
 version: 2.1
 
 defaults:
-  builder-install: &builder-install gcr.io/mobilenode-211420/builder-install:1_29
+  builder-install: &builder-install mobilecoin/builder-install:v0.0.18
   android-bindings-builder: &android-bindings-builder gcr.io/mobilenode-211420/android-bindings-builder:1_4
   default-xcode-version: &default-xcode-version "12.5.1"
 

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -60,7 +60,7 @@ jobs:
   build-rust-hardware-projects:
     runs-on: [self-hosted, Linux, large]
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.14
+      image: mobilecoin/rust-sgx-base:v0.0.18
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem
       MINTING_TRUST_ROOT_PUBLIC_KEY_PEM: ${{ github.workspace }}/.tmp/minting_trust_root.public.pem

--- a/.internal-ci/docker/Dockerfile.runtime-base
+++ b/.internal-ci/docker/Dockerfile.runtime-base
@@ -31,7 +31,7 @@ ENV LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm"
 # libsgx-enclave-common libsgx-epid libsgx-launch libsgx-pce-logic libsgx-urts
 # sgx-aesm-service
 # Use `apt show -a sgx-aesm-service` to find version
-ENV AESM_VERSION=2.17.100.3-focal1
+ENV AESM_VERSION=2.17.101.1-focal1
 # Use `apt show -a libsgx-pce-logic` to find the version thats compatible with aesm.
 ENV PCE_LOGIC_VERSION=1.14.100.3-focal1
 

--- a/.mobconf
+++ b/.mobconf
@@ -1,4 +1,3 @@
 [image]
-dockerfile-version = v0.0.14
-target = builder-install
-repository = mobilecoin
+url = mobilecoin/builder-install
+tag = v0.0.18

--- a/attest/verifier/README.md
+++ b/attest/verifier/README.md
@@ -15,7 +15,7 @@ use mc_util_encodings::FromHex;
 let mut enclave_verifier = MrEnclaveVerifier::new(MrEnclave::from_hex("BEEFCAFEDEADBEEFCAFEBEEF"));
 // Whitelist the LVI hardening advisory (assume the BEEF... enclave is hardened)
 // Whitelist the MMIO hardening advisory (assume the enclave uses [out] and 8-byte aligned writes)
-enclave_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+enclave_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"]);
 
 // Construct a new verifier using hard-coded IAS signing certificates
 let mut verifier = Verifier::default();

--- a/consensus/enclave/build.rs
+++ b/consensus/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 5;

--- a/consensus/enclave/measurement/src/lib.rs
+++ b/consensus/enclave/measurement/src/lib.rs
@@ -14,7 +14,7 @@ pub fn sigstruct() -> Signature {
 }
 
 pub const CONFIG_ADVISORIES: &[&str] = &[];
-pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615"];
+pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"];
 
 pub fn get_mr_signer_verifier(override_minimum_svn: Option<SecurityVersion>) -> MrSignerVerifier {
     let signature = sigstruct();

--- a/consensus/enclave/trusted/build.rs
+++ b/consensus/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/service/BUILD.md
+++ b/consensus/service/BUILD.md
@@ -97,7 +97,7 @@ Recommended SDK and package installation:
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin"
 	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
@@ -112,8 +112,8 @@ chmod +x ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 
 # Install the SDK to /opt/intel/sgxsdk
-chmod +x ./sgx_linux_x64_sdk_2.17.100.3.bin
-./sgx_linux_x64_sdk_2.17.100.3.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.17.101.1.bin
+./sgx_linux_x64_sdk_2.17.101.1.bin --prefix=/opt/intel
 
 apt install libsgx-uae-service sgx-aesm-service
 

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -137,7 +137,16 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         // INTEL-SA-00615: MMIO Stale Data is handled by using [out] parameters
         // in our ECALL/OCALL definitions (EDLs), and only performing direct
         // writes aligned to quadword (8B) boundaries (e.g. in ORAMStorage)
-        mr_enclave_verifier.allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+        //
+        // INTEL-SA-00657: xAPIC Stale Data is handled by ensuring reads in/out of the
+        // enclave are aligned to an 8-byte boundary, and performed in multiples
+        // of 8 bytes. In our codebase, this happens within the sgx_edger8r code-gen, so
+        // building against SGX 2.17.1 is sufficient hardening for now.
+        mr_enclave_verifier.allow_hardening_advisories(&[
+            "INTEL-SA-00334",
+            "INTEL-SA-00615",
+            "INTEL-SA-00657",
+        ]);
 
         verifier
             .mr_enclave(mr_enclave_verifier)

--- a/docker/install_sgx.sh
+++ b/docker/install_sgx.sh
@@ -24,7 +24,7 @@ cd /tmp
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 )
@@ -59,8 +59,8 @@ apt-get install -yq --no-install-recommends \
 
 # Install *after* pkg-config so that they get registered correctly.
 # pkg-config gets pulled in transitively via build-essential
-chmod +x ./sgx_linux_x64_sdk_2.17.100.3.bin
-./sgx_linux_x64_sdk_2.17.100.3.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.17.101.1.bin
+./sgx_linux_x64_sdk_2.17.101.1.bin --prefix=/opt/intel
 
 # Update .bashrc to source sgxsdk
 echo 'source /opt/intel/sgxsdk/environment' >> /root/.bashrc

--- a/fog/ingest/enclave/build.rs
+++ b/fog/ingest/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
 const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 4;

--- a/fog/ingest/enclave/measurement/src/lib.rs
+++ b/fog/ingest/enclave/measurement/src/lib.rs
@@ -14,7 +14,7 @@ pub fn sigstruct() -> Signature {
 }
 
 pub const CONFIG_ADVISORIES: &[&str] = &[];
-pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615"];
+pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"];
 
 pub fn get_mr_signer_verifier(override_minimum_svn: Option<SecurityVersion>) -> MrSignerVerifier {
     let signature = sigstruct();

--- a/fog/ingest/enclave/trusted/build.rs
+++ b/fog/ingest/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/build.rs
+++ b/fog/ledger/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
 const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 4;

--- a/fog/ledger/enclave/measurement/src/lib.rs
+++ b/fog/ledger/enclave/measurement/src/lib.rs
@@ -14,7 +14,7 @@ pub fn sigstruct() -> Signature {
 }
 
 pub const CONFIG_ADVISORIES: &[&str] = &[];
-pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615"];
+pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"];
 
 pub fn get_mr_signer_verifier(override_minimum_svn: Option<SecurityVersion>) -> MrSignerVerifier {
     let signature = sigstruct();

--- a/fog/ledger/enclave/trusted/build.rs
+++ b/fog/ledger/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/build.rs
+++ b/fog/view/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
 const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 4;

--- a/fog/view/enclave/measurement/src/lib.rs
+++ b/fog/view/enclave/measurement/src/lib.rs
@@ -14,7 +14,7 @@ pub fn sigstruct() -> Signature {
 }
 
 pub const CONFIG_ADVISORIES: &[&str] = &[];
-pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615"];
+pub const HARDENING_ADVISORIES: &[&str] = &["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"];
 
 pub fn get_mr_signer_verifier(override_minimum_svn: Option<SecurityVersion>) -> MrSignerVerifier {
     let signature = sigstruct();

--- a/fog/view/enclave/trusted/build.rs
+++ b/fog/view/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.100.3";
+const SGX_VERSION: &str = "2.17.101.1";
 
 fn main() {
     let env = Environment::default();

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -20,7 +20,7 @@ spec:
           topologyKey: "kubernetes.io/hostname"
   containers:
     - name: rust-builder-default
-      image: gcr.io/mobilenode-211420/builder-install:1_29
+      image: mobilecoin/builder-install:v0.0.18
       env:
         - name: PATH
           value: "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/intel/sgxsdk/bin:/opt/intel/sgxsdk/bin/x64"

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -176,8 +176,11 @@ impl Config {
                     signature.product_id(),
                     signature.version(),
                 );
-                mr_signer_verifier
-                    .allow_hardening_advisories(&["INTEL-SA-00334", "INTEL-SA-00615"]);
+                mr_signer_verifier.allow_hardening_advisories(&[
+                    "INTEL-SA-00334",
+                    "INTEL-SA-00615",
+                    "INTEL-SA-00657",
+                ]);
                 mr_signer_verifier
             };
 

--- a/ops/Dockerfile-consensus
+++ b/ops/Dockerfile-consensus
@@ -21,7 +21,7 @@ RUN apt-get update -q -q && \
 RUN source /etc/os-release && \
 	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin" && \
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.100.3.bin" && \
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin" && \
 	echo "deb [arch=amd64 signed-by=/usr/local/share/apt-keyrings/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 
 RUN mkdir -p /usr/local/share/apt-keyrings && \


### PR DESCRIPTION
### Motivation

This is a cherry-pick of changes from master to build using SGX 2.17.1 and allow SW_HARDENING_NEEDED results for the INTEL-SA-00657 advisory.

### In this PR
* Cherry-pick previously merged PR from master.

### Future Work
* Update ChangeLog
* Bump Versions

