### PR TITLE
fix unnecessary type parameter in build_unsigned

### DIFF
--- a/api/src/convert/input_ring.rs
+++ b/api/src/convert/input_ring.rs
@@ -150,7 +150,7 @@ mod tests {
                 .unwrap();
 
             let unsigned_tx = transaction_builder
-                .build_unsigned::<StdRng, DefaultTxOutputsOrdering>()
+                .build_unsigned::<DefaultTxOutputsOrdering>()
                 .unwrap();
 
             let input_ring = unsigned_tx.rings[0].clone();

--- a/api/src/convert/signing_data.rs
+++ b/api/src/convert/signing_data.rs
@@ -104,7 +104,7 @@ mod tests {
                 .unwrap();
 
             let unsigned_tx = transaction_builder
-                .build_unsigned::<StdRng, DefaultTxOutputsOrdering>()
+                .build_unsigned::<DefaultTxOutputsOrdering>()
                 .unwrap();
 
             let (signing_data, _, _) = unsigned_tx.get_signing_data(&mut rng).unwrap();

--- a/api/src/convert/unsigned_tx.rs
+++ b/api/src/convert/unsigned_tx.rs
@@ -95,7 +95,7 @@ mod tests {
                 .unwrap();
 
             let unsigned_tx = transaction_builder
-                .build_unsigned::<StdRng, DefaultTxOutputsOrdering>()
+                .build_unsigned::<DefaultTxOutputsOrdering>()
                 .unwrap();
 
             // Converting mc_transaction_builder::UnsignedTx -> external::UnsignedTx ->

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -674,9 +674,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
 
     /// Return low level data to sign and construct transactions with external
     /// signers
-    pub fn build_unsigned<T: RngCore + CryptoRng, O: TxOutputsOrdering>(
-        mut self,
-    ) -> Result<UnsignedTx, TxBuilderError> {
+    pub fn build_unsigned<O: TxOutputsOrdering>(mut self) -> Result<UnsignedTx, TxBuilderError> {
         // Note: Origin block has block version zero, so some clients like slam that
         // start with a bootstrapped ledger will target block version 0. However,
         // block version zero has no special rules and so targeting block version 0
@@ -813,7 +811,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
         ring_signer: &S,
         rng: &mut RNG,
     ) -> Result<Tx, TxBuilderError> {
-        let unsigned_tx = self.build_unsigned::<RNG, O>()?;
+        let unsigned_tx = self.build_unsigned::<O>()?;
         Ok(unsigned_tx.sign(ring_signer, rng)?)
     }
 }


### PR DESCRIPTION
The `build_unsigned` function takes an RNG type parameter but it is not bound to any actual inputs, or used in the function body. So all the callers have to supply a pointless type parameter.

This is a random defect that I saw when developing #2725. Pulling this out to ease review of that.