### PR TITLE
Replace ciphertext delta with explicit length field

### DIFF
--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -273,6 +273,13 @@ message TxOutSearchResult {
     /// It is be zero-padding in the other cases.
     /// FIXME: MC-1491 ensure this happens either in enclave or db, or wait for ORAM
     bytes ciphertext = 3;
+
+    /// The length of the payload that is encrypted in the ciphertext. Ciphertexts will always be 255 in length, but
+    /// the payload may be less than that, so any additional bytes should not be interpreted by the client. This value
+    /// tells the client which bytes to interpret.
+    /// TODO: Remove this field and replace with an optional `ciphertext_padding` field. This new field will contain
+    /// extra bytes to make up the difference between the shard's ciphertext length and the payload.
+    fixed32 payload_length = 4;
 }
 
 /// Corresponds to and documents values of TxOutSearchResult.result_code

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -279,7 +279,7 @@ message TxOutSearchResult {
     /// tells the client which bytes to interpret.
     /// TODO: Remove this field and replace with an optional `ciphertext_padding` field. This new field will contain
     /// extra bytes to make up the difference between the shard's ciphertext length and the payload.
-    fixed32 payload_length = 4;
+    uint32 payload_length = 4;
 }
 
 /// Corresponds to and documents values of TxOutSearchResult.result_code

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -279,7 +279,7 @@ message TxOutSearchResult {
     /// tells the client which bytes to interpret.
     /// TODO: Remove this field and replace with an optional `ciphertext_padding` field. This new field will contain
     /// extra bytes to make up the difference between the shard's ciphertext length and the payload.
-    uint32 payload_length = 4;
+    fixed32 payload_length = 4;
 }
 
 /// Corresponds to and documents values of TxOutSearchResult.result_code

--- a/fog/api/tests/fog_types.rs
+++ b/fog/api/tests/fog_types.rs
@@ -433,6 +433,7 @@ impl Sample for mc_fog_types::view::TxOutSearchResult {
             search_key: <[u8; 32]>::sample(rng).to_vec(),
             ciphertext: <[u8; 32]>::sample(rng).to_vec(),
             result_code: 1,
+            payload_length: 32,
         }
     }
 }

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -1018,7 +1018,7 @@ impl SqlRecoveryDb {
         // We will get one row for each hit in the table we found
         let rows: Vec<(i64, Vec<u8>)> = query.load(&conn)?;
 
-        if rows.len() > (block_range.len() as usize) {
+        if rows.len() > block_range.len() {
             log::warn!(
                 self.logger,
                 "When querying, more responses than expected: {} > {}",

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -913,13 +913,19 @@ impl SqlRecoveryDb {
                     search_key: search_key.clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: payload.clone(),
+                    payload_length: payload.len() as u32,
                 },
 
-                None => TxOutSearchResult {
-                    search_key: search_key.clone(),
-                    result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: Default::default(),
-                },
+                None => {
+                    let ciphertext: Vec<u8> = Default::default();
+                    let payload_length = ciphertext.len() as u32;
+                    TxOutSearchResult {
+                        search_key: search_key.clone(),
+                        result_code: TxOutSearchResultCode::NotFound as u32,
+                        ciphertext,
+                        payload_length,
+                    }
+                }
             });
         }
 
@@ -2240,7 +2246,8 @@ mod tests {
                     .map(|search_key| TxOutSearchResult {
                         search_key: search_key.clone(),
                         result_code: TxOutSearchResultCode::NotFound as u32,
-                        ciphertext: vec![]
+                        ciphertext: vec![],
+                        payload_length: 0,
                     })
                     .collect::<Vec<_>>()
             );
@@ -2261,27 +2268,32 @@ mod tests {
                 TxOutSearchResult {
                     search_key: test_case[0].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[1].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records1[0].payload.clone(),
+                    payload_length: records1[0].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[2].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records1[5].payload.clone(),
+                    payload_length: records1[5].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[3].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records2[3].payload.clone(),
+                    payload_length: records2[3].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[4].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
             ]
         );
@@ -2293,27 +2305,32 @@ mod tests {
                 TxOutSearchResult {
                     search_key: test_case[0].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[1].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records1[0].payload.clone(),
+                    payload_length: records1[0].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[2].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records1[5].payload.clone(),
+                    payload_length: records1[5].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[3].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records2[3].payload.clone(),
+                    payload_length: records2[3].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[4].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0
                 },
             ]
         );
@@ -2327,27 +2344,32 @@ mod tests {
                 TxOutSearchResult {
                     search_key: test_case[0].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[1].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[2].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[3].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[4].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
             ]
         );
@@ -2359,27 +2381,32 @@ mod tests {
                 TxOutSearchResult {
                     search_key: test_case[0].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[1].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[2].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
                 TxOutSearchResult {
                     search_key: test_case[3].clone(),
                     result_code: TxOutSearchResultCode::Found as u32,
                     ciphertext: records2[3].payload.clone(),
+                    payload_length: records2[3].payload.len() as u32,
                 },
                 TxOutSearchResult {
                     search_key: test_case[4].clone(),
                     result_code: TxOutSearchResultCode::NotFound as u32,
-                    ciphertext: vec![]
+                    ciphertext: vec![],
+                    payload_length: 0,
                 },
             ]
         );

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -218,7 +218,7 @@ pub struct TxOutSearchResult {
     #[prost(bytes, tag = "3")]
     pub ciphertext: Vec<u8>,
     /// The payload length
-    #[prost(uint32, tag = "4")]
+    #[prost(fixed32, tag = "4")]
     pub payload_length: u32,
 }
 

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -217,6 +217,9 @@ pub struct TxOutSearchResult {
     /// The ciphertext payload
     #[prost(bytes, tag = "3")]
     pub ciphertext: Vec<u8>,
+    /// The payload length
+    #[prost(fixed32, tag = "4")]
+    pub payload_length: u32,
 }
 
 /// An enum capturing the Oneof in the proto file around masked token id bytes

--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -218,7 +218,7 @@ pub struct TxOutSearchResult {
     #[prost(bytes, tag = "3")]
     pub ciphertext: Vec<u8>,
     /// The payload length
-    #[prost(fixed32, tag = "4")]
+    #[prost(uint32, tag = "4")]
     pub payload_length: u32,
 }
 

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -135,10 +135,12 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
     }
 
     pub fn find_record(&mut self, search_key: &[u8]) -> TxOutSearchResult {
+        let payload_length = ValueSize::USIZE - 1 - self.last_ciphertext_size_byte as usize;
         let mut result = TxOutSearchResult {
             search_key: search_key.to_vec(),
             result_code: TxOutSearchResultCode::InternalError as u32,
-            ciphertext: vec![0u8; ValueSize::USIZE - 1 - self.last_ciphertext_size_byte as usize],
+            ciphertext: vec![0u8; payload_length],
+            payload_length: payload_length as u32,
         };
 
         // Early return for bad search key

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -466,13 +466,16 @@ fn assert_e_tx_out_records_sanity(
             search_key: record.search_key.clone(),
             result_code: TxOutSearchResultCode::Found as u32,
             ciphertext: record.payload.clone(),
+            payload_length: record.payload.len() as u32,
         });
     }
     for i in 0..3 {
+        let payload_length = 64;
         expected_results.push(TxOutSearchResult {
             search_key: vec![i + 1; 16], // Search key if all zeros is invalid.
             result_code: TxOutSearchResultCode::NotFound as u32,
-            ciphertext: vec![0; 64],
+            ciphertext: vec![0; payload_length],
+            payload_length: payload_length as u32,
         });
     }
 


### PR DESCRIPTION
### Motivation
Previously, we were using the first byte in the `TxOutSearchResult.ciphertext` field to denote the difference in length between the ciphertext's payload and the overall length of the ciphertext. This is confusing because we're using bytes of a field to tell user's how to interpret the field. 

To make the API better, i added a `payload_length` field, which explicitly tells clients (or other portions of the code) how long the payload is. Now they won't need to do arithmetic or logic to interpet the field.


### Future Work
- Update the `TxOutSearchResult` proto to have an optional `ciphertext_padding` which holds the difference in paylaod and ciphertext length. This makes it so clients won't need to update and can continue using the old `ciphertext` field, while also maintainiing obliviousness (the same number of cmovs will occur)
