### PR TITLE
Add enclave form_block tests for nested multisigs to ensure end-to-end block forming behaves as expected.

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2491,7 +2491,6 @@ mod tests {
 
         assert!(signature.verify(&block).is_ok());
 
-        // The block contents should contain two mint txs.
         assert_eq!(block_contents.mint_txs, vec![mint_tx]);
 
         // There should be no key images or mint config txs

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2575,7 +2575,7 @@ mod tests {
                 governor_2.sign(message.as_ref()),
             ]);
             MintConfigTx {
-                prefix: mint_config_tx_prefix.clone(),
+                prefix: mint_config_tx_prefix,
                 signature,
             }
         };

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2622,7 +2622,7 @@ mod tests {
         // Initialize a ledger.
         let sender = AccountKey::random(&mut rng);
         let mut ledger = create_ledger();
-       initialize_ledger(block_version, &mut ledger, 1, &sender, &mut rng);
+        initialize_ledger(block_version, &mut ledger, 1, &sender, &mut rng);
 
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
         let root_element = ledger.get_root_tx_out_membership_element().unwrap();

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2492,7 +2492,7 @@ mod tests {
         assert!(signature.verify(&block).is_ok());
 
         // The block contents should contain two mint txs.
-        assert_eq!(block_contents.mint_txs, vec![mint_tx.clone()]);
+        assert_eq!(block_contents.mint_txs, vec![mint_tx]);
 
         // There should be no key images or mint config txs
         assert!(block_contents.key_images.is_empty());
@@ -2646,7 +2646,7 @@ mod tests {
             &parent_block,
             FormBlockInputs {
                 mint_txs_with_config: vec![(
-                    invalid_mint_tx.clone(),
+                    invalid_mint_tx,
                     valid_mint_config_tx.clone(),
                     valid_mint_config_tx.prefix.configs[0].clone(),
                 )],
@@ -2666,7 +2666,7 @@ mod tests {
             &parent_block,
             FormBlockInputs {
                 mint_txs_with_config: vec![(
-                    valid_mint_tx.clone(),
+                    valid_mint_tx,
                     invalid_mint_config_tx.clone(),
                     invalid_mint_config_tx.prefix.configs[0].clone(),
                 )],

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -2449,13 +2449,7 @@ mod tests {
         // Initialize a ledger.
         let sender = AccountKey::random(&mut rng);
         let mut ledger = create_ledger();
-
-        // We want the next block that gets appended to the ledger to exceed the
-        // tombstone limit of the mint config tx, since we want to make sure
-        // that minting that relies on an old MintConfigTx (one that is past
-        // its tombstone block) still validate and mint successfully.
-        let n_blocks = mint_config_tx.prefix.tombstone_block;
-        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+        initialize_ledger(block_version, &mut ledger, 1, &sender, &mut rng);
 
         // Form block
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
@@ -2504,8 +2498,7 @@ mod tests {
         let (amount, _) = output1
             .view_key_match(recipient1.view_private_key())
             .unwrap();
-        assert_eq!(amount.value, 12);
-        assert_eq!(amount.token_id, token_id1);
+        assert_eq!(amount, Amount::new(12, token_id1));
     }
 
     #[test_with_logger]
@@ -2629,13 +2622,7 @@ mod tests {
         // Initialize a ledger.
         let sender = AccountKey::random(&mut rng);
         let mut ledger = create_ledger();
-
-        // We want the next block that gets appended to the ledger to exceed the
-        // tombstone limit of the mint config tx, since we want to make sure
-        // that minting that relies on an old MintConfigTx (one that is past
-        // its tombstone block) still validate and mint successfully.
-        let n_blocks = mint_config_tx_prefix.tombstone_block;
-        initialize_ledger(block_version, &mut ledger, n_blocks, &sender, &mut rng);
+       initialize_ledger(block_version, &mut ledger, 1, &sender, &mut rng);
 
         let parent_block = ledger.get_block(ledger.num_blocks().unwrap() - 1).unwrap();
         let root_element = ledger.get_root_tx_out_membership_element().unwrap();


### PR DESCRIPTION
### Motivation

form_block is a critical part of our code, so I felt it is appropriate
to explicitly test out the new nested multisig behavior at that point.

I am aware these tests are long and extremely verbose. There is likely
room for improvement, but I wanted to keep the scope of this PR small.
