### PR TITLE
Make the TxSummary include a digest of input rules, per discussion

### DIFF
--- a/transaction/core/src/input_rules.rs
+++ b/transaction/core/src/input_rules.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use alloc::{collections::BTreeMap, vec::Vec};
 use displaydoc::Display;
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{Digestible, MerlinTranscript};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -83,6 +83,11 @@ impl InputRules {
             result.insert(output.tx_out.public_key, output.tx_out.clone());
         }
         result
+    }
+
+    /// Compute MCIP-52 canonical digest of input rules
+    pub fn canonical_digest(&self) -> [u8; 32] {
+        self.digest32::<MerlinTranscript>(b"mc-input-rules")
     }
 
     /// Verify that a Tx conforms to the rules.

--- a/transaction/core/src/tx_summary.rs
+++ b/transaction/core/src/tx_summary.rs
@@ -143,7 +143,7 @@ impl TxSummary {
                         ..Default::default()
                     };
                     if let Some(rules) = &input.input_rules {
-                        result.has_input_rules = true;
+                        result.input_rules_digest = rules.canonical_digest().to_vec();
                         let mut associated_tx_outs = rules.associated_tx_outs();
                         input_rules_associated_tx_outs.append(&mut associated_tx_outs);
                     }
@@ -214,7 +214,8 @@ pub struct TxInSummary {
     #[prost(message, required, tag = "1")]
     pub pseudo_output_commitment: CompressedCommitment,
 
-    /// Whether there are input rules associated to this input
-    #[prost(bool, tag = "2")]
-    pub has_input_rules: bool,
+    /// If there are input rules associated to this input, the canonical digest
+    /// of these (per MCIP 52). If not, then this field is empty.
+    #[prost(bytes, tag = "2")]
+    pub input_rules_digest: Vec<u8>,
 }


### PR DESCRIPTION
There is little downside to this since the TxInSummary is already very small compared to the TxOutSummary, and it allows that in the future we could also send the InputRules to the hardware device and verify them, if we decide that that is helpful.

This was a review comment in MCIP 52 from Ryan