### PR TITLE
Account for epochs in block tracker highest processed block count logic

### DIFF
--- a/fog/recovery_db_iface/src/types.rs
+++ b/fog/recovery_db_iface/src/types.rs
@@ -110,6 +110,8 @@ impl IngressPublicKeyRecord {
             return BlockRange::new(self.status.start_block, last_scanned_block + 1);
         }
 
+        // If we lost this key before it scanned anything, then return a
+        // default "empty" block range.
         BlockRange::new(0, 0)
     }
 


### PR DESCRIPTION
### Motivation
In #2852, I modified the `smoke_tests` to use the Fog View Router's `FogViewAPI` implementation (i.e. the new `unary` API). This caused the `test_middle_missing_range_with_decommission` to fail at line 828, which checks that the highest processed block count is 15. Instead, the test was producing 5. 

This occurs because the Fog View Server `enclave_block_tracker` doesn't track blocks for the first ingress key because its epoch doesn't account for any of that ingress key's blocks. As such, the `process_block_per_ingress_key` didn't have any entries for the first ingress key. This caused the check on line 159 to always fail, triggering the `else` block and causing the block count to never increment. 

The solution is to just skip over any keys that don't overlap with the shard's epoch.This allows the highest processed block count calculation to only incorporate keys / blocks that the shard is responsible for. 