### PR TITLE
Retry ledger "index out of bounds" errors

### DIFF
--- a/connection/src/error.rs
+++ b/connection/src/error.rs
@@ -42,6 +42,7 @@ impl Error {
         match self {
             Error::Grpc(_) => true,
             Error::Attestation(err) => err.should_retry(),
+            Error::TransactionValidation(ProposeTxResult::LedgerTxOutIndexOutOfBounds, _) => true,
             _ => false,
         }
     }

--- a/consensus/api/proto/consensus_common.proto
+++ b/consensus/api/proto/consensus_common.proto
@@ -97,6 +97,7 @@ enum ProposeTxResult {
     InputRuleInvalidAmountSharedSecret = 51;
     InputRuleTxOutConversion = 52;
     InputRuleAmount = 53;
+    LedgerTxOutIndexOutOfBounds = 54;
 }
 
 /// Response from TxPropose RPC call.

--- a/consensus/api/src/conversions.rs
+++ b/consensus/api/src/conversions.rs
@@ -49,6 +49,7 @@ impl From<Error> for ProposeTxResult {
             Error::InvalidRistrettoPublicKey => Self::InvalidRistrettoPublicKey,
             Error::InvalidLedgerContext => Self::InvalidLedgerContext,
             Error::Ledger(_) => Self::Ledger,
+            Error::LedgerTxOutIndexOutOfBounds(_) => Self::LedgerTxOutIndexOutOfBounds,
             Error::MembershipProofValidationError => Self::MembershipProofValidationError,
             Error::TxFeeError => Self::TxFeeError,
             Error::KeyError => Self::KeyError,

--- a/ledger/db/src/error.rs
+++ b/ledger/db/src/error.rs
@@ -56,8 +56,8 @@ pub enum Error {
     /// Capacity exceeded
     CapacityExceeded,
 
-    /// Index out of bounds: {0}
-    IndexOutOfBounds(u64),
+    /// TxOut Index out of bounds: {0}
+    TxOutIndexOutOfBounds(u64),
 
     /// LMDB: {0}
     Lmdb(lmdb::Error),

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -254,7 +254,7 @@ impl TxOutStore {
     ) -> Result<(), Error> {
         let num_tx_outs = self.num_tx_outs(db_transaction)?;
         if index >= num_tx_outs {
-            return Err(Error::IndexOutOfBounds(index));
+            return Err(Error::TxOutIndexOutOfBounds(index));
         }
 
         let ranges = containing_ranges(index, num_tx_outs)?;
@@ -304,7 +304,7 @@ impl TxOutStore {
     ) -> Result<TxOutMembershipProof, Error> {
         let num_tx_outs = self.num_tx_outs(db_transaction)?;
         if index >= num_tx_outs {
-            return Err(Error::IndexOutOfBounds(index));
+            return Err(Error::TxOutIndexOutOfBounds(index));
         }
 
         // These pairs correspond to the ranges we will use for the proof elements
@@ -374,7 +374,7 @@ fn range_to_key_bytes(range: &Range) -> [u8; 16] {
 /// order from smallest to largest.
 pub fn containing_ranges(index: u64, num_leaves: u64) -> Result<Vec<(u64, u64)>, Error> {
     if index >= num_leaves {
-        return Err(Error::IndexOutOfBounds(index));
+        return Err(Error::TxOutIndexOutOfBounds(index));
     }
 
     if let Some(num_leaves_full_tree) = num_leaves.checked_next_power_of_two() {
@@ -1340,7 +1340,7 @@ pub mod tx_out_store_tests {
         let ro_transaction = env.begin_ro_txn().unwrap();
         match tx_out_store.get_merkle_proof_of_membership(43, &ro_transaction) {
             Ok(_proof) => panic!("43 is out of bounds"),
-            Err(Error::IndexOutOfBounds(43)) => {
+            Err(Error::TxOutIndexOutOfBounds(43)) => {
                 // This is expected.
             }
             Err(e) => panic!("Unexpected error {:?}", e),

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -115,6 +115,9 @@ pub enum TransactionValidationError {
     /// Ledger error: `{0}`.
     Ledger(String),
 
+    /// Ledger error: TxOut Index out of bounds: {0}
+    LedgerTxOutIndexOutOfBounds(u64),
+
     /// An error occurred while validating a membership proof.
     MembershipProofValidationError,
 


### PR DESCRIPTION
Test client sometimes fails in CD with errors like this:

> 2022-11-01 23:40:23.511798629 UTC CRIT thread main on test_client panicked! panicked at 'Unexpected error SubmitTx(TxRejected(Ledger, "Ledger error: `Index out of bounds: 111964`."))', fog/test-client/src/bin/main.rs:111:23    0:     0x564d793cb0c9 - backtrace::backtrace::trace::he6de28a0cae2390a

https://github.com/mobilecoinfoundation/mobilecoin/actions/runs/3373323306/jobs/5598519127

(After this commit we can actually see the error message: https://github.com/mobilecoinfoundation/mobilecoin/commit/68c6b1afee693b9d1548a266bb247b18278306e9)

I believe that this may be caused by a race condition:
* Fog is reading from one of the consensus nodes, which is ahead of another
* The test client decides that some number of tx outs are in the ledger based on what fog says
* The test client samples ring inputs (or selects tx outs) that don't appear in the ledger of the consensus node that it actually submits to
* The submission fails with this index out of bounds error during merkle proof validation

If we retry, then the slower consensus node will have a chance to catch up and perhaps the submission will succeed, so this seems like a good error to retry on.

---

This branch makes a new grpc consensus api status code for this error condition, so that it can be cleanly identified and retried on. It also makes the thick client do that. Some clients don't use the `ThickClient` object, like SDKs, so if they want to follow suit they will need downstream changes.