### PR TITLE
Mint client checksig

### DIFF
--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -369,8 +369,19 @@ fn main() {
             hash,
             pubkey,
         } => {
-            let result = pubkey.verify(&hash, &signature);
-            println!("Verification result = {:?}", result);
+            // terminate with an exit code of 0 for success and 1 for failure
+            // allowing whoever started this binary to easily determine if submitting the
+            // transaction succeeded.
+            match pubkey.verify(&hash, &signature) {
+                Ok(()) => {
+                    println!("signature Ok");
+                    exit(0)
+                }
+                Err(e) => {
+                    println!("{:?}", e);
+                    exit(1)
+                }
+            }
         }
     }
 }

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -11,7 +11,7 @@ use mc_consensus_api::{
 };
 use mc_consensus_enclave_api::GovernorsSigner;
 use mc_consensus_mint_client::{printers, Commands, Config, FogContext, TxFile};
-use mc_crypto_keys::{Ed25519Pair, Ed25519Private, Signer};
+use mc_crypto_keys::{Ed25519Pair, Ed25519Private, Signer, Verifier};
 use mc_crypto_multisig::MultiSig;
 use mc_transaction_core::{
     constants::MAX_TOMBSTONE_BLOCKS,
@@ -362,6 +362,15 @@ fn main() {
             tx_file
                 .write_json(&tx_file_path)
                 .expect("failed writing tx file");
+        },
+
+        Commands::CheckSig {
+            signature,
+            hash,
+            pubkey,
+        } => {
+            let result = pubkey.verify(&hash, &signature);
+            println!("Verification result = {:?}", result);
         }
     }
 }

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -373,10 +373,7 @@ fn main() {
             // allowing whoever started this binary to easily determine if submitting the
             // transaction succeeded.
             match pubkey.verify(&hash, &signature) {
-                Ok(()) => {
-                    println!("signature Ok");
-                    exit(0)
-                }
+                Ok(()) => println!("signature Ok"),
                 Err(e) => {
                     println!("{:?}", e);
                     exit(1)

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -362,7 +362,7 @@ fn main() {
             tx_file
                 .write_json(&tx_file_path)
                 .expect("failed writing tx file");
-        },
+        }
 
         Commands::CheckSig {
             signature,

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -445,7 +445,7 @@ pub enum Commands {
     /// to the provided public-key
     CheckSig {
         /// The signature to verify
-        /// 
+        ///
         /// can be created with ledger-agent -e ed25519 --sign-blob <hash>
         /// <key_identifier>`
         #[clap(

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -446,7 +446,7 @@ pub enum Commands {
     CheckSig {
         /// The signature to verify
         ///
-        /// can be created with ledger-agent -e ed25519 --sign-blob <hash>
+        /// can be created with `ledger-agent -e ed25519 --sign-blob <hash>
         /// <key_identifier>`
         #[clap(
             long = "signature",

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -8,7 +8,7 @@ use mc_account_keys::PublicAddress;
 use mc_api::printable::PrintableWrapper;
 use mc_consensus_service_config::TokensConfig;
 use mc_crypto_keys::{
-    DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, Signer
+    DistinguishedEncoding, Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature, Signer,
 };
 use mc_crypto_multisig::MultiSig;
 use mc_sgx_css::Signature;
@@ -441,12 +441,13 @@ pub enum Commands {
         signatures: Vec<Ed25519Signature>,
     },
 
-    /// Verify that the signature of a hash used the private key corresponding to the provided
-    /// public-key
+    /// Verify that the signature of a hash used the private key corresponding
+    /// to the provided public-key
     CheckSig {
-	    /// The signature to verify
+        /// The signature to verify
         /// 
-        /// can be created with ledger-agent -e ed25519 --sign-blob <hash> <key_identifier>`
+        /// can be created with ledger-agent -e ed25519 --sign-blob <hash>
+        /// <key_identifier>`
         #[clap(
             long = "signature",
             value_parser = load_or_parse_ed25519_signature, env = "MC_MINTING_SIGNATURES"
@@ -454,8 +455,9 @@ pub enum Commands {
         signature: Ed25519Signature,
 
         /// The hash that was signed.
-    	///
-    	/// An example hash may be created with `hash-tx-file --tx-file mintconfig.json`
+        ///
+        /// An example hash may be created with `hash-tx-file --tx-file
+        /// mintconfig.json`
         #[clap(
             long = "hash",
             value_parser = mc_util_parse::parse_hex::<[u8; 32]>, env = "MC_MINTING_HASH"
@@ -463,8 +465,9 @@ pub enum Commands {
         hash: [u8; 32],
 
         /// The public key to verify with the signature.
-    	///
-    	/// This pemfile can be created with `ledger-agent -e ed25519 --pemout <outfile>.pub <key_identifier>`
+        ///
+        /// This pemfile can be created with `ledger-agent -e ed25519 --pemout
+        /// <outfile>.pub <key_identifier>`
         #[clap(
             long = "public-key",
             value_parser = load_key_from_pem::<Ed25519Public>, env = "MC_MINTING_PUBLIC_KEY")]
@@ -482,8 +485,9 @@ pub struct Config {
     pub command: Commands,
 }
 
-// a purpose-build pem loader for MintPrivateKey to avoid implementing DistinguishedEncoding trait
-// MintPrivateKey was needed to implement Clone trait for use with clap
+// a purpose-build pem loader for MintPrivateKey to avoid implementing
+// DistinguishedEncoding trait. MintPrivateKey was needed to implement Clone
+// trait for use with clap
 pub fn load_mint_private_key_from_pem(filename: &str) -> Result<MintPrivateKey, String> {
     let bytes =
         fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -482,6 +482,8 @@ pub struct Config {
     pub command: Commands,
 }
 
+// a purpose-build pem loader for MintPrivateKey to avoid implementing DistinguishedEncoding trait
+// MintPrivateKey was needed to implement Clone trait for use with clap
 pub fn load_mint_private_key_from_pem(filename: &str) -> Result<MintPrivateKey, String> {
     let bytes =
         fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -485,7 +485,7 @@ pub struct Config {
     pub command: Commands,
 }
 
-// a purpose-build pem loader for MintPrivateKey to avoid implementing
+// a purpose-built pem loader for MintPrivateKey to avoid implementing
 // DistinguishedEncoding trait. MintPrivateKey was needed to implement Clone
 // trait for use with clap
 pub fn load_mint_private_key_from_pem(filename: &str) -> Result<MintPrivateKey, String> {

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -450,7 +450,7 @@ pub enum Commands {
         /// <key_identifier>`
         #[clap(
             long = "signature",
-            value_parser = load_or_parse_ed25519_signature, env = "MC_MINTING_SIGNATURES"
+            value_parser = load_or_parse_ed25519_signature, env = "MC_MINTING_SIGNATURE"
         )]
         signature: Ed25519Signature,
 


### PR DESCRIPTION
adds check-sig command to mc-consensus-mint-client
### Motivation

The check-sig command lets the operator provide a public key to verify that a signature over a hash was done using the corresponding private key.  Useful for pre-validating mint config and mint transactions, as well as debugging transactions that fail.

This is a replacement for PR #2674 by @sugargoat, updated for the current master commit as well as updating terminology to be consistent with other mc-consensus-mint-client commands.

[Soundtrack of this PR]()
