### PR TITLE
V3 - CI/CD - fix tags part 2

### DIFF
--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -73,8 +73,8 @@ case "${GITHUB_REF_TYPE}" in
 
         # Set docker metadata action compatible tag. Short tag + metadata tag.
         docker_tag=$(cat << EOF
-type=raw,value=${version},priority=20
-type=raw,value=${version}.${GITHUB_RUN_NUMBER}.${sha},priority=10
+type=raw,value=${tag},priority=20
+type=raw,value=${tag}.${GITHUB_RUN_NUMBER}.${sha},priority=10
 EOF
 )
 


### PR DESCRIPTION
### Motivation

Docker tags should be constructed from the `${tag}` value and not the `${version}` value.   

A `v3.0.0` semver "tag" event should make a `v3.0.0-dev` artifact set.  We accidentally made a `v3.0.0` docker tag instead.

