### PR TITLE
release/V3 - CD from backup

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
   labels:
   - small
   - large
+  - large-cd

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -33,12 +33,14 @@ concurrency:
   group: mobilecoin-dev-cd-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# Ignore dependabot. We just need to 'if' the top level jobs.
+# Other jobs that 'need' these top level jobs will be skipped.
 jobs:
 ############################################
 # Generate environment information
 ############################################
   generate-metadata:
-    if: github.actor != 'dependabot[bot]'
+    if: "! startsWith(github.head_ref, 'dependabot/')"
     name: 👾 Environment Info 👾
     runs-on: [self-hosted, Linux, small]
     outputs:
@@ -48,7 +50,6 @@ jobs:
       docker_org: ${{ env.DOCKER_ORG }}
       chart_repo: ${{ env.CHART_REPO }}
       release_1x_tag: ${{ env.RELEASE_1X_TAG }}
-
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -72,8 +73,9 @@ jobs:
 # Build binaries
 #########################################
   build-rust-hardware-projects:
-    if: github.actor != 'dependabot[bot]'
-    runs-on: [self-hosted, Linux, large]
+    needs:
+    - generate-metadata
+    runs-on: [self-hosted, Linux, large-cd]
     container:
       image: mobilecoin/rust-sgx-base:v0.0.18
     env:
@@ -186,8 +188,9 @@ jobs:
         path: rust_build_artifacts/
 
   build-go-projects:
-    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
+    needs:
+    - generate-metadata
     container:
       image: golang:1.16.4
     steps:
@@ -235,15 +238,14 @@ jobs:
 # Create/Refresh base runtime image
 ########################################
   docker-base:
-    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
+    needs:
+    - generate-metadata
     steps:
     - name: Checkout
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: actions/checkout@v3
 
     - name: Generate Docker Tags
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_meta
       uses: docker/metadata-action@v4
       with:
@@ -254,18 +256,15 @@ jobs:
           type=sha
 
     - name: Set up Docker Buildx
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Publish to DockerHub
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_publish_dockerhub
       uses: docker/build-push-action@v3
       with:
@@ -281,7 +280,6 @@ jobs:
 # Build/Publish public artifacts
 #########################################
   docker:
-    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
     needs:
     - build-go-projects
@@ -303,25 +301,21 @@ jobs:
         - watcher
     steps:
     - name: Checkout
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: actions/checkout@v3
 
     - name: Cache rust build binaries
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: rust_artifact_cache
       uses: ./.github/actions/mobilecoin-cache-rust-binaries
       with:
         cache_buster: ${{ secrets.CACHE_BUSTER }}
 
     - name: Cache go build binaries
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: go_artifact_cache
       uses: ./.github/actions/mobilecoin-cache-go-binaries
       with:
         cache_buster: ${{ secrets.CACHE_BUSTER }}
 
     - name: Generate Docker Tags
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_meta
       uses: docker/metadata-action@v4
       with:
@@ -330,18 +324,15 @@ jobs:
           ${{ needs.generate-metadata.outputs.docker_tag }}
 
     - name: Set up Docker Buildx
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Publish to DockerHub
-      if: "! contains(github.event.head_commit.message, '[skip docker]')"
       id: docker_publish_dockerhub
       uses: docker/build-push-action@v3
       with:
@@ -358,7 +349,6 @@ jobs:
         tags: ${{ steps.docker_meta.outputs.tags }}
 
   charts:
-    if: github.actor != 'dependabot[bot]'
     runs-on: [self-hosted, Linux, small]
     needs:
     - docker
@@ -384,7 +374,7 @@ jobs:
 
     - name: Package and publish chart
       if: "! contains(github.event.head_commit.message, '[skip charts]')"
-      uses: mobilecoinofficial/gha-k8s-toolbox@a89efdf4305f3b926b1bb61a59f267532406e653
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: helm-publish
         chart_repo_username: ${{ secrets.HARBOR_USERNAME }}
@@ -394,122 +384,39 @@ jobs:
         chart_version: ${{ needs.generate-metadata.outputs.tag }}
         chart_path: .internal-ci/helm/${{ matrix.chart }}
 
-#################################
-# Reset existing namespace
-#################################
-  dev-reset:
-    if: github.actor != 'dependabot[bot]'
+################################################
+# Bootstrap namespace to v1.1.3-dev from backup
+################################################
+  bootstrap-v1-bv0:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
     needs:
     - generate-metadata
-    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
     with:
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      delete_namespace: false
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-
-#######################################
-# Deploy 1.x release to namespace
-#######################################
-  deploy-v1-bv0-release:
-    if: github.actor != 'dependabot[bot]'
-    uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
-    needs:
-    - dev-reset
-    - generate-metadata
-    with:
-      block_version: "0"
+      block_version: 0
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
-      docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
-      ingest_color: blue
-      minting_config_enabled: false
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.release_1x_tag }}
-    secrets:
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      FOG_KEYS_SEED: ${{ secrets.DEV_FOG_KEYS_SEED }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
-      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
-      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
-      INITIAL_KEYS_SEED: ${{ secrets.DEV_INITIAL_KEYS_SEED }}
-      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
-      MNEMONIC_FOG_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_FOG_KEYS_SEED }}
-      MNEMONIC_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_KEYS_SEED }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-
-  test-v1-bv0-release:
-    if: github.actor != 'dependabot[bot]'
-    uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
-    needs:
-    - deploy-v1-bv0-release
-    - generate-metadata
-    with:
-      fog_distribution: true
-      ingest_color: blue
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      testing_block_v0: true
-      testing_block_v2: false
-    secrets:
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+    secrets: inherit
 
 ###############################################
 # Deploy current version to namespace block v2
 ###############################################
   deploy-current-bv0-release:
-    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
-    - test-v1-bv0-release
+    - bootstrap-v1-bv0
     - charts
     - generate-metadata
     with:
-      block_version: "0"
+      block_version: 0
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
       ingest_color: green
-      minting_config_enabled: true
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}
-    secrets:
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      FOG_KEYS_SEED: ${{ secrets.DEV_FOG_KEYS_SEED }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
-      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
-      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
-      INITIAL_KEYS_SEED: ${{ secrets.DEV_INITIAL_KEYS_SEED }}
-      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
-      MNEMONIC_FOG_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_FOG_KEYS_SEED }}
-      MNEMONIC_KEYS_SEED: ${{ secrets.DEV_MNEMONIC_KEYS_SEED }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+    secrets: inherit
 
   test-current-bv0-release:
-    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
     - deploy-current-bv0-release
@@ -520,19 +427,12 @@ jobs:
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       testing_block_v0: true
       testing_block_v2: false
-
-    secrets:
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+    secrets: inherit
 
 #################################################
-# Update current consensus to namespace block v3
+# Update current consensus to namespace block v2
 #################################################
   update-current-to-bv2:
-    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
     needs:
     - test-current-bv0-release
@@ -540,27 +440,11 @@ jobs:
     with:
       block_version: "2"
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
-      docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
-      minting_config_enabled: true
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}
-    secrets:
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
-      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
-      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
-      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+    secrets: inherit
 
   test-current-bv2-release:
-    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
     - update-current-to-bv2
@@ -571,17 +455,24 @@ jobs:
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       testing_block_v0: false
       testing_block_v2: true
-    secrets:
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
+    secrets: inherit
 
-  cleanup-on-pr:
+###############################################################
+# Clean up deployments
+###############################################################
+# we want to clean up on everything but master and feature/*
+# run on pr, run on tag. run on branch that's not master or feature/*
+  cleanup-after-run:
     if: |
-      github.actor != 'dependabot[bot]' &&
-      (github.event_name == 'pull_request' || github.ref_type == 'tag')
+      github.event_name == 'pull_request' ||
+      github.ref_type == 'tag' ||
+      (
+        github.ref_type == 'branch' &&
+        ! (
+          github.ref_name == 'master' ||
+          startsWith('feature/', github.ref_name)
+        )
+      )
     needs:
     - test-current-bv2-release
     - generate-metadata
@@ -589,9 +480,4 @@ jobs:
     with:
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       delete_namespace: true
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+    secrets: inherit

--- a/.github/workflows/mobilecoin-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dev-delete.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   metadata:
-    if: startsWith(github.event.ref, 'feature/') || startsWith(github.event.ref, 'release/')
+    if: startsWith(github.event.ref, 'feature/')
     runs-on: [self-hosted, Linux, small]
     outputs:
       namespace: ${{ steps.meta.outputs.namespace }}
@@ -33,19 +33,4 @@ jobs:
     with:
       namespace: ${{ needs.metadata.outputs.namespace }}
       delete_namespace: true
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-
-  why-was-this-skipped:
-    if: always() && needs.metadata.result == 'skipped'
-    needs:
-      - metadata
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: details
-      run: |
-        echo "Deleted branch: ${{ github.event.ref }} did not match feature/* or release/*"
+    secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-delete.yaml
@@ -4,6 +4,8 @@
 
 name: (Manual) Delete a Dev Namespace
 
+run-name: Reset and Delete ${{ inputs.namespace }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -24,9 +26,4 @@ jobs:
     with:
       namespace: ${{ inputs.namespace }}
       delete_namespace: ${{ inputs.delete_namespace }}
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+    secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -4,6 +4,8 @@
 
 name: (Manual) Deploy to Dev Namespace
 
+run-name: Deploy ${{ inputs.version }} to ${{ inputs.namespace }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,6 +15,18 @@ on:
         required: true
       version:
         description: "Chart Version"
+        type: string
+        required: true
+      ingest_color:
+        description: "Fog Ingest blue/green"
+        type: choice
+        required: true
+        default: blue
+        options:
+        - blue
+        - green
+      block_version:
+        description: "Consensus block_version"
         type: string
         required: true
       chart_repo:
@@ -25,35 +39,11 @@ on:
         type: string
         required: true
         default: docker.io/mobilecoin
-      ingest_color:
-        description: "Fog Ingest blue/green"
-        type: string
-        required: true
-        default: blue
-      minting_config_enabled:
-        description: "Enable minting config"
-        type: boolean
-        required: true
-        default: false
-      block_version:
-        description: "Consensus block_version"
-        type: string
-        required: true
-      client_auth_enabled:
-        description: "Enable client token auth"
-        type: boolean
-        required: true
-        default: false
-      # true: use GHA secret values, false: generate random seeds
-      use_static_wallet_seeds:
-        description: "Use static wallet seeds"
-        type: boolean
-        required: true
-        default: false
+
 
 jobs:
   list-values:
-    name: 👾 Environment Info - ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.version }} 👾
+    name: 👾 Environment Info - ${{ inputs.namespace }} - ${{ inputs.version }} 👾
     runs-on: [self-hosted, Linux, small]
     steps:
     - name: Checkout
@@ -61,40 +51,19 @@ jobs:
 
     - name: 👾 Print Environment Details 👾
       env:
-        CHART_REPO: ${{ github.event.inputs.chart_repo }}
-        NAMESPACE: ${{ github.event.inputs.namespace }}
-        VERSION: ${{ github.event.inputs.version }}
+        CHART_REPO: ${{ inputs.chart_repo }}
+        NAMESPACE: ${{ inputs.namespace }}
+        VERSION: ${{ inputs.version }}
       run: |
         .internal-ci/util/print_details.sh
 
   deploy:
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:
-      namespace: ${{ github.event.inputs.namespace }}
-      version: ${{ github.event.inputs.version }}
-      docker_image_org: ${{ github.event.inputs.docker_image_org }}
-      chart_repo: ${{ github.event.inputs.chart_repo }}
-      ingest_color: ${{ github.event.inputs.ingest_color }}
-      minting_config_enabled: ${{ github.event.inputs.minting_config_enabled }}
-      block_version: ${{ github.event.inputs.block_version }}
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
-      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
-      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
-      CLIENT_AUTH_TOKEN: ${{  github.event.inputs.client_auth_enabled == 'true' && secrets.DEV_CLIENT_AUTH_TOKEN || '' }}
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      INITIAL_KEYS_SEED: ${{ github.event.inputs.use_static_wallet_seeds == 'true' && secrets.DEV_INITIAL_KEYS_SEED || '' }}
-      FOG_KEYS_SEED: ${{ github.event.inputs.use_static_wallet_seeds == 'true' && secrets.DEV_FOG_KEYS_SEED || '' }}
-      MNEMONIC_KEYS_SEED: ${{ github.event.inputs.use_static_wallet_seeds == 'true' && secrets.DEV_MNEMONIC_KEYS_SEED || '' }}
-      MNEMONIC_FOG_KEYS_SEED: ${{ github.event.inputs.use_static_wallet_seeds == 'true' && secrets.DEV_MNEMONIC_FOG_KEYS_SEED || '' }}
+      block_version: ${{ inputs.block_version }}
+      chart_repo: ${{ inputs.chart_repo }}
+      docker_image_org: ${{ inputs.docker_image_org }}
+      ingest_color: ${{ inputs.ingest_color }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.version }}
+    secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-test.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-test.yaml
@@ -4,6 +4,8 @@
 
 name: (Manual) Run Tests in Dev Namespace
 
+run-name: Test ${{ inputs.namespace }} - ${{ inputs.ingest_color }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -13,9 +15,12 @@ on:
         required: true
       ingest_color:
         description: "Fog Ingest blue/green"
-        type: string
+        type: choice
         required: true
         default: blue
+        options:
+        - blue
+        - green
       fog_distribution:
         description: "Run fog-distribution test"
         type: boolean
@@ -31,32 +36,14 @@ on:
         type: boolean
         required: false
         default: true
-      testing_block_v3:
-        description: "Run block v3 tests"
-        type: boolean
-        required: false
-        default: true
-      client_auth_enabled:
-        description: "Is client auth enabled?"
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   test:
-    name: Test ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.ingest_color }}
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     with:
-      namespace: ${{ github.event.inputs.namespace }}
-      ingest_color: ${{ github.event.inputs.ingest_color }}
-      fog_distribution: ${{ github.event.inputs.fog_distribution == 'true' && 'true' || 'false' }}
-      testing_block_v0 : ${{ github.event.inputs.testing_block_v0 == 'true' && 'true' || 'false' }}
-      testing_block_v2: ${{ github.event.inputs.testing_block_v2 == 'true' && 'true' || 'false' }}
-      testing_block_v3: ${{ github.event.inputs.testing_block_v3 == 'true' && 'true' || 'false' }}
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}
-      CACHE_BUSTER: ${{ secrets.CACHE_BUSTER }}
-      CLIENT_AUTH_USER_VALUE:  ${{ github.event.inputs.client_auth_enabled == 'true' && secrets.DEV_CLIENT_AUTH_USER_VALUE || '' }}
+      namespace: ${{ inputs.namespace }}
+      ingest_color: ${{ inputs.ingest_color }}
+      fog_distribution: ${{ inputs.fog_distribution }}
+      testing_block_v0 : ${{ inputs.testing_block_v0 }}
+      testing_block_v2: ${{ inputs.testing_block_v2 }}
+    secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -4,6 +4,8 @@
 
 name: (Manual) Upgrade Consensus Config in Dev Namespace
 
+run-name: Update Consensus Block Version - ${{ inputs.namespace }} - ${{ inputs.block_version }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -15,55 +17,23 @@ on:
         description: "Chart Version"
         type: string
         required: true
-      chart_repo:
-        description: "Chart Repo URL"
-        type: string
-        required: true
-        default: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
-      docker_image_org:
-        description: "Docker Image Org"
-        type: string
-        required: true
-        default: docker.io/mobilecoin
-      minting_config_enabled:
-        description: "Enable minting config"
-        type: boolean
-        required: true
-        default: true
       block_version:
         description: "Block Version"
         type: string
         required: true
         default: '2'
-      client_auth_enabled:
-        description: "additional shared token for client auth"
-        type: boolean
+      chart_repo:
+        description: "Chart Repo URL"
+        type: string
         required: true
-        default: false
+        default: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
 
 jobs:
   update-consensus-block-version:
-    name: Update Consensus Block Version - ${{ github.event.inputs.namespace }} - ${{ github.event.inputs.block_version }}
     uses: ./.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
     with:
-      namespace: ${{ github.event.inputs.namespace }}
-      version: ${{ github.event.inputs.version }}
-      docker_image_org: ${{ github.event.inputs.docker_image_org }}
-      chart_repo: ${{ github.event.inputs.chart_repo }}
-      minting_config_enabled: ${{ github.event.inputs.minting_config_enabled }}
-      block_version: "${{ github.event.inputs.block_version }}"
-    secrets:
-      RANCHER_CLUSTER: ${{ secrets.RANCHER_CLUSTER }}
-      RANCHER_URL: ${{ secrets.RANCHER_URL }}
-      RANCHER_TOKEN: ${{ secrets.RANCHER_TOKEN }}
-      LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
-      LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
-      IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-      IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
-      FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
-      FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
-      MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.DEV_MINTING_TRUST_ROOT_PRIVATE }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      IP_INFO_TOKEN: ${{ secrets.DEV_IP_INFO_TOKEN }}
-      CLIENT_AUTH_TOKEN: ${{  github.event.inputs.client_auth_enabled == 'true' && secrets.DEV_CLIENT_AUTH_TOKEN || '' }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.version }}
+      chart_repo: ${{ inputs.chart_repo }}
+      block_version: "${{ inputs.block_version }}"
+    secrets: inherit

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -55,6 +55,18 @@ on:
       LEDGER_AWS_SECRET_ACCESS_KEY:
         description: "(from environment) Ledger AWS S3 access"
         required: true
+      MINTING_1_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
       MINTING_8192_GOVERNOR_1_PRIVATE:
         description: "(from environment) minting governor key"
         required: true

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -55,12 +55,6 @@ on:
       LEDGER_AWS_SECRET_ACCESS_KEY:
         description: "(from environment) Ledger AWS S3 access"
         required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
       MINTING_8192_GOVERNOR_1_PRIVATE:
         description: "(from environment) minting governor key"
         required: true
@@ -72,6 +66,12 @@ on:
         required: true
       MINTING_8192_SIGNER_1_PUBLIC:
         description: "(from environment) minting governor key"
+        required: true
+      MNEMONIC_FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MNEMONIC_KEYS_SEED:
+        description: "(from environment) static wallet seed"
         required: true
       POSTGRESQL_FOG_RECOVERY_PASSWORD:
         description: "password for fog_recovery database"

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 #
-# MobileCoin Core projects - Reusable Workflow - update consensus nodes in a development namespace.
+# MobileCoin Core projects - Reusable Workflow - Restore dev env to previous release level.
 
-name: mobilecoin-workflow-dev-update-consensus
+name: mobilecoin-workflow-dev-bootstrap
 
 on:
   workflow_call:
@@ -21,7 +21,7 @@ on:
         type: string
         required: true
       version:
-        description: "release version"
+        description: "Chart Version"
         type: string
         required: true
     secrets:
@@ -68,10 +68,10 @@ on:
         description: "(from environment) minting governor key"
         required: true
       MINTING_8192_SIGNER_1_PRIVATE:
-        description: "(from environment) minting signer key"
+        description: "(from environment) minting governor key"
         required: true
       MINTING_8192_SIGNER_1_PUBLIC:
-        description: "(from environment) minting signer key"
+        description: "(from environment) minting governor key"
         required: true
       POSTGRESQL_FOG_RECOVERY_PASSWORD:
         description: "password for fog_recovery database"
@@ -87,8 +87,42 @@ on:
         required: true
 
 jobs:
+  reset:
+    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
+    with:
+      namespace: ${{ inputs.namespace }}
+      delete_namespace: true
+    secrets: inherit
+
+  restore-s3-archive:
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - reset
+    environment:
+      name: dev
+    container:
+      image: mobilecoin/gha-s3-pg-helper:v0
+    steps:
+    - name: Restore Ledger Archive from S3
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: eu-central-1
+        BUCKET: mobilecoin.eu.development.chain
+        NAMESPACE: ${{ inputs.namespace }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        for i in 1 2 3
+        do
+          aws s3 cp --only-show-errors --recursive --acl public-read \
+            s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i} \
+            s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com
+        done
+
   setup-environment:
     uses: ./.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+    needs:
+    - reset
     with:
       namespace: ${{ inputs.namespace }}
       block_version: ${{ inputs.block_version }}
@@ -96,25 +130,34 @@ jobs:
       version: ${{ inputs.version }}
     secrets: inherit
 
-  consensus-restart:
+  #  We now have a db with setup-environment
+  #  Note this only works if we are in the same cluster as the dev env.
+  restore-db-from-archive:
     runs-on: [self-hosted, Linux, small]
     needs:
     - setup-environment
     environment:
       name: dev
-    strategy:
-      matrix:
-        object_name:
-        - deployment.app/consensus-node-1
-        - deployment.app/consensus-node-2
-        - deployment.app/consensus-node-3
+    container:
+      image: mobilecoin/gha-s3-pg-helper:v0
     steps:
-    - name: Restart Consensus Nodes
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: pod-restart
-        object_name: ${{ matrix.object_name }}
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+    - name: restore-db
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: eu-central-1
+        BUCKET: mobilecoin.eu.development.chain
+        PGDATABASE: postgres
+        PGHOST: fog-recovery-postgresql-primary.${{ inputs.namespace }}
+        PGPASSWORD: ${{ secrets.POSTGRESQL_FOG_RECOVERY_PASSWORD }}
+        PGUSER: postgres
+        VERSION: ${{ inputs.version }}
+      run: |
+        # Copy sql from S3
+        aws s3 cp --only-show-errors \
+          s3://${BUCKET}/prebuilt/${VERSION}/sql/fog_recovery.sql \
+          /tmp/fog_recovery.sql
+
+        # Restore to PG
+        psql < /tmp/fog_recovery.sql
+

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -73,11 +73,17 @@ on:
       FOG_KEYS_SEED:
         description: "(from environment) static wallet seed"
         required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
         required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PUBLIC:
+        description: "(from environment) minting governor key"
         required: true
       MINTING_8192_GOVERNOR_1_PRIVATE:
         description: "(from environment) minting governor key"
@@ -91,9 +97,17 @@ on:
       MINTING_8192_SIGNER_1_PUBLIC:
         description: "(from environment) minting governor key"
         required: true
+      MNEMONIC_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MNEMONIC_FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+
 
 env:
   FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
+  VALUES_BASE_PATH: .tmp/values
 
 jobs:
   setup-environment:
@@ -118,6 +132,25 @@ jobs:
         - consensus-node-2
         - consensus-node-3
     steps:
+    # use values file because intel.com/sgx is hard to escape on the --set option.
+    - name: Generate consensus-node values file
+      run: |
+        mkdir -p ${VALUES_BASE_PATH}
+        cat <<EOF > ${VALUES_BASE_PATH}/consensus-node-values.yaml
+        image:
+          org: ${{ inputs.docker_image_org }}
+        global:
+          certManagerClusterIssuer: zerossl-prod-http
+        node:
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
+          persistence:
+            enabled: false
+        EOF
+
     - name: Deploy Consensus nodes
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -125,10 +158,7 @@ jobs:
         chart_repo: ${{ inputs.chart_repo }}
         chart_name: consensus-node
         chart_version: ${{ inputs.version }}
-        chart_set: |
-          --set=image.org=${{ inputs.docker_image_org }}
-          --set=node.persistence.enabled=false
-          --set=global.certManagerClusterIssuer=zerossl-prod-http
+        chart_values: ${{ env.VALUES_BASE_PATH }}/consensus-node-values.yaml
         chart_wait_timeout: 10m
         release_name: ${{ matrix.release_name }}
         namespace: ${{ inputs.namespace }}
@@ -166,6 +196,31 @@ jobs:
     environment:
       name: dev
     steps:
+    - name: Generate fog-services values file
+      run: |
+        mkdir -p ${VALUES_BASE_PATH}
+        cat <<EOF > ${VALUES_BASE_PATH}/fog-services-values.yaml
+        image:
+          org: ${{ inputs.docker_image_org }}
+        global:
+          certManagerClusterIssuer: zerossl-prod-http
+        fogLedger:
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
+          persistence:
+            enabled: false
+        fogView:
+          replicaCount: 2
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
+        EOF
+
     - name: Deploy fog-services
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -174,11 +229,7 @@ jobs:
         chart_name: fog-services
         chart_version: ${{ inputs.version }}
         chart_wait_timeout: 10m
-        chart_set: |
-          --set=image.org=${{ inputs.docker_image_org }}
-          --set=global.certManagerClusterIssuer=zerossl-prod-http
-          --set=fogLedger.persistence.enabled=false
-          --set=fogView.replicaCount=2
+        chart_values: ${{ env.VALUES_BASE_PATH }}/fog-services-values.yaml
         release_name: fog-services
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
@@ -192,6 +243,22 @@ jobs:
     environment:
       name: dev
     steps:
+    - name: Generate fog-ingest values file
+      run: |
+        mkdir -p ${VALUES_BASE_PATH}
+        cat <<EOF > ${VALUES_BASE_PATH}/fog-ingest-values.yaml
+        image:
+          org: ${{ inputs.docker_image_org }}
+        fogIngest:
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
+          persistence:
+            enabled: false
+        EOF
+
     - name: Deploy fog-ingest
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -200,9 +267,7 @@ jobs:
         chart_name: fog-ingest
         chart_version: ${{ inputs.version }}
         chart_wait_timeout: 10m
-        chart_set: |
-          --set=image.org=${{ inputs.docker_image_org }}
-          --set=fogIngest.persistence.enabled=false
+        chart_values: ${{ env.VALUES_BASE_PATH }}/fog-ingest-values.yaml
         release_name: fog-ingest-${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -29,237 +29,94 @@ on:
         description: "Fog Ingest blue/green"
         type: string
         required: true
-      minting_config_enabled:
-        description: "Enable minting config"
-        type: string
-        default: 'false'
-        required: false
       block_version:
         description: "block_version"
         type: string
         required: true
     secrets:
       RANCHER_CLUSTER:
-        description: "Rancher cluster name"
+        description: "(from environment) Rancher cluster name"
         required: true
       RANCHER_URL:
-        description: "Rancher server URL"
+        description: "(from environment) Rancher server URL"
         required: true
       RANCHER_TOKEN:
-        description: "Rancher access token"
+        description: "(from environment) Rancher access token"
         required: true
       LEDGER_AWS_ACCESS_KEY_ID:
-        description: "Ledger AWS S3 access"
+        description: "(from environment) Ledger AWS S3 access"
         required: true
       LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "Ledger AWS S3 access"
+        description: "(from environment) Ledger AWS S3 access"
         required: true
       IAS_KEY:
-        description: "IAS"
+        description: "(from environment) IAS"
         required: true
       IAS_SPID:
-        description: "IAS"
+        description: "(from environment) IAS"
         required: true
       FOG_REPORT_SIGNING_CERT:
-        description: "Fog Report signing cert pem"
+        description: "(from environment) Fog Report signing cert pem"
         required: true
       FOG_REPORT_SIGNING_CERT_KEY:
-        description: "Fog Report signing cert key"
+        description: "(from environment) Fog Report signing cert key"
         required: true
       FOG_REPORT_SIGNING_CA_CERT:
-        description: "Fog Report signing CA cert"
+        description: "(from environment) Fog Report signing CA cert"
         required: true
-      MINTING_TRUST_ROOT_PRIVATE:
-        description: "Root private key for singing the tokens config"
-        required: false
-      DOCKERHUB_TOKEN:
-        description: "Docker hub creds"
-        required: false
-      DOCKERHUB_USERNAME:
-        description: "Docker hub creds"
-        required: false
       IP_INFO_TOKEN:
         description: "ipinfo.io token for authenticated access"
         required: true
-      CLIENT_AUTH_TOKEN:
-        description: "shared token for client auth"
-        required: false
-      CACHE_BUSTER:
-        description: "string to make cache unique"
-        required: false
       INITIAL_KEYS_SEED:
-        description: "static wallet seed"
-        required: false
+        description: "(from environment) static wallet seed"
+        required: true
       FOG_KEYS_SEED:
-        description: "static wallet seed"
-        required: false
+        description: "(from environment) static wallet seed"
+        required: true
       MNEMONIC_KEYS_SEED:
-        description: "static wallet seed"
-        required: false
+        description: "(from environment) static wallet seed"
+        required: true
       MNEMONIC_FOG_KEYS_SEED:
-        description: "static wallet seed"
-        required: false
+        description: "(from environment) static wallet seed"
+        required: true
+      MINTING_8192_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_8192_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_8192_SIGNER_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_8192_SIGNER_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
 
 env:
   FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
 
 jobs:
-  # Reset consensus nodes between releases - if there's existing data, we'll
-  # restore from S3.
-  reset-releases:
-    runs-on: [self-hosted, Linux, small]
-    strategy:
-      matrix:
-        chart:
-        - consensus-node-1
-        - consensus-node-2
-        - consensus-node-3
-        - consensus-node-4
-        - consensus-node-5
-    steps:
-    - name: Delete release
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: helm-release-delete
-        namespace: ${{ inputs.namespace }}
-        release_name: ${{ matrix.chart }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-
   setup-environment:
-    runs-on: [self-hosted, Linux, small]
-    needs:
-    - reset-releases
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Create namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: namespace-create
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-
-    - name: Cache wallet seeds .tmp/seeds
-      uses: ./.github/actions/mobilecoin-cache-seeds
-      with:
-        cache_buster: ${{ secrets.CACHE_BUSTER }}
-
-    # use static keys if provided.
-    - name: Generate Wallet Seed
-      env:
-        INITIAL_KEYS_SEED: ${{ secrets.INITIAL_KEYS_SEED }}
-        FOG_KEYS_SEED: ${{ secrets.FOG_KEYS_SEED }}
-        MNEMONIC_KEYS_SEED: ${{ secrets.MNEMONIC_KEYS_SEED }}
-        MNEMONIC_FOG_KEYS_SEED: ${{ secrets.MNEMONIC_FOG_KEYS_SEED }}
-      run: |
-        .internal-ci/util/generate_wallet_seeds.sh
-
-    # write this to the seeds dir and set the path that toolbox will find it at.
-    - name: Write fog-report signing CA cert
-      env:
-        FOG_REPORT_SIGNING_CA_CERT: ${{ secrets.FOG_REPORT_SIGNING_CA_CERT }}
-      run: |
-        mkdir -p .tmp/seeds
-        echo -n "${FOG_REPORT_SIGNING_CA_CERT}" > .tmp/seeds/FOG_REPORT_SIGNING_CA_CERT
-        echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > .tmp/seeds/FOG_REPORT_SIGNING_CA_CERT_PATH
-        echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > .tmp/seeds/FOG_REPORT_URL
-
-    - name: Create wallet key secrets
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: secrets-create-from-file
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-        object_name: sample-keys-seeds
-        src: .tmp/seeds
-
-    - name: Create minting keys
-      if: inputs.minting_config_enabled == 'true'
-      env:
-        MINTING_TRUST_ROOT_PRIVATE: ${{ secrets.MINTING_TRUST_ROOT_PRIVATE }}
-      run: |
-        .internal-ci/util/generate_minting_keys.sh --token-id 8192
-
-    - name: Login to DockerHub
-      if: inputs.minting_config_enabled == 'true'
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    # CBB: create a minimal image with just mc-consensus-mint-client binary.
-    - name: Generate and sign tokens config
-      if: inputs.minting_config_enabled == 'true'
-      id: tokens_config
-      run: |
-        docker run \
-          -v ${{ github.workspace }}:/workspace \
-          --network none \
-          --workdir /workspace \
-          ${{ inputs.docker_image_org }}/bootstrap-tools:${{ inputs.version }} \
-          .internal-ci/util/generate_tokens_config.sh
-
-    - name: Create minting key secrets
-      if: inputs.minting_config_enabled == 'true'
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: secrets-create-from-file
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-        object_name: consensus-minting-secrets
-        src: .tmp/seeds/minting
-
-    - name: Generate environment values file
-      env:
-        IAS_KEY: ${{ secrets.IAS_KEY }}
-        IAS_SPID: ${{ secrets.IAS_SPID }}
-        LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
-        LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
-        FOG_REPORT_SIGNING_CERT: ${{ secrets.FOG_REPORT_SIGNING_CERT }}
-        FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.FOG_REPORT_SIGNING_CERT_KEY }}
-        IP_INFO_TOKEN: ${{ secrets.IP_INFO_TOKEN }}
-        CLIENT_AUTH_TOKEN: ${{ secrets.CLIENT_AUTH_TOKEN }}
-      run: |
-        mkdir -p .tmp/values/
-        .internal-ci/util/generate_dev_values.sh > .tmp/values/mc-core-dev-env-values.yaml
-
-    - name: Deploy environment setup
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: helm-deploy
-        chart_repo: ${{ inputs.chart_repo }}
-        chart_name: mc-core-dev-env-setup
-        chart_version: ${{ inputs.version }}
-        chart_values: .tmp/values/mc-core-dev-env-values.yaml
-        chart_set: |
-          --set=global.node.nodeConfig.blockVersion=${{ inputs.block_version }}
-        release_name: mc-core-dev-env-setup
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+    uses: ./.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+    with:
+      block_version: ${{ inputs.block_version }}
+      chart_repo: ${{ inputs.chart_repo }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.version }}
+    secrets: inherit
 
   consensus-deploy:
     needs:
     - setup-environment
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     strategy:
       matrix:
         release_name:
         - consensus-node-1
         - consensus-node-2
         - consensus-node-3
-        - consensus-node-4
-        - consensus-node-5
     steps:
     - name: Deploy Consensus nodes
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -270,32 +127,10 @@ jobs:
         chart_version: ${{ inputs.version }}
         chart_set: |
           --set=image.org=${{ inputs.docker_image_org }}
+          --set=node.persistence.enabled=false
           --set=global.certManagerClusterIssuer=zerossl-prod-http
         chart_wait_timeout: 10m
         release_name: ${{ matrix.release_name }}
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
-
-  postgresql-deploy:
-    needs:
-    - setup-environment
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: Deploy PostgreSQL instance
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: helm-deploy
-        chart_repo: https://charts.bitnami.com/bitnami
-        chart_name: postgresql
-        chart_version: 11.2.3
-        chart_set: |
-          --set=global.postgresql.auth.existingSecret=fog-recovery-postgresql
-          --set=global.postgresql.auth.database=fog_recovery
-          --set=architecture=replication
-        chart_wait_timeout: 5m
-        release_name: fog-recovery-postgresql
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
@@ -305,6 +140,8 @@ jobs:
     needs:
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     steps:
     - name: Deploy Consensus nodes
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -324,9 +161,10 @@ jobs:
 
   fog-services-deploy:
     needs:
-    - postgresql-deploy
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     steps:
     - name: Deploy fog-services
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -336,11 +174,11 @@ jobs:
         chart_name: fog-services
         chart_version: ${{ inputs.version }}
         chart_wait_timeout: 10m
-        # Set orderedReady for compatibility with 1.1.3 chart - remove after 1.2.x
         chart_set: |
           --set=image.org=${{ inputs.docker_image_org }}
           --set=global.certManagerClusterIssuer=zerossl-prod-http
-          --set=fogLedger.podManagementPolicy=OrderedReady
+          --set=fogLedger.persistence.enabled=false
+          --set=fogView.replicaCount=2
         release_name: fog-services
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
@@ -349,8 +187,10 @@ jobs:
 
   fog-ingest-deploy:
     needs:
-    - fog-services-deploy
+    - consensus-deploy
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     steps:
     - name: Deploy fog-ingest
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -362,6 +202,7 @@ jobs:
         chart_wait_timeout: 10m
         chart_set: |
           --set=image.org=${{ inputs.docker_image_org }}
+          --set=fogIngest.persistence.enabled=false
         release_name: fog-ingest-${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}

--- a/.github/workflows/mobilecoin-workflow-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -9,16 +9,22 @@ name: mobilecoin-workflow-dev-reset
 on:
   workflow_call:
     inputs:
-      namespace:
-        description: "Target Namespace"
-        type: string
-        required: true
       delete_namespace:
         description: "Delete Target Namespace"
         type: boolean
         default: false
         required: false
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
     secrets:
+      LEDGER_AWS_ACCESS_KEY_ID:
+        description: "Ledger AWS S3 access"
+        required: true
+      LEDGER_AWS_SECRET_ACCESS_KEY:
+        description: "Ledger AWS S3 access"
+        required: true
       RANCHER_CLUSTER:
         description: "Rancher cluster name"
         required: true
@@ -28,29 +34,25 @@ on:
       RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
-      LEDGER_AWS_ACCESS_KEY_ID:
-        description: "Ledger AWS S3 access"
-        required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "Ledger AWS S3 access"
-        required: true
 
 jobs:
-  reset-releases:
+  reset-helm:
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     strategy:
       matrix:
         chart:
         - consensus-node-1
         - consensus-node-2
         - consensus-node-3
-        - consensus-node-4
-        - consensus-node-5
         - fog-ingest-blue
         - fog-ingest-green
         - fog-recovery-postgresql
         - fog-services
         - mobilecoind
+        - mc-core-common-config
+        - mc-core-dev-env-setup
     steps:
     - name: Delete release
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -62,10 +64,12 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
 
-  reset-storage:
-    needs:
-    - reset-releases
+  reset-k8s:
     runs-on: [self-hosted, Linux, small]
+    needs:
+    - reset-helm
+    environment:
+      name: dev
     steps:
     - name: Delete PersistentVolumeClaims
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -76,12 +80,22 @@ jobs:
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
 
+    - name: Delete namespace
+      if: inputs.delete_namespace
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: namespace-delete
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
   reset-s3:
-    needs:
-    - reset-releases
+    environment:
+      name: dev
     runs-on: [self-hosted, Linux, small]
     container:
-      image: amazon/aws-cli:latest
+      image: mobilecoin/gha-s3-pg-helper:v0
     steps:
     - name: Clear out s3 bucket objects
       env:
@@ -91,23 +105,7 @@ jobs:
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
       run: |
-        aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node1.${NAMESPACE}.development.mobilecoin.com
-        aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node2.${NAMESPACE}.development.mobilecoin.com
-        aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node3.${NAMESPACE}.development.mobilecoin.com
-        aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node4.${NAMESPACE}.development.mobilecoin.com
-        aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node5.${NAMESPACE}.development.mobilecoin.com
-
-  delete-namespace:
-    if: inputs.delete_namespace
-    needs:
-    - reset-storage
-    runs-on: [self-hosted, Linux, small]
-    steps:
-    - name: Delete namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
-      with:
-        action: namespace-delete
-        namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        for i in 1 2 3
+        do
+          aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com
+        done

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -55,11 +55,17 @@ on:
       LEDGER_AWS_SECRET_ACCESS_KEY:
         description: "(from environment) Ledger AWS S3 access"
         required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
         required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PUBLIC:
+        description: "(from environment) minting governor key"
         required: true
       MINTING_8192_GOVERNOR_1_PRIVATE:
         description: "(from environment) minting governor key"
@@ -72,6 +78,12 @@ on:
         required: true
       MINTING_8192_SIGNER_1_PUBLIC:
         description: "(from environment) minting signer key"
+        required: true
+      MNEMONIC_FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MNEMONIC_KEYS_SEED:
+        description: "(from environment) static wallet seed"
         required: true
       POSTGRESQL_FOG_RECOVERY_PASSWORD:
         description: "password for fog_recovery database"
@@ -143,6 +155,10 @@ jobs:
         mkdir -p "${MINTING_BASE_PATH}"
 
         # Write values to be used as k8s secret values.
+        echo -n "${{ secrets.MINTING_1_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_governor_1.private.pem"
+        echo -n "${{ secrets.MINTING_1_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_governor_1.public.pem"
+        echo -n "${{ secrets.MINTING_1_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_signer_1.private.pem"
+        echo -n "${{ secrets.MINTING_1_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_signer_1.public.pem"
         echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.private.pem"
         echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.public.pem"
         echo -n "${{ secrets.MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.private.pem"

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -1,0 +1,213 @@
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+#
+# MobileCoin Core projects - Reusable Workflow - Deploy core apps to to the development namespace.
+
+name: mobilecoin-workflow-dev-setup-environment
+
+on:
+  workflow_call:
+    inputs:
+      block_version:
+        description: "block_version"
+        type: string
+        required: true
+      chart_repo:
+        description: "Chart Repo URL"
+        type: string
+        required: false
+        default: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+      version:
+        description: "Chart Version"
+        type: string
+        required: true
+    secrets:
+      FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      FOG_REPORT_SIGNING_CA_CERT:
+        description: "(from environment) Fog Report signing CA cert"
+        required: true
+      FOG_REPORT_SIGNING_CERT:
+        description: "(from environment) Fog Report signing cert pem"
+        required: true
+      FOG_REPORT_SIGNING_CERT_KEY:
+        description: "(from environment) Fog Report signing cert key"
+        required: true
+      IAS_KEY:
+        description: "(from environment) IAS"
+        required: true
+      IAS_SPID:
+        description: "(from environment) IAS"
+        required: true
+      INITIAL_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      IP_INFO_TOKEN:
+        description: "ipinfo.io token for authenticated access"
+        required: true
+      LEDGER_AWS_ACCESS_KEY_ID:
+        description: "(from environment) Ledger AWS S3 access"
+        required: true
+      LEDGER_AWS_SECRET_ACCESS_KEY:
+        description: "(from environment) Ledger AWS S3 access"
+        required: true
+      MNEMONIC_FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MNEMONIC_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MINTING_8192_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_8192_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_8192_SIGNER_1_PRIVATE:
+        description: "(from environment) minting signer key"
+        required: true
+      MINTING_8192_SIGNER_1_PUBLIC:
+        description: "(from environment) minting signer key"
+        required: true
+      POSTGRESQL_FOG_RECOVERY_PASSWORD:
+        description: "password for fog_recovery database"
+        required: true
+      RANCHER_CLUSTER:
+        description: "(from environment) Rancher cluster name"
+        required: true
+      RANCHER_URL:
+        description: "(from environment) Rancher server URL"
+        required: true
+      RANCHER_TOKEN:
+        description: "(from environment) Rancher access token"
+        required: true
+      TOKENS_CONFIG_JSON:
+        description: "(from environment) signed tokens config json"
+        required: true
+
+jobs:
+  setup-environment:
+    runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
+    env:
+      BASE_PATH: .tmp
+      MINTING_BASE_PATH: .tmp/minting
+      SEEDS_BASE_PATH: .tmp/seeds
+      VALUES_BASE_PATH: .tmp/values
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Create namespace
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: namespace-create
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
+    - name: Write seeds and fog-report values
+      run: |
+        # Create seeds dir.
+        mkdir -p "${SEEDS_BASE_PATH}"
+
+        # Write values to be used as k8s secret values.
+        echo -n "${{ secrets.INITIAL_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/INITIAL_KEYS_SEED"
+        echo -n "${{ secrets.FOG_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/FOG_KEYS_SEED"
+        echo -n "${{ secrets.MNEMONIC_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/MNEMONIC_KEYS_SEED"
+        echo -n "${{ secrets.MNEMONIC_FOG_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/MNEMONIC_FOG_KEYS_SEED"
+        echo -n "${{ secrets.FOG_REPORT_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT"
+        echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT_PATH"
+        echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_URL"
+
+    - name: Create wallet key secrets
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: secrets-create-from-file
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        object_name: sample-keys-seeds
+        src: ${{ env.SEEDS_BASE_PATH }}
+
+    - name: Write minting keys
+      run: |
+        # Create minting secrets dir
+        mkdir -p "${MINTING_BASE_PATH}"
+
+        # Write values to be used as k8s secret values.
+        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.private.pem"
+        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.public.pem"
+        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.private.pem"
+        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.public.pem"
+
+    - name: Create minting key secrets
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: secrets-create-from-file
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        object_name: consensus-minting-secrets
+        src: ${{ env.MINTING_BASE_PATH }}
+
+    - name: Write tokens.signed.json
+      run: |
+        mkdir -p "${BASE_PATH}"
+        echo '${{ secrets.TOKENS_CONFIG_JSON }}' > "${BASE_PATH}/tokens.signed.json"
+
+    - name: Generate environment values file
+      env:
+        IAS_KEY: ${{ secrets.IAS_KEY }}
+        IAS_SPID: ${{ secrets.IAS_SPID }}
+        LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
+        LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        FOG_REPORT_SIGNING_CERT: ${{ secrets.FOG_REPORT_SIGNING_CERT }}
+        FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.FOG_REPORT_SIGNING_CERT_KEY }}
+        IP_INFO_TOKEN: ${{ secrets.IP_INFO_TOKEN }}
+      run: |
+        mkdir -p ${VALUES_BASE_PATH}
+        .internal-ci/util/generate_dev_values.sh > ${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml
+
+    - name: Deploy environment setup
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: mc-core-dev-env-setup
+        chart_version: ${{ inputs.version }}
+        chart_values: ${{ env.VALUES_BASE_PATH }}/mc-core-dev-env-values.yaml
+        chart_set: |
+          --set=global.node.nodeConfig.blockVersion=${{ inputs.block_version }}
+          --set=fogIngestConfig.fogRecoveryDatabase.password=${{ secrets.POSTGRESQL_FOG_RECOVERY_PASSWORD }}
+        release_name: mc-core-dev-env-setup
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+
+    - name: Deploy PostgreSQL instance
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: https://charts.bitnami.com/bitnami
+        chart_name: postgresql
+        chart_version: 11.2.3
+        chart_set: |
+          --set=global.postgresql.auth.existingSecret=fog-recovery-postgresql
+          --set=global.postgresql.auth.database=fog_recovery
+          --set=architecture=replication
+        chart_wait_timeout: 5m
+        release_name: fog-recovery-postgresql
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -53,19 +53,19 @@ on:
         required: true
       fog_distribution:
         description: "Run fog-distribution test"
-        type: string
+        type: boolean
         required: false
-        default: 'true'
+        default: true
       testing_block_v0:
         description: "Run block v0 tests"
-        type: string
+        type: boolean
         required: false
-        default: 'true'
+        default: true
       testing_block_v2:
         description: "Run block v2 tests"
-        type: string
+        type: boolean
         required: false
-        default: 'true'
+        default: true
     secrets:
       RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -76,21 +76,13 @@ on:
       RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
-      FOG_REPORT_SIGNING_CA_CERT:
-        description: "Fog Report Signing CA"
-        required: true
-      CACHE_BUSTER:
-        description: "string to make cache unique"
-        required: true
-      CLIENT_AUTH_USER_VALUE:
-        description: "client auth rendered value"
-        required: false
 
 jobs:
   cd-integration-tests:
     runs-on: [self-hosted, Linux, small]
+    environment:
+      name: dev
     env:
-      FOG_REPORT_SIGNING_CA_CERT_PATH: .tmp/fog_report_signing_ca_cert.pem
       SRC_KEYS_DIR: /tmp/sample_data/keys
       SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
       V2_DST_KEYS_DIR: /tmp/2-testing/keys
@@ -129,7 +121,7 @@ jobs:
           /util/generate_origin_data.sh
 
     - name: Test - fog-distribution
-      if: inputs.fog_distribution == 'true'
+      if: inputs.fog_distribution
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -142,7 +134,7 @@ jobs:
           /test/fog-distribution-test.sh
 
     - name: Test - block-v0 - fog-test-client
-      if: inputs.testing_block_v0 == 'true'
+      if: inputs.testing_block_v0
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -161,11 +153,11 @@ jobs:
             --num-transactions 32 \
             --consensus-wait 300 \
             --transfer-amount 20 \
-            --fog-view fog-view://${{ secrets.CLIENT_AUTH_USER_VALUE }}fog.${{ inputs.namespace }}.development.mobilecoin.com:443 \
-            --fog-ledger fog-ledger://${{ secrets.CLIENT_AUTH_USER_VALUE }}fog.${{ inputs.namespace }}.development.mobilecoin.com:443
+            --fog-view fog-view://fog.${{ inputs.namespace }}.development.mobilecoin.com:443 \
+            --fog-ledger fog-ledger://fog.${{ inputs.namespace }}.development.mobilecoin.com:443
 
     - name: Test - block-v0 - mobilecoind-grpc (previously Wallet Integration)
-      if: inputs.testing_block_v0 == 'true'
+      if: inputs.testing_block_v0
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -178,7 +170,7 @@ jobs:
           /test/mobilecoind-integration-test.sh
 
     - name: Setup - block-v2 - Copy subset of non-fog keys
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -195,7 +187,7 @@ jobs:
             --end ${{ env.END_KEYS }}
 
     - name: Setup - block-v2 - Copy subset of fog keys
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -212,7 +204,7 @@ jobs:
             --end ${{ env.END_KEYS }}
 
     - name: Test - block-v2 - Minting config tx
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -226,7 +218,7 @@ jobs:
             --token-id 8192
 
     - name: Test - block-v2 - Minting tx
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -241,7 +233,7 @@ jobs:
             --token-id 8192
 
     - name: Test - block-v2 - mobilecoind-json integration
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -255,7 +247,7 @@ jobs:
             --key-dir ${{ env.V2_DST_KEYS_DIR }}
 
     - name: Test - block-v2 - use drain_accounts to transfer id 1 balances to fog keys
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -272,7 +264,7 @@ jobs:
             --token-id 8192
 
     - name: Test - block-v2 - fog-test-client token id 0
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec
@@ -287,7 +279,7 @@ jobs:
             --token-id 0
 
     - name: Test - block-v2 - fog-test-client token id 1
-      if: inputs.testing_block_v2 == 'true'
+      if: inputs.testing_block_v2
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: toolbox-exec

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -55,11 +55,17 @@ on:
       LEDGER_AWS_SECRET_ACCESS_KEY:
         description: "(from environment) Ledger AWS S3 access"
         required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PRIVATE:
+        description: "(from environment) minting governor key"
         required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      MINTING_1_GOVERNOR_1_PUBLIC:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PRIVATE:
+        description: "(from environment) minting governor key"
+        required: true
+      MINTING_1_SIGNER_1_PUBLIC:
+        description: "(from environment) minting governor key"
         required: true
       MINTING_8192_GOVERNOR_1_PRIVATE:
         description: "(from environment) minting governor key"
@@ -72,6 +78,12 @@ on:
         required: true
       MINTING_8192_SIGNER_1_PUBLIC:
         description: "(from environment) minting signer key"
+        required: true
+      MNEMONIC_FOG_KEYS_SEED:
+        description: "(from environment) static wallet seed"
+        required: true
+      MNEMONIC_KEYS_SEED:
+        description: "(from environment) static wallet seed"
         required: true
       POSTGRESQL_FOG_RECOVERY_PASSWORD:
         description: "password for fog_recovery database"

--- a/.internal-ci/helm/mc-core-dev-env-setup/Chart.yaml
+++ b/.internal-ci/helm/mc-core-dev-env-setup/Chart.yaml
@@ -26,16 +26,6 @@ dependencies:
   repository: file://../consensus-node-config
   version: 0.0.0
   condition: consensusNodeConfig3.enabled
-- name: consensus-node-config
-  alias: consensusNodeConfig4
-  repository: file://../consensus-node-config
-  version: 0.0.0
-  condition: consensusNodeConfig4.enabled
-- name: consensus-node-config
-  alias: consensusNodeConfig5
-  repository: file://../consensus-node-config
-  version: 0.0.0
-  condition: consensusNodeConfig5.enabled
 - name: fog-ingest-config
   alias: fogIngestConfig
   repository: file://../fog-ingest-config

--- a/.internal-ci/helm/mc-core-dev-env-setup/values.yaml
+++ b/.internal-ci/helm/mc-core-dev-env-setup/values.yaml
@@ -8,7 +8,7 @@ global:
       startFrom: last
 
     networkConfig:
-      threshold: '3'
+      threshold: '2'
       peers:
         1:
           peer:
@@ -28,18 +28,6 @@ global:
             port: '443'
           signerPublicKey: ''
           ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-        4:
-          peer:
-            hostname: '{{ printf "peer4.%s.development.mobilecoin.com" .Release.Namespace }}'
-            port: '443'
-          signerPublicKey: ''
-          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node4.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-        5:
-          peer:
-            hostname: '{{ printf "peer5.%s.development.mobilecoin.com" .Release.Namespace }}'
-            port: '443'
-          signerPublicKey: ''
-          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node5.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
 
     # Add signed tokens.json with --set-file=global.node.tokensConfig."tokens\.signed\.json"=tokens.signed.json
     tokensConfig:
@@ -52,7 +40,7 @@ mcCoreCommonConfig:
     network: '{{ .Release.Namespace }}'
     partner: 'dev'
   mobilecoind:
-    threshold: '3'
+    threshold: '2'
     nodes:
     - client: '{{ printf "node1.%s.development.mobilecoin.com:443" .Release.Namespace }}'
       txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
@@ -60,10 +48,6 @@ mcCoreCommonConfig:
       txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
     - client: '{{ printf "node3.%s.development.mobilecoin.com:443" .Release.Namespace }}'
       txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-    - client: '{{ printf "node4.%s.development.mobilecoin.com:443" .Release.Namespace }}'
-      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node4.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-    - client: '{{ printf "node5.%s.development.mobilecoin.com:443" .Release.Namespace }}'
-      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node5.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
 
 
 consensusNodeConfig1:
@@ -95,26 +79,6 @@ consensusNodeConfig3:
     peer:
       hostname: '{{ printf "peer3.%s.development.mobilecoin.com" .Release.Namespace }}'
     txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-
-consensusNodeConfig4:
-  enabled: true
-  fullnameOverride: 'consensus-node-4'
-  node:
-    client:
-      hostname: '{{ printf "node4.%s.development.mobilecoin.com" .Release.Namespace }}'
-    peer:
-      hostname: '{{ printf "peer4.%s.development.mobilecoin.com" .Release.Namespace }}'
-    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node4.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-
-consensusNodeConfig5:
-  enabled: true
-  fullnameOverride: 'consensus-node-5'
-  node:
-    client:
-      hostname: '{{ printf "node5.%s.development.mobilecoin.com" .Release.Namespace }}'
-    peer:
-      hostname: '{{ printf "peer5.%s.development.mobilecoin.com" .Release.Namespace }}'
-    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node5.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
 
 fogIngestConfig:
   enabled: true

--- a/.internal-ci/test/mint-auditor-test.sh
+++ b/.internal-ci/test/mint-auditor-test.sh
@@ -93,7 +93,7 @@ python3 -m grpc_tools.protoc \
 echo ""
 echo "-- Run integration_test.py"
 echo ""
-token_signer_key="/minting-keys/token${token_id}_signer.private.pem"
+token_signer_key="/minting-keys/token_${token_id}_signer_1.private.pem"
 
 python3 integration_test.py \
     --mobilecoind-addr "mobilecoind:3229" \

--- a/.internal-ci/test/minting-config-tx-test.sh
+++ b/.internal-ci/test/minting-config-tx-test.sh
@@ -46,8 +46,8 @@ is_set token_id
 is_set NAMESPACE
 
 # These should be populated by volume in toolbox container.
-governor_signer_key="/minting-keys/minter${token_id}_governor.private.pem"
-token_signer_key="/minting-keys/token${token_id}_signer.public.pem"
+governor_signer_key="/minting-keys/token_${token_id}_governor_1.private.pem"
+token_signer_key="/minting-keys/token_${token_id}_signer_1.public.pem"
 
 mc-consensus-mint-client generate-and-submit-mint-config-tx \
     --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \

--- a/.internal-ci/test/minting-tx-test.sh
+++ b/.internal-ci/test/minting-tx-test.sh
@@ -52,7 +52,7 @@ is_set token_id
 is_set NAMESPACE
 
 # These should be populated by volume in toolbox container.
-token_signer_key="/minting-keys/token${token_id}_signer.private.pem"
+token_signer_key="/minting-keys/token_${token_id}_signer_1.private.pem"
 
 keys=$(find "${key_dir}" -name "*.b58pub")
 

--- a/.internal-ci/util/generate_dev_values.sh
+++ b/.internal-ci/util/generate_dev_values.sh
@@ -11,7 +11,7 @@ declare -a signer_keys_pub
 declare -a signer_keys_pri
 
 count=1
-while [ ${count} -le 5 ]
+while [ ${count} -le 3 ]
 do
   key=$("${location}/generate_ed25519_keys.sh")
   signer_keys_pub+=("$(echo -n "${key}" | grep public | awk -F': ' '{print $2}')")
@@ -41,10 +41,6 @@ global:
           signerPublicKey: ${signer_keys_pub[1]}
         3:
           signerPublicKey: ${signer_keys_pub[2]}
-        4:
-          signerPublicKey: ${signer_keys_pub[3]}
-        5:
-          signerPublicKey: ${signer_keys_pub[4]}
 
     tokensConfig:
       tokensSignedJson: |
@@ -80,16 +76,6 @@ consensusNodeConfig3:
   node:
     msgSignerKey:
       privateKey: ${signer_keys_pri[2]}
-
-consensusNodeConfig4:
-  node:
-    msgSignerKey:
-      privateKey: ${signer_keys_pri[3]}
-
-consensusNodeConfig5:
-  node:
-    msgSignerKey:
-      privateKey: ${signer_keys_pri[4]}
 
 fogServicesConfig:
   fogReport:

--- a/.internal-ci/util/generate_minting_keys.sh
+++ b/.internal-ci/util/generate_minting_keys.sh
@@ -14,6 +14,7 @@ usage()
     echo "Usage:"
     echo "${0} --token-id 8192"
     echo "    --token-id - id to generate keys for"
+    echo "    --key-id - default:1 - sig name for key files. use for multi sig"
 }
 
 is_set()
@@ -38,6 +39,10 @@ do
             token_id="${2}"
             shift 2
             ;;
+        --key-id )
+            key_id="${2}"
+            shift 2
+        ;;
         *)
             break
             ;;
@@ -46,35 +51,37 @@ done
 
 is_set token_id
 
-BASE_PATH="${BASE_PATH:-.tmp/seeds/minting}"
+key_id=${key_id:-1}
+BASE_PATH="${BASE_PATH:-.tmp/minting}"
 mkdir -p "${BASE_PATH}"
 
 # Token governor keys
 # This key pair is used to validate MintConfigTxs
-if [[ ! -f "${BASE_PATH}/minter${token_id}_governor.private.pem" ]]
+if [[ ! -f "${BASE_PATH}/token_${token_id}_governor_${key_id}.private.pem" ]]
 then
+    echo "Writing token_${token_id}_governor_${key_id} keys"
     "${location}/generate_ed25519_keys.sh" \
-        --public-out "${BASE_PATH}/minter${token_id}_governor.public.pem" \
-        --private-out "${BASE_PATH}/minter${token_id}_governor.private.pem"
+        --public-out "${BASE_PATH}/token_${token_id}_governor_${key_id}.public.pem" \
+        --private-out "${BASE_PATH}/token_${token_id}_governor_${key_id}.private.pem"
 else
-    echo "minter${token_id}_governor keys already exist"
+    echo "minter ${token_id}_governor_${key_id} keys already exist"
 fi
-sha256sum "${BASE_PATH}/minter${token_id}_governor.private.pem"
-sha256sum "${BASE_PATH}/minter${token_id}_governor.public.pem"
+sha256sum "${BASE_PATH}/token_${token_id}_governor_${key_id}.private.pem"
+sha256sum "${BASE_PATH}/token_${token_id}_governor_${key_id}.public.pem"
 
 # Token signer keys
 # This key pair is used to validate MintTX
-if [[ ! -f "${BASE_PATH}/token_signer.private.pem" ]]
+if [[ ! -f "${BASE_PATH}/token_${token_id}_signer_${key_id}.private.pem" ]]
 then
-    echo "Writing token${token_id}_signer keys"
+    echo "Writing token_${token_id}_signer_${key_id} keys"
     "${location}/generate_ed25519_keys.sh" \
-        --public-out "${BASE_PATH}/token${token_id}_signer.public.pem" \
-        --private-out "${BASE_PATH}/token${token_id}_signer.private.pem"
+        --public-out "${BASE_PATH}/token_${token_id}_signer_${key_id}.public.pem" \
+        --private-out "${BASE_PATH}/token_${token_id}_signer_${key_id}.private.pem"
 else
-    echo "token${token_id}_signer keys already exist"
+    echo "token ${token_id}_signer_${key_id} keys already exist"
 fi
-sha256sum "${BASE_PATH}/token${token_id}_signer.private.pem"
-sha256sum "${BASE_PATH}/token${token_id}_signer.public.pem"
+sha256sum "${BASE_PATH}/token_${token_id}_signer_${key_id}.private.pem"
+sha256sum "${BASE_PATH}/token_${token_id}_signer_${key_id}.public.pem"
 
 # Write minting trust root private key if its defined.
 if [[ -n "${MINTING_TRUST_ROOT_PRIVATE}" ]]

--- a/.internal-ci/util/generate_tokens_config.sh
+++ b/.internal-ci/util/generate_tokens_config.sh
@@ -16,7 +16,7 @@ exists()
 
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 BASE_PATH="${BASE_PATH:-.tmp}"
-minting_path="${BASE_PATH}/seeds/minting"
+MINTING_BASE_PATH="${MINTING_BASE_PATH:-.tmp/minting}"
 
 # check for required files
 exists "${location}/tokens.base.json"
@@ -34,28 +34,41 @@ do
     fi
 
     echo "Token ID: ${id} - Checking for governor ed25519 keys"
-    exists "${minting_path}/minter${id}_governor.public.pem"
-    sha256sum "${minting_path}/minter8192_governor.public.pem"
+    threshold=0
+    governors=""
 
-    echo "Token ID: ${id} - Add governor signer pub keys and threshold to json"
-    minter_governor=$(cat "${minting_path}/minter${id}_governor.public.pem")
+    files="${MINTING_BASE_PATH}/token_${id}_governor_*"
 
-    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.signers) |= \"${minter_governor}\"")
+    # concat governor keys
+    for g in $files
+    do
+        if [[ "${g}" =~ "public" ]]
+        then
+            echo "-- Found governor: ${g}, adding it to the governors list."
+            sha256sum "${g}"
 
-    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.threshold) |= 1")
+            governors="${governors}$(cat "${g}")"
+            ((threshold+=1))
+        fi
+    done
+
+
+    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.signers) |= \"${governors}\"")
+
+    json=$(echo "${json}" | jq "(.tokens[] | select(.token_id == ${id}) | .governors.threshold) |= ${threshold}")
 done
 
 #output unsigned tokens
 echo "$json" | jq . > "${BASE_PATH}/tokens.json"
 
 echo "Checking for minting_trust_root ed25519 keys"
-exists "${minting_path}/minting_trust_root.private.pem"
-sha256sum "${minting_path}/minting_trust_root.private.pem"
+exists "${MINTING_BASE_PATH}/minting_trust_root.private.pem"
+sha256sum "${MINTING_BASE_PATH}/minting_trust_root.private.pem"
 
 # Sign tokens file
 echo "Signing the tokens file"
 mc-consensus-mint-client sign-governors --tokens "${BASE_PATH}/tokens.json" \
-    --signing-key "${minting_path}/minting_trust_root.private.pem" \
+    --signing-key "${MINTING_BASE_PATH}/minting_trust_root.private.pem" \
     --output-json "${BASE_PATH}/tokens.signed.json"  >/dev/null
 
 cat "${BASE_PATH}/tokens.signed.json"

--- a/.internal-ci/util/tokens.base.json
+++ b/.internal-ci/util/tokens.base.json
@@ -6,6 +6,14 @@
             "minimum_fee": 400000000
         },
         {
+            "token_id": 1,
+            "minimum_fee": 1024,
+            "governors": {
+                "signers": "",
+                "threshold": 1
+            }
+        },
+        {
             "token_id": 8192,
             "minimum_fee": 1024,
             "governors": {


### PR DESCRIPTION
### Motivation

Bootstrap environment from S3/PG backups. Reduce the amount of steps required to deploy and test.

### Work done but not captured in this PR

Build out `v1.1.3-dev` environment, initialize ledger, run block_version 0 testing and capture block chain s3 buckets and fog recovery database. 

Backups are located in the development ledger bucket: `mobilecoin.eu.development.chain`

- `/prebuilt/${VERSION}/chain/node[1-3]/`
- `/prebuilt/${VERSION}/sql/fog_recovery.sql`

### Changes

- Break setup steps into their own reusable workflow (more DRY)
- Use github `environments` feature for name spacing required secrets/configuration values.  (Step towards reusing workflows for alpha/beta/test/main artifact builds and deployments)
- Add bootstrap reusable workflow that will restore from a specified backup in s3.
- Remove all v1.1.3 deployment and testing steps. The results of these tests are captured in the backups.
- Clean up dev env after runs on a pull_request, a tag, and release/* branches.  Keep master and feature/* until the branches are deleted.

### Major changes in dev env workings.

- Reduce deployment/testing complexity by only using pre-built tokens.json, token governor keys, token signer keys and  wallet/ledger seeds.
- Create static tokens.json with IDs 0, 1 and 8192
- Remove `client_auth` option.  Just run the test environments like we run MC prod envs.
- Don't launch dev envs with persistent disk.  Faster deploys and more density on SGX nodes
- Move to 3 consensus and 2 view nodes.
- Reduce "sgx" requests and limits for more density on SGX nodes.

### What are all these "Deployment" events in the PR?

GH has tied this idea of "Deployments" to the "Environments" feature. I believe this came from the pre-action days. Each time an Action does a Job using an Environment, it creates a Deployment event.  This might have had value in the pre-action days, but now its just noise IMO.  

This PR is an extreme example because I did a whole bunch of rapid iteration and testing on the CD process.  

I think the advantages of being able to create a standardized set of secrets/variables in a workflow and switch the values based on the "Environment" out weighs the extra noise.  There's a few long running issues and community posts about it asking GH to make the "Deployment" optional, it could happen.

### `.github/workflows/mobilecoin-dev-cd.yaml`

- Move to ignore dependabot head ref branches instead of actor.
- Use `large-cd` class of github-runners so we don't compete for resources with with CI runs.
- Change dependency order
  - Put `Environment Info` first so we only need to declare ignore for dependabot (and others) on one job
  - Other job that `need` this job will be skipped when the parent job is skipped.
- Remove "skip" logic for docker and charts.  We will need to build these artifacts on each run.  
- Add bootstrap job
- Remove 1.1.3
- Move from specific secrets declaration to `secrets: inherit`

### `.github/workflows/mobilecoin-dev-delete.yaml`

- Clean up delete on branch delete action
- Only filter on `feature/*` branches. Other CD deployments will be cleaned up by a successful CD run.
- Move from specific secrets declaration to `secrets: inherit`

### `.github/workflows/mobilecoin-dispatch-dev-delete.yaml`

- Add `run-name:` for better Actions tab labels.
- Move from specific secrets declaration to `secrets: inherit`

### `.github/workflows/mobilecoin-dispatch-dev-deploy.yaml`

- Add `run-name:` for better Actions tab labels.
- Remove `client_auth` option.
- Reorder options for better display in GH GUI.
- Move from specific secrets declaration to `secrets: inherit`

### `.github/workflows/mobilecoin-dispatch-dev-test.yaml`

- Add `run-name:` for better Actions tab labels.
- Remove `client_auth` option.
- Move from specific secrets declaration to `secrets: inherit`
- Remove `testing_block_v3` option that somehow snuck into the v3 release branch.

### `.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml`

- Add `run-name:` for better Actions tab labels.
- Remove `client_auth` option.
- Move from specific secrets declaration to `secrets: inherit`
- Since we're not generating a dynamic tokens.config, we can do away with the kludgy docker call to run the toolbox container. 
- Remove unnecessary `docker_image_org` options
- Remove `minting_config` option, we will always have a tokens.json deployed. 

### `.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml`

Add bootstrap workflow to restore from backup.

### `.github/workflows/mobilecoin-workflow-dev-deploy.yaml`

- Move to use `.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml` instead of copy/paste setup.
- Remove `minting_config` option, we will always have a tokens.json deployed. 
- Order secrets to find values easier 
- Move from a single governor/signer set to secrets for governor/signer by token id.
- Remove reset job.   Will be called from bootstrap or dispatch as necessary.
- Use GH environment for dev specific secrets and config.
- Don't launch dev envs with persistent disk.  Faster deploys and more density on SGX nodes
- Move to 3 consensus and 2 view nodes.
- Reduce "sgx" requests and limits for more density on SGX nodes.

### `.github/workflows/mobilecoin-workflow-dev-reset.yaml`

- Use GH environment for dev specific secrets and config.
- Remove `delete-namespace` move that functionality up to reset dispatch workflow.
- Move to using `mobilecoin/gha-s3-pg-helper:v0` for aws/pg work. Less external dependancies.

### `.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml`

- Move environment setup into this reusable workflow.
- Reduce complexity by remove dynamic seeds and signed tokens.json functionality.  Now uses static secrets/configs for consistency in testing for all dev deployments.
- Move postgres deployment into this stage so can have the db instance setup for restoring the fog recovery database.

### `.github/workflows/mobilecoin-workflow-dev-test.yaml`

- Move to using actual boolean values, GHA finally fixed this.
- Remove some unused secret and env var definitions. 

### `.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml`

- Use setup workflow.
- Use GH environment for dev specific secrets and config.

### `.internal-ci/helm/mc-core-dev-env-setup/*`

- remove consensus nodes 4/5 from the config

### `.internal-ci/test/minting-config-tx-test.sh`

- Support more than one set of tokens with governors and signers.

### `.internal-ci/util/generate_dev_values.sh`

- remove consensus nodes 4/5

### `.internal-ci/util/generate_minting_keys.sh`

- Support more than one set of tokens with governors and signers.
- Not actively used as part of the dev deployment anymore.
- Still useful in setting up manual environments or refreshing dev config.

### ` .internal-ci/util/generate_minting_keys.sh`

- Support more than one set of tokens with governors and signers.
- Not actively used as part of the dev deployment anymore.
- Still useful in setting up manual environments or refreshing dev config.

### `.internal-ci/util/generate_tokens_config.sh`

- Support more than one set of tokens with governors and signers.
- Not actively used as part of the dev deployment anymore.
- Still useful in setting up manual environments or refreshing dev config.

###  `.internal-ci/util/tokens.base.json`

- Add 1 and 8192 tokens for testing