### PR TITLE
[TOB-5] add fee_map_digest to Tx

### DIFF
--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -352,6 +352,13 @@ message Tx {
 
     // The RingCT signature on the prefix.
     SignatureRctBulletproofs signature = 2;
+
+    // Client's belief about the minimum fee map, expressed as a merlin digest.
+    //
+    // The enclave must reject the proposal if this doesn't match the enclave's
+    // belief, to protect the client from information disclosure attacks.
+    // (This is TOB-MCCT-5)
+    bytes fee_map_digest = 3;
 }
 
 message TxHash {

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -11,6 +11,7 @@ impl From<&tx::Tx> for external::Tx {
         let mut tx = external::Tx::new();
         tx.set_prefix(external::TxPrefix::from(&source.prefix));
         tx.set_signature(external::SignatureRctBulletproofs::from(&source.signature));
+        tx.set_fee_map_digest(source.fee_map_digest.clone());
         tx
     }
 }
@@ -22,7 +23,12 @@ impl TryFrom<&external::Tx> for tx::Tx {
     fn try_from(source: &external::Tx) -> Result<Self, Self::Error> {
         let prefix = tx::TxPrefix::try_from(source.get_prefix())?;
         let signature = SignatureRctBulletproofs::try_from(source.get_signature())?;
-        Ok(tx::Tx { prefix, signature })
+        let fee_map_digest = source.get_fee_map_digest().to_vec();
+        Ok(tx::Tx {
+            prefix,
+            signature,
+            fee_map_digest,
+        })
     }
 }
 
@@ -62,6 +68,8 @@ mod tests {
                 EmptyMemoBuilder::default(),
             )
             .unwrap();
+
+            transaction_builder.set_fee_map(Default::default());
 
             transaction_builder.add_input(get_input_credentials(
                 block_version,

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -98,6 +98,7 @@ enum ProposeTxResult {
     InputRuleTxOutConversion = 52;
     InputRuleAmount = 53;
     LedgerTxOutIndexOutOfBounds = 54;
+    FeeMapDigestMismatch = 55;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/enclave/api/src/config.rs
+++ b/consensus/enclave/api/src/config.rs
@@ -67,15 +67,18 @@ impl BlockchainConfig {
 pub struct BlockchainConfigWithDigest {
     config: BlockchainConfig,
     cached_digest: String,
+    fee_map_digest: [u8; 32],
 }
 
 impl From<BlockchainConfig> for BlockchainConfigWithDigest {
     fn from(config: BlockchainConfig) -> Self {
         let digest = config.digest32::<MerlinTranscript>(b"mc-blockchain-config");
         let cached_digest = hex::encode(digest);
+        let fee_map_digest = config.fee_map.canonical_digest();
         Self {
             config,
             cached_digest,
+            fee_map_digest,
         }
     }
 }
@@ -102,6 +105,11 @@ impl BlockchainConfigWithDigest {
     /// Get the config (non mutably)
     pub fn get_config(&self) -> &BlockchainConfig {
         &self.config
+    }
+
+    /// Get canonical fee map digest
+    pub fn canonical_fee_map_digest(&self) -> &[u8; 32] {
+        &self.fee_map_digest
     }
 }
 

--- a/consensus/enclave/api/src/error.rs
+++ b/consensus/enclave/api/src/error.rs
@@ -77,6 +77,9 @@ pub enum Error {
 
     /// Failed parsing minting trust root public key
     ParseMintingTrustRootPublicKey(KeyError),
+
+    /// Fee Map Digest Mismatch
+    FeeMapDigestMismatch,
 }
 
 impl From<ParseSealedError> for Error {

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -600,6 +600,18 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Try and deserialize.
         let tx: Tx = mc_util_serial::decode(&tx_bytes)?;
 
+        // Verify fee map digest if it is present.
+        if !tx.fee_map_digest.is_empty()
+            && tx.fee_map_digest[..]
+                != self
+                    .blockchain_config
+                    .get()
+                    .ok_or(Error::NotInitialized)?
+                    .canonical_fee_map_digest()[..]
+        {
+            return Err(Error::FeeMapDigestMismatch);
+        }
+
         // Convert to TxContext
         let maybe_locally_encrypted_tx: Result<LocallyEncryptedTx> = {
             let mut cipher = self.locally_encrypted_tx_cipher.lock()?;

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -82,18 +82,7 @@ impl ClientApiService {
         msg: Message,
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
-        let tx_context = match self.enclave.client_tx_propose(msg.into()) {
-            Ok(tx_context) => tx_context,
-            Err(EnclaveError::FeeMapDigestMismatch) => {
-                let mut response = ProposeTxResponse::new();
-                response.set_result(ProposeTxResult::FeeMapDigestMismatch);
-                response.set_err_msg(EnclaveError::FeeMapDigestMismatch.to_string());
-                return Ok(response);
-            }
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
+        let tx_context = self.enclave.client_tx_propose(msg.into())?;
 
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -19,7 +19,7 @@ use mc_consensus_api::{
     consensus_config::{ConsensusNodeConfig, TokenConfig},
     empty::Empty,
 };
-use mc_consensus_enclave::ConsensusEnclave;
+use mc_consensus_enclave::{ConsensusEnclave, Error as EnclaveError};
 use mc_consensus_service_config::Config;
 use mc_ledger_db::Ledger;
 use mc_peers::ConsensusValue;
@@ -82,7 +82,18 @@ impl ClientApiService {
         msg: Message,
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
-        let tx_context = self.enclave.client_tx_propose(msg.into())?;
+        let tx_context = match self.enclave.client_tx_propose(msg.into()) {
+            Ok(tx_context) => tx_context,
+            Err(EnclaveError::FeeMapDigestMismatch) => {
+                let mut response = ProposeTxResponse::new();
+                response.set_result(ProposeTxResult::FeeMapDigestMismatch);
+                response.set_err_msg(EnclaveError::FeeMapDigestMismatch.to_string());
+                return Ok(response);
+            }
+            Err(err) => {
+                return Err(err.into());
+            }
+        };
 
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -143,6 +143,13 @@ impl From<ConsensusGrpcError> for Result<ProposeTxResponse, RpcStatus> {
                 resp.set_result(ProposeTxResult::from(err));
                 Ok(resp)
             }
+            ConsensusGrpcError::Enclave(EnclaveError::FeeMapDigestMismatch) => {
+                let mut resp = ProposeTxResponse::new();
+                resp.set_err_msg(EnclaveError::FeeMapDigestMismatch.to_string());
+                resp.set_result(ProposeTxResult::FeeMapDigestMismatch);
+                Ok(resp)
+            }
+
             _ => Err(RpcStatus::from(src)),
         }
     }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -367,8 +367,7 @@ impl Client {
 
         let block_version = BlockVersion::try_from(self.tx_data.get_latest_block_version())?;
 
-        let last_block_info = self.get_last_block_info(true)?;
-        let fee_map = FeeMap::try_from(last_block_info.minimum_fees)?;
+        let fee_map = self.get_fee_map(true)?;
 
         // Make fog resolver
         let fog_uris = (&[&self.account_key.change_subaddress(), target_address])
@@ -608,8 +607,7 @@ impl Client {
         )?;
         tx_builder.set_tombstone_block(tombstone_block);
 
-        let last_block_info = self.get_last_block_info(true)?;
-        tx_builder.set_fee_map(FeeMap::try_from(last_block_info.minimum_fees)?);
+        tx_builder.set_fee_map(self.get_fee_map(true)?);
 
         // Aggregate total required outlay due to the SCI
         // (Note: In the partial fill case, there will be more outlays later)

--- a/fog/sample-paykit/src/error.rs
+++ b/fog/sample-paykit/src/error.rs
@@ -12,7 +12,7 @@ use mc_fog_report_connection::Error as FogResolutionError;
 use mc_fog_types::view::FogTxOutError;
 use mc_fog_view_protocol::TxOutPollingError;
 use mc_transaction_builder::{SignedContingentInputBuilderError, TxBuilderError};
-use mc_transaction_core::{AmountError, BlockVersionError, TxOutConversionError};
+use mc_transaction_core::{AmountError, BlockVersionError, FeeMapError, TxOutConversionError};
 use mc_transaction_extra::SignedContingentInputError;
 use mc_util_uri::UriParseError;
 use std::result::Result as StdResult;
@@ -145,6 +145,9 @@ pub enum Error {
 
     /// Fog merkle proof: {0}
     FogMerkleProof(String),
+
+    /// Fee Map: {0}
+    FeeMap(FeeMapError),
 }
 
 impl From<ConnectionError> for Error {
@@ -219,5 +222,11 @@ impl From<UriParseError> for Error {
 impl From<BlockVersionError> for Error {
     fn from(src: BlockVersionError) -> Self {
         Self::BlockVersion(src)
+    }
+}
+
+impl From<FeeMapError> for Error {
+    fn from(x: FeeMapError) -> Error {
+        Error::FeeMap(x)
     }
 }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -249,6 +249,36 @@ impl TestClient {
         clients
     }
 
+    // Get the minium fee amount for a given token id, or an error if it can't
+    // be determined.
+    //
+    // Arguments
+    // * token_id The token id we are interested in
+    // * source_client The client used to make the request / get cached value from
+    fn get_minimum_fee(
+        &self,
+        token_id: TokenId,
+        source_client: &mut Client,
+    ) -> Result<Amount, TestClientError> {
+        // Get the current minimum fee from consensus for given token id
+        // FIXME: #1671, this retry should be inside ThickClient and not here.
+        let fee_value = self
+            .grpc_retry_config
+            .retry(|| -> Result<Option<u64>, _> {
+                let mut maybe_fee = source_client.get_minimum_fee(token_id, true)?;
+                // If the token id doesn't appear to be configured, but we are expecting
+                // it to be, let's try again with "allow_cached = false".
+                if maybe_fee.is_none() {
+                    maybe_fee = source_client.get_minimum_fee(token_id, false)?;
+                }
+                Ok(maybe_fee)
+            })
+            .map_err(|retry_error| TestClientError::GetFee(retry_error.error))?
+            .ok_or(TestClientError::TokenNotConfigured(token_id))?;
+
+        Ok(Amount::new(fee_value, token_id))
+    }
+
     /// Conduct a transfer between two clients, according to the policy
     /// Returns the transaction and the block count of the node it was submitted
     /// to.
@@ -284,13 +314,7 @@ impl TestClient {
         let mut rng = McRng::default();
         assert!(target_address.fog_report_url().is_some());
 
-        // Get the current minimum fee from consensus
-        // FIXME: #1671, this retry should be inside ThickClient and not here.
-        let fee = self
-            .grpc_retry_config
-            .retry(|| -> Result<Option<u64>, _> { source_client.get_minimum_fee(token_id) })
-            .map_err(|retry_error| TestClientError::GetFee(retry_error.error))?
-            .ok_or(TestClientError::TokenNotConfigured(token_id))?;
+        let fee = self.get_minimum_fee(token_id, source_client)?;
 
         // Scope for build operation
         let transaction = {
@@ -300,7 +324,7 @@ impl TestClient {
                     Amount::new(self.policy.transfer_amount, token_id),
                     &target_address,
                     &mut rng,
-                    fee,
+                    fee.value,
                 )
                 .map_err(TestClientError::BuildTx)?;
             counters::TX_BUILD_TIME.observe(start.elapsed().as_secs_f64());
@@ -321,7 +345,7 @@ impl TestClient {
         Ok(TransferData {
             transaction,
             block_count,
-            fee: Amount::new(fee, token_id),
+            fee,
         })
     }
 
@@ -744,14 +768,7 @@ impl TestClient {
 
         assert!(target_address.fog_report_url().is_some());
 
-        // Get the current minimum fee from consensus
-        // FIXME: #1671, this retry should be inside ThickClient and not here.
-        let fee_value = self
-            .grpc_retry_config
-            .retry(|| -> Result<Option<u64>, _> { source_client.get_minimum_fee(token_id1) })
-            .map_err(|retry_error| TestClientError::GetFee(retry_error.error))?
-            .ok_or(TestClientError::TokenNotConfigured(token_id1))?;
-        let fee = Amount::new(fee_value, token_id1);
+        let fee = self.get_minimum_fee(token_id1, source_client)?;
 
         // Build swap proposal
         let signed_input = source_client

--- a/transaction/core/src/fee_map.rs
+++ b/transaction/core/src/fee_map.rs
@@ -5,7 +5,7 @@
 use crate::{tokens::Mob, Token, TokenId};
 use alloc::collections::BTreeMap;
 use displaydoc::Display;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use serde::{Deserialize, Serialize};
 
 /// The log base 2 of the smallest allowed minimum fee, in the smallest
@@ -140,6 +140,11 @@ impl FeeMap {
         let mut map = BTreeMap::new();
         map.insert(Mob::ID, Mob::MINIMUM_FEE);
         map
+    }
+
+    /// Get a canonical digest of the minimum fee map
+    pub fn canonical_digest(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(b"mc-fee-map")
     }
 }
 

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -112,6 +112,14 @@ pub struct Tx {
     /// The transaction signature.
     #[prost(message, required, tag = "2")]
     pub signature: SignatureRctBulletproofs,
+
+    /// Client's belief about the minimum fee map, expressed as a merlin digest.
+    ///
+    /// The enclave must reject the proposal if this doesn't match the enclave's
+    /// belief, to protect the client from information disclosure attacks.
+    /// (This is TOB-MCCT-5)
+    #[prost(bytes, tag = "3")]
+    pub fee_map_digest: Vec<u8>,
 }
 
 impl fmt::Display for Tx {
@@ -700,7 +708,11 @@ mod tests {
             // TODO: use a meaningful signature.
             let signature = SignatureRctBulletproofs::default();
 
-            let tx = Tx { prefix, signature };
+            let tx = Tx {
+                prefix,
+                signature,
+                fee_map_digest: vec![],
+            };
 
             let recovered_tx: Tx = Tx::decode(&tx.encode_to_vec()[..]).unwrap();
             assert_eq!(tx, recovered_tx);


### PR DESCRIPTION
This is an alternative approach to #2670. The description here is copied
from there.

TOB-MCCT-5 is about a "token id oracle" described by TOB during review of confidential tokens design. The idea is that the consensus enclave fee map can be changed by the untrusted side, by restarting the node. If the attacker controls a node and is able to get the user to submit their Tx once with one fee map, and once with another, then the priority value leaks information about what the token id of the Tx is.

In principle they could do this without the user knowing -- they would restart the node and it would not be able to attest to the peers after changing the fee map, but it could still accept Tx proposals and see the WellFormedTxContext which conatins the priority number. Then they turn the node back to normal. The user's app retries when their transaction doesn't land, and the same Tx comes back to their node, now with the regular fee map.

This requires having root on a consensus node, but the threat model is that attackers with root on the consensus node should not be able to see the user's token id.

We view this as a time-of-check-vs-time-of-use (TOCTOU) bug, and we try to fix it a way that those bugs are sometimes fixed. The user, who checked the fee map, also makes an assertion about what the fee-map is when they try to use the system (by submitting a Tx). Before acting on the data (which the attacker has potentially tampered with), the enclave checks if the user's assertion is correct, and rejects the Tx without creating a WellFormedTxContext if the assertion is not correct. (This is sort of like dealing with races when manipulating atomic variables by using compare-and-swap.)

The advantage of the approach in this PR is that it allows clients to
immediately start including the digest_fee_map field, it will just get
ignored by consensus before a version that supports it is deployed.
This saves us from having to put logic in clients (mobilecoind,
full-service, mobile apps, etc) that chooses which API endpoint to use
based on block version/enclave version/etc.

~Note: A unit test for this will be written once https://github.com/mobilecoinfoundation/mobilecoin/pull/2790 is merged~ - this was done
