### PR TITLE
Add a way for outputting JSON-formatted log messages to stdout/stderr

### DIFF
--- a/common/src/logger/loggers/mod.rs
+++ b/common/src/logger/loggers/mod.rs
@@ -8,7 +8,6 @@ const TRIM_MARKER: &str = "... <trimmed>";
 
 /// Macros to ease with tests/benches that require a Logger instance.
 pub use mc_util_logger_macros::{bench_with_logger, test_with_logger};
-use slog_term::TermDecorator;
 
 use super::*;
 
@@ -22,6 +21,7 @@ use sentry_logger::SentryLogger;
 use slog::Drain;
 use slog_gelf::Gelf;
 use slog_json::Json;
+use slog_term::TermDecorator;
 use std::{env, io, sync::Mutex};
 
 /// Custom timestamp function for use with slog-term


### PR DESCRIPTION
### Motivation

We'd like to have a way to format our stdout/stderr log messages as JSON strings, this will make it easier for machines to ingest our log messages.

The change proposed here allows switching to JSON output by setting the env var `MC_LOG_JSON=1`.

This fixes #2273