### PR TITLE
Payment Intent and Request ID Memos

### DIFF
--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -122,12 +122,15 @@ impl MemoHandler {
             }
             MemoType::AuthenticatedSenderWithPaymentIntentId(memo) => {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
-                    memo.validate(
+                    if bool::from(memo.validate(
                         addr,
                         &account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
-                    ).map(|_| Some(memo_type))
-                    .map_err(|_| MemoHandlerError::FailedHmacValidation)
+                    )) {
+                        Ok(Some(memo_type))
+                    } else {
+                        Err(MemoHandlerError::FailedHmacValidation)
+                    }
                 } else {
                     Err(MemoHandlerError::UnknownSender)
                 }

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -122,15 +122,12 @@ impl MemoHandler {
             }
             MemoType::AuthenticatedSenderWithPaymentIntentId(memo) => {
                 if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
-                    if bool::from(memo.validate(
+                    memo.validate(
                         addr,
                         &account_key.default_subaddress_view_private(),
                         &tx_out.public_key,
-                    )) {
-                        Ok(Some(memo_type))
-                    } else {
-                        Err(MemoHandlerError::FailedHmacValidation)
-                    }
+                    ).map(|_| Some(memo_type))
+                    .map_err(|_| MemoHandlerError::FailedHmacValidation)
                 } else {
                     Err(MemoHandlerError::UnknownSender)
                 }

--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -120,6 +120,35 @@ impl MemoHandler {
                 // TODO: Add Gift Code Validation
                 Ok(Some(memo_type))
             }
+            MemoType::AuthenticatedSenderWithPaymentIntentId(memo) => {
+                if let Some(addr) = self.contacts.get(&memo.sender_address_hash()) {
+                    if bool::from(memo.validate(
+                        addr,
+                        &account_key.default_subaddress_view_private(),
+                        &tx_out.public_key,
+                    )) {
+                        Ok(Some(memo_type))
+                    } else {
+                        Err(MemoHandlerError::FailedHmacValidation)
+                    }
+                } else {
+                    Err(MemoHandlerError::UnknownSender)
+                }
+            }
+            MemoType::DestinationWithPaymentRequestId(_) => {
+                if subaddress_matches_tx_out(account_key, CHANGE_SUBADDRESS_INDEX, tx_out)? {
+                    Ok(Some(memo_type))
+                } else {
+                    Err(MemoHandlerError::FailedSubaddressValidation)
+                }
+            }
+            MemoType::DestinationWithPaymentIntentId(_) => {
+                if subaddress_matches_tx_out(account_key, CHANGE_SUBADDRESS_INDEX, tx_out)? {
+                    Ok(Some(memo_type))
+                } else {
+                    Err(MemoHandlerError::FailedSubaddressValidation)
+                }
+            }
         }
     }
 }

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -1945,7 +1945,7 @@ pub mod transaction_builder_tests {
                     if block_version.e_memo_feature_is_supported() {
                         let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
-                            MemoType::Destination(memo) => {
+                            MemoType::DestinationWithPaymentRequestId(memo) => {
                                 assert_eq!(
                                     memo.get_address_hash(),
                                     &ShortAddressHash::from(&recipient_address),
@@ -1958,6 +1958,7 @@ pub mod transaction_builder_tests {
                                     value - change_value,
                                     "outlay should be amount sent to recipient + fee"
                                 );
+                                assert_eq!(memo.get_payment_request_id(), 42);
                             }
                             _ => {
                                 panic!("unexpected memo type")
@@ -2243,7 +2244,7 @@ pub mod transaction_builder_tests {
                     if block_version.e_memo_feature_is_supported() {
                         let memo = change.e_memo.unwrap().decrypt(&ss);
                         match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
-                            MemoType::Destination(memo) => {
+                            MemoType::DestinationWithPaymentRequestId(memo) => {
                                 assert_eq!(
                                     memo.get_address_hash(),
                                     &ShortAddressHash::from(&recipient_address),
@@ -2256,6 +2257,173 @@ pub mod transaction_builder_tests {
                                     value - change_value,
                                     "outlay should be amount sent to recipient + fee"
                                 );
+                                assert_eq!(memo.get_payment_request_id(), 47);
+                            }
+                            _ => {
+                                panic!("unexpected memo type")
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Enable both sender and destination memos, and set a payment intent id
+            {
+                let mut memo_builder = RTHMemoBuilder::default();
+                memo_builder.set_sender_credential(SenderMemoCredential::from(&sender));
+                memo_builder.enable_destination_memo();
+                memo_builder.set_payment_intent_id(4855282172840142080);
+
+                let mut transaction_builder = TransactionBuilder::new(
+                    block_version,
+                    Amount::new(Mob::MINIMUM_FEE, token_id),
+                    fog_resolver.clone(),
+                    memo_builder,
+                )
+                .unwrap();
+
+                transaction_builder.set_tombstone_block(2000);
+
+                let input_credentials = get_input_credentials(
+                    block_version,
+                    Amount { value, token_id },
+                    &sender,
+                    &fog_resolver,
+                    &mut rng,
+                );
+                transaction_builder.add_input(input_credentials);
+
+                transaction_builder
+                    .add_output(
+                        Amount::new(value - change_value - Mob::MINIMUM_FEE, token_id),
+                        &recipient_address,
+                        &mut rng,
+                    )
+                    .unwrap();
+
+                transaction_builder
+                    .add_change_output(
+                        Amount::new(change_value, token_id),
+                        &sender_change_dest,
+                        &mut rng,
+                    )
+                    .unwrap();
+
+                let tx = transaction_builder
+                    .build(&NoKeysRingSigner {}, &mut rng)
+                    .unwrap();
+
+                // The transaction should have two output.
+                assert_eq!(tx.prefix.outputs.len(), 2);
+
+                // The tombstone block should be the min of what the user requested, and what
+                // fog limits it to
+                assert_eq!(tx.prefix.tombstone_block, 1000);
+
+                let output = tx
+                    .prefix
+                    .outputs
+                    .iter()
+                    .find(|tx_out| {
+                        subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, tx_out)
+                            .unwrap()
+                    })
+                    .expect("Didn't find recipient's output");
+                let change = tx
+                    .prefix
+                    .outputs
+                    .iter()
+                    .find(|tx_out| {
+                        subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, tx_out).unwrap()
+                    })
+                    .expect("Didn't find sender's output");
+
+                validate_tx_out(block_version, output).unwrap();
+                validate_tx_out(block_version, change).unwrap();
+
+                assert!(
+                    !subaddress_matches_tx_out(&recipient, DEFAULT_SUBADDRESS_INDEX, change)
+                        .unwrap()
+                );
+                assert!(
+                    !subaddress_matches_tx_out(&sender, DEFAULT_SUBADDRESS_INDEX, change).unwrap()
+                );
+                assert!(
+                    !subaddress_matches_tx_out(&sender, CHANGE_SUBADDRESS_INDEX, output).unwrap()
+                );
+                assert!(
+                    !subaddress_matches_tx_out(&recipient, CHANGE_SUBADDRESS_INDEX, output)
+                        .unwrap()
+                );
+
+                // The 1st output should belong to the correct recipient and have correct amount
+                // and have correct memo
+                {
+                    let ss = get_tx_out_shared_secret(
+                        recipient.view_private_key(),
+                        &RistrettoPublic::try_from(&output.public_key).unwrap(),
+                    );
+                    let (amount, _) = output.get_masked_amount().unwrap().get_value(&ss).unwrap();
+                    assert_eq!(amount.value, value - change_value - Mob::MINIMUM_FEE);
+                    assert_eq!(amount.token_id, token_id);
+
+                    if block_version.e_memo_feature_is_supported() {
+                        let memo = output.e_memo.unwrap().decrypt(&ss);
+                        match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                            MemoType::AuthenticatedSenderWithPaymentIntentId(memo) => {
+                                assert_eq!(
+                                    memo.sender_address_hash(),
+                                    ShortAddressHash::from(&sender_addr),
+                                    "lookup based on address hash failed"
+                                );
+                                assert!(
+                                    bool::from(
+                                        memo.validate(
+                                            &sender_addr,
+                                            &recipient
+                                                .subaddress_view_private(DEFAULT_SUBADDRESS_INDEX),
+                                            &output.public_key,
+                                        )
+                                    ),
+                                    "hmac validation failed"
+                                );
+                                assert_eq!(memo.payment_intent_id(), 4855282172840142080);
+                            }
+                            _ => {
+                                panic!("unexpected memo type")
+                            }
+                        }
+                    }
+                }
+
+                // The 2nd output should belong to the correct recipient and have correct amount
+                // and have correct memo
+                {
+                    let ss = get_tx_out_shared_secret(
+                        sender.view_private_key(),
+                        &RistrettoPublic::try_from(&change.public_key).unwrap(),
+                    );
+                    let (amount, _) = change.get_masked_amount().unwrap().get_value(&ss).unwrap();
+                    assert_eq!(amount.value, change_value);
+                    assert_eq!(amount.token_id, token_id);
+
+                    if block_version.e_memo_feature_is_supported() {
+                        let memo = change.e_memo.unwrap().decrypt(&ss);
+                        match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                            MemoType::DestinationWithPaymentIntentId(memo) => {
+                                assert_eq!(
+                                    memo.get_address_hash(),
+                                    &ShortAddressHash::from(&recipient_address),
+                                    "lookup based on address hash failed"
+                                );
+                                assert_eq!(memo.get_num_recipients(), 1);
+                                assert_eq!(memo.get_fee(), Mob::MINIMUM_FEE);
+                                assert_eq!(
+                                    memo.get_total_outlay(),
+                                    value - change_value,
+                                    "outlay should be amount sent to recipient + fee"
+                                );
+                                assert_eq!(memo.get_payment_intent_id(), 4855282172840142080);
                             }
                             _ => {
                                 panic!("unexpected memo type")

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -96,6 +96,8 @@ pub enum NewMemoError {
     Utf8Decoding,
     /// Attempted value: {1} > Max Value: {0}
     MaxFeeExceeded(u64, u64),
+    /// Payment request and intent ID both are set
+    RequestAndIntentIdSet,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/extra/src/lib.rs
+++ b/transaction/extra/src/lib.rs
@@ -19,10 +19,11 @@ mod tx_out_gift_code;
 mod unsigned_tx;
 
 pub use memo::{
-    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo,
-    DestinationMemo, DestinationMemoError, GiftCodeCancellationMemo, GiftCodeFundingMemo,
-    GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType, SenderMemoCredential,
-    UnusedMemo,
+    AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentIntentIdMemo,
+    AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo, DestinationMemo,
+    DestinationMemoError, DestinationWithPaymentIntentIdMemo, DestinationWithPaymentRequestIdMemo,
+    GiftCodeCancellationMemo, GiftCodeFundingMemo, GiftCodeSenderMemo, MemoDecodingError, MemoType,
+    RegisteredMemoType, SenderMemoCredential, UnusedMemo,
 };
 pub use signed_contingent_input::{
     SignedContingentInput, SignedContingentInputError, UnmaskedAmount,

--- a/transaction/extra/src/memo/authenticated_sender_with_payment_intent_id.rs
+++ b/transaction/extra/src/memo/authenticated_sender_with_payment_intent_id.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Object for 0x0102 Authenticated Sender With Payment Intent Id memo type
+//!
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/54
+
+use super::{
+    authenticated_common::{compute_category1_hmac, validate_authenticated_sender},
+    credential::SenderMemoCredential,
+    RegisteredMemoType,
+};
+use crate::impl_memo_type_conversions;
+use mc_account_keys::{PublicAddress, ShortAddressHash};
+use mc_crypto_keys::{
+    CompressedRistrettoPublic, KexReusablePrivate, RistrettoPrivate, RistrettoPublic,
+};
+use subtle::Choice;
+
+/// A memo that the sender writes to convey their identity in an authenticated
+/// but deniable way, for the recipient of a TxOut, which also includes a
+/// payment intent id number under the MAC.
+///
+/// See mobilecoinfoundation/mcips/pull/4 for a discussion of the deniability
+/// property.
+///
+/// The recipient of this memo type should:
+/// * First, use sender_address_hash to look up the address of the sender, from
+///   among their contacts. If the sender isn't known then we can't validate.
+/// * Then, call validate to check the mac and confirm authenticity.
+/// * We can extract the payment intent id to link this to a payment intent.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct AuthenticatedSenderWithPaymentIntentIdMemo {
+    /// The memo data
+    memo_data: [u8; 64],
+}
+
+impl RegisteredMemoType for AuthenticatedSenderWithPaymentIntentIdMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x01, 0x02];
+}
+
+impl AuthenticatedSenderWithPaymentIntentIdMemo {
+    /// Create a new AuthenticatedSenderMemo given credential, recipient public
+    /// key, and tx out public key
+    ///
+    /// # Arguments:
+    /// * cred: A sender memo credential tied to the address we wish to identify
+    ///   ourselves as
+    /// * receiving_subaddress_view_public_key: This is the view public key from
+    ///   the public address of recipient
+    /// * tx_out_public_key: The public_key of the TxOut to which we will attach
+    ///   this memo
+    /// * payment_intent_id: The ID of the associated payment intent
+    pub fn new(
+        cred: &SenderMemoCredential,
+        receiving_subaddress_view_public_key: &RistrettoPublic,
+        tx_out_public_key: &CompressedRistrettoPublic,
+        payment_intent_id: u64,
+    ) -> Self {
+        // The layout of the memo is:
+        // [0-16) address hash
+        // [16-24) payment intent id
+        // [24-48) unused
+        // [48-64) HMAC
+
+        let mut memo_data = [0u8; 64];
+        memo_data[..16].copy_from_slice(cred.address_hash.as_ref());
+        memo_data[16..24].copy_from_slice(&payment_intent_id.to_be_bytes());
+
+        let shared_secret = cred
+            .subaddress_spend_private_key
+            .key_exchange(receiving_subaddress_view_public_key);
+
+        let hmac_value = compute_category1_hmac(
+            shared_secret.as_ref(),
+            tx_out_public_key,
+            Self::MEMO_TYPE_BYTES,
+            &memo_data,
+        );
+        memo_data[48..].copy_from_slice(&hmac_value);
+
+        Self { memo_data }
+    }
+
+    /// Get the sender address hash from the memo
+    pub fn sender_address_hash(&self) -> ShortAddressHash {
+        let bytes: [u8; 16] = self.memo_data[0..16].try_into().unwrap();
+        ShortAddressHash::from(bytes)
+    }
+
+    /// Get the payment intent id from the memo
+    pub fn payment_intent_id(&self) -> u64 {
+        u64::from_be_bytes(self.memo_data[16..24].try_into().unwrap())
+    }
+
+    /// Validate an AuthenticatedSenderMemo
+    ///
+    /// First, the client should look up the sender's Public Address from their
+    /// hash. If it isn't a known contact we won't be able to authenticate
+    /// them.
+    ///
+    /// Then they need to get the view private key corresponding to the
+    /// subaddress that this TxOut was sent to. This is usually our default
+    /// subaddress view private key.
+    ///
+    /// Finally we can validate the memo against these data. The
+    /// tx_out_public_key is also under the mac, which prevents replay
+    /// attacks.
+    ///
+    /// Arguments:
+    /// * sender_address: The public address of the sender. This can be looked
+    ///   up by the ShortAddressHash provided.
+    /// * receiving_subaddress_view_private_key: This is usually our
+    ///   default_subaddress_view_private_key, but should correspond to whatever
+    ///   subaddress recieved this TxOut.
+    /// * tx_out_public_key: The public key of the TxOut to which this memo is
+    ///   attached.
+    ///
+    /// Returns:
+    /// * subtle::Choice(1u8) if validation passed, subtle::Choice(0u8) if hmac
+    ///   comparison failed.
+    ///
+    /// This function is constant-time.
+    pub fn validate(
+        &self,
+        sender_address: &PublicAddress,
+        receiving_subaddress_view_private_key: &RistrettoPrivate,
+        tx_out_public_key: &CompressedRistrettoPublic,
+    ) -> Choice {
+        validate_authenticated_sender(
+            sender_address,
+            receiving_subaddress_view_private_key,
+            tx_out_public_key,
+            Self::MEMO_TYPE_BYTES,
+            &self.memo_data,
+        )
+    }
+}
+
+impl From<&[u8; 64]> for AuthenticatedSenderWithPaymentIntentIdMemo {
+    fn from(src: &[u8; 64]) -> Self {
+        let mut memo_data = [0u8; 64];
+        memo_data.copy_from_slice(src);
+        Self { memo_data }
+    }
+}
+
+impl From<AuthenticatedSenderWithPaymentIntentIdMemo> for [u8; 64] {
+    fn from(src: AuthenticatedSenderWithPaymentIntentIdMemo) -> [u8; 64] {
+        src.memo_data
+    }
+}
+
+impl_memo_type_conversions! { AuthenticatedSenderWithPaymentIntentIdMemo }

--- a/transaction/extra/src/memo/destination_with_payment_intent_id.rs
+++ b/transaction/extra/src/memo/destination_with_payment_intent_id.rs
@@ -1,12 +1,11 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Object for 0x0200 Destination memo type
+//! Object for 0x0204 Destination With Payment Intent Id memo type
 //!
-//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/54
 
-use super::RegisteredMemoType;
+use super::{DestinationMemoError, RegisteredMemoType};
 use crate::impl_memo_type_conversions;
-use displaydoc::Display;
 use mc_account_keys::ShortAddressHash;
 
 /// A memo that the sender writes to themself to record details of the
@@ -18,7 +17,7 @@ use mc_account_keys::ShortAddressHash;
 /// This memo should be validated by confirming that the TxOut matches to the
 /// change subaddress.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct DestinationMemo {
+pub struct DestinationWithPaymentIntentIdMemo {
     /// The address hash of the recipient to whom the payment is attributed
     address_hash: ShortAddressHash,
     /// The number of recipients of the transaction (ignoring the change output
@@ -50,13 +49,24 @@ pub struct DestinationMemo {
     /// as a u64. In that case, the memo builder is responsible to signal an
     /// an error. The client may disable destination memos for this transaction.
     total_outlay: u64,
+    /// An ID number which uniquely identifies an intent to send a payment
+    ///
+    /// This ID isn't necessarily unique on the blockchain. The ID number itself
+    /// provides a standard way for client applications to keep records of
+    /// payment intents and recover them using only data on the blockchain.
+    /// The exact details of a payment intent need to be made and agreed upon
+    /// off of the blockchain. Having the ID in the memo only enables client
+    /// applications to associate TxOuts to payment intents without storing any
+    /// information about the TxOuts outside of the blockchain alongside the
+    /// payment intent ID.
+    payment_intent_id: u64,
 }
 
-impl RegisteredMemoType for DestinationMemo {
-    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x00];
+impl RegisteredMemoType for DestinationWithPaymentIntentIdMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x04];
 }
 
-impl DestinationMemo {
+impl DestinationWithPaymentIntentIdMemo {
     /// Create a new destination memo set up for a single recipient
     /// (To create a memo for multiple recipients, use set_num_recipients)
     ///
@@ -65,12 +75,14 @@ impl DestinationMemo {
         address_hash: ShortAddressHash,
         total_outlay: u64,
         fee: u64,
+        payment_intent_id: u64,
     ) -> Result<Self, DestinationMemoError> {
         let mut result = Self {
             address_hash,
             num_recipients: 1,
             total_outlay,
             fee: 0,
+            payment_intent_id,
         };
         result.set_fee(fee)?;
         Ok(result)
@@ -112,15 +124,24 @@ impl DestinationMemo {
     pub fn set_total_outlay(&mut self, val: u64) {
         self.total_outlay = val;
     }
+    /// Get the payment intent ID
+    pub fn get_payment_intent_id(&self) -> u64 {
+        self.payment_intent_id
+    }
+    /// Set the payment intent ID
+    pub fn set_payment_intent_id(&mut self, val: u64) {
+        self.payment_intent_id = val;
+    }
 }
 
-impl From<&[u8; 64]> for DestinationMemo {
+impl From<&[u8; 64]> for DestinationWithPaymentIntentIdMemo {
     // The layout of the memo data in 64 bytes is:
     // [0-16): sender_address_hash
     // [16]: num_recipients
     // [17-24): fee
     // [24-32): total outlay
-    // [32-64): unused
+    // [32-40): payment intent id
+    // [40-64): unused
     fn from(src: &[u8; 64]) -> Self {
         let address_hash: [u8; 16] = src[0..16].try_into().expect("arithmetic error");
         let num_recipients = src[16];
@@ -130,31 +151,28 @@ impl From<&[u8; 64]> for DestinationMemo {
             u64::from_be_bytes(fee_bytes)
         };
         let total_outlay = u64::from_be_bytes(src[24..32].try_into().expect("arithmetic error"));
+        let payment_intent_id =
+            u64::from_be_bytes(src[32..40].try_into().expect("arithmetic error"));
         Self {
             address_hash: address_hash.into(),
             num_recipients,
             fee,
             total_outlay,
+            payment_intent_id,
         }
     }
 }
 
-impl From<DestinationMemo> for [u8; 64] {
-    fn from(src: DestinationMemo) -> [u8; 64] {
+impl From<DestinationWithPaymentIntentIdMemo> for [u8; 64] {
+    fn from(src: DestinationWithPaymentIntentIdMemo) -> [u8; 64] {
         let mut memo_data = [0u8; 64];
         memo_data[0..16].copy_from_slice(src.address_hash.as_ref());
         memo_data[16..24].copy_from_slice(&src.fee.to_be_bytes());
         memo_data[16] = src.num_recipients;
         memo_data[24..32].copy_from_slice(&src.total_outlay.to_be_bytes());
+        memo_data[32..40].copy_from_slice(&src.payment_intent_id.to_be_bytes());
         memo_data
     }
 }
 
-/// An error that can occur when configuring a destination memo
-#[derive(Display, Debug)]
-pub enum DestinationMemoError {
-    /// The fee amount is too large to be represented in the destination memo
-    FeeTooLarge,
-}
-
-impl_memo_type_conversions! { DestinationMemo }
+impl_memo_type_conversions! { DestinationWithPaymentIntentIdMemo }

--- a/transaction/extra/src/memo/destination_with_payment_request_id.rs
+++ b/transaction/extra/src/memo/destination_with_payment_request_id.rs
@@ -1,12 +1,11 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-//! Object for 0x0200 Destination memo type
+//! Object for 0x0203 Destination With Payment Request Id memo type
 //!
-//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/4
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/54
 
-use super::RegisteredMemoType;
+use super::{DestinationMemoError, RegisteredMemoType};
 use crate::impl_memo_type_conversions;
-use displaydoc::Display;
 use mc_account_keys::ShortAddressHash;
 
 /// A memo that the sender writes to themself to record details of the
@@ -18,7 +17,7 @@ use mc_account_keys::ShortAddressHash;
 /// This memo should be validated by confirming that the TxOut matches to the
 /// change subaddress.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct DestinationMemo {
+pub struct DestinationWithPaymentRequestIdMemo {
     /// The address hash of the recipient to whom the payment is attributed
     address_hash: ShortAddressHash,
     /// The number of recipients of the transaction (ignoring the change output
@@ -50,13 +49,24 @@ pub struct DestinationMemo {
     /// as a u64. In that case, the memo builder is responsible to signal an
     /// an error. The client may disable destination memos for this transaction.
     total_outlay: u64,
+    /// An ID number which uniquely identifies a request for payment
+    ///
+    /// This ID isn't necessarily unique on the blockchain. The ID number itself
+    /// provides a standard way for client applications to keep records of
+    /// payment requests and recover them using only data on the blockchain.
+    /// The exact details of a payment request need to be made and agreed upon
+    /// off of the blockchain. Having the ID in the memo only enables client
+    /// applications to associate TxOuts to payment requests without storing
+    /// any information about the TxOuts outside of the blockchain alongside
+    /// the payment request ID.
+    payment_request_id: u64,
 }
 
-impl RegisteredMemoType for DestinationMemo {
-    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x00];
+impl RegisteredMemoType for DestinationWithPaymentRequestIdMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x02, 0x03];
 }
 
-impl DestinationMemo {
+impl DestinationWithPaymentRequestIdMemo {
     /// Create a new destination memo set up for a single recipient
     /// (To create a memo for multiple recipients, use set_num_recipients)
     ///
@@ -65,12 +75,14 @@ impl DestinationMemo {
         address_hash: ShortAddressHash,
         total_outlay: u64,
         fee: u64,
+        payment_request_id: u64,
     ) -> Result<Self, DestinationMemoError> {
         let mut result = Self {
             address_hash,
             num_recipients: 1,
             total_outlay,
             fee: 0,
+            payment_request_id,
         };
         result.set_fee(fee)?;
         Ok(result)
@@ -112,15 +124,24 @@ impl DestinationMemo {
     pub fn set_total_outlay(&mut self, val: u64) {
         self.total_outlay = val;
     }
+    /// Get the payment request ID
+    pub fn get_payment_request_id(&self) -> u64 {
+        self.payment_request_id
+    }
+    /// Set the payment request ID
+    pub fn set_payment_request_id(&mut self, val: u64) {
+        self.payment_request_id = val;
+    }
 }
 
-impl From<&[u8; 64]> for DestinationMemo {
+impl From<&[u8; 64]> for DestinationWithPaymentRequestIdMemo {
     // The layout of the memo data in 64 bytes is:
     // [0-16): sender_address_hash
     // [16]: num_recipients
     // [17-24): fee
     // [24-32): total outlay
-    // [32-64): unused
+    // [32-40): payment request id
+    // [40-64): unused
     fn from(src: &[u8; 64]) -> Self {
         let address_hash: [u8; 16] = src[0..16].try_into().expect("arithmetic error");
         let num_recipients = src[16];
@@ -130,31 +151,28 @@ impl From<&[u8; 64]> for DestinationMemo {
             u64::from_be_bytes(fee_bytes)
         };
         let total_outlay = u64::from_be_bytes(src[24..32].try_into().expect("arithmetic error"));
+        let payment_request_id =
+            u64::from_be_bytes(src[32..40].try_into().expect("arithmetic error"));
         Self {
             address_hash: address_hash.into(),
             num_recipients,
             fee,
             total_outlay,
+            payment_request_id,
         }
     }
 }
 
-impl From<DestinationMemo> for [u8; 64] {
-    fn from(src: DestinationMemo) -> [u8; 64] {
+impl From<DestinationWithPaymentRequestIdMemo> for [u8; 64] {
+    fn from(src: DestinationWithPaymentRequestIdMemo) -> [u8; 64] {
         let mut memo_data = [0u8; 64];
         memo_data[0..16].copy_from_slice(src.address_hash.as_ref());
         memo_data[16..24].copy_from_slice(&src.fee.to_be_bytes());
         memo_data[16] = src.num_recipients;
         memo_data[24..32].copy_from_slice(&src.total_outlay.to_be_bytes());
+        memo_data[32..40].copy_from_slice(&src.payment_request_id.to_be_bytes());
         memo_data
     }
 }
 
-/// An error that can occur when configuring a destination memo
-#[derive(Display, Debug)]
-pub enum DestinationMemoError {
-    /// The fee amount is too large to be represented in the destination memo
-    FeeTooLarge,
-}
-
-impl_memo_type_conversions! { DestinationMemo }
+impl_memo_type_conversions! { DestinationWithPaymentRequestIdMemo }

--- a/transaction/extra/src/memo/mod.rs
+++ b/transaction/extra/src/memo/mod.rs
@@ -39,17 +39,23 @@
 //! | 0x0002          | Gift Code Sender Memo                             |
 //! | 0x0100          | Authenticated Sender Memo                         |
 //! | 0x0101          | Authenticated Sender With Payment Request Id Memo |
+//! | 0x0102          | Authenticated Sender With Payment Intent Id Memo  |
 //! | 0x0200          | Destination Memo                                  |
 //! | 0x0201          | Gift Code Funding Memo                            |
 //! | 0x0202          | Gift Code Cancellation Memo                       |
+//! | 0x0203          | Destination With Payment Request Id Memo          |
+//! | 0x0204          | Destination With Payment Intent Id Memo           |
 
 pub use self::{
     authenticated_common::compute_category1_hmac,
     authenticated_sender::AuthenticatedSenderMemo,
+    authenticated_sender_with_payment_intent_id::AuthenticatedSenderWithPaymentIntentIdMemo,
     authenticated_sender_with_payment_request_id::AuthenticatedSenderWithPaymentRequestIdMemo,
     burn_redemption::BurnRedemptionMemo,
     credential::SenderMemoCredential,
     destination::{DestinationMemo, DestinationMemoError},
+    destination_with_payment_intent_id::DestinationWithPaymentIntentIdMemo,
+    destination_with_payment_request_id::DestinationWithPaymentRequestIdMemo,
     gift_code_cancellation::GiftCodeCancellationMemo,
     gift_code_funding::GiftCodeFundingMemo,
     gift_code_sender::GiftCodeSenderMemo,
@@ -58,10 +64,13 @@ pub use self::{
 
 mod authenticated_common;
 mod authenticated_sender;
+mod authenticated_sender_with_payment_intent_id;
 mod authenticated_sender_with_payment_request_id;
 mod burn_redemption;
 mod credential;
 mod destination;
+mod destination_with_payment_intent_id;
+mod destination_with_payment_request_id;
 mod gift_code_cancellation;
 mod gift_code_funding;
 mod gift_code_sender;
@@ -96,8 +105,11 @@ pub enum MemoDecodingError {
 impl_memo_enum! { MemoType,
     AuthenticatedSender(AuthenticatedSenderMemo),
     AuthenticatedSenderWithPaymentRequestId(AuthenticatedSenderWithPaymentRequestIdMemo),
+    AuthenticatedSenderWithPaymentIntentId(AuthenticatedSenderWithPaymentIntentIdMemo),
     BurnRedemption(BurnRedemptionMemo),
     Destination(DestinationMemo),
+    DestinationWithPaymentRequestId(DestinationWithPaymentRequestIdMemo),
+    DestinationWithPaymentIntentId(DestinationWithPaymentIntentIdMemo),
     GiftCodeCancellation(GiftCodeCancellationMemo),
     GiftCodeFunding(GiftCodeFundingMemo),
     GiftCodeSender(GiftCodeSenderMemo),


### PR DESCRIPTION
Copied changes from pull #2805 to fix GHA

Adding DestinationWithPaymentRequestIdMemo
Adding SenderWithPaymentIntentIdMemo
Adding DestinationWithPaymentIntentIdMemo
Motivation

This PR implements the changes outlined in https://github.com/mobilecoinfoundation/mcips/pull/54.

The current SenderWithPaymentRequestIdMemo allows the sender of a transaction to inform the recipient that an incoming payment pertains to some prior agreed upon payment request. That recipient can always reconstruct the history of that payment request using the ID in the memo. The new DestinationWithPaymentRequestIdMemo will provide the ability for the sender reconstruct the history of that payment ID as well.

The Sender and DestinationWithPaymentIntentIdMemos allow clients to implement a payment intent flow. This will allow for easier implementation of features such as inviting users with a payment.