### PR TITLE
URIs for Fog Ledger Router

### DIFF
--- a/fog/api/proto/ledger.proto
+++ b/fog/api/proto/ledger.proto
@@ -15,12 +15,12 @@ import "google/protobuf/empty.proto";
 ////
 
 service LedgerAPI {
-    rpc request(stream LedgerRequest) returns (stream LedgerResponse) {}
+    rpc Request(stream LedgerRequest) returns (stream LedgerResponse) {}
 }
 
 service LedgerRouterAdminAPI {
     // Adds a shard to the Fog Ledger Router's list of shards to query.
-    rpc addShard(fog_common.AddShardRequest) returns (google.protobuf.Empty) {}
+    rpc AddShard(fog_common.AddShardRequest) returns (google.protobuf.Empty) {}
 }
 
 /// Fulfills requests sent by the Fog Ledger Router. This is not meant to fulfill requests sent directly by the client.

--- a/fog/ledger/enclave/api/src/messages.rs
+++ b/fog/ledger/enclave/api/src/messages.rs
@@ -4,12 +4,10 @@
 use crate::UntrustedKeyImageQueryResponse;
 use alloc::{collections::BTreeMap, vec::Vec};
 use mc_attest_core::{Quote, Report, TargetInfo, VerificationReport};
-
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientSession, EnclaveMessage, NonceAuthRequest, NonceAuthResponse,
     NonceSession, SealedClientMessage,
 };
-
 use mc_common::ResponderId;
 use mc_fog_types::ledger::GetOutputsResponse;
 use mc_transaction_core::ring_signature::KeyImage;

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -60,20 +60,6 @@ impl UriScheme for FogLedgerScheme {
     const DEFAULT_INSECURE_PORT: u16 = 3223;
 }
 
-/// Fog Ledger Router Admin Scheme
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct FogLedgerRouterAdminScheme {}
-
-impl UriScheme for FogLedgerRouterAdminScheme {
-    /// The part before the '://' of a URL.
-    const SCHEME_SECURE: &'static str = "fog-ledger-router-admin";
-    const SCHEME_INSECURE: &'static str = "insecure-fog-ledger-router-admin";
-
-    /// Default port numbers
-    const DEFAULT_SECURE_PORT: u16 = 443;
-    const DEFAULT_INSECURE_PORT: u16 = 3223;
-}
-
 /// Key Image Store (for use with router) Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct KeyImageStoreScheme {}
@@ -193,17 +179,6 @@ mod tests {
         );
         assert!(!uri.use_tls());
 
-        let uri = FogLedgerRouterAdminUri::from_str(
-            "insecure-fog-ledger-router-admin://node1.test.mobilecoin.com:3223/",
-        )
-        .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
-        assert_eq!(
-            uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
-        );
-        assert!(!uri.use_tls());
-
         let uri = KeyImageStoreUri::from_str(
             "insecure-key-image-store://node1.test.mobilecoin.com:3223/",
         )
@@ -307,17 +282,6 @@ mod tests {
 
         let uri = FogViewRouterUri::from_str(
             "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
-        )
-        .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
-        assert_eq!(
-            uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
-        );
-        assert!(!uri.use_tls());
-
-        let uri = FogViewRouterAdminUri::from_str(
-            "insecure-fog-view-router-admin://node1.test.mobilecoin.com:3225/",
         )
         .unwrap();
         assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");

--- a/fog/uri/src/lib.rs
+++ b/fog/uri/src/lib.rs
@@ -60,6 +60,34 @@ impl UriScheme for FogLedgerScheme {
     const DEFAULT_INSECURE_PORT: u16 = 3223;
 }
 
+/// Fog Ledger Router Admin Scheme
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FogLedgerRouterAdminScheme {}
+
+impl UriScheme for FogLedgerRouterAdminScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "fog-ledger-router-admin";
+    const SCHEME_INSECURE: &'static str = "insecure-fog-ledger-router-admin";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3223;
+}
+
+/// Key Image Store (for use with router) Uri Scheme
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct KeyImageStoreScheme {}
+
+impl UriScheme for KeyImageStoreScheme {
+    /// The part before the '://' of a URL.
+    const SCHEME_SECURE: &'static str = "key-image-store";
+    const SCHEME_INSECURE: &'static str = "insecure-key-image-store";
+
+    /// Default port numbers
+    const DEFAULT_SECURE_PORT: u16 = 443;
+    const DEFAULT_INSECURE_PORT: u16 = 3223;
+}
+
 /// Fog Ingest Uri Scheme
 #[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct FogIngestScheme {}
@@ -92,7 +120,11 @@ impl UriScheme for IngestPeerScheme {
 pub type FogIngestUri = Uri<FogIngestScheme>;
 /// Uri used when talking to fog-ledger service, with the right default ports
 /// and scheme.
+/// FogLedgerUri is also used for the router / client-facing part of the
+/// router & store system.
 pub type FogLedgerUri = Uri<FogLedgerScheme>;
+/// Uri for a Fog key image store, to be queried by a Key Image Router.
+pub type KeyImageStoreUri = Uri<KeyImageStoreScheme>;
 /// Uri used when talking to fog view router service.
 pub type FogViewRouterUri = Uri<FogViewRouterScheme>;
 /// Uri used when talking to fog view store service.
@@ -161,24 +193,25 @@ mod tests {
         );
         assert!(!uri.use_tls());
 
-        let uri = FogViewRouterUri::from_str(
-            "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
+        let uri = FogLedgerRouterAdminUri::from_str(
+            "insecure-fog-ledger-router-admin://node1.test.mobilecoin.com:3223/",
         )
         .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
         assert!(!uri.use_tls());
 
-        let uri =
-            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
-                .unwrap();
-        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        let uri = KeyImageStoreUri::from_str(
+            "insecure-key-image-store://node1.test.mobilecoin.com:3223/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3223");
         assert_eq!(
             uri.responder_id().unwrap(),
-            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+            ResponderId::from_str("node1.test.mobilecoin.com:3223").unwrap()
         );
         assert!(!uri.use_tls());
     }
@@ -269,6 +302,38 @@ mod tests {
         assert_eq!(
             uri.responder_id().unwrap(),
             ResponderId::from_str("node1.test.mobilecoin.com:666").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri = FogViewRouterUri::from_str(
+            "insecure-fog-view-router://node1.test.mobilecoin.com:3225/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri = FogViewRouterAdminUri::from_str(
+            "insecure-fog-view-router-admin://node1.test.mobilecoin.com:3225/",
+        )
+        .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
+        );
+        assert!(!uri.use_tls());
+
+        let uri =
+            FogViewStoreUri::from_str("insecure-fog-view-store://node1.test.mobilecoin.com:3225/")
+                .unwrap();
+        assert_eq!(uri.addr(), "node1.test.mobilecoin.com:3225");
+        assert_eq!(
+            uri.responder_id().unwrap(),
+            ResponderId::from_str("node1.test.mobilecoin.com:3225").unwrap()
         );
         assert!(!uri.use_tls());
     }


### PR DESCRIPTION
Add new URIs for Fog Ledger / Key Image Router and Store.

### Motivation

The new Fog Ledger Router and its Key Image Store require two new URI types to exist, one for admin access to the Fog Ledger Router which can add new shards, and one for Key Image Store which will be communicated with by the router.

### Future Work

I don't think there is any future work for this particular PR.

