### PR TITLE
Throttle dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
     time: "22:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 25
+  open-pull-requests-limit: 5
   labels:
     - "blocks-v4.0.0"
     - "dependencies"
@@ -17,7 +17,7 @@ updates:
     interval: daily
     time: "23:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 2
   labels:
     - "blocks-v4.0.0"
     - "dependencies"
@@ -28,7 +28,7 @@ updates:
     interval: daily
     time: "00:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 2
   labels:
     - "blocks-v4.0.0"
     - "dependencies"
@@ -39,7 +39,7 @@ updates:
     interval: daily
     time: "01:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 2
   labels:
     - "blocks-v4.0.0"
     - "dependencies"
@@ -50,7 +50,7 @@ updates:
     interval: daily
     time: "02:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 2
   labels:
     - "blocks-v4.0.0"
     - "dependencies"
@@ -61,4 +61,4 @@ updates:
     interval: daily
     time: "03:00"
     timezone: "America/Los_Angeles"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 2


### PR DESCRIPTION
The motivation for this is, dependabot may under various circumstances decide to rebase and force push all its open branchs. With the current configuration, that can cause 50 PRs to trigger CI all at once, which effectively DOS'es the engineers from using CI.

This change will cut down the number of open dependabot PRs at any point in time by about a factor of 5, so these force push events will cause much less load on the cluster and engineers will not be forced to manually cancel dependabot CI runs to get their work done.