### PR TITLE
`mob prompt`: limit number of cores based on memory

### DIFF
--- a/mob
+++ b/mob
@@ -56,7 +56,6 @@ import grp
 import os
 import pathlib
 import platform
-import psutil
 import subprocess
 import sys
 
@@ -138,6 +137,48 @@ def get_git_commit():
         except subprocess.CalledProcessError:
             eprint("Couldn't get git revision")
             return None
+
+def get_cargo_build_jobs():
+    """
+    Return the value to use for the `CARGO_BUILD_JOBS` environment variable. If
+    this is `None` then `CARGO_BUILD_JOBS` should not be set.
+
+    When the `CARGO_BUILD_JOBS` environment variable is already set, it's value
+    will be returned. Otherwise, a value will be provided that tries to maximize
+    resource usage without hitting limits.
+    """
+    jobs = os.environ.get("CARGO_BUILD_JOBS")
+
+    # The user set the jobs value so prefer it.
+    if jobs is not None:
+        return jobs
+
+    try:
+        import psutil
+    except ImportError:
+        return None
+
+    # For many binaries linking takes 2GB per binary. This often happens at the
+    # end of a build which can result in all cores trying to link, thus using
+    # 2GB per core. For a 16 core machine 32GB would need to be available. This
+    # logic will limit the build jobs to prevent out of memory issues.
+    # https://github.com/rust-lang/cargo/issues/9157 talks about trying to fix
+    # this in cargo.
+    cpus = psutil.cpu_count()
+    ram = psutil.virtual_memory().total
+
+    one_gig = 2**30
+
+    # Remove 5GB for local PC overhead
+    max_jobs = (ram - (5 * one_gig)) // (2 * one_gig)
+    jobs = min(max_jobs, cpus)
+
+    # Can happen if `ram` happened to be less than 5GB.
+    if jobs <= 0:
+        return None
+
+    return jobs
+
 
 ##
 # Environment checks
@@ -250,21 +291,9 @@ if git_commit:
 for pair in build_env:
     docker_run.extend(["--env", pair])
 
-# For many binaries linking takes 2GB per binary. This often happens at the end
-# of a build which can result in all cores trying to link, thus using 2GB per
-# core. For a 16 core machine 32GB would need to be available.
-# This logic will limit the build jobs to prevent out of memory issues.
-# https://github.com/rust-lang/cargo/issues/9157 talks about trying to fix this
-# in cargo.
-jobs = os.environ.get("CARGO_BUILD_JOBS")
-if jobs is None:
-    cpus = psutil.cpu_count()
-    ram = psutil.virtual_memory().total
-    # Remove 5GB for local PC overhead
-    max_jobs = (ram - 5_000_000_000) // 2_000_000_000
-    jobs = min(max_jobs, cpus)
-
-docker_run.extend(["--env", f"CARGO_BUILD_JOBS={jobs}"])
+jobs = get_cargo_build_jobs()
+if jobs is not None:
+    docker_run.extend(["--env", f"CARGO_BUILD_JOBS={jobs}"])
 
 # If running interactively (with a tty), get a tty in the container also
 # This allows colored build logs when running locally without messing up logs in CI

--- a/mob
+++ b/mob
@@ -56,6 +56,7 @@ import grp
 import os
 import pathlib
 import platform
+import psutil
 import subprocess
 import sys
 
@@ -248,6 +249,22 @@ if git_commit:
 
 for pair in build_env:
     docker_run.extend(["--env", pair])
+
+# For many binaries linking takes 2GB per binary. This often happens at the end
+# of a build which can result in all cores trying to link, thus using 2GB per
+# core. For a 16 core machine 32GB would need to be available.
+# This logic will limit the build jobs to prevent out of memory issues.
+# https://github.com/rust-lang/cargo/issues/9157 talks about trying to fix this
+# in cargo.
+jobs = os.environ.get("CARGO_BUILD_JOBS")
+if jobs is None:
+    cpus = psutil.cpu_count()
+    ram = psutil.virtual_memory().total
+    # Remove 5GB for local PC overhead
+    max_jobs = (ram - 5_000_000_000) // 2_000_000_000
+    jobs = min(max_jobs, cpus)
+
+docker_run.extend(["--env", f"CARGO_BUILD_JOBS={jobs}"])
 
 # If running interactively (with a tty), get a tty in the container also
 # This allows colored build logs when running locally without messing up logs in CI


### PR DESCRIPTION
Building the entire workspace requires ~2GB per core.
Some machines have many cores but a small amount of ram resulting in out
of memory issues. When using `mob prompt` the number of jobs will be
limited based on the physical memory size. Developers can override this
by explicitly setting the `CARGO_BUILD_JOBS` environment variable to the
desired number of jobs `CARGO_BUILD_JOBS=4 ./mob prompt`.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
