### PR TITLE
Update runtime container AESM and SGX libs to 2.17.101.1

### DIFF
--- a/.internal-ci/docker/Dockerfile.runtime-base
+++ b/.internal-ci/docker/Dockerfile.runtime-base
@@ -31,7 +31,7 @@ ENV LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm"
 # libsgx-enclave-common libsgx-epid libsgx-launch libsgx-pce-logic libsgx-urts
 # sgx-aesm-service
 # Use `apt show -a sgx-aesm-service` to find version
-ENV AESM_VERSION=2.17.100.3-focal1
+ENV AESM_VERSION=2.17.101.1-focal1
 # Use `apt show -a libsgx-pce-logic` to find the version thats compatible with aesm.
 ENV PCE_LOGIC_VERSION=1.14.100.3-focal1
 


### PR DESCRIPTION
### Motivation

Bump runtime container AESM and associated packages to 2.17.101.1 to resolve report failure.
