### PR TITLE
release/v3.0 - CI/CD - CD on PR

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -8,7 +8,6 @@ env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
   RELEASE_1X_TAG: v1.1.3-dev
-  PREVIOUS_RELEASE: v1.1.3-dev
 
 on:
   pull_request:
@@ -39,6 +38,7 @@ jobs:
 # Generate environment information
 ############################################
   generate-metadata:
+    if: github.actor != 'dependabot[bot]'
     name: 👾 Environment Info 👾
     runs-on: [self-hosted, Linux, small]
     outputs:
@@ -47,7 +47,6 @@ jobs:
       docker_tag: ${{ steps.meta.outputs.docker_tag }}
       docker_org: ${{ env.DOCKER_ORG }}
       chart_repo: ${{ env.CHART_REPO }}
-      previous_release: ${{ env.PREVIOUS_RELEASE }}
       release_1x_tag: ${{ env.RELEASE_1X_TAG }}
 
     steps:
@@ -73,6 +72,7 @@ jobs:
 # Build binaries
 #########################################
   build-rust-hardware-projects:
+    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, large]
     container:
       image: mobilecoin/rust-sgx-base:v0.0.14
@@ -186,6 +186,7 @@ jobs:
         path: rust_build_artifacts/
 
   build-go-projects:
+    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, large]
     container:
       image: golang:1.16.4
@@ -234,6 +235,7 @@ jobs:
 # Create/Refresh base runtime image
 ########################################
   docker-base:
+    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
     steps:
     - name: Checkout
@@ -279,6 +281,7 @@ jobs:
 # Build/Publish public artifacts
 #########################################
   docker:
+    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
     needs:
     - build-go-projects
@@ -354,6 +357,7 @@ jobs:
         tags: ${{ steps.docker_meta.outputs.tags }}
 
   charts:
+    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
     needs:
     - docker
@@ -393,6 +397,7 @@ jobs:
 # Reset existing namespace
 #################################
   dev-reset:
+    if: github.actor != 'dependabot[bot]'
     needs:
     - generate-metadata
     uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -410,6 +415,7 @@ jobs:
 # Deploy 1.x release to namespace
 #######################################
   deploy-v1-bv0-release:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
     - dev-reset
@@ -444,6 +450,7 @@ jobs:
       RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
   test-v1-bv0-release:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
     - deploy-v1-bv0-release
@@ -465,6 +472,7 @@ jobs:
 # Deploy current version to namespace block v2
 ###############################################
   deploy-current-bv0-release:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
     - test-v1-bv0-release
@@ -500,6 +508,7 @@ jobs:
       RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
   test-current-bv0-release:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
     - deploy-current-bv0-release
@@ -522,6 +531,7 @@ jobs:
 # Update current consensus to namespace block v3
 #################################################
   update-current-to-bv2:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
     needs:
     - test-current-bv0-release
@@ -549,6 +559,7 @@ jobs:
       RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
   test-current-bv2-release:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
     - update-current-to-bv2
@@ -567,7 +578,9 @@ jobs:
       RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
   cleanup-on-pr:
-    if: github.event_name == 'pull_request'
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event_name == 'pull_request'
     needs:
     - test-current-bv2-release
     - generate-metadata

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -467,7 +467,7 @@ jobs:
   deploy-current-bv0-release:
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
-    - test-v0-bv0-release
+    - test-v1-bv0-release
     - charts
     - generate-metadata
     with:
@@ -569,7 +569,7 @@ jobs:
   cleanup-on-pr:
     if: github.event_name == 'pull_request'
     needs:
-    - test-current-bv3-release
+    - test-current-bv2-release
     - generate-metadata
     uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
     with:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -2,23 +2,37 @@
 #
 # MobileCoin Core projects - Build, deploy to development.
 
-name: mobilecoin-dev-cd
+name: Mobilecoin CD
 
 env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
+  RELEASE_1X_TAG: v1.1.3-dev
   PREVIOUS_RELEASE: v1.1.3-dev
 
 on:
+  pull_request:
+    branches:
+    - master
+    - main
+    - release/*
+    paths-ignore:
+    - '**.md'
   push:
     branches:
+    - master
+    - main
     - feature/*
     - release/*
     tags:
       - v[0-9]+*
+    paths-ignore:
+    - '**.md'
 
 # don't run more than one at a time for a branch/tag
-concurrency: mobilecoin-dev-cd-${{ github.ref }}
+concurrency:
+  group: mobilecoin-dev-cd-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 ############################################
@@ -34,6 +48,7 @@ jobs:
       docker_org: ${{ env.DOCKER_ORG }}
       chart_repo: ${{ env.CHART_REPO }}
       previous_release: ${{ env.PREVIOUS_RELEASE }}
+      release_1x_tag: ${{ env.RELEASE_1X_TAG }}
 
     steps:
     - name: Checkout
@@ -228,7 +243,7 @@ jobs:
     - name: Generate Docker Tags
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ env.DOCKER_ORG }}/runtime-base
         flavor: |
@@ -238,11 +253,11 @@ jobs:
 
     - name: Set up Docker Buildx
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -250,7 +265,7 @@ jobs:
     - name: Publish to DockerHub
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_publish_dockerhub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         build-args: |
           REPO_ORG=${{ env.DOCKER_ORG }}
@@ -305,18 +320,18 @@ jobs:
     - name: Generate Docker Tags
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ env.DOCKER_ORG }}/${{ matrix.image }}
         tags: ${{ needs.generate-metadata.outputs.docker_tag }}
 
     - name: Set up Docker Buildx
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -324,7 +339,7 @@ jobs:
     - name: Publish to DockerHub
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_publish_dockerhub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         build-args: |
           REPO_ORG=${{ env.DOCKER_ORG }}
@@ -392,174 +407,178 @@ jobs:
       LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
 
 #######################################
-# Deploy previous release to namespace
+# Deploy 1.x release to namespace
 #######################################
-  previous-release-deploy:
-    runs-on: [self-hosted, Linux, small]
+  deploy-v1-bv0-release:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
     - dev-reset
     - generate-metadata
-    steps:
-    - name: Deploy Release
-      if: "! contains(github.event.head_commit.message, '[skip previous-release-deploy]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-deploy
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "block_version": "0",
-            "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
-            "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
-            "minting_config_enabled": "false",
-            "ingest_color": "blue",
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.previous_release }}",
-            "client_auth_enabled": "false",
-            "use_static_wallet_seeds": "true"
-          }
+    with:
+      block_version: "0"
+      chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
+      docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
+      ingest_color: blue
+      minting_config_enabled: false
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      version: ${{ needs.generate-metadata.outputs.release_1x_tag }}
+    secrets:
+      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      FOG_KEYS_SEED: ${{ secrets.DEV_FOG_KEYS_SEED }}
+      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
+      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
+      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
+      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+      INITIAL_KEYS_SEED: ${{ secrets.DEV_INITIAL_KEYS_SEED }}
+      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
+      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
+      MNEMONIC_FOG_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_FOG_KEYS_SEED }}
+      MNEMONIC_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_KEYS_SEED }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
-  previous-release-test:
-    runs-on: [self-hosted, Linux, small]
+  test-v1-bv0-release:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
-    - previous-release-deploy
+    - deploy-v1-bv0-release
     - generate-metadata
-    steps:
-    - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip previous-release-test]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-test
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "ingest_color": "blue",
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "fog_distribution": "true",
-            "testing_1_1": "true",
-            "testing_1_2": "false",
-            "client_auth_enabled": "false"
-          }
+    with:
+      fog_distribution: true
+      ingest_color: blue
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      testing_block_v0: true
+      testing_block_v2: false
+    secrets:
+      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
+      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
 ###############################################
-# Deploy current version to namespace block v0
+# Deploy current version to namespace block v2
 ###############################################
-  current-release-v0-deploy:
-    runs-on: [self-hosted, Linux, small]
+  deploy-current-bv0-release:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
-    - previous-release-test
-    - generate-metadata
+    - test-v0-bv0-release
     - charts
-    steps:
-    - name: Deploy Release
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v0-deploy]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-deploy
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "block_version": "0",
-            "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
-            "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
-            "minting_config_enabled": "true",
-            "ingest_color": "green",
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.tag }}",
-            "client_auth_enabled": "false",
-            "use_static_wallet_seeds": "true"
-          }
-
-  current-release-v0-test:
-    runs-on: [self-hosted, Linux, small]
-    needs:
-    - current-release-v0-deploy
     - generate-metadata
-    steps:
-    - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v0-test]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-test
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "ingest_color": "green",
-            "fog_distribution": "false",
-            "testing_1_1": "true",
-            "testing_1_2": "false",
-            "client_auth_enabled": "false"
-          }
+    with:
+      block_version: "0"
+      chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
+      docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
+      ingest_color: green
+      minting_config_enabled: true
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      version: ${{ needs.generate-metadata.outputs.tag }}
+    secrets:
+      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      FOG_KEYS_SEED: ${{ secrets.DEV_FOG_KEYS_SEED }}
+      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
+      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
+      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
+      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+      INITIAL_KEYS_SEED: ${{ secrets.DEV_INITIAL_KEYS_SEED }}
+      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
+      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
+      MNEMONIC_FOG_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_FOG_KEYS_SEED }}
+      MNEMONIC_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_KEYS_SEED }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+
+  test-current-bv0-release:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
+    needs:
+    - deploy-current-bv0-release
+    - generate-metadata
+    with:
+      fog_distribution: false
+      ingest_color: green
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      testing_block_v0: true
+      testing_block_v2: false
+
+    secrets:
+      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
+      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
 #################################################
-# Update current consensus to namespace block v1
+# Update current consensus to namespace block v3
 #################################################
-  current-release-v2-update:
-    runs-on: [self-hosted, Linux, small]
+  update-current-to-bv2:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
     needs:
-    - current-release-v0-test
+    - test-current-bv0-release
     - generate-metadata
-    steps:
-    - name: Update consensus config
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v2-update]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-update-consensus
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "block_version": "2",
-            "client_auth_enabled": "false",
-            "minting_config_enabled": "true",
-            "docker_image_org": "${{ needs.generate-metadata.outputs.docker_org }}",
-            "chart_repo": "${{ needs.generate-metadata.outputs.chart_repo }}",
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "version": "${{ needs.generate-metadata.outputs.tag }}"
-          }
+    with:
+      block_version: "2"
+      chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
+      docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
+      minting_config_enabled: true
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      version: ${{ needs.generate-metadata.outputs.tag }}
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
+      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
+      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
+      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
 
-  current-release-v2-test:
-    runs-on: [self-hosted, Linux, small]
+  test-current-bv2-release:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
-    - current-release-v2-update
+    - update-current-to-bv2
     - generate-metadata
-    steps:
-    - name: Run MobileCoin integration tests
-      if: "! contains(github.event.head_commit.message, '[skip current-release-v2-test]')"
-      uses: mobilecoinofficial/gha-workflow-dispatch@v2.1.3
-      with:
-        workflow: mobilecoin-dispatch-dev-test
-        token: ${{ secrets.ACTIONS_TOKEN }}
-        wait-for-completion: true
-        wait-for-completion-timeout: 30m
-        wait-for-completion-interval: 30s
-        display-workflow-run-url-interval: 30s
-        inputs: |
-          {
-            "namespace": "${{ needs.generate-metadata.outputs.namespace }}",
-            "ingest_color": "green",
-            "fog_distribution": "false",
-            "testing_1_1": "true",
-            "testing_1_2": "true",
-            "client_auth_enabled": "false"
-          }
+    with:
+      fog_distribution: false
+      ingest_color: green
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      testing_block_v0: false
+      testing_block_v2: true
+    secrets:
+      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
+      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+
+  cleanup-on-pr:
+    if: github.event_name == 'pull_request'
+    needs:
+    - test-current-bv3-release
+    - generate-metadata
+    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
+    with:
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      delete_namespace: true
+    secrets:
+      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
+      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
+      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+

--- a/.github/workflows/mobilecoin-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dev-delete.yaml
@@ -2,7 +2,7 @@
 #
 # MobileCoin Core projects - Delete development namespaces when branch is removed.
 
-name: mobilecoin-dev-delete
+name: Mobilecoin Dev Clean Up
 
 on:
   delete: {}

--- a/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
@@ -2,7 +2,7 @@
 #
 # MobileCoin Core projects - Dispatch (manual) Job - Delete target dev env components and optionally the k8s namespace.
 
-name: mobilecoin-dispatch-dev-delete
+name: (Manual) Delete a Dev Namespace
 
 on:
   workflow_dispatch:
@@ -19,6 +19,7 @@ on:
 
 jobs:
   reset:
+    name: Reset Dev Namespace - ${{ inputs.namespace }}
     uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
     with:
       namespace: ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -2,7 +2,7 @@
 #
 # MobileCoin Core projects - Dispatch (manual) Job - Deploy core apps to the development namespace.
 
-name: mobilecoin-dispatch-dev-deploy
+name: (Manual) Deploy to Dev Namespace
 
 on:
   workflow_dispatch:
@@ -52,6 +52,21 @@ on:
         default: false
 
 jobs:
+  list-values:
+    name: 👾 Environment Info - ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.version }} 👾
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: 👾 Print Environment Details 👾
+      env:
+        CHART_REPO: ${{ github.event.inputs.chart_repo }}
+        NAMESPACE: ${{ github.event.inputs.namespace }}
+        VERSION: ${{ github.event.inputs.version }}
+      run: |
+        .internal-ci/util/print_details.sh
+
   deploy:
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:

--- a/.github/workflows/mobilecoin-dispatch-dev-test.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-test.yaml
@@ -2,7 +2,7 @@
 #
 # MobileCoin Core projects - Dispatch (manual) Job - Run integration tests in a development namespace.
 
-name: mobilecoin-dispatch-dev-test
+name: (Manual) Run Tests in Dev Namespace
 
 on:
   workflow_dispatch:
@@ -20,14 +20,19 @@ on:
         description: "Run fog-distribution test"
         type: boolean
         required: false
-        default: true
-      testing_1_1:
-        description: "Run v1.1.x tests (block_version 0)"
+        default: false
+      testing_block_v0:
+        description: "Run block v0 tests"
         type: boolean
         required: false
         default: true
-      testing_1_2:
-        description: "Run v1.2.x tests (block_version 0/2)"
+      testing_block_v2:
+        description: "Run block v2 tests"
+        type: boolean
+        required: false
+        default: true
+      testing_block_v3:
+        description: "Run block v3 tests"
         type: boolean
         required: false
         default: true
@@ -39,13 +44,15 @@ on:
 
 jobs:
   test:
+    name: Test ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.ingest_color }}
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     with:
       namespace: ${{ github.event.inputs.namespace }}
       ingest_color: ${{ github.event.inputs.ingest_color }}
       fog_distribution: ${{ github.event.inputs.fog_distribution == 'true' && 'true' || 'false' }}
-      testing_1_1 : ${{ github.event.inputs.testing_1_1 == 'true' && 'true' || 'false' }}
-      testing_1_2: ${{ github.event.inputs.testing_1_2 == 'true' && 'true' || 'false' }}
+      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 == 'true' && 'true' || 'false' }}
+      testing_block_v2: ${{ github.event.inputs.testing_block_v2 == 'true' && 'true' || 'false' }}
+      testing_block_v3: ${{ github.event.inputs.testing_block_v3 == 'true' && 'true' || 'false' }}
     secrets:
       RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
       RANCHER_URL: ${{ secrets.RANCHER_URL }}

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -2,7 +2,7 @@
 #
 # MobileCoin Core projects - Dispatch (manual) Job - Update consensus nodes in a development namespace.
 
-name: mobilecoin-dispatch-dev-update-consensus
+name: (Manual) Upgrade Consensus Config in Dev Namespace
 
 on:
   workflow_dispatch:
@@ -43,6 +43,7 @@ on:
 
 jobs:
   update-consensus-block-version:
+    name: Update Consensus Block Version - ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.block_version }}
     uses: ./.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
     with:
       namespace: ${{ github.event.inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -100,31 +100,10 @@ on:
         description: "static wallet seed"
         required: false
 
+env:
+  FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
+
 jobs:
-  list-values:
-    name: 👾 Environment Info 👾
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: List input values
-      run: |
-        echo namespace ${{ inputs.namespace }}
-        echo version ${{ inputs.version }}
-        echo docker_image_org ${{ inputs.docker_image_org }}
-        echo ingest_color ${{ inputs.ingest_color }}
-        echo minting_config_enabled ${{ inputs.minting_config_enabled }}
-        echo chart_repo ${{ inputs.chart_repo }}
-
-    - name: 👾 Print Environment Details 👾
-      env:
-        CHART_REPO: ${{ inputs.chart_repo }}
-        NAMESPACE: ${{ inputs.namespace }}
-        VERSION: ${{ inputs.version }}
-      run: |
-        .internal-ci/util/print_details.sh
-
   # Reset consensus nodes between releases - if there's existing data, we'll
   # restore from S3.
   reset-releases:
@@ -210,7 +189,7 @@ jobs:
 
     - name: Login to DockerHub
       if: inputs.minting_config_enabled == 'true'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -343,10 +322,34 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
 
-  fog-ingest-deploy:
+  fog-services-deploy:
     needs:
     - postgresql-deploy
     - consensus-deploy
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Deploy fog-services
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: fog-services
+        chart_version: ${{ inputs.version }}
+        chart_wait_timeout: 10m
+        # Set orderedReady for compatibility with 1.1.3 chart - remove after 1.2.x
+        chart_set: |
+          --set=image.org=${{ inputs.docker_image_org }}
+          --set=global.certManagerClusterIssuer=zerossl-prod-http
+          --set=fogLedger.podManagementPolicy=OrderedReady
+        release_name: fog-services
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
+  fog-ingest-deploy:
+    needs:
+    - fog-services-deploy
     runs-on: [self-hosted, Linux, small]
     steps:
     - name: Deploy fog-ingest
@@ -387,27 +390,12 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
 
-  fog-services-deploy:
-    needs:
-    - postgresql-deploy
-    - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: Deploy fog-services
+    - name: Delete retired flipside ingest (if exists)
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
-        action: helm-deploy
-        chart_repo: ${{ inputs.chart_repo }}
-        chart_name: fog-services
-        chart_version: ${{ inputs.version }}
-        chart_wait_timeout: 10m
-        # Set orderedReady for compatibility with 1.1.3 chart - remove after 1.2.x
-        chart_set: |
-          --set=image.org=${{ inputs.docker_image_org }}
-          --set=global.certManagerClusterIssuer=zerossl-prod-http
-          --set=fogLedger.podManagementPolicy=OrderedReady
-        release_name: fog-services
+        action: helm-release-delete
         namespace: ${{ inputs.namespace }}
+        release_name: fog-ingest-${{ env.FLIPSIDE }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -36,13 +36,6 @@ on:
         required: true
 
 jobs:
-  list-values:
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: values
-      run: |
-        echo namespace ${{ inputs.namespace }}
-
   reset-releases:
     runs-on: [self-hosted, Linux, small]
     strategy:

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -37,7 +37,6 @@
 #   - All tests run with in the kubernetes namespace context so we can reach internally hosted endpoints,
 #      like mobilecoind. (CBB: add full-service?)
 #
-# CBB: make tests work if client_auth_token is enabled. Will require generating the auth tokens.
 
 name: mobilecoin-workflow-dev-test
 
@@ -57,13 +56,13 @@ on:
         type: string
         required: false
         default: 'true'
-      testing_1_1:
-        description: "Run v1.1.x tests (block_version 0)"
+      testing_block_v0:
+        description: "Run block v0 tests"
         type: string
         required: false
         default: 'true'
-      testing_1_2:
-        description: "Run v1.2.x tests (block_version 0/2"
+      testing_block_v2:
+        description: "Run block v2 tests"
         type: string
         required: false
         default: 'true'
@@ -88,21 +87,16 @@ on:
         required: false
 
 jobs:
-  list-values:
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: values
-      run: |
-        echo namespace ${{ inputs.namespace }}
-        echo ingest_color ${{ inputs.ingest_color }}
-        echo fog_distribution ${{ inputs.fog_distribution }}
-        echo testing_1_1 ${{ inputs.testing_1_1 }}
-        echo testing_1_2 ${{ inputs.testing_1_2 }}
-
-  setup-environment:
+  cd-integration-tests:
     runs-on: [self-hosted, Linux, small]
     env:
       FOG_REPORT_SIGNING_CA_CERT_PATH: .tmp/fog_report_signing_ca_cert.pem
+      SRC_KEYS_DIR: /tmp/sample_data/keys
+      SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
+      V2_DST_KEYS_DIR: /tmp/2-testing/keys
+      V2_DST_FOG_KEYS_DIR: /tmp/2-testing/fog_keys
+      START_KEYS: '494'
+      END_KEYS: '499'
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -134,12 +128,6 @@ jobs:
           FOG_REPORT_URL="fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" \
           /util/generate_origin_data.sh
 
-  fog-distribution:
-    name: fog-distribution ${{ inputs.fog_distribution == 'true' && '(run)' || '(skipped)' }}
-    runs-on: [self-hosted, Linux, small]
-    needs:
-    - setup-environment
-    steps:
     - name: Test - fog-distribution
       if: inputs.fog_distribution == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -153,14 +141,8 @@ jobs:
         command: |
           /test/fog-distribution-test.sh
 
-  testing-1-1:
-    name: testing-1-1 ${{ inputs.testing_1_1 == 'true' && '(run)' || '(skipped)' }}
-    runs-on: [self-hosted, Linux, small]
-    needs:
-    - fog-distribution
-    steps:
-    - name: Test - fog-test-client
-      if: inputs.testing_1_1 == 'true'
+    - name: Test - block-v0 - fog-test-client
+      if: inputs.testing_block_v0 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -182,9 +164,8 @@ jobs:
             --fog-view fog-view://${{ secrets.CLIENT_AUTH_USER_VALUE }}fog.${{ inputs.namespace }}.development.mobilecoin.com:443 \
             --fog-ledger fog-ledger://${{ secrets.CLIENT_AUTH_USER_VALUE }}fog.${{ inputs.namespace }}.development.mobilecoin.com:443
 
-
-    - name: Test - mobilecoind-grpc (previously Wallet Integration)
-      if: inputs.testing_1_1 == 'true'
+    - name: Test - block-v0 - mobilecoind-grpc (previously Wallet Integration)
+      if: inputs.testing_block_v0 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -196,21 +177,8 @@ jobs:
         command: |
           /test/mobilecoind-integration-test.sh
 
-  testing-1-2:
-    name: Testing for v1.2.x ${{ inputs.testing_1_2 == 'true' && '(run)' || '(skipped)' }}
-    runs-on: [self-hosted, Linux, small]
-    needs:
-    - testing-1-1
-    env:
-      SRC_KEYS_DIR: /tmp/sample_data/keys
-      SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
-      DST_KEYS_DIR: /tmp/1.2-testing/keys
-      DST_FOG_KEYS_DIR: /tmp/1.2-testing/fog_keys
-      START_KEYS: '494'
-      END_KEYS: '499'
-    steps:
-    - name: Copy subset of non-fog keys
-      if: inputs.testing_1_2 == 'true'
+    - name: Setup - block-v2 - Copy subset of non-fog keys
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -222,12 +190,12 @@ jobs:
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_KEYS_DIR }} \
-            --dst ${{ env.DST_KEYS_DIR }} \
+            --dst ${{ env.V2_DST_KEYS_DIR }} \
             --start ${{ env.START_KEYS }} \
             --end ${{ env.END_KEYS }}
 
-    - name: Copy subset of fog keys
-      if: inputs.testing_1_2 == 'true'
+    - name: Setup - block-v2 - Copy subset of fog keys
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -239,12 +207,12 @@ jobs:
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_FOG_KEYS_DIR }} \
-            --dst ${{ env.DST_FOG_KEYS_DIR }} \
+            --dst ${{ env.V2_DST_FOG_KEYS_DIR }} \
             --start ${{ env.START_KEYS }} \
             --end ${{ env.END_KEYS }}
 
-    - name: Test - Minting config tx
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - Minting config tx
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -257,8 +225,8 @@ jobs:
           /test/minting-config-tx-test.sh \
             --token-id 8192
 
-    - name: Test - Minting tx
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - Minting tx
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -272,8 +240,8 @@ jobs:
             --key-dir ${{ env.DST_KEYS_DIR }} \
             --token-id 8192
 
-    - name: Test - mobilecoind-json integration
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - mobilecoind-json integration
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -284,24 +252,10 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/mobilecoind-json-integration-test.sh \
-            --key-dir ${{ env.DST_KEYS_DIR }}
+            --key-dir ${{ env.V2_DST_KEYS_DIR }}
 
-    - name: Test - mint-auditor
-      if: inputs.testing_1_2 == 'true'
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: toolbox-exec
-        ingest_color: ${{ inputs.ingest_color }}
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-        command: |
-          /test/mint-auditor-test.sh \
-            --token-id 8192 --token-fee 1024
-
-    - name: Test - use drain_accounts to transfer id 8192 balances to fog keys
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - use drain_accounts to transfer id 1 balances to fog keys
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -312,13 +266,13 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /util/drain_accounts.sh \
-            --src ${{ env.DST_KEYS_DIR }} \
-            --dst ${{ env.DST_FOG_KEYS_DIR }} \
+            --src ${{ env.V2_DST_KEYS_DIR }} \
+            --dst ${{ env.V2_DST_FOG_KEYS_DIR }} \
             --fee 1024 \
             --token-id 8192
 
-    - name: Test - fog-test-client token id 0
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - fog-test-client token id 0
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -329,11 +283,11 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/fog-test-client.sh \
-            --key-dir ${{ env.DST_FOG_KEYS_DIR }} \
+            --key-dir ${{ env.V2_DST_FOG_KEYS_DIR }} \
             --token-id 0
 
-    - name: Test - fog-test-client token id 1
-      if: inputs.testing_1_2 == 'true'
+    - name: Test - block-v2 - fog-test-client token id 1
+      if: inputs.testing_block_v2 == 'true'
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -237,7 +237,7 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/minting-tx-test.sh \
-            --key-dir ${{ env.DST_KEYS_DIR }} \
+            --key-dir ${{ env.V2_DST_KEYS_DIR }} \
             --token-id 8192
 
     - name: Test - block-v2 - mobilecoind-json integration
@@ -298,5 +298,5 @@ jobs:
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
           /test/fog-test-client.sh \
-            --key-dir ${{ env.DST_FOG_KEYS_DIR }} \
+            --key-dir ${{ env.V2_DST_FOG_KEYS_DIR }} \
             --token-id 8192

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Login to DockerHub
       if: inputs.minting_config_enabled == 'true'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -32,8 +32,16 @@ is_set GITHUB_SHA
 
 # Make sure prefix is less that 18 characters or k8s limits.
 namespace_prefix="mc"
-branch="${GITHUB_REF_NAME}"
 sha="sha-${GITHUB_SHA:0:8}"
+
+# Set branch name. Where we get this ref is different for branch, pull_request or delete event
+branch="${GITHUB_REF_NAME}"
+
+# Override branch name with head when event is a PR
+if [[ -n "${GITHUB_HEAD_REF}" ]]
+then
+    branch="${GITHUB_HEAD_REF}"
+fi
 
 # Override branch with delete ref if set.
 if [[ -n "${DELETE_REF_NAME}" ]]
@@ -73,48 +81,41 @@ case "${GITHUB_REF_TYPE}" in
         is_set tag
         is_set docker_tag
     ;;
+    # Branches and pull requests will set type as branch.
+    # Don't filter on "valid" branches, rely on workflows to filter out their accepted events.
     branch)
-        # Check for valid branches. Using case if we want add more or split branch types later.
-        case "${branch}" in
-            release/*|feature/*)
-                # All branch builds will just have a "dummy" tag.
-                version="v0"
+        # All branch builds will just have a "dummy" tag.
+        version="v0"
 
-                echo "Clean up branch. Remove feature|deploy|release prefix and replace ._/ with -"
-                normalized_branch="$(normalize_ref_name "${branch}")"
+        echo "Clean up branch. Remove feature|deploy|release prefix and replace ._/ with -"
+        normalized_branch="$(normalize_ref_name "${branch}")"
 
-                # Check and truncate branch name if total tag length exceeds the 63 character K8s label value limit.
-                label_limit=63
-                version_len=${#version}
-                sha_len=${#sha}
-                run_number_len=${#GITHUB_RUN_NUMBER}
-                # number of separators in tag
-                dots=3
+        # Check and truncate branch name if total tag length exceeds the 63 character K8s label value limit.
+        label_limit=63
+        version_len=${#version}
+        sha_len=${#sha}
+        run_number_len=${#GITHUB_RUN_NUMBER}
+        # number of separators in tag
+        dots=3
 
-                cutoff=$((label_limit - version_len - sha_len - run_number_len - dots))
+        cutoff=$((label_limit - version_len - sha_len - run_number_len - dots))
 
-                if [[ ${#normalized_branch} -gt ${cutoff} ]]
-                then
-                    cut_branch=$(echo "${normalized_branch}" | cut -c -${cutoff})
-                    echo "Your branch name ${normalized_branch} + metadata exceeds the maximum length for K8s identifiers, truncating to ${cut_branch}"
-                    normalized_branch="${cut_branch}"
-                fi
+        if [[ ${#normalized_branch} -gt ${cutoff} ]]
+        then
+            cut_branch=$(echo "${normalized_branch}" | cut -c -${cutoff})
+            echo "Your branch name ${normalized_branch} + metadata exceeds the maximum length for K8s identifiers, truncating to ${cut_branch}"
+            normalized_branch="${cut_branch}"
+        fi
 
-                echo "Before: '${branch}'"
-                echo "After: '${normalized_branch}'"
+        echo "Before: '${branch}'"
+        echo "After: '${normalized_branch}'"
 
-                # Set artifact tag
-                tag="${version}-${normalized_branch}.${GITHUB_RUN_NUMBER}.${sha}"
-                # Set docker metadata action compatible tag
-                docker_tag="type=raw,value=${tag}"
-                # Set namespace from normalized branch value
-                namespace="${namespace_prefix}-${normalized_branch}"
-            ;;
-            *)
-                echo "Branch: ${branch} is not a release/ or feature/ branch"
-                exit 1
-            ;;
-        esac
+        # Set artifact tag
+        tag="${version}-${normalized_branch}.${GITHUB_RUN_NUMBER}.${sha}"
+        # Set docker metadata action compatible tag
+        docker_tag="type=raw,value=${tag}"
+        # Set namespace from normalized branch value
+        namespace="${namespace_prefix}-${normalized_branch}"
     ;;
     *)
         echo "${GITHUB_REF_TYPE} is an unknown GitHub Reference Type"
@@ -122,8 +123,11 @@ case "${GITHUB_REF_TYPE}" in
     ;;
 esac
 
-echo "::set-output name=version::${version}"
-echo "::set-output name=namespace::${namespace}"
-echo "::set-output name=sha::${sha}"
-echo "::set-output name=tag::${tag}"
-echo "::set-output name=docker_tag::${docker_tag}"
+# Set GHA output vars
+cat <<EOF >> "${GITHUB_OUTPUT}"
+version=${version}
+namespace=${namespace}
+sha=${sha}
+tag=${tag}
+docker_tag=${docker_tag}
+EOF


### PR DESCRIPTION
### Motivation
Make sure that CD is run when we have a PR to master or release/ branches. Skip CI/CD when changes are only to .md files.

### When to require CI/CD runs:

- PR to master
- PR to release/

### Opt into CD:

- create a branch with feature/

How to opt out of CI/CD runs:

- add the GHA built in [skip ci] to your commit message.

Changes:
- on.pull_request CD workflow
- move all CD dispatch calls to workflow calls.
- clean up steps that described the workflow calls.
- Add human names to the manual dispatch calls.
- make testing workflow line up with current master.
- remove CD debugging skip filters for now.
- update docker actions to remove deprecated nodejs version warnings
- update metadata to remove deprecated GHA set-output calls

Future Work:
- add more file exclusions
- Add logic to skip just CD or just CI.

