### PR TITLE
Bump enclave svn for next release.

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
-const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 5;
+const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
-const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 6;
 const INGEST_ENCLAVE_NAME: &str = "ingest-enclave";
 const INGEST_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
-const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 6;
 const LEDGER_ENCLAVE_NAME: &str = "ledger-enclave";
 const LEDGER_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.17.101.1";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
-const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 4;
+const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 6;
 const VIEW_ENCLAVE_NAME: &str = "view-enclave";
 const VIEW_ENCLAVE_DIR: &str = "../trusted";
 


### PR DESCRIPTION
- Bump the enclave security version for all enclaves

### Motivation

In the `release/v3.0` branch, we've bumped the enclave security version to 6/5 for consensus/fog enclaves, respectively. This bumps them one more step beyond that, in preparation for the next release.

### Future Work
- Bump version
- Update ChangeLog
