### PR TITLE
Refactor BlockchainConfig validation into the actual object.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -35,3 +35,6 @@ mc-util-serial = { path = "../../../util/serial", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
### Motivation

This makes it easier to expand and test the validation criteria as the object evolves. https://github.com/mobilecoinfoundation/mobilecoin/pull/2767/ is going to add some more validation scenarios, and @nick-mobilecoin [pointed out](https://github.com/mobilecoinfoundation/mobilecoin/pull/2767/files#r1004662057) that breaking this out of `enclave_init` would simplify testing (and I agree).