### PR TITLE
Pull in protobuf changes from milliec/ledger-router-dev

### DIFF
--- a/fog/api/proto/fog_common.proto
+++ b/fog/api/proto/fog_common.proto
@@ -13,3 +13,8 @@ message BlockRange {
     /// One-past-the-end of the range
     uint64 end_block = 2;
 }
+
+message AddShardRequest {
+    // The shard's URI in string format.
+    string shard_uri = 1;
+}

--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -35,7 +35,7 @@ message LedgerRequest {
     oneof request_data { 
         attest.AuthMessage auth = 1;
         attest.Message check_key_images = 2;
-        // TODO: Fill in block query service and merkele proof service.
+        // TODO: Fill in block query service and merkle proof service.
         // Potentially untrusted_tx_out_service? To be decided.     
     }
 }
@@ -44,12 +44,12 @@ message LedgerResponse {
     oneof response_data { 
         attest.AuthMessage auth = 1;
         attest.Message check_key_image_response = 2;
-        // TODO: Fill in block query service and merkele proof service.
+        // TODO: Fill in block query service and merkle proof service.
         // Potentially untrusted_tx_out_service? To be decided.     
     }
 }
 
-// Identical to FogViewStoreDecryptionError - TODO, determine if we should unify these types.
+// Identical to FogViewStoreDecryptionError
 message FogLedgerStoreDecryptionError {
     /// The FogLedgerStoreUri for the specific Fog Ledger Store that
     /// tried to decrypt the MultiKeyImageStoreRequest and failed.
@@ -70,14 +70,16 @@ message MultiKeyImageStoreRequest {
 
 /// The status associated with a MultiViewStoreQueryResponse
 enum MultiKeyImageStoreResponseStatus {
+    /// Ensure default value (unfilled status) doesn't falsely appear to be a success 
+    UNKNOWN = 0;
     /// The Fog Ledger Store successfully fulfilled the request.
-    SUCCESS = 0;
+    SUCCESS = 1;
     /// The Fog Ledger Store is unable to decrypt a query within the MultiKeyImageStoreRequest. It needs to be authenticated
     /// by the router.
-    AUTHENTICATION_ERROR = 1;
+    AUTHENTICATION_ERROR = 2;
     /// The Fog Ledger Store is not ready to service a MultiViewStoreQueryRequest. This might be because the store has
     /// not loaded enough blocks yet.
-    NOT_READY = 2;
+    NOT_READY = 3;
 }
 
 message MultiKeyImageStoreResponse {
@@ -86,11 +88,11 @@ message MultiKeyImageStoreResponse {
     //  query. This is an encrypted CheckKeyImagesResponse.
     attest.NonceMessage query_response = 1;
 
-    /// The FogViewStoreUri for the specific Fog View Store that
-    /// tried to decrypt the MultiViewStoreQueryRequest and failed.
+    /// The FogLedgerStore for the specific Fog View Store that
+    /// tried to decrypt the MultiLedgerStoreQueryRequest and failed.
     /// The client should subsequently authenticate with the machine
     /// described by this URI.
-    string fog_ledger_store_uri = 2;
+    string store_uri = 2;
 
     /// Status that gets returned when the Fog Ledger Store services a MultiKeyImageStoreRequest.
     MultiKeyImageStoreResponseStatus status = 3;

--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -8,6 +8,100 @@ import "fog_common.proto";
 package fog_ledger;
 option go_package = "mobilecoin/api";
 
+import "google/protobuf/empty.proto";
+
+////
+// Ledger router API
+////
+
+service LedgerAPI {
+    rpc request(stream LedgerRequest) returns (stream LedgerResponse) {}
+}
+
+service LedgerRouterAdminAPI {
+    // Adds a shard to the Fog View Router's list of shards to query.
+    rpc addShard(AddShardRequest) returns (google.protobuf.Empty) {}
+}
+
+message AddShardRequest {
+    // The shard's URI in string format.
+    string shard_uri = 1;
+}
+
+
+/// Fulfills requests sent by the Fog Ledger Router. This is not meant to fulfill requests sent directly by the client.
+service KeyImageStoreAPI {
+    /// This is called to perform IX key exchange with the enclave before calling GetOutputs.
+    rpc Auth(attest.AuthMessage) returns (attest.AuthMessage) {}
+    /// Input should be an encrypted MultiKeyImageStoreRequest, result is an encrypted response.
+    rpc MultiKeyImageStoreQuery(MultiKeyImageStoreRequest) returns (MultiKeyImageStoreResponse) {}
+}
+
+message LedgerRequest {
+    oneof request_data { 
+        attest.AuthMessage auth = 1;
+        attest.Message check_key_images = 2;
+        // TODO: Fill in block query service and merkele proof service.
+        // Potentially untrusted_tx_out_service? To be decided.     
+    }
+}
+
+message LedgerResponse {
+    oneof response_data { 
+        attest.AuthMessage auth = 1;
+        attest.Message check_key_image_response = 2;
+        // TODO: Fill in block query service and merkele proof service.
+        // Potentially untrusted_tx_out_service? To be decided.     
+    }
+}
+
+// Identical to FogViewStoreDecryptionError - TODO, determine if we should unify these types.
+message FogLedgerStoreDecryptionError {
+    /// The FogLedgerStoreUri for the specific Fog Ledger Store that
+    /// tried to decrypt the MultiKeyImageStoreRequest and failed.
+    /// The client should subsequently authenticate with the machine
+    /// described by this URI.
+    string store_uri = 1;
+
+    /// An error message that describes the decryption error.
+    string error_message = 2;
+}
+
+// Identical to MultiViewStoreQueryRequest - TODO, determine if we should unify these types.
+message MultiKeyImageStoreRequest {
+    /// A list of queries encrypted for Fog Ledger Stores.
+    repeated attest.NonceMessage queries = 1;
+}
+
+
+/// The status associated with a MultiViewStoreQueryResponse
+enum MultiKeyImageStoreResponseStatus {
+    /// The Fog Ledger Store successfully fulfilled the request.
+    SUCCESS = 0;
+    /// The Fog Ledger Store is unable to decrypt a query within the MultiKeyImageStoreRequest. It needs to be authenticated
+    /// by the router.
+    AUTHENTICATION_ERROR = 1;
+    /// The Fog Ledger Store is not ready to service a MultiViewStoreQueryRequest. This might be because the store has
+    /// not loaded enough blocks yet.
+    NOT_READY = 2;
+}
+
+message MultiKeyImageStoreResponse {
+    /// Optional field that gets set when the Fog Ledger Store is able to decrypt a query
+    /// included in the MultiKeyImageStoreRequest and create a query response for that
+    //  query. This is an encrypted CheckKeyImagesResponse.
+    attest.NonceMessage query_response = 1;
+
+    /// The FogViewStoreUri for the specific Fog View Store that
+    /// tried to decrypt the MultiViewStoreQueryRequest and failed.
+    /// The client should subsequently authenticate with the machine
+    /// described by this URI.
+    string fog_ledger_store_uri = 2;
+
+    /// Status that gets returned when the Fog Ledger Store services a MultiKeyImageStoreRequest.
+    MultiKeyImageStoreResponseStatus status = 3;
+}
+
 ////
 // Merkle proofs
 ////

--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -19,7 +19,7 @@ service LedgerAPI {
 }
 
 service LedgerRouterAdminAPI {
-    // Adds a shard to the Fog View Router's list of shards to query.
+    // Adds a shard to the Fog Ledger Router's list of shards to query.
     rpc addShard(fog_common.AddShardRequest) returns (google.protobuf.Empty) {}
 }
 
@@ -61,14 +61,14 @@ message FogLedgerStoreDecryptionError {
     string error_message = 2;
 }
 
-// Identical to MultiViewStoreQueryRequest - TODO, determine if we should unify these types.
+// Identical to MultiViewStoreQueryRequest
 message MultiKeyImageStoreRequest {
     /// A list of queries encrypted for Fog Ledger Stores.
     repeated attest.NonceMessage queries = 1;
 }
 
 
-/// The status associated with a MultiViewStoreQueryResponse
+/// The status associated with a MultiKeyImageStoreQueryResponse
 enum MultiKeyImageStoreResponseStatus {
     /// Ensure default value (unfilled status) doesn't falsely appear to be a success 
     UNKNOWN = 0;
@@ -77,7 +77,7 @@ enum MultiKeyImageStoreResponseStatus {
     /// The Fog Ledger Store is unable to decrypt a query within the MultiKeyImageStoreRequest. It needs to be authenticated
     /// by the router.
     AUTHENTICATION_ERROR = 2;
-    /// The Fog Ledger Store is not ready to service a MultiViewStoreQueryRequest. This might be because the store has
+    /// The Fog Ledger Store is not ready to service a MultiLedgerStoreQueryRequest. This might be because the store has
     /// not loaded enough blocks yet.
     NOT_READY = 3;
 }
@@ -88,7 +88,7 @@ message MultiKeyImageStoreResponse {
     //  query. This is an encrypted CheckKeyImagesResponse.
     attest.NonceMessage query_response = 1;
 
-    /// The FogLedgerStore for the specific Fog View Store that
+    /// The FogLedgerStore for the specific Fog Ledger Store that
     /// tried to decrypt the MultiLedgerStoreQueryRequest and failed.
     /// The client should subsequently authenticate with the machine
     /// described by this URI.

--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -20,14 +20,8 @@ service LedgerAPI {
 
 service LedgerRouterAdminAPI {
     // Adds a shard to the Fog View Router's list of shards to query.
-    rpc addShard(AddShardRequest) returns (google.protobuf.Empty) {}
+    rpc addShard(fog_common.AddShardRequest) returns (google.protobuf.Empty) {}
 }
-
-message AddShardRequest {
-    // The shard's URI in string format.
-    string shard_uri = 1;
-}
-
 
 /// Fulfills requests sent by the Fog Ledger Router. This is not meant to fulfill requests sent directly by the client.
 service KeyImageStoreAPI {

--- a/fog/api/proto/view.proto
+++ b/fog/api/proto/view.proto
@@ -20,12 +20,7 @@ service FogViewRouterAPI {
 
 service FogViewRouterAdminAPI {
     // Adds a shard to the Fog View Router's list of shards to query.
-    rpc addShard(AddShardRequest) returns (google.protobuf.Empty) {}
-}
-
-message AddShardRequest {
-    // The shard's URI in string format.
-    string shard_uri = 1;
+    rpc addShard(fog_common.AddShardRequest) returns (google.protobuf.Empty) {}
 }
 
 message FogViewRouterRequest {

--- a/fog/view/server/src/router_admin_service.rs
+++ b/fog/view/server/src/router_admin_service.rs
@@ -4,7 +4,7 @@ use grpcio::{ChannelBuilder, RpcContext, RpcStatus, UnarySink};
 use itertools::Itertools;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
-    view::AddShardRequest,
+    fog_common::AddShardRequest,
     view_grpc::{FogViewRouterAdminApi, FogViewStoreApiClient},
 };
 use mc_fog_uri::FogViewStoreUri;


### PR DESCRIPTION
- Defines necessary protobuf messages for key image lookups in a Fog ledger router/store system.
- Moves AddShardRequest to fog_common.proto (see #2888)

### Motivation

As part of the ongoing project to improve Fog's scalability and stability, we're working on implementing a system that divides Fog ledger servers into a router (which routes requests from the client to a number of ledger store backends) and many stores (which actually hold relevant ledger data). Currently, only key image look-ups are supported.

### Future Work

* Pulling in the rest of the fog-ledger-router work from [milliec/ledger-router-dev into this branch](https://github.com/mobilecoinfoundation/mobilecoin/tree/milliec/ledger-router-dev) - so enclave API changes, implementation of the new enclave API methods, grpc servers, tests, etc. 