### PR TITLE
Collate remaining QueryResponse fields

### DIFF
--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -150,7 +150,7 @@ service FogViewStoreAPI {
 /// if you already have some Rng's before you make that request.
 ///
 /// The highest_processed_block_count value from the first request in a given session should become the
-/// start_from_block_index value the next time you make a request. Similarly, next_start_from_user_event_id should
+/// start_from_block_index value the next time you make a request. Similarly, NEXT_START_FROM_USER_EVENT_ID should
 /// become start_from_user_event_id for the next request.
 ///
 // After the interaction, you can be sure that you got every Txo of yours up to those cursor values.
@@ -186,7 +186,7 @@ message QueryResponse {
     /// The number of blocks processed at the time that the request was evaluated.
     ///
     /// The semantics of the result as a whole are, we guarantee to get you all
-    /// relevant event data from start_from_user_event_id to next_start_from_user_event_id
+    /// relevant event data from start_from_user_event_id to NEXT_START_FROM_USER_EVENT_ID
     /// and all TxOutSearchResults from start_from_block_index to highest_processed_block_count.
     ///
     /// The highest_processed_block_count value you had last time should generally be the start_from_block_index
@@ -201,7 +201,7 @@ message QueryResponse {
 
     /// The next value to use for start_from_user_event_id. For the first query, this should
     /// be 0.
-    int64 next_start_from_user_event_id = 3;
+    int64 NEXT_START_FROM_USER_EVENT_ID = 3;
 
     /// Any block ranges that are missed.
     /// These ranges are guaranteed to be non-overlapping.

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -150,7 +150,7 @@ service FogViewStoreAPI {
 /// if you already have some Rng's before you make that request.
 ///
 /// The highest_processed_block_count value from the first request in a given session should become the
-/// start_from_block_index value the next time you make a request. Similarly, NEXT_START_FROM_USER_EVENT_ID should
+/// start_from_block_index value the next time you make a request. Similarly, next_start_from_user_event_id should
 /// become start_from_user_event_id for the next request.
 ///
 // After the interaction, you can be sure that you got every Txo of yours up to those cursor values.
@@ -186,7 +186,7 @@ message QueryResponse {
     /// The number of blocks processed at the time that the request was evaluated.
     ///
     /// The semantics of the result as a whole are, we guarantee to get you all
-    /// relevant event data from start_from_user_event_id to NEXT_START_FROM_USER_EVENT_ID
+    /// relevant event data from start_from_user_event_id to next_start_from_user_event_id
     /// and all TxOutSearchResults from start_from_block_index to highest_processed_block_count.
     ///
     /// The highest_processed_block_count value you had last time should generally be the start_from_block_index
@@ -201,7 +201,7 @@ message QueryResponse {
 
     /// The next value to use for start_from_user_event_id. For the first query, this should
     /// be 0.
-    int64 NEXT_START_FROM_USER_EVENT_ID = 3;
+    int64 next_start_from_user_event_id= 3;
 
     /// Any block ranges that are missed.
     /// These ranges are guaranteed to be non-overlapping.

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -201,7 +201,7 @@ message QueryResponse {
 
     /// The next value to use for start_from_user_event_id. For the first query, this should
     /// be 0.
-    int64 next_start_from_user_event_id= 3;
+    int64 next_start_from_user_event_id = 3;
 
     /// Any block ranges that are missed.
     /// These ranges are guaranteed to be non-overlapping.

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -10,11 +10,8 @@ mod e_tx_out_store;
 mod oblivious_utils;
 mod types;
 
-use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
-use types::{BlockData, DecryptedMultiViewStoreQueryResponse, LastKnownData};
-
-use crate::types::SharedData;
 use alloc::vec::Vec;
+use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
@@ -37,6 +34,7 @@ use mc_fog_view_enclave_api::{
 use mc_oblivious_traits::ORAMStorageCreator;
 use mc_sgx_compat::sync::Mutex;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
+use types::{BlockData, CommonShardData, DecryptedMultiViewStoreQueryResponse, LastKnownData};
 
 pub struct ViewEnclave<OSC>
 where
@@ -335,7 +333,7 @@ where
         shard_query_response.last_known_block_count = last_known_data.last_known_block_count;
         shard_query_response.last_known_block_cumulative_txo_count =
             last_known_data.last_known_block_cumulative_txo_count;
-        let shared_data: SharedData = shard_query_responses.as_slice().into();
+        let shared_data: CommonShardData = shard_query_responses.as_slice().into();
         shard_query_response.missed_block_ranges = shared_data.missed_block_ranges;
         shard_query_response.rng_records = shared_data.rng_records;
         shard_query_response.decommissioned_ingest_invocations =

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -13,6 +13,7 @@ mod types;
 use e_tx_out_store::{ETxOutStore, StorageDataSize, StorageMetaSize};
 use types::{BlockData, DecryptedMultiViewStoreQueryResponse, LastKnownData};
 
+use crate::types::SharedData;
 use alloc::vec::Vec;
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
 use mc_attest_enclave_api::{
@@ -334,6 +335,14 @@ where
         shard_query_response.last_known_block_count = last_known_data.last_known_block_count;
         shard_query_response.last_known_block_cumulative_txo_count =
             last_known_data.last_known_block_cumulative_txo_count;
+        let shared_data: SharedData = shard_query_responses.as_slice().into();
+        shard_query_response.missed_block_ranges = shared_data.missed_block_ranges;
+        shard_query_response.rng_records = shared_data.rng_records;
+        shard_query_response.decommissioned_ingest_invocations =
+            shared_data.decommissioned_ingest_invocations;
+        shard_query_response.next_start_from_user_event_id =
+            shared_data.next_start_from_user_event_id;
+
         let block_data = get_block_data(shard_query_responses);
         shard_query_response.highest_processed_block_count =
             block_data.highest_processed_block_count;

--- a/fog/view/enclave/impl/src/types.rs
+++ b/fog/view/enclave/impl/src/types.rs
@@ -1,0 +1,67 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Helper structs for client `QueryResponse` collation.
+
+use mc_fog_types::{common::BlockRange, view::QueryResponse};
+
+/// Helper struct that contains the decrypted `QueryResponse` and the
+/// `BlockRange` the shard is responsible for.
+#[derive(Clone)]
+pub(crate) struct DecryptedMultiViewStoreQueryResponse {
+    /// Decrypted `QueryResponse`
+    pub(crate) query_response: QueryResponse,
+    /// The `BlockRange` that the shard is meant to process.
+    pub(crate) block_range: BlockRange,
+}
+
+/// Helper struct that contains block data for the client `QueryResponse`
+#[derive(Clone)]
+pub(crate) struct BlockData {
+    /// The highest processed block count that will be returned to the client.
+    pub(crate) highest_processed_block_count: u64,
+    /// The timestamp for the highest processed block count
+    pub(crate) highest_processed_block_signature_timestamp: u64,
+}
+
+/// Helper struct that contains data associated with the "last known" fields in
+/// the `QueryResponse`.
+#[derive(Default)]
+pub(crate) struct LastKnownData {
+    /// The globally maximum block count that any store has seen but not
+    /// necessarily processed.
+    pub(crate) last_known_block_count: u64,
+    /// The cumulative TxOut count associated with the last known block count.
+    pub(crate) last_known_block_cumulative_txo_count: u64,
+}
+
+impl BlockData {
+    pub(crate) fn new(
+        highest_processed_block_count: u64,
+        highest_processed_block_signature_timestamp: u64,
+    ) -> Self {
+        Self {
+            highest_processed_block_count,
+            highest_processed_block_signature_timestamp,
+        }
+    }
+}
+impl Default for BlockData {
+    fn default() -> Self {
+        Self {
+            highest_processed_block_count: u64::MIN,
+            highest_processed_block_signature_timestamp: u64::MIN,
+        }
+    }
+}
+
+impl LastKnownData {
+    pub(crate) fn new(
+        last_known_block_count: u64,
+        last_known_block_cumulative_txo_count: u64,
+    ) -> Self {
+        Self {
+            last_known_block_count,
+            last_known_block_cumulative_txo_count,
+        }
+    }
+}

--- a/fog/view/enclave/impl/src/types.rs
+++ b/fog/view/enclave/impl/src/types.rs
@@ -2,7 +2,12 @@
 
 //! Helper structs for client `QueryResponse` collation.
 
-use mc_fog_types::{common::BlockRange, view::QueryResponse};
+use alloc::vec::Vec;
+use mc_common::HashSet;
+use mc_fog_types::{
+    common::BlockRange,
+    view::{DecommissionedIngestInvocation, QueryResponse, RngRecord},
+};
 
 /// Helper struct that contains the decrypted `QueryResponse` and the
 /// `BlockRange` the shard is responsible for.
@@ -34,6 +39,20 @@ pub(crate) struct LastKnownData {
     pub(crate) last_known_block_cumulative_txo_count: u64,
 }
 
+/// Helper struct that contains `QueryResponse` fields that should be shared
+/// across all shards, but might not be do to distributed system latencies.
+pub(crate) struct SharedData {
+    /// Blocks that Fog Ingest was unable to process.
+    pub(crate) missed_block_ranges: Vec<BlockRange>,
+    /// All RNG records for a given user.
+    pub(crate) rng_records: Vec<RngRecord>,
+    /// Any records of decommissioned ingest invocations, which implies that an
+    /// RNG will no longer be used.
+    pub(crate) decommissioned_ingest_invocations: Vec<DecommissionedIngestInvocation>,
+    /// The index of the next user id event that the user should query.
+    pub(crate) next_start_from_user_event_id: i64,
+}
+
 impl BlockData {
     pub(crate) fn new(
         highest_processed_block_count: u64,
@@ -63,5 +82,246 @@ impl LastKnownData {
             last_known_block_count,
             last_known_block_cumulative_txo_count,
         }
+    }
+}
+
+impl SharedData {
+    pub(crate) fn new(
+        missed_block_ranges: Vec<BlockRange>,
+        rng_records: Vec<RngRecord>,
+        decommissioned_ingest_invocations: Vec<DecommissionedIngestInvocation>,
+        next_start_from_user_event_id: i64,
+    ) -> Self {
+        Self {
+            missed_block_ranges,
+            rng_records,
+            decommissioned_ingest_invocations,
+            next_start_from_user_event_id,
+        }
+    }
+}
+
+impl From<&[DecryptedMultiViewStoreQueryResponse]> for SharedData {
+    fn from(responses: &[DecryptedMultiViewStoreQueryResponse]) -> Self {
+        let mut missed_block_ranges = HashSet::default();
+        let mut rng_records = HashSet::default();
+        let mut decommissioned_ingest_invocations = HashSet::default();
+        let mut next_start_from_user_event_id = i64::MIN;
+
+        for response in responses {
+            missed_block_ranges.extend(response.query_response.missed_block_ranges.clone());
+            rng_records.extend(response.query_response.rng_records.clone());
+            decommissioned_ingest_invocations.extend(
+                response
+                    .query_response
+                    .decommissioned_ingest_invocations
+                    .clone(),
+            );
+            next_start_from_user_event_id = core::cmp::max(
+                response.query_response.next_start_from_user_event_id,
+                next_start_from_user_event_id,
+            );
+        }
+
+        let missed_block_ranges = missed_block_ranges.into_iter().collect::<Vec<BlockRange>>();
+        let rng_records = rng_records.into_iter().collect::<Vec<RngRecord>>();
+        let decommissioned_ingest_invocations = decommissioned_ingest_invocations
+            .into_iter()
+            .collect::<Vec<DecommissionedIngestInvocation>>();
+
+        SharedData::new(
+            missed_block_ranges,
+            rng_records,
+            decommissioned_ingest_invocations,
+            next_start_from_user_event_id,
+        )
+    }
+}
+
+#[cfg(test)]
+mod shared_data_tests {
+    extern crate std;
+    use crate::{DecryptedMultiViewStoreQueryResponse, SharedData};
+    use alloc::{vec, vec::Vec};
+    use mc_fog_types::{
+        common::BlockRange,
+        view::{DecommissionedIngestInvocation, KexRngPubkey, QueryResponse, RngRecord},
+    };
+    use std::collections::HashSet;
+
+    fn create_query_response(
+        missed_block_ranges: Vec<BlockRange>,
+        rng_records: Vec<RngRecord>,
+        decommissioned_ingest_invocations: Vec<DecommissionedIngestInvocation>,
+        next_start_from_user_event_id: i64,
+    ) -> QueryResponse {
+        QueryResponse {
+            highest_processed_block_count: 0,
+            highest_processed_block_signature_timestamp: 0,
+            next_start_from_user_event_id,
+            missed_block_ranges,
+            rng_records,
+            decommissioned_ingest_invocations,
+            tx_out_search_results: vec![],
+            last_known_block_count: 0,
+            last_known_block_cumulative_txo_count: 0,
+        }
+    }
+
+    #[test]
+    fn responses_have_same_values() {
+        const STORE_COUNT: usize = 4;
+        let mut decrypted_query_responses = Vec::with_capacity(STORE_COUNT);
+
+        let missed_block_ranges = vec![
+            BlockRange::new(0, 1),
+            BlockRange::new(10, 12),
+            BlockRange::new(33, 100),
+            BlockRange::new(100, 200),
+        ];
+
+        let mut rng_records = Vec::with_capacity(STORE_COUNT);
+        for i in 0..STORE_COUNT {
+            let egress_public_key = KexRngPubkey {
+                public_key: vec![i as u8; 32],
+                version: i as u32,
+            };
+            let rng_record = RngRecord {
+                ingest_invocation_id: i as i64,
+                pubkey: egress_public_key,
+                start_block: 0,
+            };
+            rng_records.push(rng_record);
+        }
+
+        let mut decommissioned_ingest_invocations = Vec::with_capacity(STORE_COUNT);
+        for i in 0..STORE_COUNT {
+            let decommissioned_ingest_invocation = DecommissionedIngestInvocation {
+                ingest_invocation_id: i as i64,
+                last_ingested_block: 10,
+            };
+            decommissioned_ingest_invocations.push(decommissioned_ingest_invocation);
+        }
+
+        const NEXT_START_FROM_USER_EVENT_ID: i64 = 100;
+
+        for i in 0..STORE_COUNT {
+            let query_response = create_query_response(
+                missed_block_ranges.clone(),
+                rng_records.clone(),
+                decommissioned_ingest_invocations.clone(),
+                NEXT_START_FROM_USER_EVENT_ID,
+            );
+            let block_range = BlockRange::new(i as u64, (i + 1) as u64);
+            let decrypted_query_response = DecryptedMultiViewStoreQueryResponse {
+                query_response,
+                block_range,
+            };
+            decrypted_query_responses.push(decrypted_query_response);
+        }
+
+        let shared_data: SharedData = decrypted_query_responses.as_slice().into();
+
+        let actual_missed_block_ranges =
+            HashSet::<_>::from_iter(shared_data.missed_block_ranges.iter());
+        let actual_rng_records = HashSet::<_>::from_iter(shared_data.rng_records.iter());
+        let actual_decommissioned_ingest_invocations =
+            HashSet::<_>::from_iter(shared_data.decommissioned_ingest_invocations.iter());
+
+        let expected_missed_block_ranges = HashSet::<_>::from_iter(missed_block_ranges.iter());
+        let expected_rng_records = HashSet::<_>::from_iter(rng_records.iter());
+        let expected_decommissioned_ingest_invocations =
+            HashSet::<_>::from_iter(decommissioned_ingest_invocations.iter());
+
+        assert_eq!(actual_missed_block_ranges, expected_missed_block_ranges);
+        assert_eq!(actual_rng_records, expected_rng_records);
+        assert_eq!(
+            actual_decommissioned_ingest_invocations,
+            expected_decommissioned_ingest_invocations
+        );
+        assert_eq!(
+            shared_data.next_start_from_user_event_id,
+            NEXT_START_FROM_USER_EVENT_ID
+        );
+    }
+
+    #[test]
+    fn responses_have_different_values() {
+        const STORE_COUNT: usize = 4;
+        let mut decrypted_query_responses = Vec::with_capacity(STORE_COUNT);
+
+        let missed_block_ranges = vec![
+            BlockRange::new(0, 1),
+            BlockRange::new(10, 12),
+            BlockRange::new(33, 100),
+            BlockRange::new(100, 200),
+        ];
+
+        let mut rng_records = Vec::with_capacity(STORE_COUNT);
+        for i in 0..STORE_COUNT {
+            let egress_public_key = KexRngPubkey {
+                public_key: vec![i as u8; 32],
+                version: i as u32,
+            };
+            let rng_record = RngRecord {
+                ingest_invocation_id: i as i64,
+                pubkey: egress_public_key,
+                start_block: 0,
+            };
+            rng_records.push(rng_record);
+        }
+
+        let mut decommissioned_ingest_invocations = Vec::with_capacity(STORE_COUNT);
+        for i in 0..STORE_COUNT {
+            let decommissioned_ingest_invocation = DecommissionedIngestInvocation {
+                ingest_invocation_id: i as i64,
+                last_ingested_block: 10,
+            };
+            decommissioned_ingest_invocations.push(decommissioned_ingest_invocation);
+        }
+
+        for i in 0..STORE_COUNT {
+            let missed_block_ranges = vec![missed_block_ranges[i].clone()];
+            let rng_records = vec![rng_records[i].clone()];
+            let decommissioned_ingest_invocations =
+                vec![decommissioned_ingest_invocations[i].clone()];
+
+            let query_response = create_query_response(
+                missed_block_ranges,
+                rng_records,
+                decommissioned_ingest_invocations,
+                (i + 1) as i64,
+            );
+            let block_range = BlockRange::new(i as u64, (i + 1) as u64);
+            let decrypted_query_response = DecryptedMultiViewStoreQueryResponse {
+                query_response,
+                block_range,
+            };
+            decrypted_query_responses.push(decrypted_query_response);
+        }
+
+        let shared_data: SharedData = decrypted_query_responses.as_slice().into();
+
+        let actual_missed_block_ranges =
+            HashSet::<_>::from_iter(shared_data.missed_block_ranges.iter());
+        let actual_rng_records = HashSet::<_>::from_iter(shared_data.rng_records.iter());
+        let actual_decommissioned_ingest_invocations =
+            HashSet::<_>::from_iter(shared_data.decommissioned_ingest_invocations.iter());
+
+        let expected_missed_block_ranges = HashSet::<_>::from_iter(missed_block_ranges.iter());
+        let expected_rng_records = HashSet::<_>::from_iter(rng_records.iter());
+        let expected_decommissioned_ingest_invocations =
+            HashSet::<_>::from_iter(decommissioned_ingest_invocations.iter());
+
+        assert_eq!(actual_missed_block_ranges, expected_missed_block_ranges);
+        assert_eq!(actual_rng_records, expected_rng_records);
+        assert_eq!(
+            actual_decommissioned_ingest_invocations,
+            expected_decommissioned_ingest_invocations
+        );
+        assert_eq!(
+            shared_data.next_start_from_user_event_id,
+            STORE_COUNT as i64
+        );
     }
 }

--- a/fog/view/enclave/impl/src/types.rs
+++ b/fog/view/enclave/impl/src/types.rs
@@ -41,7 +41,7 @@ pub(crate) struct LastKnownData {
 
 /// Helper struct that contains `QueryResponse` fields that should be shared
 /// across all shards, but might not be do to distributed system latencies.
-pub(crate) struct SharedData {
+pub(crate) struct CommonShardData {
     /// Blocks that Fog Ingest was unable to process.
     pub(crate) missed_block_ranges: Vec<BlockRange>,
     /// All RNG records for a given user.
@@ -85,7 +85,7 @@ impl LastKnownData {
     }
 }
 
-impl SharedData {
+impl CommonShardData {
     pub(crate) fn new(
         missed_block_ranges: Vec<BlockRange>,
         rng_records: Vec<RngRecord>,
@@ -101,7 +101,7 @@ impl SharedData {
     }
 }
 
-impl From<&[DecryptedMultiViewStoreQueryResponse]> for SharedData {
+impl From<&[DecryptedMultiViewStoreQueryResponse]> for CommonShardData {
     fn from(responses: &[DecryptedMultiViewStoreQueryResponse]) -> Self {
         let mut missed_block_ranges = HashSet::default();
         let mut rng_records = HashSet::default();
@@ -129,7 +129,7 @@ impl From<&[DecryptedMultiViewStoreQueryResponse]> for SharedData {
             .into_iter()
             .collect::<Vec<DecommissionedIngestInvocation>>();
 
-        SharedData::new(
+        CommonShardData::new(
             missed_block_ranges,
             rng_records,
             decommissioned_ingest_invocations,
@@ -141,7 +141,7 @@ impl From<&[DecryptedMultiViewStoreQueryResponse]> for SharedData {
 #[cfg(test)]
 mod shared_data_tests {
     extern crate std;
-    use crate::{DecryptedMultiViewStoreQueryResponse, SharedData};
+    use crate::{CommonShardData, DecryptedMultiViewStoreQueryResponse};
     use alloc::{vec, vec::Vec};
     use mc_fog_types::{
         common::BlockRange,
@@ -220,7 +220,7 @@ mod shared_data_tests {
             decrypted_query_responses.push(decrypted_query_response);
         }
 
-        let shared_data: SharedData = decrypted_query_responses.as_slice().into();
+        let shared_data: CommonShardData = decrypted_query_responses.as_slice().into();
 
         let actual_missed_block_ranges =
             HashSet::<_>::from_iter(shared_data.missed_block_ranges.iter());
@@ -300,7 +300,7 @@ mod shared_data_tests {
             decrypted_query_responses.push(decrypted_query_response);
         }
 
-        let shared_data: SharedData = decrypted_query_responses.as_slice().into();
+        let shared_data: CommonShardData = decrypted_query_responses.as_slice().into();
 
         let actual_missed_block_ranges =
             HashSet::<_>::from_iter(shared_data.missed_block_ranges.iter());


### PR DESCRIPTION
### Motivation
The `QueryResponse`'s `missed_block_ranges`, `rng_records`, and `decommissioned_ingest_invocations` fields were previously not being collated. This wasn't a huge issue because each store should, in theory, produce the same values for these fields (because they are all supplied by the DB and have nothing to do with the store's sharding strategy). That said, there may be slight variations in these values if different stores experience more intense loads and are slightly behind the DB's most recent values. To cover our bases, this PR takes the union of all these field's values.
