### PR TITLE
Initialize the logger before doing other operations, so that if something uses the global logger we do not get a panic

### DIFF
--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -124,9 +124,10 @@ async fn main() -> Result<(), rocket::Error> {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
 
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
     let config = Config::parse();
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
     log::info!(
         logger,
         "Starting admin HTTP gateway on {}:{}, connecting to {}",

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -121,10 +121,9 @@ fn metrics(state: &rocket::State<State>) -> Result<String, String> {
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
-    let (logger, _global_logger_guard) = create_app_logger(o!());
-
-    mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
 
     let config = Config::parse();
 

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -121,10 +121,10 @@ fn metrics(state: &rocket::State<State>) -> Result<String, String> {
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
-
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = Config::parse();
 

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -28,9 +28,6 @@ use std::{
 };
 
 fn main() -> Result<(), ConsensusServiceError> {
-    mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
-
     let config = Config::parse();
     let local_node_id = config.node_id();
     let fee_map = config.tokens().fee_map().expect("Could not parse fee map");
@@ -42,6 +39,8 @@ fn main() -> Result<(), ConsensusServiceError> {
     let (logger, _global_logger_guard) = create_app_logger(o!(
         "mc.local_node_id" => local_node_id.responder_id.to_string(),
     ));
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -28,6 +28,7 @@ use std::{
 };
 
 fn main() -> Result<(), ConsensusServiceError> {
+    let _sentry_guard = mc_common::sentry::init();
     let config = Config::parse();
     let local_node_id = config.node_id();
     let fee_map = config.tokens().fee_map().expect("Could not parse fee map");
@@ -40,7 +41,6 @@ fn main() -> Result<(), ConsensusServiceError> {
         "mc.local_node_id" => local_node_id.responder_id.to_string(),
     ));
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -115,8 +115,8 @@ struct SpendableTxOut {
 }
 
 fn main() {
-    mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
 
     let config = Config::parse();
 

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -19,12 +19,12 @@ use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let config = IngestConfig::parse();
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(
         o!("mc.local_node_id" => config.local_node_id.to_string()),
     );
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -19,12 +19,12 @@ use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};
 
 fn main() {
-    mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
     let config = IngestConfig::parse();
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(
         o!("mc.local_node_id" => config.local_node_id.to_string()),
     );
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/fog/ledger/server/src/bin/main.rs
+++ b/fog/ledger/server/src/bin/main.rs
@@ -18,10 +18,10 @@ use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};
 
 fn main() {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
     let config = LedgerServerConfig::parse();
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(

--- a/fog/ledger/server/src/bin/main.rs
+++ b/fog/ledger/server/src/bin/main.rs
@@ -18,9 +18,9 @@ use mc_watcher::watcher_db::WatcherDB;
 use std::{env, sync::Arc};
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = LedgerServerConfig::parse();
 

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -16,8 +16,9 @@ use mc_util_cli::ParserWithBuildInfo;
 async fn main() -> Result<(), rocket::Error> {
     mc_common::setup_panic_handler();
     let _sentry_guard = sentry::init();
-    let config = OverseerConfig::parse();
     let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());
+
+    let config = OverseerConfig::parse();
 
     // Open the database.
     let database_url =

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -14,9 +14,9 @@ use mc_util_cli::ParserWithBuildInfo;
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = sentry::init();
-    let (logger, _global_logger_guard) = mc_common::logger::create_app_logger(o!());
 
     let config = OverseerConfig::parse();
 

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -10,10 +10,10 @@ use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 
 fn main() {
+    let (logger, _global_logger_guard) = logger::create_app_logger(logger::o!());
+
     mc_common::setup_panic_handler();
     let _sentry_guard = sentry::init();
-
-    let (logger, _global_logger_guard) = logger::create_app_logger(logger::o!());
 
     let config = Config::parse();
 

--- a/fog/sql_recovery_db/cleanup/src/main.rs
+++ b/fog/sql_recovery_db/cleanup/src/main.rs
@@ -15,8 +15,9 @@ mod db_cleaner;
 static EXPIRATION_DAYS: i64 = 2;
 
 fn main() {
-    let config = SqlRecoveryDbCleanupConfig::parse();
     let (logger, _global_logger_guard) = create_app_logger(mc_common::logger::o!());
+
+    let config = SqlRecoveryDbCleanupConfig::parse();
 
     let database_url = env::var("DATABASE_URL").expect("Missing DATABASE_URL environment variable");
     let db = SqlRecoveryDb::new_from_url(&database_url, Default::default(), logger.clone())

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -24,8 +24,8 @@ struct JsonData {
 }
 
 fn main() {
-    mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
 
     let config = TestClientConfig::parse();
 

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -12,10 +12,10 @@ use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 
 fn main() {
-    mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) =
         mc_common::logger::create_app_logger(mc_common::logger::o!());
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
     let config = MobileAcctViewConfig::parse();
 
     let database_url = env::var("DATABASE_URL").expect("Missing DATABASE_URL environment variable");

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -12,10 +12,10 @@ use mc_util_grpc::AdminServer;
 use std::{env, sync::Arc};
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) =
         mc_common::logger::create_app_logger(mc_common::logger::o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
     let config = MobileAcctViewConfig::parse();
 
     let database_url = env::var("DATABASE_URL").expect("Missing DATABASE_URL environment variable");

--- a/go-grpc-gateway/testing/src/bin/main.rs
+++ b/go-grpc-gateway/testing/src/bin/main.rs
@@ -8,9 +8,8 @@ use fog_stub_server::{Config, Server};
 use mc_common::logger;
 
 fn main() {
-    mc_common::setup_panic_handler();
-
     let (logger, _global_logger_guard) = logger::create_app_logger(logger::o!());
+    mc_common::setup_panic_handler();
 
     let config = Config::parse();
 

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -293,11 +293,11 @@ impl BlockHandler for LocalBlockWriter {
 
 // Implements the ledger db polling loop
 fn main() {
-    let config = Config::parse();
-
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+
+    let config = Config::parse();
 
     let _tracer = mc_util_telemetry::setup_default_tracer(env!("CARGO_PKG_NAME"))
         .expect("Failed setting telemetry tracer");

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -293,9 +293,9 @@ impl BlockHandler for LocalBlockWriter {
 
 // Implements the ledger db polling loop
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = Config::parse();
 

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -293,9 +293,9 @@ impl BlockHandler for LocalBlockWriter {
 
 // Implements the ledger db polling loop
 fn main() {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = Config::parse();
 

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -12,8 +12,8 @@ use mc_ledger_db::{create_ledger_in, Ledger};
 use mc_ledger_sync::ReqwestTransactionsFetcher;
 
 fn main() {
-    mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
 
     let config = LedgerFromArchiveConfig::parse();
 

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -18,11 +18,11 @@ pub struct Config {
 }
 
 fn main() {
-    let config = Config::parse();
-
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+
+    let config = Config::parse();
 
     migrate(&config.ledger_db, &logger);
 

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -18,9 +18,9 @@ pub struct Config {
 }
 
 fn main() {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = Config::parse();
 

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -18,9 +18,9 @@ pub struct Config {
 }
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = Config::parse();
 

--- a/mobilecoind-dev-faucet/src/bin/main.rs
+++ b/mobilecoind-dev-faucet/src/bin/main.rs
@@ -50,12 +50,12 @@ async fn status(state: &rocket::State<State>) -> Json<JsonFaucetStatus> {
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
 
     let config = Config::parse();
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
     log::info!(
         logger,
         "Starting mobilecoind-dev-faucet HTTP on {}:{}, connecting to {}",

--- a/mobilecoind-dev-faucet/src/bin/main.rs
+++ b/mobilecoind-dev-faucet/src/bin/main.rs
@@ -50,9 +50,9 @@ async fn status(state: &rocket::State<State>) -> Json<JsonFaucetStatus> {
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = Config::parse();
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -781,9 +781,10 @@ async fn main() -> Result<(), rocket::Error> {
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
 
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
     let config = Config::parse();
 
-    let (logger, _global_logger_guard) = create_app_logger(o!());
     log::info!(
         logger,
         "Starting mobilecoind HTTP gateway on {}:{}, connecting to {}",

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -778,10 +778,9 @@ fn get_mixins(
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
-    let (logger, _global_logger_guard) = create_app_logger(o!());
-
-    mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
 
     let config = Config::parse();
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -778,10 +778,10 @@ fn get_mixins(
 
 #[rocket::main]
 async fn main() -> Result<(), rocket::Error> {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
-
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = Config::parse();
 

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -19,9 +19,9 @@ use std::{
 };
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = Config::parse();
     if !cfg!(debug_assertions) && !config.offline {

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -19,9 +19,9 @@ use std::{
 };
 
 fn main() {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
     let _sentry_guard = mc_common::sentry::init();
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let config = Config::parse();
     if !cfg!(debug_assertions) && !config.offline {

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -19,14 +19,14 @@ use std::{
 };
 
 fn main() {
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+
     let config = Config::parse();
     if !cfg!(debug_assertions) && !config.offline {
         config.validate_host().expect("Could not validate host");
     }
-
-    mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
-    let (logger, _global_logger_guard) = create_app_logger(o!());
 
     let _tracer =
         setup_default_tracer(env!("CARGO_PKG_NAME")).expect("Failed setting telemetry tracer");

--- a/util/grpc-admin-tool/src/bin/main.rs
+++ b/util/grpc-admin-tool/src/bin/main.rs
@@ -43,9 +43,9 @@ pub enum Command {
 }
 
 fn main() {
-    mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) =
         mc_common::logger::create_app_logger(mc_common::logger::o!());
+    mc_common::setup_panic_handler();
     let config = Config::parse();
 
     let env = Arc::new(grpcio::EnvBuilder::new().build());

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -27,8 +27,9 @@ use std::{
 };
 
 fn main() {
-    mc_common::setup_panic_handler();
     let (logger, _global_logger_guard) = create_app_logger(o!());
+    mc_common::setup_panic_handler();
+    let _sentry_guard = mc_common::sentry::init();
 
     let config = WatcherConfig::parse();
     let sources_config = config.sources_config();

--- a/watcher/src/bin/main.rs
+++ b/watcher/src/bin/main.rs
@@ -27,9 +27,9 @@ use std::{
 };
 
 fn main() {
+    let _sentry_guard = mc_common::sentry::init();
     let (logger, _global_logger_guard) = create_app_logger(o!());
     mc_common::setup_panic_handler();
-    let _sentry_guard = mc_common::sentry::init();
 
     let config = WatcherConfig::parse();
     let sources_config = config.sources_config();


### PR DESCRIPTION
### Motivation

I was handed the following stacktrace:
```
OH NO, WE CRASHED :( thread main on /home/sam/mobilecoin/target/release/mc-admin-http-gateway
Details: panicked at 'slog-scope: No logger set. Use `slog_scope::set_global_logger` or `slog_scope::scope`.', /home/sam/.cargo/registry/src/github.com-1ecc6299db9ec823/slog-scope-4.4.0/lib.rs:125:13
   0:     0x55cb59de1029 - backtrace::backtrace::trace::h636b2a06fc441be5
   1:     0x55cb59dcc5b7 - backtrace::capture::Backtrace::new::h4e4c6302f49df649
   2:     0x55cb59a1f8b4 - mc_common::panic_handler::setup_panic_handler::{{closure}}::h238b670fdff24b81
   3:     0x55cb5a2a3aa6 - std::panicking::rust_panic_with_hook::h9ade200275992b5b
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:702:17
   4:     0x55cb59e187cb - std::panicking::begin_panic::{{closure}}::h65ee692573396385
   5:     0x55cb59e18794 - std::sys_common::backtrace::__rust_end_short_backtrace::hd7688a000e6984a9
   6:     0x55cb597e43fc - std::panicking::begin_panic::h8ae49916a3662961
   7:     0x55cb59e18429 - <slog_scope::NoGlobalLoggerSet as slog::Drain>::log::h5ab078a0d92d961d
   8:     0x55cb59a3d3da - std::thread::local::LocalKey<T>::with::he8ca72944d9b00b6
   9:     0x55cb59a1fb23 - mc_common::panic_handler::setup_panic_handler::{{closure}}::h238b670fdff24b81
  10:     0x55cb5a2a3aa6 - std::panicking::rust_panic_with_hook::h9ade200275992b5b
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:702:17
  11:     0x55cb59e187cb - std::panicking::begin_panic::{{closure}}::h65ee692573396385
  12:     0x55cb59e18794 - std::sys_common::backtrace::__rust_end_short_backtrace::hd7688a000e6984a9
  13:     0x55cb597e43fc - std::panicking::begin_panic::h8ae49916a3662961
  14:     0x55cb59e18429 - <slog_scope::NoGlobalLoggerSet as slog::Drain>::log::h5ab078a0d92d961d
  15:     0x55cb59a51365 - std::thread::local::LocalKey<T>::with::hc50ce162db573904
  16:     0x55cb59a50f69 - <slog_stdlog::Logger as log::Log>::log::h866a96a82bb173fd
  17:     0x55cb5a234819 - log::__private_api_log::h700398d8ab9eff8d
  18:     0x55cb59d6a5bb - <tokio::io::poll_evented::PollEvented<E> as core::ops::drop::Drop>::drop::h1e16ac53a79aad67
  19:     0x55cb59d72a0c - core::ptr::drop_in_place<tokio::io::poll_evented::PollEvented<mio::net::uds::stream::UnixStream>>::heaebb82a302951f8
  20:     0x55cb59d71fa7 - core::ptr::drop_in_place<tokio::park::either::Either<tokio::process::imp::driver::Driver,tokio::park::thread::ParkThread>>::h509d275cedb38f68
  21:     0x55cb59d73dde - alloc::sync::Arc<T>::drop_slow::h51509e20441fe743
  22:     0x55cb59d73aca - alloc::sync::Arc<T>::drop_slow::h3733124ee463c6a6
  23:     0x55cb59d71e31 - core::ptr::drop_in_place<alloc::boxed::Box<[tokio::runtime::scheduler::multi_thread::worker::Remote]>>::hb69682fc1c9464c5
  24:     0x55cb59d741b5 - alloc::sync::Arc<T>::drop_slow::h97ddfa06735a75e7
  25:     0x55cb59d6466f - core::ptr::drop_in_place<tokio::runtime::Runtime>::h756f65cb0927f1f0
  26:     0x55cb59859461 - rocket::async_main::h00bcbb9d701313bd
  27:     0x55cb598fa949 - mc_admin_http_gateway::main::h87ff988d3415e8d8
  28:     0x55cb59871866 - std::sys_common::backtrace::__rust_begin_short_backtrace::hfc81b1dc52e40064
  29:     0x55cb59888308 - std::rt::lang_start::{{closure}}::he600a958da2a0e01
  30:     0x55cb5a2946ae - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hb78536f761ac4ccf
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/core/src/ops/function.rs:280:13
                           std::panicking::try::do_call::h0a4e2429dcf6aa05
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:492:40
                           std::panicking::try::ha28d384da4d3830b
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:456:19
                           std::panic::catch_unwind::h5128220fb91881a2
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panic.rs:137:14
                           std::rt::lang_start_internal::{{closure}}::h93d0c63c493948b2
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/rt.rs:128:48
                           std::panicking::try::do_call::hed0daa62200c4fcd
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:492:40
                           std::panicking::try::h19cdb5136875f739
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panicking.rs:456:19
                           std::panic::catch_unwind::h1df1a585997fa257
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/panic.rs:137:14
                           std::rt::lang_start_internal::h191f82060be993ea
                               at /rustc/e85edd9a844b523a02dbd89f3c02cd13e4c9fe46/library/std/src/rt.rs:128:20
  31:     0x55cb598fee22 - main
  32:     0x7f39cec29d90 - __libc_start_call_main
                               at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  33:     0x7f39cec29e40 - __libc_start_main_impl
                               at ./csu/../csu/libc-start.c:392:3
  34:     0x55cb5980d5d5 - _start
  35:                0x0 - <unknown>
```

I believe it is caused by something trying to log using `slog` before the logger is actually initialized. Moving the initialization to the top of `main()` should fix it. In most places the  first thing we do is initialize the logger, but there are a few places where we could potentially be emitting logs before doing that. So this should fix it.