### PR TITLE
Bump enclave security versions.

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
-const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 5;
+const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 6;
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
-const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 5;
 const INGEST_ENCLAVE_NAME: &str = "ingest-enclave";
 const INGEST_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
-const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 5;
 const LEDGER_ENCLAVE_NAME: &str = "ledger-enclave";
 const LEDGER_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
-const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 5;
 const VIEW_ENCLAVE_NAME: &str = "view-enclave";
 const VIEW_ENCLAVE_DIR: &str = "../trusted";
 


### PR DESCRIPTION
### Motivation

We need to bump the enclave security version for new enclave releases.

### In this PR
* Bump enclave svns for consensus, fog ingest, fog view, fog ledger enclaves.

