### PR TITLE
Protobuf conversion functions for Fog Ledger Router

### DIFF
--- a/fog/api/src/conversions.rs
+++ b/fog/api/src/conversions.rs
@@ -2,7 +2,9 @@
 //
 // Contains helper methods that enable conversions for Fog Api types.
 
-use crate::{fog_common, ingest_common, view::MultiViewStoreQueryRequest};
+use crate::{
+    fog_common, ingest_common, ledger::MultiKeyImageStoreRequest, view::MultiViewStoreQueryRequest,
+};
 use mc_api::ConversionError;
 use mc_attest_api::attest;
 use mc_attest_enclave_api::{EnclaveMessage, NonceSession};
@@ -27,6 +29,25 @@ impl From<Vec<attest::NonceMessage>> for MultiViewStoreQueryRequest {
         multi_view_store_query_request.set_queries(attested_query_messages.into());
 
         multi_view_store_query_request
+    }
+}
+
+impl From<Vec<EnclaveMessage<NonceSession>>> for MultiKeyImageStoreRequest {
+    fn from(enclave_messages: Vec<EnclaveMessage<NonceSession>>) -> MultiKeyImageStoreRequest {
+        enclave_messages
+            .into_iter()
+            .map(|enclave_message| enclave_message.into())
+            .collect::<Vec<attest::NonceMessage>>()
+            .into()
+    }
+}
+
+impl From<Vec<attest::NonceMessage>> for MultiKeyImageStoreRequest {
+    fn from(attested_query_messages: Vec<attest::NonceMessage>) -> MultiKeyImageStoreRequest {
+        let mut multi_key_image_store_request = MultiKeyImageStoreRequest::new();
+        multi_key_image_store_request.set_queries(attested_query_messages.into());
+
+        multi_key_image_store_request
     }
 }
 

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -60,20 +60,6 @@ impl UriScheme for FogLedgerScheme {
     const DEFAULT_INSECURE_PORT: u16 = 3223;
 }
 
-/// Fog Ledger Router Admin Scheme
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct FogLedgerRouterAdminScheme {}
-
-impl UriScheme for FogLedgerRouterAdminScheme {
-    /// The part before the '://' of a URL.
-    const SCHEME_SECURE: &'static str = "fog-ledger-router-admin";
-    const SCHEME_INSECURE: &'static str = "insecure-fog-ledger-router-admin";
-
-    /// Default port numbers
-    const DEFAULT_SECURE_PORT: u16 = 443;
-    const DEFAULT_INSECURE_PORT: u16 = 3223;
-}
-
 /// Key Image Store (for use with router) Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct KeyImageStoreScheme {}
@@ -193,17 +179,6 @@ mod tests {
         );
         assert!(!uri.use_tls());
 
-        let uri = FogLedgerRouterAdminUri::from_str(
-            "insecure-fog-ledger-router-admin://node1.test.mobilecoin.com:3223/",
-        )
-        .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
-        assert_eq!(
-            uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
-        );
-        assert!(!uri.use_tls());
-
         let uri = KeyImageStoreUri::from_str(
             "insecure-key-image-store://node1.test.mobilecoin.com:3223/",
         )
@@ -307,17 +282,6 @@ mod tests {
 
         let uri = FogViewRouterUri::from_str(
             "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
-        )
-        .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
-        assert_eq!(
-            uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
-        );
-        assert!(!uri.use_tls());
-
-        let uri = FogViewRouterAdminUri::from_str(
-            "insecure-fog-view-router-admin://node1.test.mobilecoin.com:3225/",
         )
         .unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -60,6 +60,34 @@ impl UriScheme for FogLedgerScheme {
     const DEFAULT_INSECURE_PORT: u16 = 3223;
 }
 
+/// Fog Ledger Router Admin Scheme
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FogLedgerRouterAdminScheme {}
+
+impl UriScheme for FogLedgerRouterAdminScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "fog-ledger-router-admin";
+    const SCHEME_INSECURE: &'static str = "insecure-fog-ledger-router-admin";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3223;
+}
+
+/// Key Image Store (for use with router) Uri Scheme
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct KeyImageStoreScheme {}
+
+impl UriScheme for KeyImageStoreScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "key-image-store";
+    const SCHEME_INSECURE: &'static str = "insecure-key-image-store";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3223;
+}
+
 /// Fog Ingest Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct FogIngestScheme {}
@@ -92,7 +120,11 @@ impl UriScheme for IngestPeerScheme {
 pub type FogIngestUri = Uri<FogIngestScheme>;
 /// Uri used when talking to fog-ledger service, with the right default ports
 /// and scheme.
+/// FogLedgerUri is also used for the router / client-facing part of the
+/// router & store system.
 pub type FogLedgerUri = Uri<FogLedgerScheme>;
+/// Uri for a Fog key image store, to be queried by a Key Image Router.
+pub type KeyImageStoreUri = Uri<KeyImageStoreScheme>;
 /// Uri used when talking to fog view router service.
 pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
 /// Uri used when talking to fog view store service.
@@ -161,24 +193,25 @@ mod tests {
         );
         assert!(!uri.use_tls());
 
-        let uri = FogViewRouterUri::from_str(
-            "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
+        let uri = FogLedgerRouterAdminUri::from_str(
+            "insecure-fog-ledger-router-admin://node1.test.mobilecoin.com:3223/",
         )
         .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
         assert!(!uri.use_tls());
 
-        let uri =
-            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
-                .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        let uri = KeyImageStoreUri::from_str(
+            "insecure-key-image-store://node1.test.mobilecoin.com:3223/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
         assert!(!uri.use_tls());
     }
@@ -269,6 +302,38 @@ mod tests {
         assert_eq!(
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri = FogViewRouterUri::from_str(
+            "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri = FogViewRouterAdminUri::from_str(
+            "insecure-fog-view-router-admin://node1.test.mobilecoin.com:3225/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri =
+            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
+                .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
         assert!(!uri.use_tls());
     }


### PR DESCRIPTION
Pull in protobuf object conversion functions for Fog Ledger Router

### Motivation

As part of the Fog Ledger Router project, we need functions to convert from protobuf objects to various Rust objects. This pulls in the changes made to conversions.rs for upstreaming.

### Future Work

The next PR in this series will be the stubs of the APIs added to the Fog Ledger enclave to support the Fog Ledger Router.
