### PR TITLE
Ledger enclave support for router and store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3901,7 +3901,6 @@ dependencies = [
  "mc-oblivious-ram",
  "mc-oblivious-traits",
  "mc-sgx-compat",
- "mc-sgx-debug",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",
@@ -5178,10 +5177,6 @@ dependencies = [
  "hex_fmt",
  "mc-sgx-css",
 ]
-
-[[package]]
-name = "mc-sgx-debug"
-version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3890,6 +3890,7 @@ dependencies = [
  "aligned-cmov",
  "mc-attest-core",
  "mc-attest-enclave-api",
+ "mc-blockchain-types",
  "mc-common",
  "mc-crypto-ake-enclave",
  "mc-crypto-keys",
@@ -3900,6 +3901,7 @@ dependencies = [
  "mc-oblivious-ram",
  "mc-oblivious-traits",
  "mc-sgx-compat",
+ "mc-sgx-debug",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",
@@ -5176,6 +5178,10 @@ dependencies = [
  "hex_fmt",
  "mc-sgx-css",
 ]
+
+[[package]]
+name = "mc-sgx-debug"
+version = "2.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::{
     error::{AddRecordsError, Error},
     messages::{EnclaveCall, KeyImageData},
 };
-use alloc::{vec::Vec, collections::BTreeMap};
+use alloc::{collections::BTreeMap, vec::Vec};
 use core::result::Result as StdResult;
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
@@ -109,10 +109,12 @@ pub trait LedgerEnclave: ReportableEnclave {
     /// Store.
     fn ledger_store_init(&self, ledger_store_id: ResponderId) -> Result<NonceAuthRequest>;
 
-    /// As a "Store" in a Router/Store system, 
-    /// accept a connection from a Router. 
-    fn frontend_accept(&self, auth_request: NonceAuthRequest) 
-        -> Result<(NonceAuthResponse, NonceSession)>;
+    /// As a "Store" in a Router/Store system,
+    /// accept a connection from a Router.
+    fn frontend_accept(
+        &self,
+        auth_request: NonceAuthRequest,
+    ) -> Result<(NonceAuthResponse, NonceSession)>;
 
     /// Complete the connection to a Fog Ledger Store that has accepted our
     /// NonceAuthRequest. This is meant to be called after the enclave has

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -126,8 +126,8 @@ pub trait LedgerEnclave: ReportableEnclave {
     ) -> Result<()>;
 
     /// Check to see if a particular key image is present on this key image
-    /// store. Used by the store server in a router/store system to respond 
-    /// to requests from a ledger router. 
+    /// store. Used by the store server in a router/store system to respond
+    /// to requests from a ledger router.
     fn check_key_image_store(
         &self,
         msg: EnclaveMessage<NonceSession>,

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -35,7 +35,7 @@ pub type Result<T> = StdResult<T, Error>;
 /// gather data that will be encrypted for the client in `outputs_for_client`.
 ///
 /// Key image check is now in ORAM, replacing untrusted
-/// which was doing the check directly.Sha
+/// which was doing the check directly.
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct OutputContext {
     /// The global txout indices being requested
@@ -109,8 +109,8 @@ pub trait LedgerEnclave: ReportableEnclave {
     /// Store.
     fn ledger_store_init(&self, ledger_store_id: ResponderId) -> Result<NonceAuthRequest>;
 
-    /// As a "Store" in a Router/Store system,
-    /// accept a connection from a Router.
+    /// Called by a ledger store server to accept an incoming connection from a
+    /// Fog Ledger Router instance acting as a frontend to the Ledger Store.
     fn frontend_accept(
         &self,
         auth_request: NonceAuthRequest,

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -125,8 +125,9 @@ pub trait LedgerEnclave: ReportableEnclave {
         ledger_store_auth_response: NonceAuthResponse,
     ) -> Result<()>;
 
-    /// Extract context data to be handed back to untrusted so that it could
-    /// collect the information required.
+    /// Check to see if a particular key image is present on this key image
+    /// store. Used by the store server in a router/store system to respond 
+    /// to requests from a ledger router. 
     fn check_key_image_store(
         &self,
         msg: EnclaveMessage<NonceSession>,

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -96,7 +96,7 @@ pub trait LedgerEnclave: ReportableEnclave {
     fn check_key_images(
         &self,
         msg: EnclaveMessage<ClientSession>,
-        untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        response: UntrustedKeyImageQueryResponse,
     ) -> Result<Vec<u8>>;
 
     /// Add a key image data to the oram Using thrm -rf targete key image
@@ -131,7 +131,7 @@ pub trait LedgerEnclave: ReportableEnclave {
     fn check_key_image_store(
         &self,
         msg: EnclaveMessage<NonceSession>,
-        untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        response: UntrustedKeyImageQueryResponse,
     ) -> Result<EnclaveMessage<NonceSession>>;
 
     /// Decrypts a client query message and converts it into a

--- a/fog/ledger/enclave/api/src/messages.rs
+++ b/fog/ledger/enclave/api/src/messages.rs
@@ -2,12 +2,12 @@
 
 //! The message types used by the ledger_enclave_api.
 use crate::UntrustedKeyImageQueryResponse;
-use alloc::{vec::Vec, collections::BTreeMap};
+use alloc::{collections::BTreeMap, vec::Vec};
 use mc_attest_core::{Quote, Report, TargetInfo, VerificationReport};
 
 use mc_attest_enclave_api::{
-    ClientAuthRequest, ClientSession, EnclaveMessage, NonceAuthResponse, NonceSession,
-    SealedClientMessage, NonceAuthRequest,
+    ClientAuthRequest, ClientSession, EnclaveMessage, NonceAuthRequest, NonceAuthResponse,
+    NonceSession, SealedClientMessage,
 };
 
 use mc_common::ResponderId;

--- a/fog/ledger/enclave/api/src/messages.rs
+++ b/fog/ledger/enclave/api/src/messages.rs
@@ -2,9 +2,14 @@
 
 //! The message types used by the ledger_enclave_api.
 use crate::UntrustedKeyImageQueryResponse;
-use alloc::vec::Vec;
+use alloc::{vec::Vec, collections::BTreeMap};
 use mc_attest_core::{Quote, Report, TargetInfo, VerificationReport};
-use mc_attest_enclave_api::{ClientAuthRequest, ClientSession, EnclaveMessage};
+
+use mc_attest_enclave_api::{
+    ClientAuthRequest, ClientSession, EnclaveMessage, NonceAuthResponse, NonceSession,
+    SealedClientMessage, NonceAuthRequest,
+};
+
 use mc_common::ResponderId;
 use mc_fog_types::ledger::GetOutputsResponse;
 use mc_transaction_core::ring_signature::KeyImage;
@@ -34,7 +39,7 @@ pub struct KeyImageData {
 
 /// An enumeration of API calls and their arguments for use across serialization
 /// boundaries.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum EnclaveCall {
     /// The [LedgerEnclave::enclave_init()] method.
     EnclaveInit(ResponderId, u64),
@@ -101,4 +106,50 @@ pub enum EnclaveCall {
     ///
     ///  Add key image data to the ORAM.
     AddKeyImageData(Vec<KeyImageData>),
+
+    /// The [LedgerEnclave::ledger_store_init()] method.
+    ///
+    /// Begin a connection to a Fog Ledger Store. The enclave calling this
+    /// method, most likely a router, will act as a client to the Fog Ledger
+    /// Store.
+    LedgerStoreInit(ResponderId),
+
+    /// The [LedgerEnclave::ledger_store_connect()] method.
+    ///
+    /// Complete the connection to a Fog Ledger Store that has accepted our
+    /// ClientAuthRequest. This is meant to be called after the enclave has
+    /// initialized and discovers a new Fog Ledger Store.
+    LedgerStoreConnect(ResponderId, NonceAuthResponse),
+
+    /// The [LedgerEnclave::decrypt_and_seal_query()] method.
+    ///
+    /// Takes a client query message and returns a SealedClientMessage
+    /// sealed for the current enclave.
+    DecryptAndSealQuery(EnclaveMessage<ClientSession>),
+
+    /// The [LedgerEnclave::create_multi_key_image_store_query()] method.
+    ///
+    /// Transforms a client query request into a list of query request data.
+    ///
+    /// The returned list is meant to be used to construct the
+    /// MultiKeyImageStoreRequest, which is sent to each shard.
+    CreateMultiKeyImageStoreQueryData(SealedClientMessage),
+
+    /// Collates shard query responses into a single query response for the
+    /// client.
+    CollateQueryResponses(
+        SealedClientMessage,
+        BTreeMap<ResponderId, EnclaveMessage<NonceSession>>,
+    ),
+
+    /// The [LedgerEnclave::client_check_key_image_store()] method.
+    /// Store-side Ledger/Router system equivalent to
+    /// [EnclaveCall::CheckKeyImages] Start a new key image check from a
+    /// client.
+    CheckKeyImageStore(EnclaveMessage<NonceSession>, UntrustedKeyImageQueryResponse),
+
+    /// The [LedgerEnclave::FrontendAccept()] method.
+    /// Called by a Store accepting a Router's incoming
+    /// connection.
+    FrontendAccept(NonceAuthRequest),
 }

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -12,11 +12,13 @@ license = "GPL-3.0"
 # mobilecoin
 mc-attest-core = { path = "../../../../attest/core", default-features = false }
 mc-attest-enclave-api = { path = "../../../../attest/enclave-api", default-features = false }
+mc-blockchain-types = { path = "../../../../blockchain/types" }
 mc-common = { path = "../../../../common", default-features = false }
 mc-crypto-ake-enclave = { path = "../../../../crypto/ake/enclave", default-features = false }
 mc-crypto-keys = { path = "../../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../../crypto/rand" }
 mc-sgx-compat = { path = "../../../../sgx/compat", default-features = false }
+mc-sgx-debug = { path = "../../../../sgx/debug" }
 mc-sgx-report-cache-api = { path = "../../../../sgx/report-cache/api" }
 mc-transaction-core = { path = "../../../../transaction/core" }
 mc-util-serial = { path = "../../../../util/serial" }
@@ -31,3 +33,4 @@ mc-oblivious-traits = "2.2"
 # fog
 mc-fog-ledger-enclave-api = { path = "../api", default-features = false }
 mc-fog-types = { path = "../../../types" }
+

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -18,7 +18,6 @@ mc-crypto-ake-enclave = { path = "../../../../crypto/ake/enclave", default-featu
 mc-crypto-keys = { path = "../../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../../crypto/rand" }
 mc-sgx-compat = { path = "../../../../sgx/compat", default-features = false }
-mc-sgx-debug = { path = "../../../../sgx/debug" }
 mc-sgx-report-cache-api = { path = "../../../../sgx/report-cache/api" }
 mc-transaction-core = { path = "../../../../transaction/core" }
 mc-util-serial = { path = "../../../../util/serial" }

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -201,7 +201,6 @@ where
         Ok(self.ake.backend_init(ledger_store_id)?)
     }
 
-    #[allow(unused_variables)]
     fn ledger_store_connect(
         &self,
         ledger_store_id: ResponderId,
@@ -238,7 +237,6 @@ where
         }
         let channel_id = sealed_query.channel_id.clone();
         let client_query_plaintext = self.ake.unseal(&sealed_query)?;
-        // TODO this will (possibly?) be used when we implement obliviousness
         let _client_query_request: CheckKeyImagesRequest =
             mc_util_serial::decode(&client_query_plaintext).map_err(|e| {
                 log::error!(self.logger, "Could not decode client query request: {}", e);
@@ -326,8 +324,7 @@ where
             latest_block_version: untrusted_key_image_query_response.latest_block_version,
             max_block_version: untrusted_key_image_query_response.max_block_version,
         };
-
-        // Do the scope lock of keyimagetore
+        
         {
             let mut lk = self.key_image_store.lock()?;
             let store = lk.as_mut().ok_or(Error::EnclaveNotInitialized)?;

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -13,10 +13,15 @@
 extern crate alloc;
 
 mod key_image_store;
-use alloc::vec::Vec;
+use alloc::{vec::Vec, collections::BTreeMap};
+use core::cmp::max;
 use key_image_store::{KeyImageStore, StorageDataSize, StorageMetaSize};
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
-use mc_attest_enclave_api::{ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage};
+use mc_attest_enclave_api::{
+    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
+    NonceAuthResponse, NonceSession, SealedClientMessage,
+};
+use mc_blockchain_types::MAX_BLOCK_VERSION;
 use mc_common::{
     logger::{log, Logger},
     ResponderId,
@@ -190,6 +195,163 @@ where
         }
 
         Ok(())
+    }
+
+    fn ledger_store_init(&self, ledger_store_id: ResponderId) -> Result<NonceAuthRequest> {
+        Ok(self.ake.backend_init(ledger_store_id)?)
+    }
+
+    #[allow(unused_variables)]
+    fn ledger_store_connect(
+        &self,
+        ledger_store_id: ResponderId,
+        ledger_store_auth_response: NonceAuthResponse,
+    ) -> Result<()> {
+        Ok(self
+            .ake
+            .backend_connect(ledger_store_id, ledger_store_auth_response)?)
+    }
+
+    fn decrypt_and_seal_query(
+        &self,
+        client_query: EnclaveMessage<ClientSession>,
+    ) -> Result<SealedClientMessage> {
+        Ok(self.ake.decrypt_client_message_for_enclave(client_query)?)
+    }
+
+    fn create_multi_key_image_store_query_data(
+        &self,
+        sealed_query: SealedClientMessage,
+    ) -> Result<Vec<EnclaveMessage<NonceSession>>> {
+        Ok(self
+            .ake
+            .reencrypt_sealed_message_for_backends(&sealed_query)?)
+    }
+
+    fn collate_shard_query_responses(
+        &self,
+        sealed_query: SealedClientMessage,
+        shard_query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>>,
+    ) -> Result<EnclaveMessage<ClientSession>> {
+        if shard_query_responses.is_empty() {
+            return Ok(EnclaveMessage::default());
+        }
+        let channel_id = sealed_query.channel_id.clone();
+        let client_query_plaintext = self.ake.unseal(&sealed_query)?;
+        // TODO this will (possibly?) be used when we implement obliviousness
+        let _client_query_request: CheckKeyImagesRequest =
+            mc_util_serial::decode(&client_query_plaintext).map_err(|e| {
+                log::error!(self.logger, "Could not decode client query request: {}", e);
+                Error::ProstDecode
+            })?;
+
+        let shard_query_responses = shard_query_responses
+            .into_iter()
+            .map(|(responder_id, query_response)| {
+                let plaintext_bytes = self.ake.backend_decrypt(&responder_id, &query_response)?;
+                let query_response: CheckKeyImagesResponse =
+                    mc_util_serial::decode(&plaintext_bytes)?;
+
+                Ok(query_response)
+            })
+            .collect::<Result<Vec<CheckKeyImagesResponse>>>()?;
+
+        // NOTES:
+        // num_blocks = min(responses.num_blocks)
+        // global_txo_count = min(global_txo_count) TODO CONFIRM
+        // results = cat(responses.results)
+        // latest_block_version = max(responses.latest_block_version)
+        // max_block_version = max(latest_block_version,
+        // mc_transaction_core::MAX_BLOCK_VERSION
+
+        // TODO no unwraps
+        let num_blocks = shard_query_responses
+            .iter()
+            .map(|query_response| query_response.num_blocks)
+            .min()
+            .unwrap();
+        let global_txo_count = shard_query_responses
+            .iter()
+            .map(|query_response| query_response.global_txo_count)
+            .min()
+            .unwrap();
+        let latest_block_version = shard_query_responses
+            .iter()
+            .map(|query_response| query_response.latest_block_version)
+            .max()
+            .unwrap();
+        // TODO I believe this needs to be implemented in an oblivious way to meet the
+        // security requirements. I'm not 100% sure what an oblivious approach
+        // to this looks like, though. In general this kind of thing needs to be
+        // talked about.
+        let results = shard_query_responses
+            .into_iter()
+            .flat_map(|query_response| query_response.results)
+            .collect();
+        let max_block_version = max(latest_block_version, *MAX_BLOCK_VERSION);
+
+        let client_query_response = CheckKeyImagesResponse {
+            num_blocks,
+            global_txo_count,
+            results,
+            latest_block_version,
+            max_block_version,
+        };
+        let response_plaintext_bytes = mc_util_serial::encode(&client_query_response);
+        let response =
+            self.ake
+                .client_encrypt(&channel_id, &sealed_query.aad, &response_plaintext_bytes)?;
+
+        Ok(response)
+    }
+
+    fn check_key_image_store(
+        &self,
+        msg: EnclaveMessage<NonceSession>,
+        untrusted_key_image_query_response: UntrustedKeyImageQueryResponse,
+    ) -> Result<EnclaveMessage<NonceSession>> {
+        let channel_id = msg.channel_id.clone();
+        let user_plaintext = self.ake.frontend_decrypt(msg)?;
+
+        let req: CheckKeyImagesRequest = mc_util_serial::decode(&user_plaintext).map_err(|e| {
+            log::error!(self.logger, "Could not decode user request: {}", e);
+            Error::ProstDecode
+        })?;
+
+        let mut resp = CheckKeyImagesResponse {
+            num_blocks: untrusted_key_image_query_response.highest_processed_block_count,
+            results: Default::default(),
+            global_txo_count: untrusted_key_image_query_response
+                .last_known_block_cumulative_txo_count,
+            latest_block_version: untrusted_key_image_query_response.latest_block_version,
+            max_block_version: untrusted_key_image_query_response.max_block_version,
+        };
+
+        // Do the scope lock of keyimagetore
+        {
+            let mut lk = self.key_image_store.lock()?;
+            let store = lk.as_mut().ok_or(Error::EnclaveNotInitialized)?;
+
+            resp.results = req
+                .queries
+                .iter() //  get the key images used to find the key image data using the oram
+                .map(|key| store.find_record(&key.key_image))
+                .collect();
+        }
+
+        // Encrypt for return to router
+        let response_plaintext_bytes = mc_util_serial::encode(&resp);
+        let response = self
+            .ake
+            .frontend_encrypt(&channel_id, &[], &response_plaintext_bytes)?;
+
+        Ok(response)
+    }
+
+    fn frontend_accept(&self, auth_request: NonceAuthRequest) 
+        -> Result<(NonceAuthResponse, NonceSession)> {
+        self.ake.frontend_accept(auth_request)
+            .map_err(|e| e.into())
     }
 }
 

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -324,7 +324,7 @@ where
             latest_block_version: untrusted_key_image_query_response.latest_block_version,
             max_block_version: untrusted_key_image_query_response.max_block_version,
         };
-        
+
         {
             let mut lk = self.key_image_store.lock()?;
             let store = lk.as_mut().ok_or(Error::EnclaveNotInitialized)?;

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -13,7 +13,7 @@
 extern crate alloc;
 
 mod key_image_store;
-use alloc::{vec::Vec, collections::BTreeMap};
+use alloc::{collections::BTreeMap, vec::Vec};
 use core::cmp::max;
 use key_image_store::{KeyImageStore, StorageDataSize, StorageMetaSize};
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
@@ -348,10 +348,11 @@ where
         Ok(response)
     }
 
-    fn frontend_accept(&self, auth_request: NonceAuthRequest) 
-        -> Result<(NonceAuthResponse, NonceSession)> {
-        self.ake.frontend_accept(auth_request)
-            .map_err(|e| e.into())
+    fn frontend_accept(
+        &self,
+        auth_request: NonceAuthRequest,
+    ) -> Result<(NonceAuthResponse, NonceSession)> {
+        self.ake.frontend_accept(auth_request).map_err(|e| e.into())
     }
 }
 

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -28,7 +28,7 @@ use mc_sgx_types::{
     sgx_attributes_t, sgx_enclave_id_t, sgx_launch_token_t, sgx_misc_attribute_t, sgx_status_t,
 };
 use mc_sgx_urts::SgxEnclave;
-use std::{path, result::Result as StdResult, sync::Arc, collections::BTreeMap};
+use std::{collections::BTreeMap, path, result::Result as StdResult, sync::Arc};
 
 /// The default filename of the fog ledger's SGX enclave binary.
 pub const ENCLAVE_FILE: &str = "libledger-enclave.signed.so";
@@ -193,8 +193,7 @@ impl LedgerEnclave for LedgerSgxEnclave {
 
     // Router/store system.
     fn ledger_store_init(&self, ledger_store_id: ResponderId) -> Result<NonceAuthRequest> {
-        let inbuf =
-            mc_util_serial::serialize(&EnclaveCall::LedgerStoreInit(ledger_store_id))?;
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::LedgerStoreInit(ledger_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
@@ -260,11 +259,11 @@ impl LedgerEnclave for LedgerSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn frontend_accept(&self, auth_request: NonceAuthRequest) 
-        -> Result<(NonceAuthResponse, NonceSession)> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::FrontendAccept(
-            auth_request
-        ))?;
+    fn frontend_accept(
+        &self,
+        auth_request: NonceAuthRequest,
+    ) -> Result<(NonceAuthResponse, NonceSession)> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::FrontendAccept(auth_request))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -191,14 +191,12 @@ impl LedgerEnclave for LedgerSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    // Router/store system.
     fn ledger_store_init(&self, ledger_store_id: ResponderId) -> Result<NonceAuthRequest> {
         let inbuf = mc_util_serial::serialize(&EnclaveCall::LedgerStoreInit(ledger_store_id))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    #[allow(unused_variables)]
     fn ledger_store_connect(
         &self,
         ledger_store_id: ResponderId,

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -174,12 +174,9 @@ impl LedgerEnclave for LedgerSgxEnclave {
     fn check_key_images(
         &self,
         msg: EnclaveMessage<ClientSession>,
-        untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        response: UntrustedKeyImageQueryResponse,
     ) -> Result<Vec<u8>> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::CheckKeyImages(
-            msg,
-            untrusted_keyimagequery_response,
-        ))?;
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::CheckKeyImages(msg, response))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
@@ -247,12 +244,9 @@ impl LedgerEnclave for LedgerSgxEnclave {
     fn check_key_image_store(
         &self,
         msg: EnclaveMessage<NonceSession>,
-        untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        response: UntrustedKeyImageQueryResponse,
     ) -> Result<EnclaveMessage<NonceSession>> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::CheckKeyImageStore(
-            msg,
-            untrusted_keyimagequery_response,
-        ))?;
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::CheckKeyImageStore(msg, response))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -850,6 +850,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-blockchain-types"
+version = "2.1.0-pre0"
+dependencies = [
+ "displaydoc",
+ "hex_fmt",
+ "mc-account-keys",
+ "mc-attest-verifier-types",
+ "mc-common",
+ "mc-consensus-scp-types",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-signature",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-core",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "prost",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-common"
 version = "2.1.0-pre0"
 dependencies = [
@@ -869,6 +892,18 @@ dependencies = [
  "sha3",
  "siphasher",
  "slog",
+]
+
+[[package]]
+name = "mc-consensus-scp-types"
+version = "2.1.0-pre0"
+dependencies = [
+ "mc-common",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "prost",
+ "serde",
 ]
 
 [[package]]
@@ -1170,6 +1205,7 @@ dependencies = [
  "aligned-cmov",
  "mc-attest-core",
  "mc-attest-enclave-api",
+ "mc-blockchain-types",
  "mc-common",
  "mc-crypto-ake-enclave",
  "mc-crypto-keys",
@@ -1180,6 +1216,7 @@ dependencies = [
  "mc-oblivious-ram",
  "mc-oblivious-traits",
  "mc-sgx-compat",
+ "mc-sgx-debug",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1216,7 +1216,6 @@ dependencies = [
  "mc-oblivious-ram",
  "mc-oblivious-traits",
  "mc-sgx-compat",
- "mc-sgx-debug",
  "mc-sgx-report-cache-api",
  "mc-transaction-core",
  "mc-util-serial",

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -61,6 +61,32 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         }
         // Add Key Image Data
         EnclaveCall::AddKeyImageData(records) => serialize(&ENCLAVE.add_key_image_data(records)),
+
+        // Router / Store system
+        // Router-side
+        EnclaveCall::LedgerStoreInit(responder_id) => {
+            serialize(&ENCLAVE.ledger_store_init(responder_id))
+        }
+        EnclaveCall::LedgerStoreConnect(responder_id, client_auth_response) => {
+            serialize(
+                &ENCLAVE.ledger_store_connect(responder_id, client_auth_response),
+            )
+        }
+        EnclaveCall::DecryptAndSealQuery(client_query) => {
+            serialize(&ENCLAVE.decrypt_and_seal_query(client_query))
+        }
+        EnclaveCall::CreateMultiKeyImageStoreQueryData(msg) => {
+            serialize(&ENCLAVE.create_multi_key_image_store_query_data(msg))
+        }
+        EnclaveCall::CollateQueryResponses(sealed_query, shard_query_responses) => {
+            serialize(&ENCLAVE.collate_shard_query_responses(sealed_query, shard_query_responses))
+        }
+        EnclaveCall::CheckKeyImageStore(req, untrusted_keyimagequery_response) => {
+            serialize(&ENCLAVE.check_key_image_store(req, untrusted_keyimagequery_response))
+        }
+        EnclaveCall::FrontendAccept(auth_message) => {
+            serialize(&ENCLAVE.frontend_accept(auth_message))
+        }
     }
     .or(Err(sgx_status_t::SGX_ERROR_UNEXPECTED))
 }

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -56,8 +56,8 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
             serialize(&ENCLAVE.get_outputs_data(resp, client))
         }
         // Check Key image
-        EnclaveCall::CheckKeyImages(req, untrusted_keyimagequery_response) => {
-            serialize(&ENCLAVE.check_key_images(req, untrusted_keyimagequery_response))
+        EnclaveCall::CheckKeyImages(req, response) => {
+            serialize(&ENCLAVE.check_key_images(req, response))
         }
         // Add Key Image Data
         EnclaveCall::AddKeyImageData(records) => serialize(&ENCLAVE.add_key_image_data(records)),
@@ -79,8 +79,8 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::CollateQueryResponses(sealed_query, shard_query_responses) => {
             serialize(&ENCLAVE.collate_shard_query_responses(sealed_query, shard_query_responses))
         }
-        EnclaveCall::CheckKeyImageStore(req, untrusted_keyimagequery_response) => {
-            serialize(&ENCLAVE.check_key_image_store(req, untrusted_keyimagequery_response))
+        EnclaveCall::CheckKeyImageStore(req, response) => {
+            serialize(&ENCLAVE.check_key_image_store(req, response))
         }
         EnclaveCall::FrontendAccept(auth_message) => {
             serialize(&ENCLAVE.frontend_accept(auth_message))

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -68,9 +68,7 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
             serialize(&ENCLAVE.ledger_store_init(responder_id))
         }
         EnclaveCall::LedgerStoreConnect(responder_id, client_auth_response) => {
-            serialize(
-                &ENCLAVE.ledger_store_connect(responder_id, client_auth_response),
-            )
+            serialize(&ENCLAVE.ledger_store_connect(responder_id, client_auth_response))
         }
         EnclaveCall::DecryptAndSealQuery(client_query) => {
             serialize(&ENCLAVE.decrypt_and_seal_query(client_query))

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -88,10 +88,7 @@ impl LedgerEnclave for MockEnclave {
         unimplemented!()
     }
 
-    fn ledger_store_init(
-        &self,
-        _ledger_store_id: ResponderId,
-    ) -> EnclaveResult<NonceAuthRequest> {
+    fn ledger_store_init(&self, _ledger_store_id: ResponderId) -> EnclaveResult<NonceAuthRequest> {
         unimplemented!()
     }
 
@@ -121,8 +118,9 @@ impl LedgerEnclave for MockEnclave {
         &self,
         _sealed_query: mc_attest_enclave_api::SealedClientMessage,
         _shard_query_responses: std::collections::BTreeMap<
-            ResponderId, 
-            EnclaveMessage<NonceSession>>,
+            ResponderId,
+            EnclaveMessage<NonceSession>,
+        >,
     ) -> Result<EnclaveMessage<ClientSession>, mc_fog_ledger_enclave::Error> {
         unimplemented!()
     }
@@ -137,7 +135,7 @@ impl LedgerEnclave for MockEnclave {
 
     fn frontend_accept(
         &self,
-        _auth_message: NonceAuthRequest
+        _auth_message: NonceAuthRequest,
     ) -> EnclaveResult<(NonceAuthResponse, NonceSession)> {
         unimplemented!()
     }

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -3,7 +3,10 @@
 //! Functionality for mocking and testing components in the ledger server
 
 use mc_attest_core::{IasNonce, Quote, QuoteNonce, Report, TargetInfo, VerificationReport};
-use mc_attest_enclave_api::{ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage};
+use mc_attest_enclave_api::{
+    ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, NonceAuthRequest,
+    NonceAuthResponse, NonceSession,
+};
 use mc_blockchain_types::{
     Block, BlockContents, BlockData, BlockIndex, BlockMetadata, BlockSignature,
 };
@@ -82,6 +85,60 @@ impl LedgerEnclave for MockEnclave {
         &self,
         _records: Vec<KeyImageData>,
     ) -> Result<(), mc_fog_ledger_enclave::Error> {
+        unimplemented!()
+    }
+
+    fn ledger_store_init(
+        &self,
+        _ledger_store_id: ResponderId,
+    ) -> EnclaveResult<NonceAuthRequest> {
+        unimplemented!()
+    }
+
+    fn ledger_store_connect(
+        &self,
+        _ledger_store_id: ResponderId,
+        _ledger_store_auth_response: NonceAuthResponse,
+    ) -> EnclaveResult<()> {
+        unimplemented!()
+    }
+
+    fn decrypt_and_seal_query(
+        &self,
+        _client_query: EnclaveMessage<ClientSession>,
+    ) -> EnclaveResult<mc_attest_enclave_api::SealedClientMessage> {
+        unimplemented!()
+    }
+
+    fn create_multi_key_image_store_query_data(
+        &self,
+        _sealed_query: mc_attest_enclave_api::SealedClientMessage,
+    ) -> EnclaveResult<Vec<EnclaveMessage<NonceSession>>> {
+        unimplemented!()
+    }
+
+    fn collate_shard_query_responses(
+        &self,
+        _sealed_query: mc_attest_enclave_api::SealedClientMessage,
+        _shard_query_responses: std::collections::BTreeMap<
+            ResponderId, 
+            EnclaveMessage<NonceSession>>,
+    ) -> Result<EnclaveMessage<ClientSession>, mc_fog_ledger_enclave::Error> {
+        unimplemented!()
+    }
+
+    fn check_key_image_store(
+        &self,
+        _msg: EnclaveMessage<NonceSession>,
+        _untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+    ) -> EnclaveResult<EnclaveMessage<NonceSession>> {
+        unimplemented!()
+    }
+
+    fn frontend_accept(
+        &self,
+        _auth_message: NonceAuthRequest
+    ) -> EnclaveResult<(NonceAuthResponse, NonceSession)> {
         unimplemented!()
     }
 }

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -76,7 +76,7 @@ impl LedgerEnclave for MockEnclave {
     fn check_key_images(
         &self,
         _msg: EnclaveMessage<ClientSession>,
-        _untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        _response: UntrustedKeyImageQueryResponse,
     ) -> Result<Vec<u8>, mc_fog_ledger_enclave::Error> {
         unimplemented!()
     }
@@ -128,7 +128,7 @@ impl LedgerEnclave for MockEnclave {
     fn check_key_image_store(
         &self,
         _msg: EnclaveMessage<NonceSession>,
-        _untrusted_keyimagequery_response: UntrustedKeyImageQueryResponse,
+        _response: UntrustedKeyImageQueryResponse,
     ) -> EnclaveResult<EnclaveMessage<NonceSession>> {
         unimplemented!()
     }


### PR DESCRIPTION
- Adds `ledger_store_init()`, `frontend_accept()`, and `ledger_store_connect()` to the Fog ledger enclave API for general use with a fog ledger router/store system
- Adds `check_key_image_store()`, `decrypt_and_seal_query()`, `create_multi_key_image_store_query_data()`, and `collate_shard_query_responses()` to the Fog ledger enclave API, which are currently specific to key-image store queries
- Implements all of the above new API methods, including stub methods for testing. 
- New EnclaveCall variants for the above methods. 

Depends on #2889

### Motivation

As part of the ongoing project to improve Fog's scalability and stability, we're working on implementing a system that divides Fog ledger servers into a router (which routes requests from the client to a number of ledger store backends) and many stores (which actually hold relevant ledger data). Currently, only key image look-ups are supported.

### Future Work

* Generalize such that the ledger router/store system can be used for other ledger queries, not just key image queries (for example, merkele proofs).
