### PR TITLE
V3 - CI/CD - Fix docker tags

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -187,7 +187,7 @@ jobs:
 
   build-go-projects:
     if: github.actor != 'dependabot[bot]'
-    runs-on: [self-hosted, Linux, large]
+    runs-on: [self-hosted, Linux, small]
     container:
       image: golang:1.16.4
     steps:
@@ -326,7 +326,8 @@ jobs:
       uses: docker/metadata-action@v4
       with:
         images: ${{ env.DOCKER_ORG }}/${{ matrix.image }}
-        tags: ${{ needs.generate-metadata.outputs.docker_tag }}
+        tags: |
+          ${{ needs.generate-metadata.outputs.docker_tag }}
 
     - name: Set up Docker Buildx
       if: "! contains(github.event.head_commit.message, '[skip docker]')"
@@ -580,7 +581,7 @@ jobs:
   cleanup-on-pr:
     if: |
       github.actor != 'dependabot[bot]' &&
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' || github.ref_type == 'tag')
     needs:
     - test-current-bv2-release
     - generate-metadata
@@ -594,4 +595,3 @@ jobs:
       RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
       LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
       LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -28,7 +28,7 @@ on:
     paths-ignore:
     - '**.md'
 
-# don't run more than one at a time for a  branch/tag
+# don't run more than one at a time for a branch/tag
 concurrency:
   group: mobilecoin-dev-cd-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -28,7 +28,7 @@ on:
     paths-ignore:
     - '**.md'
 
-# don't run more than one at a time for a branch/tag
+# don't run more than one at a time for a  branch/tag
 concurrency:
   group: mobilecoin-dev-cd-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -13,7 +13,8 @@ is_set()
   var_name="${1}"
 
   if [ -z "${!var_name}" ]; then
-    error_exit "${var_name} is not set."
+    echo "${var_name} is not set."
+    exit 1
   fi
 }
 
@@ -64,17 +65,20 @@ case "${GITHUB_REF_TYPE}" in
             echo "Found pre-release tag."
             # set artifact tag
             tag="${version}"
-            docker_tag="type=raw,value=${version},priority=20%0Atype=raw,value=${version}.${GITHUB_RUN_NUMBER}.${sha},priority=10"
         else
             echo "Found release tag."
             # set artifact tag
             tag="${version}-dev"
-            #set docker metadata action compatible tag. Short tag + metadata tag.
-            docker_tag="type=raw,value=${version}-dev,priority=20%0Atype=raw,value=${version}-dev.${GITHUB_RUN_NUMBER}.${sha},priority=10"
         fi
 
-        normalized_tag=$(normalize_ref_name "${tag}")
+        # Set docker metadata action compatible tag. Short tag + metadata tag.
+        docker_tag=$(cat << EOF
+type=raw,value=${version}-dev,priority=20
+type=raw,value=${version}-dev.${GITHUB_RUN_NUMBER}.${sha},priority=10
+EOF
+)
 
+        normalized_tag=$(normalize_ref_name "${tag}")
         namespace="${namespace_prefix}-${normalized_tag}"
 
         # just make sure we have these set to avoid weird edge cases.
@@ -124,10 +128,14 @@ case "${GITHUB_REF_TYPE}" in
 esac
 
 # Set GHA output vars
-cat <<EOF >> "${GITHUB_OUTPUT}"
+cat <<EOO >> "${GITHUB_OUTPUT}"
 version=${version}
 namespace=${namespace}
 sha=${sha}
 tag=${tag}
-docker_tag=${docker_tag}
+docker_tag<<EOF
+${docker_tag}
 EOF
+EOO
+
+cat "${GITHUB_OUTPUT}"

--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -73,8 +73,8 @@ case "${GITHUB_REF_TYPE}" in
 
         # Set docker metadata action compatible tag. Short tag + metadata tag.
         docker_tag=$(cat << EOF
-type=raw,value=${version}-dev,priority=20
-type=raw,value=${version}-dev.${GITHUB_RUN_NUMBER}.${sha},priority=10
+type=raw,value=${version},priority=20
+type=raw,value=${version}.${GITHUB_RUN_NUMBER}.${sha},priority=10
 EOF
 )
 


### PR DESCRIPTION
### Motivation

Between the upgrade to docker/metadata-actions@v4 and the deprecation of GHA `set-output::`, something broke multiline outputs between jobs.

- Fix `docker_tag` output
