### PR TITLE
Change mint-client to accept MintConfigTx parameters from a JSON file

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -490,6 +490,7 @@ jobs:
       testing_block_v0: false
       testing_block_v2: true
       testing_block_v3: false
+      generate_and_submit_mint_config_tx_uses_json: true
     secrets: inherit
 
 #################################################
@@ -520,6 +521,7 @@ jobs:
       testing_block_v0: false
       testing_block_v2: false
       testing_block_v3: true
+      generate_and_submit_mint_config_tx_uses_json: true
     secrets: inherit
 
 ###############################################################

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -71,6 +71,11 @@ on:
         type: boolean
         required: false
         default: true
+      generate_and_submit_mint_config_tx_uses_json:
+        description: "Whether the generate-and-submit-mint-config-tx command uses a JSON file (true) or command line arguments (false)"
+        type: boolean
+        required: false
+        default: false
     secrets:
       RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -221,7 +226,12 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
+          JSON_FLAG=""
+          if [ "${{ inputs.generate_and_submit_mint_config_tx_uses_json }}" == "true" ]; then
+            JSON_FLAG="--json"
+          fi
           /test/minting-config-tx-test.sh \
+            $JSON_FLAG \
             --token-id 8192
 
     - name: Test - block-v2 - Minting tx
@@ -345,7 +355,12 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
         command: |
+          JSON_FLAG=""
+          if [ "${{ inputs.generate_and_submit_mint_config_tx_uses_json }}" == "true" ]; then
+            JSON_FLAG="--json"
+          fi
           /test/minting-config-tx-test.sh \
+            $JSON_FLAG \
             --token-id 8192
 
     - name: Test - block-v3 - Minting tx

--- a/.internal-ci/test/minting-config-tx-test.sh
+++ b/.internal-ci/test/minting-config-tx-test.sh
@@ -28,6 +28,9 @@ get_block_count()
     curl http://mobilecoind-json:9090/ledger/local | jq -r .block_count
 }
 
+# Whether we pass a json file to the mint client or use command line arguments instead
+json_flag="0"
+
 while (( "$#" ))
 do
     case "${1}" in
@@ -38,6 +41,10 @@ do
         --token-id )
             token_id="${2}"
             shift 2
+            ;;
+        --json )
+            json_flag="1"
+            shift 1
             ;;
         *)
             echo "${1} unknown option"
@@ -53,17 +60,42 @@ is_set NAMESPACE
 # check block height before config tx
 block_count=$(get_block_count)
 echo "Current block count: $block_count"
+echo "JSON flag: $json_flag"
 
 # These should be populated by volume in toolbox container.
 governor_signer_key="/minting-keys/token_${token_id}_governor_1.private.pem"
 token_signer_key="/minting-keys/token_${token_id}_signer_1.public.pem"
 
-mc-consensus-mint-client generate-and-submit-mint-config-tx \
-    --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
-    --signing-key "${governor_signer_key}" \
-    --token-id "${token_id}" \
-    --config "1000000000:1:${token_signer_key}" \
-    --total-mint-limit 10000000000
+if [ "$json_flag" == "0" ]; then
+    mc-consensus-mint-client generate-and-submit-mint-config-tx \
+        --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
+        --signing-key "${governor_signer_key}" \
+        --token-id "${token_id}" \
+        --config "1000000000:1:${token_signer_key}" \
+        --total-mint-limit 10000000000
+else
+    location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+    mint_config_file="${location}/minting-config-tx.json"
+    if [[ ! -f "$mint_config_file" ]]; then
+        echo "$mint_config_file does not exist"
+        exit 1
+    fi
+
+    token_signer_key_contents=$(cat ${token_signer_key})
+
+    json=$(cat "${mint_config_file}")
+    json=$(echo "${json}" | jq ".token_id = $token_id")
+    json=$(echo "${json}" | jq ".configs[0].minters.pub_key = \"$token_signer_key_contents\"")
+    echo $json
+
+    json_file="/tmp/mint-config.${token_id}.json"
+    echo $json > ${json_file}
+
+    mc-consensus-mint-client generate-and-submit-mint-config-tx \
+        --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
+        --signing-key "${governor_signer_key}" \
+        --mint-config-tx-file "${json_file}"
+fi
 
 new_block_count=0
 echo "-- Waiting for mint config tx to commit to the block chain"

--- a/.internal-ci/test/minting-config-tx.json
+++ b/.internal-ci/test/minting-config-tx.json
@@ -1,0 +1,13 @@
+{
+    "token_id": null,
+    "total_mint_limit": 10000000000,
+    "configs": [
+        {
+            "mint_limit": 10000000000,
+            "minters": {
+                "type": "Single",
+                "pub_key": ""
+            }
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex_fmt"

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -35,7 +35,7 @@ mc-util-uri = { path = "../../util/uri" }
 clap = { version = "4.0", features = ["derive", "env"] }
 displaydoc = "0.2"
 grpcio = "0.11.0"
-hex = "0.4"
+hex = { version = "0.4", features = ["serde"] }
 pem = "1.1"
 protobuf = "2.27.1"
 rand = "0.8"

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -61,9 +61,27 @@ fn main() {
             exit(resp.get_result().get_code().value());
         }
 
-        Commands::GenerateMintConfigTx { out, params } => {
+        Commands::GenerateMintConfigTx {
+            out,
+            tombstone_from_node,
+            params,
+        } => {
             let tx = params
-                .try_into_mint_config_tx(|| panic!("missing tombstone block"))
+                .try_into_mint_config_tx(|| {
+                    if let Some(node) = &tombstone_from_node {
+                        let env =
+                            Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
+                        let ch = ChannelBuilder::default_channel_builder(env)
+                            .connect_to_uri(node, &logger);
+                        let blockchain_api = BlockchainApiClient::new(ch);
+                        let last_block_info = blockchain_api
+                            .get_last_block_info(&Empty::new())
+                            .expect("get last block info");
+                        last_block_info.index + MAX_TOMBSTONE_BLOCKS - 1
+                    } else {
+                        panic!("missing tombstone block")
+                    }
+                })
                 .expect("failed creating tx");
 
             TxFile::from(tx)

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -69,7 +69,7 @@ fn main() {
             let tx = params
                 .try_into_mint_config_tx(|| {
                     if let Some(node) = &tombstone_from_node {
-                        let ch = ChannelBuilder::default_channel_builder(env)
+                        let ch = ChannelBuilder::default_channel_builder(env.clone())
                             .connect_to_uri(node, &logger);
                         let blockchain_api = BlockchainApiClient::new(ch);
                         let last_block_info = blockchain_api

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -69,8 +69,6 @@ fn main() {
             let tx = params
                 .try_into_mint_config_tx(|| {
                     if let Some(node) = &tombstone_from_node {
-                        let env =
-                            Arc::new(EnvBuilder::new().name_prefix("mint-client-grpc").build());
                         let ch = ChannelBuilder::default_channel_builder(env)
                             .connect_to_uri(node, &logger);
                         let blockchain_api = BlockchainApiClient::new(ch);

--- a/consensus/mint-client/src/lib.rs
+++ b/consensus/mint-client/src/lib.rs
@@ -2,10 +2,12 @@
 
 mod config;
 mod fog;
+mod mint_config_tx_file;
 mod tx_file;
 
 pub mod printers;
 
 pub use config::{Commands, Config};
 pub use fog::FogContext;
+pub use mint_config_tx_file::{MintConfigTxFile, MintConfigTxFileError};
 pub use tx_file::TxFile;

--- a/consensus/mint-client/src/mint_config_tx_file.rs
+++ b/consensus/mint-client/src/mint_config_tx_file.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use displaydoc::Display;
+use mc_consensus_service_config::{SignerIdentity, SignerIdentityError, SignerIdentityMap};
+use mc_transaction_core::{mint::MintConfigTxPrefix, TokenId};
+use serde::{Deserialize, Serialize};
+use serde_json::Error as JsonError;
+use std::{fs, io::Error as IoError, path::Path};
+
+/// A MintConfig in a human readable format. This is meant to be JSON
+/// serialized.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MintConfig {
+    /// The maximum amount that this configuration is allowed to mint during the
+    /// time it is active.
+    pub mint_limit: u64,
+
+    /// Signer identities - this allows the configuration to contain a human
+    /// readable mapping of names to signer identities.
+    #[serde(default)]
+    pub signer_identities: SignerIdentityMap,
+
+    /// Governors - the set of keys that can sign mint transactions.
+    pub minters: SignerIdentity,
+}
+
+/// A file format for serializing/deserializing a MintConfigTx in a human
+/// readable format. This is meant to be JSON serialized.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MintConfigTxFile {
+    /// Token id being configured.
+    pub token_id: TokenId,
+
+    /// Mint configurations
+    pub configs: Vec<MintConfig>,
+
+    /// Nonce, which is optional in the case we want this tool to auto-generate
+    /// one.
+    pub nonce: Option<Vec<u8>>,
+
+    /// Tombstone block, which is optional in case we want this tool to populate
+    /// it.
+    pub tombstone_block: Option<u64>,
+
+    /// The maximal amount that can be minted by configurations specified in
+    /// this tx. This amount is shared amongst all configs.
+    pub total_mint_limit: u64,
+}
+
+impl MintConfigTxFile {
+    /// Load a [MintConfigFile] from a JSON file.
+    pub fn from_json_file<P: AsRef<Path>>(path: P) -> Result<Self, MintConfigTxFileError> {
+        let json = fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&json)?)
+    }
+}
+
+impl TryFrom<&MintConfigTxFile> for MintConfigTxPrefix {
+    type Error = MintConfigTxFileError;
+
+    fn try_from(src: &MintConfigTxFile) -> Result<Self, Self::Error> {
+        let nonce = src
+            .nonce
+            .as_ref()
+            .ok_or(MintConfigTxFileError::MissingNonce)?
+            .clone();
+
+        let tombstone_block = src
+            .tombstone_block
+            .ok_or(MintConfigTxFileError::MissingTombstoneBlock)?;
+
+        let configs = src
+            .configs
+            .iter()
+            .map(|config| {
+                let signer_set = config
+                    .minters
+                    .try_into_signer_set(&config.signer_identities)?;
+                Ok(mc_transaction_core::mint::MintConfig {
+                    token_id: *src.token_id,
+                    signer_set,
+                    mint_limit: config.mint_limit,
+                })
+            })
+            .collect::<Result<Vec<_>, Self::Error>>()?;
+
+        Ok(Self {
+            token_id: *src.token_id,
+            configs,
+            nonce,
+            tombstone_block,
+            total_mint_limit: src.total_mint_limit,
+        })
+    }
+}
+
+/// Error data type
+#[derive(Debug, Display)]
+pub enum MintConfigTxFileError {
+    /// Missing nonce
+    MissingNonce,
+
+    /// Missing tombstone block
+    MissingTombstoneBlock,
+
+    /// IO error: {0}
+    Io(IoError),
+
+    /// JSON error: {0}
+    Json(JsonError),
+
+    /// Signer identity error: {0}
+    SignerIdentity(SignerIdentityError),
+}
+
+impl From<IoError> for MintConfigTxFileError {
+    fn from(src: IoError) -> Self {
+        Self::Io(src)
+    }
+}
+
+impl From<JsonError> for MintConfigTxFileError {
+    fn from(src: JsonError) -> Self {
+        Self::Json(src)
+    }
+}
+
+impl From<SignerIdentityError> for MintConfigTxFileError {
+    fn from(src: SignerIdentityError) -> Self {
+        Self::SignerIdentity(src)
+    }
+}

--- a/consensus/mint-client/src/mint_config_tx_file.rs
+++ b/consensus/mint-client/src/mint_config_tx_file.rs
@@ -15,11 +15,6 @@ pub struct MintConfig {
     /// time it is active.
     pub mint_limit: u64,
 
-    /// Signer identities - this allows the configuration to contain a human
-    /// readable mapping of names to signer identities.
-    #[serde(default)]
-    pub signer_identities: SignerIdentityMap,
-
     /// Governors - the set of keys that can sign mint transactions.
     pub minters: SignerIdentity,
 }
@@ -46,6 +41,12 @@ pub struct MintConfigTxFile {
     /// The maximal amount that can be minted by configurations specified in
     /// this tx. This amount is shared amongst all configs.
     pub total_mint_limit: u64,
+
+    /// Signer identities - this allows the configuration to contain a human
+    /// readable mapping of names to signer identities. These are shared amongst
+    /// all MintConfigs.
+    #[serde(default)]
+    pub signer_identities: SignerIdentityMap,
 }
 
 impl MintConfigTxFile {
@@ -66,9 +67,7 @@ impl TryFrom<&MintConfigTxFile> for MintConfigTxPrefix {
             .configs
             .iter()
             .map(|config| {
-                let signer_set = config
-                    .minters
-                    .try_into_signer_set(&config.signer_identities)?;
+                let signer_set = config.minters.try_into_signer_set(&src.signer_identities)?;
                 Ok(mc_transaction_core::mint::MintConfig {
                     token_id: *src.token_id,
                     signer_set,


### PR DESCRIPTION
### Motivation

Following a discussion with @holtzman, we reached the conclusion that generating a `MintConfigTx` file prior to signing would be easier if all the parameters for the transaction were self-contained inside a single JSON file.

To get an idea of what this file looks like, take a look [here](https://github.com/mobilecoinfoundation/mobilecoin/blob/eran/nested-signer-mint-config/tools/local-network/authorize-minters.py#L30-L39).

Following this change, this allows either specifying the nonce in the input JSON file, or via `--nonce` or to have it be randomly generated.
In addition, the tombstone block can either be specified in the JSON file, or via `--tombstone`, or queried from a node by using `--tombstone-from-node`.
