### PR TITLE
master - ci/cd - Reduce dependabot pr limit, set ci/cd concurrency logic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
     time: "00:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 25
+  open-pull-requests-limit: 10
   labels:
     - "blocks-v3.x"
     - "dependencies"
@@ -61,4 +61,4 @@ updates:
     interval: daily
     time: "02:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ on:
     - '**.md'
   workflow_dispatch:
 
+concurrency:
+  # Limit to one concurrent process on master and release/*.
+  # Limit other events, PRs and other branches, by actor (user or dependabot).
+  group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/') ) && github.ref || github.actor }}
+  # Cancel in progress if master or release/*, but keep queue for PRs and other actors.
+  cancel-in-progress: ${{ ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/') )}}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -647,8 +654,3 @@ jobs:
       with:
         check_name: Test Report
         report_paths: '**/*.xml'
-
-# via https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -29,10 +29,13 @@ on:
     paths-ignore:
     - '**.md'
 
-# don't run more than one at a time for a branch/tag
 concurrency:
-  group: mobilecoin-dev-cd-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  # Limit to one concurrent process on master and release/*.
+  # Limit other events, PRs and other branches, by actor (user or dependabot).
+  group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/') ) && github.ref || github.actor }}
+  # Cancel in progress if master or release/*, but keep queue for PRs and other actors.
+  cancel-in-progress: ${{ ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/') )}}
+
 
 jobs:
 ############################################


### PR DESCRIPTION
### Motivation

Set concurrency logic for ci and cd workflows:

- Limit to one concurrent process on master and release/*.
- Limit other events, PRs and other branches, by actor (user or dependabot).
- Cancel in progress if master or release/*, but keep queue for PRs and other actors.

Reduce the dependabot open-pull-requests-limit to 10 for / and 5 for github actions (we only have a couple external actions at this point)

### Future Work

- Wish GHA logic was cleaner or regex was available. 
