### PR TITLE
master (CI/CD) feat: CD don't use Github Environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,13 +177,17 @@ jobs:
             grep -v -e mc-fog -e mc-consensus | \
             awk "{ print \"-p \" \$1 }" | \
             sort > /tmp/test-packages
-          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+
+          split -n "l/$RUNNER_INDEX/$NUM_RUNNERS" /tmp/test-packages | \
             tee /tmp/mc-test-packages
+
           # Hack: mc-util-sample-ledger needs mc-util-keyfile bins.
           # TODO: Replace with artifact deps when that does not require
           # additional cargo flags.
-          grep -q generate-sample-ledger /tmp/mc-test-packages && \
-            echo '-p mc-util-keyfile' >> /tmp/mc-test-packages || true
+          if grep -q generate-sample-ledger /tmp/mc-test-packages
+          then
+            echo '-p mc-util-keyfile' >> /tmp/mc-test-packages
+          fi
       - name: Run tests
         uses: ./.github/actions/run-mc-tests
         with:
@@ -215,7 +219,7 @@ jobs:
           cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name' | \
             awk "/mc-consensus/ { print \"-p \" \$1 }" | \
             sort > /tmp/test-packages
-          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+          split -n "l/$RUNNER_INDEX/$NUM_RUNNERS" /tmp/test-packages | \
             tee /tmp/consensus-test-packages
       - name: Run tests
         uses: ./.github/actions/run-mc-tests
@@ -249,14 +253,17 @@ jobs:
             awk "/mc-fog/ { print \"-p \" \$1 }" | \
             grep -v mc-fog-ingest | \
             sort > /tmp/test-packages
-          split -n l/$RUNNER_INDEX/$NUM_RUNNERS /tmp/test-packages | \
+          split -n "l/$RUNNER_INDEX/$NUM_RUNNERS" /tmp/test-packages | \
             tee /tmp/fog-test-packages
+
           # Hack: mc-fog-distribution needs bins from
           # mc-util-{keyfile,generate-sample-ledger}.
           # TODO: Replace with artifact deps when that does not require
           # additional cargo flags.
-          grep -q fog-distribution /tmp/fog-test-packages && \
-            echo '-p mc-util-keyfile -p mc-util-generate-sample-ledger' >> /tmp/fog-test-packages || true
+          if grep -q fog-distribution /tmp/fog-test-packages
+          then
+            echo '-p mc-util-keyfile -p mc-util-generate-sample-ledger' >> /tmp/fog-test-packages
+          fi
       - name: Start postgres
         run: service postgresql start
       - name: Run tests
@@ -394,7 +401,7 @@ jobs:
           "$BIN_DIR/generate-sample-ledger" --txs 100
 
           # Generate sample Fog keys.
-          "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
+          "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root "$FOG_AUTHORITY_ROOT"
 
           service postgresql start
       - name: Run local network
@@ -420,13 +427,13 @@ jobs:
 
           # Give it time to spin up
           for PORT in 3200 3201 3202 3203 3204 4444; do
-            for i in $(seq 0 60); do
+            for _unused in $(seq 0 60); do
               if ss -l | grep -q ":$PORT"; then break; else sleep 1; fi;
             done
           done
 
           # Save some typing
-          export MC_PEER=insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/
+          export MC_PEER="insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/"
 
           # Run fog-distribution client to exercise Fog
           echo "Running fog distro"
@@ -460,7 +467,7 @@ jobs:
           echo "Authorizing minters"
           python3 "$SCRIPT_DIR/../local-network/authorize-minters.py"
 
-          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_AUTH_BLOCK_INDEX)
+          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block="$PRE_AUTH_BLOCK_INDEX")
           echo "Done waiting, PRE_MINT_BLOCK_INDEX=${PRE_MINT_BLOCK_INDEX}"
 
           # Mint 1 million token1's to the first 4 fog accounts
@@ -470,13 +477,13 @@ jobs:
                   "generate-and-submit-mint-tx" \
                   --node insecure-mc://localhost:3200/ \
                   --signing-key "$BIN_DIR/mc-local-network/minting-keys/minter1" \
-                  --recipient $(cat fog_keys/account_keys_${ACCOUNT_NUM}.b58pub) \
+                  --recipient "$(cat "fog_keys/account_keys_${ACCOUNT_NUM}.b58pub")" \
                   --fog-ingest-enclave-css "$BIN_DIR/ingest-enclave.css" \
                   --token-id 1 \
                   --amount 1000000
           done
 
-          "$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_MINT_BLOCK_INDEX
+          "$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block="$PRE_MINT_BLOCK_INDEX"
 
           # Run test-client
           echo "Running test client (tokens 0 and 1)"
@@ -501,7 +508,7 @@ jobs:
             --keyfile "$PWD/keys/account_keys_0.json" &
 
           # Give it time to spin up
-          for i in $(seq 0 60); do
+          for _unused in $(seq 0 60); do
             if ss -l | grep -q ":9090"; then break; else sleep 1; fi;
           done
 
@@ -573,7 +580,7 @@ jobs:
 
           # Run in temp dir to appease check-dirty-git.
           mkdir -p /tmp/fog-local-network
-          cd /tmp/fog-local-network
+          cd /tmp/fog-local-network || exit 1
 
           # Generate sample keys and ledger.
           FOG_AUTHORITY_ROOT=$("$BIN_DIR/mc-crypto-x509-test-vectors" --type=chain --test-name=ok_rsa_head)
@@ -581,7 +588,7 @@ jobs:
           "$BIN_DIR/generate-sample-ledger" --txs 100
 
           # Generate sample Fog keys.
-          "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root $FOG_AUTHORITY_ROOT
+          "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root "$FOG_AUTHORITY_ROOT"
 
           service postgresql start
       - name: Run local network
@@ -600,7 +607,7 @@ jobs:
           export MC_LOG_STDERR=1
 
           # Used by mc-consensus-tool
-          export MC_PEER=insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/
+          export MC_PEER="insecure-mc://localhost:3200/,insecure-mc://localhost:3201/,insecure-mc://localhost:3202/,insecure-mc://localhost:3203/,insecure-mc://localhost:3204/"
 
           cd /tmp/fog-local-network
           export LEDGER_BASE="$PWD/ledger"
@@ -611,7 +618,7 @@ jobs:
 
           # Give it time to spin up
           for PORT in 3200 3201 3202 3203 3204 4444; do
-            for i in $(seq 0 60); do
+            for _unused in $(seq 0 60); do
               if ss -l | grep -q ":$PORT"; then break; else sleep 1; fi;
             done
           done
@@ -623,27 +630,27 @@ jobs:
           python3 "$SCRIPT_DIR/../local-network/authorize-minters.py"
 
           echo "Waiting for quiet after authorizing minters..."
-          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block=$PRE_AUTH_BLOCK_INDEX)
+          PRE_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block="$PRE_AUTH_BLOCK_INDEX")
           echo "Done waiting, PRE_MINT_BLOCK_INDEX=${PRE_MINT_BLOCK_INDEX}"
 
           # Mint 1 million token1's to the first 4 accounts
           echo "Minting"
           for ACCOUNT_NUM in $(seq 0 4); do
               "$BIN_DIR/mc-consensus-mint-client" \
-                  "generate-and-submit-mint-tx" \
+                  generate-and-submit-mint-tx \
                   --node insecure-mc://localhost:3200/ \
                   --signing-key "$BIN_DIR/mc-local-network/minting-keys/minter1" \
-                  --recipient $(cat keys/account_keys_${ACCOUNT_NUM}.b58pub) \
+                  --recipient "$(cat "keys/account_keys_${ACCOUNT_NUM}.b58pub")" \
                   --token-id 1 \
                   --amount 1000000
           done
 
           echo "Waiting for quiet after minting"
-          POST_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block $PRE_MINT_BLOCK_INDEX)
+          POST_MINT_BLOCK_INDEX=$("$BIN_DIR/mc-consensus-tool" wait-for-quiet --beyond-block "$PRE_MINT_BLOCK_INDEX")
           echo "Done waiting, POST_MINT_BLOCK_INDEX = ${POST_MINT_BLOCK_INDEX}"
 
           # Use burn.py to burn some token1
-          cd "$STRATEGIES_DIR"
+          cd "$STRATEGIES_DIR" || exit 1
           ./compile_proto.sh
           python3 burn.py \
                --mobilecoind-host localhost \

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -81,6 +81,7 @@ jobs:
     runs-on: [self-hosted, Linux, large-cd]
     container:
       image: mobilecoin/rust-sgx-base:v0.0.20
+
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem
       MINTING_TRUST_ROOT_PUBLIC_KEY_PEM: ${{ github.workspace }}/.tmp/minting_trust_root.public.pem
@@ -174,7 +175,7 @@ jobs:
         for i in *.signed.so
         do
           css=$(echo -n "${i}" | sed -r 's/(.*)\.signed\.so/\1/')
-          sgx_sign dump -enclave "${i}" -dumpfile /dev/null -cssfile ${css}.css
+          sgx_sign dump -enclave "${i}" -dumpfile /dev/null -cssfile "${css}.css"
         done
 
     - name: Check artifacts

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -25,77 +25,14 @@ on:
         type: string
         required: true
     secrets:
-      FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      DEV_LEDGER_AWS_ACCESS_KEY_ID:
+        description: "Ledger AWS S3 access"
         required: true
-      FOG_REPORT_SIGNING_CA_CERT:
-        description: "(from environment) Fog Report signing CA cert"
+      DEV_LEDGER_AWS_SECRET_ACCESS_KEY:
+        description: "Ledger AWS S3 access"
         required: true
-      FOG_REPORT_SIGNING_CERT:
-        description: "(from environment) Fog Report signing cert pem"
-        required: true
-      FOG_REPORT_SIGNING_CERT_KEY:
-        description: "(from environment) Fog Report signing cert key"
-        required: true
-      IAS_KEY:
-        description: "(from environment) IAS"
-        required: true
-      IAS_SPID:
-        description: "(from environment) IAS"
-        required: true
-      INITIAL_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      IP_INFO_TOKEN:
-        description: "ipinfo.io token for authenticated access"
-        required: true
-      LEDGER_AWS_ACCESS_KEY_ID:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      MINTING_1_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      POSTGRESQL_FOG_RECOVERY_PASSWORD:
+      DEV_POSTGRESQL_FOG_RECOVERY_PASSWORD:
         description: "password for fog_recovery database"
-        required: true
-      RANCHER_CLUSTER:
-        description: "(from environment) Rancher cluster name"
-        required: true
-      RANCHER_URL:
-        description: "(from environment) Rancher server URL"
-        required: true
-      RANCHER_TOKEN:
-        description: "(from environment) Rancher access token"
         required: true
 
 jobs:
@@ -110,15 +47,13 @@ jobs:
     runs-on: [self-hosted, Linux, small]
     needs:
     - reset
-    environment:
-      name: dev
     container:
       image: mobilecoin/gha-s3-pg-helper:v0
     steps:
     - name: Restore Ledger Archive from S3
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: eu-central-1
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
@@ -127,8 +62,8 @@ jobs:
         for i in 1 2 3
         do
           aws s3 cp --only-show-errors --recursive --acl public-read \
-            s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i} \
-            s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com
+            "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
+            "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com"
         done
 
   setup-environment:
@@ -148,28 +83,25 @@ jobs:
     runs-on: [self-hosted, Linux, small]
     needs:
     - setup-environment
-    environment:
-      name: dev
     container:
       image: mobilecoin/gha-s3-pg-helper:v0
     steps:
     - name: restore-db
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: eu-central-1
         BUCKET: mobilecoin.eu.development.chain
         PGDATABASE: postgres
         PGHOST: fog-recovery-postgresql-primary.${{ inputs.namespace }}
-        PGPASSWORD: ${{ secrets.POSTGRESQL_FOG_RECOVERY_PASSWORD }}
+        PGPASSWORD: ${{ secrets.DEV_POSTGRESQL_FOG_RECOVERY_PASSWORD }}
         PGUSER: postgres
         VERSION: ${{ inputs.version }}
       run: |
         # Copy sql from S3
         aws s3 cp --only-show-errors \
-          s3://${BUCKET}/prebuilt/${VERSION}/sql/fog_recovery.sql \
+          "s3://${BUCKET}/prebuilt/${VERSION}/sql/fog_recovery.sql" \
           /tmp/fog_recovery.sql
 
         # Restore to PG
         psql < /tmp/fog_recovery.sql
-

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -39,76 +39,15 @@ on:
         default: '1'
         required: false
     secrets:
-      RANCHER_CLUSTER:
-        description: "(from environment) Rancher cluster name"
+      DEV_RANCHER_CLUSTER:
+        description: "Rancher cluster name"
         required: true
-      RANCHER_URL:
-        description: "(from environment) Rancher server URL"
+      DEV_RANCHER_URL:
+        description: "Rancher server URL"
         required: true
-      RANCHER_TOKEN:
-        description: "(from environment) Rancher access token"
+      DEV_RANCHER_TOKEN:
+        description: "Rancher access token"
         required: true
-      LEDGER_AWS_ACCESS_KEY_ID:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      IAS_KEY:
-        description: "(from environment) IAS"
-        required: true
-      IAS_SPID:
-        description: "(from environment) IAS"
-        required: true
-      FOG_REPORT_SIGNING_CERT:
-        description: "(from environment) Fog Report signing cert pem"
-        required: true
-      FOG_REPORT_SIGNING_CERT_KEY:
-        description: "(from environment) Fog Report signing cert key"
-        required: true
-      FOG_REPORT_SIGNING_CA_CERT:
-        description: "(from environment) Fog Report signing CA cert"
-        required: true
-      IP_INFO_TOKEN:
-        description: "ipinfo.io token for authenticated access"
-        required: true
-      INITIAL_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MINTING_1_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-
 
 env:
   FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
@@ -129,8 +68,6 @@ jobs:
     needs:
     - setup-environment
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     strategy:
       matrix:
         release_name:
@@ -141,8 +78,8 @@ jobs:
     # use values file because intel.com/sgx is hard to escape on the --set option.
     - name: Generate consensus-node values file
       run: |
-        mkdir -p ${VALUES_BASE_PATH}
-        cat <<EOF > ${VALUES_BASE_PATH}/consensus-node-values.yaml
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/consensus-node-values.yaml"
         image:
           org: ${{ inputs.docker_image_org }}
         global:
@@ -168,16 +105,14 @@ jobs:
         chart_wait_timeout: 10m
         release_name: ${{ matrix.release_name }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   mobilecoind-deploy:
     needs:
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     steps:
     - name: Deploy Consensus nodes
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -191,21 +126,19 @@ jobs:
         chart_wait_timeout: 5m
         release_name: mobilecoind
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   fog-services-deploy:
     needs:
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     steps:
     - name: Generate fog-services values file
       run: |
-        mkdir -p ${VALUES_BASE_PATH}
-        cat <<EOF > ${VALUES_BASE_PATH}/fog-services-values.yaml
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/fog-services-values.yaml"
         image:
           org: ${{ inputs.docker_image_org }}
         global:
@@ -238,21 +171,19 @@ jobs:
         chart_values: ${{ env.VALUES_BASE_PATH }}/fog-services-values.yaml
         release_name: fog-services
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   fog-ingest-deploy:
     needs:
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     steps:
     - name: Generate fog-ingest values file
       run: |
-        mkdir -p ${VALUES_BASE_PATH}
-        cat <<EOF > ${VALUES_BASE_PATH}/fog-ingest-values.yaml
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/fog-ingest-values.yaml"
         image:
           org: ${{ inputs.docker_image_org }}
         fogIngest:
@@ -276,9 +207,9 @@ jobs:
         chart_values: ${{ env.VALUES_BASE_PATH }}/fog-ingest-values.yaml
         release_name: fog-ingest-${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
     - name: Run fog-recovery database migrations
       uses: mobilecoinofficial/gha-k8s-toolbox@v1.0.13
@@ -286,9 +217,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           fog-sql-recovery-db-migrations
 
@@ -298,9 +229,9 @@ jobs:
         action: fog-ingest-activate
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
     - name: Delete retired flipside ingest (if exists)
       uses: mobilecoinofficial/gha-k8s-toolbox@v1.0.13
@@ -308,6 +239,6 @@ jobs:
         action: helm-release-delete
         namespace: ${{ inputs.namespace }}
         release_name: fog-ingest-${{ env.FLIPSIDE }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -19,27 +19,25 @@ on:
         type: string
         required: true
     secrets:
-      LEDGER_AWS_ACCESS_KEY_ID:
+      DEV_LEDGER_AWS_ACCESS_KEY_ID:
         description: "Ledger AWS S3 access"
         required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
+      DEV_LEDGER_AWS_SECRET_ACCESS_KEY:
         description: "Ledger AWS S3 access"
         required: true
-      RANCHER_CLUSTER:
+      DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
         required: true
-      RANCHER_URL:
+      DEV_RANCHER_URL:
         description: "Rancher server URL"
         required: true
-      RANCHER_TOKEN:
+      DEV_RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
 
 jobs:
   reset-helm:
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     strategy:
       matrix:
         chart:
@@ -60,25 +58,23 @@ jobs:
         action: helm-release-delete
         namespace: ${{ inputs.namespace }}
         release_name: ${{ matrix.chart }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   reset-k8s:
     runs-on: [self-hosted, Linux, small]
     needs:
     - reset-helm
-    environment:
-      name: dev
     steps:
     - name: Delete PersistentVolumeClaims
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: pvcs-delete
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
     - name: Delete namespace
       if: inputs.delete_namespace
@@ -86,26 +82,24 @@ jobs:
       with:
         action: namespace-delete
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   reset-s3:
-    environment:
-      name: dev
     runs-on: [self-hosted, Linux, small]
     container:
       image: mobilecoin/gha-s3-pg-helper:v0
     steps:
     - name: Clear out s3 bucket objects
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: eu-central-1
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
       run: |
         for i in 1 2 3
         do
-          aws s3 rm --only-show-errors --recursive s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com
+          aws s3 rm --only-show-errors --recursive "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com"
         done

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -11,11 +11,6 @@ on:
         description: "block_version"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -25,95 +20,98 @@ on:
         description: "Target Namespace"
         type: string
         required: true
+      tokens_json_version:
+        description: "The version of the tokens.json file we will generate"
+        type: string
+        default: '1'
+        required: false
       version:
         description: "Chart Version"
         type: string
         required: true
     secrets:
-      FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      DEV_FOG_REPORT_SIGNING_CA_CERT:
+        description: "Fog Report signing CA cert"
         required: true
-      FOG_REPORT_SIGNING_CA_CERT:
-        description: "(from environment) Fog Report signing CA cert"
+      DEV_FOG_REPORT_SIGNING_CERT:
+        description: "Fog Report signing cert pem"
         required: true
-      FOG_REPORT_SIGNING_CERT:
-        description: "(from environment) Fog Report signing cert pem"
+      DEV_FOG_REPORT_SIGNING_CERT_KEY:
+        description: "Fog Report signing cert key"
         required: true
-      FOG_REPORT_SIGNING_CERT_KEY:
-        description: "(from environment) Fog Report signing cert key"
+      DEV_IAS_KEY:
+        description: "IAS"
         required: true
-      IAS_KEY:
-        description: "(from environment) IAS"
+      DEV_IAS_SPID:
+        description: "IAS"
         required: true
-      IAS_SPID:
-        description: "(from environment) IAS"
+      DEV_KEYS_SEED_FOG:
+        description: "static wallet seed"
         required: true
-      INITIAL_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      DEV_KEYS_SEED_INITIAL:
+        description: "static wallet seed"
+        required: true
+      DEV_KEYS_SEED_MNEMONIC:
+        description: "static wallet seed"
+        required: true
+      DEV_KEYS_SEED_MNEMONIC_FOG:
+        description: "static wallet seed"
+        required: true
+      DEV_LEDGER_AWS_ACCESS_KEY_ID:
+        description: "Ledger AWS S3 access"
+        required: true
+      DEV_LEDGER_AWS_SECRET_ACCESS_KEY:
+        description: "Ledger AWS S3 access"
+        required: true
+      DEV_MINTING_1_GOVERNOR_1_PRIVATE:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_1_GOVERNOR_1_PUBLIC:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_1_SIGNER_1_PRIVATE:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_1_SIGNER_1_PUBLIC:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_8192_GOVERNOR_1_PRIVATE:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_8192_GOVERNOR_1_PUBLIC:
+        description: "minting governor key"
+        required: true
+      DEV_MINTING_8192_SIGNER_1_PRIVATE:
+        description: "minting signer key"
+        required: true
+      DEV_MINTING_8192_SIGNER_1_PUBLIC:
+        description: "minting signer key"
+        required: true
+      DEV_POSTGRESQL_FOG_RECOVERY_PASSWORD:
+        description: "password for fog_recovery database"
+        required: true
+      DEV_RANCHER_CLUSTER:
+        description: "Rancher cluster name"
+        required: true
+      DEV_RANCHER_URL:
+        description: "Rancher server URL"
+        required: true
+      DEV_RANCHER_TOKEN:
+        description: "Rancher access token"
+        required: true
+      DEV_TOKENS_CONFIG_V1_JSON:
+        description: "signed tokens config json"
+        required: true
+      DEV_TOKENS_CONFIG_V2_JSON:
+        description: "signed tokens config json"
         required: true
       IP_INFO_TOKEN:
         description: "ipinfo.io token for authenticated access"
-        required: true
-      LEDGER_AWS_ACCESS_KEY_ID:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      MINTING_1_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PRIVATE:
-        description: "(from environment) minting signer key"
-        required: true
-      MINTING_8192_SIGNER_1_PUBLIC:
-        description: "(from environment) minting signer key"
-        required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      POSTGRESQL_FOG_RECOVERY_PASSWORD:
-        description: "password for fog_recovery database"
-        required: true
-      RANCHER_CLUSTER:
-        description: "(from environment) Rancher cluster name"
-        required: true
-      RANCHER_URL:
-        description: "(from environment) Rancher server URL"
-        required: true
-      RANCHER_TOKEN:
-        description: "(from environment) Rancher access token"
-        required: true
-      TOKENS_CONFIG_JSON:
-        description: "(from environment) signed tokens config json"
-        required: true
-      V2_TOKENS_CONFIG_JSON:
-        description: "(from environment) signed tokens config json"
         required: true
 
 jobs:
   setup-environment:
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     env:
       BASE_PATH: .tmp
       MINTING_BASE_PATH: .tmp/minting
@@ -128,9 +126,9 @@ jobs:
       with:
         action: namespace-create
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
     - name: Write seeds and fog-report values
       run: |
@@ -138,11 +136,11 @@ jobs:
         mkdir -p "${SEEDS_BASE_PATH}"
 
         # Write values to be used as k8s secret values.
-        echo -n "${{ secrets.INITIAL_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/INITIAL_KEYS_SEED"
-        echo -n "${{ secrets.FOG_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/FOG_KEYS_SEED"
-        echo -n "${{ secrets.MNEMONIC_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/MNEMONIC_KEYS_SEED"
-        echo -n "${{ secrets.MNEMONIC_FOG_KEYS_SEED }}" > "${SEEDS_BASE_PATH}/MNEMONIC_FOG_KEYS_SEED"
-        echo -n "${{ secrets.FOG_REPORT_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT"
+        echo -n "${{ secrets.DEV_KEYS_SEED_INITIAL }}" > "${SEEDS_BASE_PATH}/INITIAL_KEYS_SEED"
+        echo -n "${{ secrets.DEV_KEYS_SEED_FOG }}" > "${SEEDS_BASE_PATH}/FOG_KEYS_SEED"
+        echo -n "${{ secrets.DEV_KEYS_SEED_MNEMONIC }}" > "${SEEDS_BASE_PATH}/MNEMONIC_KEYS_SEED"
+        echo -n "${{ secrets.DEV_KEYS_SEED_MNEMONIC_FOG }}" > "${SEEDS_BASE_PATH}/MNEMONIC_FOG_KEYS_SEED"
+        echo -n "${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT"
         echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT_PATH"
         echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_URL"
 
@@ -151,9 +149,9 @@ jobs:
       with:
         action: secrets-create-from-file
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         object_name: sample-keys-seeds
         src: ${{ env.SEEDS_BASE_PATH }}
 
@@ -163,29 +161,29 @@ jobs:
         mkdir -p "${MINTING_BASE_PATH}"
 
         # Write values to be used as k8s secret values.
-        echo -n "${{ secrets.MINTING_1_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_governor_1.private.pem"
-        echo -n "${{ secrets.MINTING_1_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_governor_1.public.pem"
-        echo -n "${{ secrets.MINTING_1_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_signer_1.private.pem"
-        echo -n "${{ secrets.MINTING_1_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_signer_1.public.pem"
-        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.private.pem"
-        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.public.pem"
-        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.private.pem"
-        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_1_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_governor_1.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_1_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_governor_1.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_1_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_1_signer_1.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_1_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_1_signer_1.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_governor_1.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token_8192_signer_1.public.pem"
 
         # values for v3.0.0-dev release
-        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/minter8192_governor.private.pem"
-        echo -n "${{ secrets.MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/minter8192_governor.public.pem"
-        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token8192_signer.private.pem"
-        echo -n "${{ secrets.MINTING_8192_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token8192_signer.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_GOVERNOR_1_PRIVATE }}" > "${MINTING_BASE_PATH}/minter8192_governor.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_GOVERNOR_1_PUBLIC }}" > "${MINTING_BASE_PATH}/minter8192_governor.public.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_SIGNER_1_PRIVATE }}" > "${MINTING_BASE_PATH}/token8192_signer.private.pem"
+        echo -n "${{ secrets.DEV_MINTING_8192_SIGNER_1_PUBLIC }}" > "${MINTING_BASE_PATH}/token8192_signer.public.pem"
 
     - name: Create minting key secrets
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: secrets-create-from-file
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         object_name: consensus-minting-secrets
         src: ${{ env.MINTING_BASE_PATH }}
 
@@ -195,10 +193,10 @@ jobs:
         mkdir -p "${BASE_PATH}"
         case "${{ inputs.tokens_json_version }}" in
           1)
-            echo '${{ secrets.TOKENS_CONFIG_JSON }}' > "${BASE_PATH}/tokens.signed.json"
+            echo '${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}' > "${BASE_PATH}/tokens.signed.json"
             ;;
           2)
-            echo '${{ secrets.V2_TOKENS_CONFIG_JSON }}' > "${BASE_PATH}/tokens.signed.json"
+            echo '${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}' > "${BASE_PATH}/tokens.signed.json"
             ;;
           *)
             echo "Unknown tokens.json version ${{ inputs.tokens_json_version }}"
@@ -208,16 +206,16 @@ jobs:
 
     - name: Generate environment values file
       env:
-        IAS_KEY: ${{ secrets.IAS_KEY }}
-        IAS_SPID: ${{ secrets.IAS_SPID }}
-        LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.LEDGER_AWS_ACCESS_KEY_ID }}
-        LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.LEDGER_AWS_SECRET_ACCESS_KEY }}
-        FOG_REPORT_SIGNING_CERT: ${{ secrets.FOG_REPORT_SIGNING_CERT }}
-        FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.FOG_REPORT_SIGNING_CERT_KEY }}
+        IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+        IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+        LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
+        LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
+        FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
+        FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
         IP_INFO_TOKEN: ${{ secrets.IP_INFO_TOKEN }}
       run: |
-        mkdir -p ${VALUES_BASE_PATH}
-        .internal-ci/util/generate_dev_values.sh > ${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml
+        mkdir -p "${VALUES_BASE_PATH}"
+        .internal-ci/util/generate_dev_values.sh > "${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml"
 
     - name: Deploy environment setup
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -229,12 +227,12 @@ jobs:
         chart_values: ${{ env.VALUES_BASE_PATH }}/mc-core-dev-env-values.yaml
         chart_set: |
           --set=global.node.nodeConfig.blockVersion=${{ inputs.block_version }}
-          --set=fogIngestConfig.fogRecoveryDatabase.password=${{ secrets.POSTGRESQL_FOG_RECOVERY_PASSWORD }}
+          --set=fogIngestConfig.fogRecoveryDatabase.password=${{ secrets.DEV_POSTGRESQL_FOG_RECOVERY_PASSWORD }}
         release_name: mc-core-dev-env-setup
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
     - name: Deploy PostgreSQL instance
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
@@ -250,6 +248,6 @@ jobs:
         chart_wait_timeout: 5m
         release_name: fog-recovery-postgresql
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -77,21 +77,19 @@ on:
         required: false
         default: false
     secrets:
-      RANCHER_CLUSTER:
+      DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
         required: true
-      RANCHER_URL:
+      DEV_RANCHER_URL:
         description: "Rancher server URL"
         required: true
-      RANCHER_TOKEN:
+      DEV_RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
 
 jobs:
   cd-integration-tests:
     runs-on: [self-hosted, Linux, small]
-    environment:
-      name: dev
     env:
       SRC_KEYS_DIR: /tmp/sample_data/keys
       SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
@@ -111,9 +109,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           rm -rf /tmp/sample_data
 
@@ -124,9 +122,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           INITIALIZE_LEDGER="true" \
           FOG_REPORT_URL="fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" \
@@ -139,9 +137,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/fog-distribution-test.sh
 
@@ -152,9 +150,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           test_client \
             --key-dir /tmp/sample_data/fog_keys \
@@ -175,9 +173,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/mobilecoind-integration-test.sh
 
@@ -188,9 +186,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_KEYS_DIR }} \
@@ -205,9 +203,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_FOG_KEYS_DIR }} \
@@ -222,9 +220,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           JSON_FLAG=""
           if [ "${{ inputs.generate_and_submit_mint_config_tx_uses_json }}" == "true" ]; then
@@ -241,9 +239,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/minting-tx-test.sh \
             --key-dir ${{ env.V2_DST_KEYS_DIR }} \
@@ -256,9 +254,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/mobilecoind-json-integration-test.sh \
             --key-dir ${{ env.V2_DST_KEYS_DIR }}
@@ -270,9 +268,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/drain_accounts.sh \
             --src ${{ env.V2_DST_KEYS_DIR }} \
@@ -287,9 +285,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V2_DST_FOG_KEYS_DIR }} \
@@ -302,9 +300,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V2_DST_FOG_KEYS_DIR }} \
@@ -317,9 +315,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_KEYS_DIR }} \
@@ -334,9 +332,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_FOG_KEYS_DIR }} \
@@ -351,9 +349,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           JSON_FLAG=""
           if [ "${{ inputs.generate_and_submit_mint_config_tx_uses_json }}" == "true" ]; then
@@ -370,9 +368,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/minting-tx-test.sh \
             --key-dir ${{ env.V3_DST_KEYS_DIR }} \
@@ -385,9 +383,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/mobilecoind-json-integration-test.sh \
             --key-dir ${{ env.V3_DST_KEYS_DIR }}
@@ -399,9 +397,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /util/drain_accounts.sh \
             --src ${{ env.V3_DST_KEYS_DIR }} \
@@ -416,9 +414,9 @@ jobs:
         action: toolbox-exec
         ingest_color: ${{ inputs.ingest_color }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V3_DST_FOG_KEYS_DIR }} \

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -11,11 +11,6 @@ on:
         description: "block_version"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -25,82 +20,24 @@ on:
         description: "Target Namespace"
         type: string
         required: true
+      tokens_json_version:
+        description: "The version of the tokens.json file we will generate"
+        type: string
+        default: '1'
+        required: false
       version:
         description: "release version"
         type: string
         required: true
     secrets:
-      FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
+      DEV_RANCHER_CLUSTER:
+        description: "Rancher cluster name"
         required: true
-      FOG_REPORT_SIGNING_CA_CERT:
-        description: "(from environment) Fog Report signing CA cert"
+      DEV_RANCHER_URL:
+        description: "Rancher server URL"
         required: true
-      FOG_REPORT_SIGNING_CERT:
-        description: "(from environment) Fog Report signing cert pem"
-        required: true
-      FOG_REPORT_SIGNING_CERT_KEY:
-        description: "(from environment) Fog Report signing cert key"
-        required: true
-      IAS_KEY:
-        description: "(from environment) IAS"
-        required: true
-      IAS_SPID:
-        description: "(from environment) IAS"
-        required: true
-      INITIAL_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      IP_INFO_TOKEN:
-        description: "ipinfo.io token for authenticated access"
-        required: true
-      LEDGER_AWS_ACCESS_KEY_ID:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      LEDGER_AWS_SECRET_ACCESS_KEY:
-        description: "(from environment) Ledger AWS S3 access"
-        required: true
-      MINTING_1_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_1_SIGNER_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PRIVATE:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_GOVERNOR_1_PUBLIC:
-        description: "(from environment) minting governor key"
-        required: true
-      MINTING_8192_SIGNER_1_PRIVATE:
-        description: "(from environment) minting signer key"
-        required: true
-      MINTING_8192_SIGNER_1_PUBLIC:
-        description: "(from environment) minting signer key"
-        required: true
-      MNEMONIC_FOG_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      MNEMONIC_KEYS_SEED:
-        description: "(from environment) static wallet seed"
-        required: true
-      POSTGRESQL_FOG_RECOVERY_PASSWORD:
-        description: "password for fog_recovery database"
-        required: true
-      RANCHER_CLUSTER:
-        description: "(from environment) Rancher cluster name"
-        required: true
-      RANCHER_URL:
-        description: "(from environment) Rancher server URL"
-        required: true
-      RANCHER_TOKEN:
-        description: "(from environment) Rancher access token"
+      DEV_RANCHER_TOKEN:
+        description: "Rancher access token"
         required: true
 
 jobs:
@@ -118,8 +55,6 @@ jobs:
     runs-on: [self-hosted, Linux, small]
     needs:
     - setup-environment
-    environment:
-      name: dev
     strategy:
       matrix:
         object_name:
@@ -133,6 +68,6 @@ jobs:
         action: pod-restart
         object_name: ${{ matrix.object_name }}
         namespace: ${{ inputs.namespace }}
-        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
-        rancher_url: ${{ secrets.RANCHER_URL }}
-        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}


### PR DESCRIPTION
### Motivation

Undo using GitHub Environments feature.  It's nice for organizing the secrets in a clean way, but it just makes a mess of the PR conversation history because of its integration with Deployments. Every action that references an environment creates its own "Deployment" in the pr log.

- fix: `actionlint` errors and warnings from `shellcheck`
  - `actionlint` is checking shell code with `shellcheck` in GHA workflows.  This is good, but required some cleanup.
- fix: remove references to `dev` Environment
- fix: check and cleanup `secrets` names
  - Just update and remap some var names for better organization 


