### PR TITLE
Allow Custom S3 Regions with Ledger Distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,7 +7113,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.48.0"
-source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
+source = "git+https://github.com/mobilecoinfoundation/rusoto.git#dfbae360f7267782e9d35b59b5db83fd4fdbe799"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -7137,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.48.0"
-source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
+source = "git+https://github.com/mobilecoinfoundation/rusoto.git#dfbae360f7267782e9d35b59b5db83fd4fdbe799"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7154,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "rusoto_s3"
 version = "0.48.0"
-source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
+source = "git+https://github.com/mobilecoinfoundation/rusoto.git#dfbae360f7267782e9d35b59b5db83fd4fdbe799"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -7166,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "rusoto_signature"
 version = "0.48.0"
-source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
+source = "git+https://github.com/mobilecoinfoundation/rusoto.git#dfbae360f7267782e9d35b59b5db83fd4fdbe799"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7113,8 +7113,7 @@ dependencies = [
 [[package]]
 name = "rusoto_core"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
+source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -7138,8 +7137,7 @@ dependencies = [
 [[package]]
 name = "rusoto_credential"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
+source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7156,8 +7154,7 @@ dependencies = [
 [[package]]
 name = "rusoto_s3"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aae4677183411f6b0b412d66194ef5403293917d66e70ab118f07cc24c5b14d"
+source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -7169,8 +7166,7 @@ dependencies = [
 [[package]]
 name = "rusoto_signature"
 version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
+source = "git+https://github.com/legokichi/rusoto.git?branch=enable-http1#bf26da8fa88b9f05311488754c14b50340e85364"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.1.0",

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -25,8 +25,8 @@ displaydoc = "0.2"
 protobuf = "2.27.1"
 retry = "2.0"
 # TODO: Replace with https://github.com/awslabs/aws-sdk-rust when it is ready.
-rusoto_core = { git = "https://github.com/legokichi/rusoto.git", branch = "enable-http1", features = ["rustls"], default_features = false }
-rusoto_s3 = { git = "https://github.com/legokichi/rusoto.git", branch = "enable-http1", features = ["rustls"], default_features = false }
+rusoto_core = { git = "https://github.com/mobilecoinfoundation/rusoto.git", features = ["rustls"], default_features = false }
+rusoto_s3 = { git = "https://github.com/mobilecoinfoundation/rusoto.git", features = ["rustls"], default_features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -25,8 +25,8 @@ displaydoc = "0.2"
 protobuf = "2.27.1"
 retry = "2.0"
 # TODO: Replace with https://github.com/awslabs/aws-sdk-rust when it is ready.
-rusoto_core = { version = "0.48.0", features = ["rustls"], default_features = false }
-rusoto_s3 = { version = "0.48.0", features = ["rustls"], default_features = false }
+rusoto_core = { git = "https://github.com/legokichi/rusoto.git", branch = "enable-http1", features = ["rustls"], default_features = false }
+rusoto_s3 = { git = "https://github.com/legokichi/rusoto.git", branch = "enable-http1", features = ["rustls"], default_features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/ledger/distribution/src/uri.rs
+++ b/ledger/distribution/src/uri.rs
@@ -76,7 +76,7 @@ impl FromStr for Uri {
                     }
                 });
 
-                let region = region_param.map_or(Region::default, |param| {
+                let region = region_param.map_or_else(Region::default, |param| {
                     Region::from_str(&param).unwrap_or(Region::Custom {
                         name: "custom".to_string(),
                         endpoint: param,

--- a/ledger/distribution/src/uri.rs
+++ b/ledger/distribution/src/uri.rs
@@ -76,8 +76,12 @@ impl FromStr for Uri {
                     }
                 });
 
-                let region = region_param
-                    .map_or_else(|| Region::default(), |param| Region::from_str(&param).unwrap_or(Region::Custom { name: "custom".to_string(), endpoint: param }));
+                let region = region_param.map_or(Region::default, |param| {
+                    Region::from_str(&param).unwrap_or(Region::Custom {
+                        name: "custom".to_string(),
+                        endpoint: param,
+                    })
+                });
 
                 Destination::S3 {
                     path: PathBuf::from(path),

--- a/ledger/distribution/src/uri.rs
+++ b/ledger/distribution/src/uri.rs
@@ -77,8 +77,7 @@ impl FromStr for Uri {
                 });
 
                 let region = region_param
-                    .map_or_else(|| Ok(Region::default()), |param| Region::from_str(&param))
-                    .map_err(UriParseError::InvalidS3Region)?;
+                    .map_or_else(|| Region::default(), |param| Region::from_str(&param).unwrap_or(Region::Custom { name: "custom".to_string(), endpoint: param }));
 
                 Destination::S3 {
                     path: PathBuf::from(path),


### PR DESCRIPTION
This enables us to use localstack (a mock AWS instance) with an insecure connection (HTTP)

This is mainly for local network setups where secure connections are not required. A small change was made to the rusoto library to allow HTTP connections and currently lives in a fork. This will be reverted once the change makes it into the base library.