### PR TITLE
Make query batch logic compatible with sharding strategy

### DIFF
--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -264,8 +264,7 @@ pub trait RecoveryDb {
     ///
     /// Arguments:
     /// * ingress_key: The ingress key we need ETxOutRecords from
-    /// * block_index: The first block we need ETxOutRecords from
-    /// * block_count: How many consecutive blocks to also request data for.
+    /// * block_range: The range of blocks to get ETxOutRecords from.
     ///
     /// Returns:
     /// * The sequence of ETxOutRecord's, from consecutive blocks starting from
@@ -273,8 +272,7 @@ pub trait RecoveryDb {
     fn get_tx_outs_by_block_range_and_key(
         &self,
         ingress_key: CompressedRistrettoPublic,
-        block_index: u64,
-        block_count: usize,
+        block_range: &BlockRange,
     ) -> Result<Vec<Vec<ETxOutRecord>>, Self::Error>;
 
     /// Get the invocation id that published this block with this key.

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -1012,7 +1012,7 @@ impl SqlRecoveryDb {
         // We will get one row for each hit in the table we found
         let rows: Vec<(i64, Vec<u8>)> = query.load(&conn)?;
 
-        if rows.len() > (block_range.len() as usize) {
+        if (rows.len() as u64) > block_range.len() {
             log::warn!(
                 self.logger,
                 "When querying, more responses than expected: {} > {}",
@@ -1031,7 +1031,7 @@ impl SqlRecoveryDb {
 
         let mut result = Vec::new();
         for (idx, (block_number, proto)) in rows.into_iter().enumerate() {
-            if block_range.start_block + idx as u64 == block_number as u64 {
+            if block_range.start_block + (idx as u64) == block_number as u64 {
                 let proto = ProtoIngestedBlockData::decode(&*proto)?;
                 result.push(proto.e_tx_out_records);
             } else {

--- a/fog/types/src/common.rs
+++ b/fog/types/src/common.rs
@@ -26,10 +26,10 @@ impl BlockRange {
     }
 
     /// Create a new block range from length
-    pub fn new_from_length(start_block: u64, length: usize) -> Self {
+    pub fn new_from_length(start_block: u64, length: u64) -> Self {
         Self {
             start_block,
-            end_block: start_block + (length as u64),
+            end_block: start_block + length,
         }
     }
 
@@ -49,8 +49,8 @@ impl BlockRange {
     }
 
     /// Returns the length of the BlockRange, i.e. the number of blocks.
-    pub fn len(&self) -> usize {
-        (self.end_block - self.start_block) as usize
+    pub fn len(&self) -> u64 {
+        self.end_block - self.start_block
     }
 
     /// Returns true if the BlockRange length is 0.

--- a/fog/types/src/common.rs
+++ b/fog/types/src/common.rs
@@ -25,6 +25,14 @@ impl BlockRange {
         }
     }
 
+    /// Create a new block range from length
+    pub fn new_from_length(start_block: u64, length: usize) -> Self {
+        Self {
+            start_block,
+            end_block: start_block + (length as u64),
+        }
+    }
+
     /// Test if a block index is in the range
     pub fn contains(&self, block: u64) -> bool {
         block >= self.start_block && block < self.end_block
@@ -38,6 +46,16 @@ impl BlockRange {
     /// Test if two block ranges overlap
     pub fn overlaps(&self, other: &BlockRange) -> bool {
         self.start_block < other.end_block && other.start_block < self.end_block
+    }
+
+    /// Returns the length of the BlockRange, i.e. the number of blocks.
+    pub fn len(&self) -> usize {
+        (self.end_block - self.start_block) as usize
+    }
+
+    /// Returns true if the BlockRange length is 0.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }
 

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -303,7 +303,8 @@ where
         );
 
         for (ingress_key, block_index) in next_block_index_per_ingress_key.into_iter() {
-            let block_range = BlockRange::new_from_length(block_index, self.block_query_batch_size);
+            let block_range =
+                BlockRange::new_from_length(block_index, self.block_query_batch_size as u64);
             // Attempt to load data for the block range.
             let get_tx_outs_by_block_result = {
                 let _metrics_timer = counters::GET_TX_OUTS_BY_BLOCK_TIME.start_timer();
@@ -334,7 +335,7 @@ where
                     for (idx, tx_outs) in block_results.into_iter().enumerate() {
                         // shadow block_index using the offset from enumerate
                         // block_index is now the index of these tx_outs
-                        let block_index = block_index + idx as u64;
+                        let block_index = block_index + (idx as u64);
                         let num_tx_outs = tx_outs.len();
 
                         if !self.block_tracker.block_processed(ingress_key, block_index) {

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -6,7 +6,7 @@ use crate::{block_tracker::BlockTracker, counters, sharding_strategy::ShardingSt
 use mc_common::logger::{log, Logger};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_recovery_db_iface::{IngressPublicKeyRecord, IngressPublicKeyRecordFilters, RecoveryDb};
-use mc_fog_types::ETxOutRecord;
+use mc_fog_types::{common::BlockRange, ETxOutRecord};
 use mc_util_grpc::ReadinessIndicator;
 use std::{
     sync::{
@@ -303,14 +303,12 @@ where
         );
 
         for (ingress_key, block_index) in next_block_index_per_ingress_key.into_iter() {
-            // Attempt to load data for the next block.
+            let block_range = BlockRange::new_from_length(block_index, self.block_query_batch_size);
+            // Attempt to load data for the block range.
             let get_tx_outs_by_block_result = {
                 let _metrics_timer = counters::GET_TX_OUTS_BY_BLOCK_TIME.start_timer();
-                self.db.get_tx_outs_by_block_range_and_key(
-                    ingress_key,
-                    block_index,
-                    self.block_query_batch_size,
-                )
+                self.db
+                    .get_tx_outs_by_block_range_and_key(ingress_key, &block_range)
             };
 
             match get_tx_outs_by_block_result {
@@ -327,20 +325,6 @@ where
                         block_index,
                     );
 
-                    // Ingest has produced data for this block, we'd like to keep trying the
-                    // next block on the next loop iteration.
-                    may_have_more_work = true;
-
-                    // Mark that we are done fetching data for this block.
-                    if !self.block_tracker.block_processed(ingress_key, block_index) {
-                        log::trace!(
-                            self.logger,
-                            "Not adding block_index {} TxOuts because this shard is not responsible for it.",
-                            block_index,
-                        );
-                        continue;
-                    }
-
                     if block_results.len() == self.block_query_batch_size {
                         // Ingest has produced as much block data as we asked for,
                         // we'd like to keep trying to download in the next loop iteration.
@@ -353,8 +337,14 @@ where
                         let block_index = block_index + idx as u64;
                         let num_tx_outs = tx_outs.len();
 
-                        // Mark that we are done fetching data for this block.
-                        self.block_tracker.block_processed(ingress_key, block_index);
+                        if !self.block_tracker.block_processed(ingress_key, block_index) {
+                            log::trace!(
+                            self.logger,
+                            "Not adding block_index {} TxOuts because this shard is not responsible for it.",
+                            block_index,
+                        );
+                            continue;
+                        }
 
                         // Store the fetched records so that they could be consumed by the
                         // enclave when its ready.


### PR DESCRIPTION
### Motivation
I merged `master` into `feature/fog-view-router` and didn't accurately resolve merge conflicts for changes introduced by PR #2708. This PR fixes that merge issue and also updates the `sql_recovery_db` method to use a `BlockRange` (this is not strictly necessary for this PR but thought it was a good and easy cleanup)