### PR TITLE
Key Image Router Service

### DIFF
--- a/fog/ledger/server/src/error.rs
+++ b/fog/ledger/server/src/error.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use displaydoc::Display;
+use grpcio::RpcStatus;
+use mc_common::logger::Logger;
+use mc_fog_ledger_enclave_api::Error as LedgerEnclaveError;
+use mc_sgx_report_cache_untrusted::Error as ReportCacheError;
+use mc_util_grpc::{rpc_internal_error, rpc_permissions_error};
+
+#[derive(Debug, Display)]
+pub enum RouterServerError {
+    /// Error related to contacting Fog Ledger Store: {0}
+    LedgerStoreError(String),
+    /// Ledger Enclave error: {0}
+    Enclave(LedgerEnclaveError),
+}
+
+impl From<grpcio::Error> for RouterServerError {
+    fn from(src: grpcio::Error) -> Self {
+        RouterServerError::LedgerStoreError(format!("{}", src))
+    }
+}
+
+impl From<mc_common::ResponderIdParseError> for RouterServerError {
+    fn from(src: mc_common::ResponderIdParseError) -> Self {
+        RouterServerError::LedgerStoreError(format!("{}", src))
+    }
+}
+
+impl From<mc_util_uri::UriParseError> for RouterServerError {
+    fn from(src: mc_util_uri::UriParseError) -> Self {
+        RouterServerError::LedgerStoreError(format!("{}", src))
+    }
+}
+
+impl From<mc_util_uri::UriConversionError> for RouterServerError {
+    fn from(src: mc_util_uri::UriConversionError) -> Self {
+        RouterServerError::LedgerStoreError(format!("{}", src))
+    }
+}
+
+pub fn router_server_err_to_rpc_status(
+    context: &str,
+    src: RouterServerError,
+    logger: Logger,
+) -> RpcStatus {
+    match src {
+        RouterServerError::LedgerStoreError(_) => {
+            rpc_internal_error(context, format!("{}", src), &logger)
+        }
+        RouterServerError::Enclave(_) => {
+            rpc_permissions_error(context, format!("{}", src), &logger)
+        }
+    }
+}
+
+impl From<LedgerEnclaveError> for RouterServerError {
+    fn from(src: LedgerEnclaveError) -> Self {
+        RouterServerError::Enclave(src)
+    }
+}
+
+#[derive(Display)]
+pub enum LedgerServerError {
+    /// Ledger Enclave error: {0}
+    Enclave(LedgerEnclaveError),
+    // Failed to join thread: {0}
+    //ThreadJoin(String),
+    // RPC shutdown failure: {0}
+    //RpcShutdown(String),
+    /// Report cache error: {0}
+    ReportCache(ReportCacheError),
+}
+
+impl From<LedgerEnclaveError> for LedgerServerError {
+    fn from(src: LedgerEnclaveError) -> Self {
+        LedgerServerError::Enclave(src)
+    }
+}
+
+impl From<ReportCacheError> for LedgerServerError {
+    fn from(src: ReportCacheError) -> Self {
+        Self::ReportCache(src)
+    }
+}

--- a/fog/ledger/server/src/error.rs
+++ b/fog/ledger/server/src/error.rs
@@ -64,10 +64,6 @@ impl From<LedgerEnclaveError> for RouterServerError {
 pub enum LedgerServerError {
     /// Ledger Enclave error: {0}
     Enclave(LedgerEnclaveError),
-    // Failed to join thread: {0}
-    //ThreadJoin(String),
-    // RPC shutdown failure: {0}
-    //RpcShutdown(String),
     /// Report cache error: {0}
     ReportCache(ReportCacheError),
 }

--- a/fog/ledger/server/src/key_image_router_service.rs
+++ b/fog/ledger/server/src/key_image_router_service.rs
@@ -56,7 +56,6 @@ where
         requests: RequestStream<LedgerRequest>,
         responses: DuplexSink<LedgerResponse>,
     ) {
-        log::info!(self.logger, "Request received in request fn");
         let _timer = SVC_COUNTERS.req(&ctx);
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             log::warn!(

--- a/fog/ledger/server/src/key_image_router_service.rs
+++ b/fog/ledger/server/src/key_image_router_service.rs
@@ -73,7 +73,7 @@ where
                 responses,
                 logger.clone(),
             )
-            .map_err(move |err: grpcio::Error| log::error!(&logger, "failed to reply: {}", err))
+            .map_err(move |err| log::error!(&logger, "failed to reply: {}", err))
             // TODO: Do more with the error than just push it to the log.
             .map(|_| ());
 

--- a/fog/ledger/server/src/key_image_router_service.rs
+++ b/fog/ledger/server/src/key_image_router_service.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use futures::{FutureExt, TryFutureExt};
+use grpcio::{DuplexSink, RequestStream, RpcContext};
+use mc_common::logger::{log, Logger};
+use mc_fog_api::{
+    ledger::{LedgerRequest, LedgerResponse},
+    ledger_grpc::{self, LedgerApi},
+};
+use mc_fog_ledger_enclave::LedgerEnclaveProxy;
+use mc_fog_uri::KeyImageStoreUri;
+use mc_util_grpc::rpc_logger;
+use mc_util_metrics::SVC_COUNTERS;
+
+use crate::router_handlers;
+
+#[derive(Clone)]
+pub struct KeyImageRouterService<E>
+where
+    E: LedgerEnclaveProxy,
+{
+    enclave: E,
+    shards: Arc<RwLock<HashMap<KeyImageStoreUri, Arc<ledger_grpc::KeyImageStoreApiClient>>>>,
+    logger: Logger,
+}
+
+impl<E: LedgerEnclaveProxy> KeyImageRouterService<E> {
+    /// Creates a new LedgerRouterService that can be used by a gRPC server to
+    /// fulfill gRPC requests.
+    #[allow(dead_code)] // FIXME
+    pub fn new(
+        enclave: E,
+        shards: Arc<RwLock<HashMap<KeyImageStoreUri, Arc<ledger_grpc::KeyImageStoreApiClient>>>>,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            enclave,
+            shards,
+            logger,
+        }
+    }
+}
+
+impl<E> LedgerApi for KeyImageRouterService<E>
+where
+    E: LedgerEnclaveProxy,
+{
+    fn request(
+        &mut self,
+        ctx: RpcContext,
+        requests: RequestStream<LedgerRequest>,
+        responses: DuplexSink<LedgerResponse>,
+    ) {
+        log::info!(self.logger, "Request received in request fn");
+        let _timer = SVC_COUNTERS.req(&ctx);
+        mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
+            log::warn!(
+                self.logger,
+                "Streaming GRPC Ledger API only partially implemented."
+            );
+            let logger = logger.clone();
+
+            let shards = self.shards.read().expect("RwLock poisoned");
+            let future = router_handlers::handle_requests(
+                shards.values().cloned().collect(),
+                self.enclave.clone(),
+                requests,
+                responses,
+                logger.clone(),
+            )
+            .map_err(move |err: grpcio::Error| log::error!(&logger, "failed to reply: {}", err))
+            // TODO: Do more with the error than just push it to the log.
+            .map(|_| ());
+
+            ctx.spawn(future)
+        });
+    }
+}

--- a/fog/ledger/server/src/key_image_router_service.rs
+++ b/fog/ledger/server/src/key_image_router_service.rs
@@ -1,10 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
-
+use crate::router_handlers;
 use futures::{FutureExt, TryFutureExt};
 use grpcio::{DuplexSink, RequestStream, RpcContext};
 use mc_common::logger::{log, Logger};
@@ -16,8 +12,10 @@ use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::KeyImageStoreUri;
 use mc_util_grpc::rpc_logger;
 use mc_util_metrics::SVC_COUNTERS;
-
-use crate::router_handlers;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 #[derive(Clone)]
 pub struct KeyImageRouterService<E>

--- a/fog/ledger/server/src/key_image_router_service.rs
+++ b/fog/ledger/server/src/key_image_router_service.rs
@@ -26,6 +26,7 @@ where
 {
     enclave: E,
     shards: Arc<RwLock<HashMap<KeyImageStoreUri, Arc<ledger_grpc::KeyImageStoreApiClient>>>>,
+    query_retries: usize,
     logger: Logger,
 }
 
@@ -36,11 +37,13 @@ impl<E: LedgerEnclaveProxy> KeyImageRouterService<E> {
     pub fn new(
         enclave: E,
         shards: Arc<RwLock<HashMap<KeyImageStoreUri, Arc<ledger_grpc::KeyImageStoreApiClient>>>>,
+        query_retries: usize,
         logger: Logger,
     ) -> Self {
         Self {
             enclave,
             shards,
+            query_retries,
             logger,
         }
     }
@@ -70,6 +73,7 @@ where
                 self.enclave.clone(),
                 requests,
                 responses,
+                self.query_retries,
                 logger.clone(),
             )
             .map_err(move |err| log::error!(&logger, "failed to reply: {}", err))

--- a/fog/ledger/server/src/lib.rs
+++ b/fog/ledger/server/src/lib.rs
@@ -4,10 +4,14 @@ mod block_service;
 mod config;
 mod counters;
 mod db_fetcher;
+mod error;
 mod key_image_service;
 mod merkle_proof_service;
 mod server;
 mod untrusted_tx_out_service;
+
+mod key_image_router_service;
+mod router_handlers;
 
 pub use block_service::BlockService;
 pub use config::LedgerServerConfig;

--- a/fog/ledger/server/src/lib.rs
+++ b/fog/ledger/server/src/lib.rs
@@ -5,13 +5,12 @@ mod config;
 mod counters;
 mod db_fetcher;
 mod error;
+mod key_image_router_service;
 mod key_image_service;
 mod merkle_proof_service;
+mod router_handlers;
 mod server;
 mod untrusted_tx_out_service;
-
-mod key_image_router_service;
-mod router_handlers;
 
 pub use block_service::BlockService;
 pub use config::LedgerServerConfig;

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -15,7 +15,6 @@ use mc_fog_api::{
 };
 use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
-//use mc_fog_ledger_enclave_api::LedgerEnclaveProxy;
 use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -112,7 +112,7 @@ impl ProcessedShardResponseData {
     }
 }
 
-/// Processes the MultiLedgerStoreQueryResponses returned by each Ledger Shard.
+/// Processes the MultiKeyImageStoreResponses returned by each Ledger Shard.
 pub fn process_shard_responses(
     clients_and_responses: Vec<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse)>,
 ) -> Result<ProcessedShardResponseData, RouterServerError> {

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -176,7 +176,7 @@ where
     E: LedgerEnclaveProxy,
 {
     let mut query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>> = BTreeMap::new();
-    let mut shard_clients = shard_clients.clone();
+    let mut shards_to_query = shard_clients.clone();
     let sealed_query = enclave
         .decrypt_and_seal_query(query.into())
         .map_err(|err| {
@@ -207,7 +207,7 @@ where
             })?
             .into();
         let clients_and_responses =
-            route_query(&multi_ledger_store_query_request, shard_clients.clone())
+            route_query(&multi_ledger_store_query_request, shards_to_query.clone())
                 .await
                 .map_err(|err| {
                     router_server_err_to_rpc_status(
@@ -237,8 +237,8 @@ where
             break;
         }
 
-        shard_clients = processed_shard_response_data.shard_clients_for_retry;
-        if !shard_clients.is_empty() {
+        shards_to_query = processed_shard_response_data.shard_clients_for_retry;
+        if !shards_to_query.is_empty() {
             authenticate_ledger_stores(
                 enclave.clone(),
                 processed_shard_response_data.store_uris_for_authentication,

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -1,0 +1,346 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+use crate::error::{router_server_err_to_rpc_status, RouterServerError};
+use futures::{future::try_join_all, SinkExt, TryStreamExt};
+use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
+use mc_attest_api::attest;
+use mc_attest_enclave_api::{EnclaveMessage, NonceSession};
+use mc_common::{logger::Logger, ResponderId};
+use mc_fog_api::{
+    ledger::{
+        LedgerRequest, LedgerResponse, MultiKeyImageStoreRequest, MultiKeyImageStoreResponse,
+        MultiKeyImageStoreResponseStatus,
+    },
+    ledger_grpc::KeyImageStoreApiClient,
+};
+use mc_fog_ledger_enclave::LedgerEnclaveProxy;
+use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
+//use mc_fog_ledger_enclave_api::LedgerEnclaveProxy;
+use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
+use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+
+#[allow(dead_code)] //FIXME
+const RETRY_COUNT: usize = 3;
+
+/// Handles a series of requests sent by the Fog Ledger Router client,
+/// routing them out to shards.
+pub async fn handle_requests<E>(
+    shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
+    enclave: E,
+    mut requests: RequestStream<LedgerRequest>,
+    mut responses: DuplexSink<LedgerResponse>,
+    logger: Logger,
+) -> Result<(), grpcio::Error>
+where
+    E: LedgerEnclaveProxy,
+{
+    while let Some(request) = requests.try_next().await? {
+        let result = handle_request(
+            request,
+            shard_clients.clone(),
+            enclave.clone(),
+            logger.clone(),
+        )
+        .await;
+        match result {
+            Ok(response) => responses.send((response, WriteFlags::default())).await?,
+            Err(rpc_status) => return responses.fail(rpc_status).await,
+        }
+    }
+    responses.close().await?;
+    Ok(())
+}
+
+/// Handles a client's request by performing either an authentication or a
+/// query.
+pub async fn handle_request<E>(
+    mut request: LedgerRequest,
+    shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
+    enclave: E,
+    logger: Logger,
+) -> Result<LedgerResponse, RpcStatus>
+where
+    E: LedgerEnclaveProxy,
+{
+    if request.has_auth() {
+        handle_auth_request(enclave, request.take_auth(), logger)
+    } else if request.has_check_key_images() {
+        handle_query_request(
+            request.take_check_key_images(),
+            enclave,
+            shard_clients,
+            logger,
+        )
+        .await
+        // TODO: Handle other cases here as they are added, such as the merkele
+        // proof service.
+    } else {
+        let rpc_status = rpc_invalid_arg_error(
+            "Inavlid LedgerRequest request",
+            "Neither the query nor auth fields were set".to_string(),
+            &logger,
+        );
+        Err(rpc_status)
+    }
+}
+
+/// The result of processing the MultiLedgerStoreQueryResponse from each Fog
+/// Ledger Shard.
+pub struct ProcessedShardResponseData {
+    /// gRPC clients for Shards that need to be retried for a successful
+    /// response.
+    pub shard_clients_for_retry: Vec<Arc<KeyImageStoreApiClient>>,
+
+    /// Uris for individual Fog Ledger Stores that need to be authenticated with
+    /// by the Fog Router. It should only have entries if
+    /// `shard_clients_for_retry` has entries.
+    pub store_uris_for_authentication: Vec<KeyImageStoreUri>,
+
+    /// New, successfully processed query responses.
+    pub new_query_responses: Vec<(ResponderId, attest::NonceMessage)>,
+}
+
+impl ProcessedShardResponseData {
+    pub fn new(
+        shard_clients_for_retry: Vec<Arc<KeyImageStoreApiClient>>,
+        store_uris_for_authentication: Vec<KeyImageStoreUri>,
+        new_query_responses: Vec<(ResponderId, attest::NonceMessage)>,
+    ) -> Self {
+        ProcessedShardResponseData {
+            shard_clients_for_retry,
+            store_uris_for_authentication,
+            new_query_responses,
+        }
+    }
+}
+
+/// Processes the MultiLedgerStoreQueryResponses returned by each Ledger Shard.
+pub fn process_shard_responses(
+    clients_and_responses: Vec<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse)>,
+) -> Result<ProcessedShardResponseData, RouterServerError> {
+    let mut shard_clients_for_retry = Vec::new();
+    let mut store_uris_for_authentication = Vec::new();
+    let mut new_query_responses = Vec::new();
+
+    for (shard_client, mut response) in clients_and_responses {
+        // We did not receive a query_response for this shard.Therefore, we need to:
+        //  (a) retry the query
+        //  (b) authenticate with the Ledger Store that returned the decryption_error
+        let store_uri = KeyImageStoreUri::from_str(response.get_fog_ledger_store_uri())?;
+        match response.get_status() {
+            MultiKeyImageStoreResponseStatus::SUCCESS => {
+                let store_responder_id = store_uri.responder_id()?;
+                new_query_responses.push((store_responder_id, response.take_query_response()));
+            }
+            MultiKeyImageStoreResponseStatus::AUTHENTICATION_ERROR => {
+                shard_clients_for_retry.push(shard_client);
+                store_uris_for_authentication.push(store_uri);
+            }
+            // This call will be retried as part of the larger retry logic
+            MultiKeyImageStoreResponseStatus::NOT_READY => (),
+        }
+    }
+
+    Ok(ProcessedShardResponseData::new(
+        shard_clients_for_retry,
+        store_uris_for_authentication,
+        new_query_responses,
+    ))
+}
+
+/// Handles a client's authentication request.
+fn handle_auth_request<E>(
+    enclave: E,
+    auth_message: attest::AuthMessage,
+    logger: Logger,
+) -> Result<LedgerResponse, RpcStatus>
+where
+    E: LedgerEnclaveProxy,
+{
+    let (client_auth_response, _) = enclave.client_accept(auth_message.into()).map_err(|err| {
+        router_server_err_to_rpc_status("Auth: e client accept", err.into(), logger)
+    })?;
+
+    let mut response = LedgerResponse::new();
+    response.mut_auth().set_data(client_auth_response.into());
+    Ok(response)
+}
+
+#[allow(unused_variables)]
+/// Handles a client's query request.
+async fn handle_query_request<E>(
+    query: attest::Message,
+    enclave: E,
+    shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
+    logger: Logger,
+) -> Result<LedgerResponse, RpcStatus>
+where
+    E: LedgerEnclaveProxy,
+{
+    let mut query_responses: BTreeMap<ResponderId, EnclaveMessage<NonceSession>> = BTreeMap::new();
+    let mut shard_clients = shard_clients.clone();
+    let sealed_query = enclave
+        .decrypt_and_seal_query(query.into())
+        .map_err(|err| {
+            router_server_err_to_rpc_status(
+                "Query: internal encryption error",
+                err.into(),
+                logger.clone(),
+            )
+        })?;
+
+    // The retry logic here is:
+    // Set retries remaining to RETRY_COUNT
+    // Send query and process responses
+    // If there's a response from every shard, we're done
+    // If there's a new store, repeat
+    // If there's no new store and we don't have enough responses, decrement
+    // RETRY_COUNT and loop
+    let mut remaining_retries = RETRY_COUNT;
+    while remaining_retries > 0 {
+        let multi_ledger_store_query_request = enclave
+            .create_multi_key_image_store_query_data(sealed_query.clone())
+            .map_err(|err| {
+                router_server_err_to_rpc_status(
+                    "Query: internal encryption error",
+                    err.into(),
+                    logger.clone(),
+                )
+            })?
+            .into();
+        let clients_and_responses =
+            route_query(&multi_ledger_store_query_request, shard_clients.clone())
+                .await
+                .map_err(|err| {
+                    router_server_err_to_rpc_status(
+                        "Query: internal query routing error",
+                        err,
+                        logger.clone(),
+                    )
+                })?;
+
+        let processed_shard_response_data = process_shard_responses(clients_and_responses)
+            .map_err(|err| {
+                router_server_err_to_rpc_status(
+                    "Query: internal query response processing",
+                    err,
+                    logger.clone(),
+                )
+            })?;
+
+        for (store_responder_id, new_query_response) in processed_shard_response_data
+            .new_query_responses
+            .into_iter()
+        {
+            query_responses.insert(store_responder_id, new_query_response.into());
+        }
+
+        if query_responses.len() >= shard_clients.len() {
+            break;
+        }
+
+        shard_clients = processed_shard_response_data.shard_clients_for_retry;
+        if !shard_clients.is_empty() {
+            authenticate_ledger_stores(
+                enclave.clone(),
+                processed_shard_response_data.store_uris_for_authentication,
+                logger.clone(),
+            )
+            .await?;
+        } else {
+            remaining_retries -= 1;
+        }
+    }
+
+    if remaining_retries == 0 {
+        return Err(router_server_err_to_rpc_status(
+            "Query: timed out connecting to key image stores",
+            RouterServerError::LedgerStoreError(format!(
+                "Received {} responses which failed to advance the MultiKeyImageStoreRequest",
+                RETRY_COUNT
+            )),
+            logger.clone(),
+        ));
+    }
+
+    let query_response = enclave
+        .collate_shard_query_responses(sealed_query, query_responses)
+        .map_err(|err| {
+            router_server_err_to_rpc_status(
+                "Query: shard response collation",
+                RouterServerError::Enclave(err),
+                logger.clone(),
+            )
+        })?;
+
+    let mut response = LedgerResponse::new();
+    response.set_check_key_image_response(query_response.into());
+    Ok(response)
+}
+
+/// Sends a client's query request to all of the Fog Ledger shards.
+async fn route_query(
+    request: &MultiKeyImageStoreRequest,
+    shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
+) -> Result<Vec<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse)>, RouterServerError> {
+    let responses = shard_clients
+        .into_iter()
+        .map(|shard_client| query_shard(request, shard_client));
+    try_join_all(responses).await
+}
+
+/// Sends a client's query request to one of the Fog Ledger shards.
+async fn query_shard(
+    request: &MultiKeyImageStoreRequest,
+    shard_client: Arc<KeyImageStoreApiClient>,
+) -> Result<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse), RouterServerError> {
+    let client_unary_receiver = shard_client.multi_key_image_store_query_async(request)?;
+    let response = client_unary_receiver.await?;
+
+    Ok((shard_client, response))
+}
+
+// Authenticates Fog Ledger Stores that have previously not been authenticated.
+async fn authenticate_ledger_stores<E: LedgerEnclaveProxy>(
+    enclave: E,
+    ledger_store_uris: Vec<KeyImageStoreUri>,
+    logger: Logger,
+) -> Result<Vec<()>, RpcStatus> {
+    let pending_auth_requests = ledger_store_uris
+        .into_iter()
+        .map(|store_uri| authenticate_ledger_store(enclave.clone(), store_uri, logger.clone()));
+
+    try_join_all(pending_auth_requests).await.map_err(|err| {
+        router_server_err_to_rpc_status(
+            "Query: cannot authenticate with each Fog Ledger Store:",
+            err,
+            logger.clone(),
+        )
+    })
+}
+
+// Authenticates a Fog Ledger Store that has previously not been authenticated.
+async fn authenticate_ledger_store<E: LedgerEnclaveProxy>(
+    enclave: E,
+    ledger_store_url: KeyImageStoreUri,
+    logger: Logger,
+) -> Result<(), RouterServerError> {
+    let ledger_store_id = ResponderId::from_str(&ledger_store_url.to_string())?;
+    let client_auth_request = enclave.ledger_store_init(ledger_store_id.clone())?;
+    let grpc_env = Arc::new(
+        grpcio::EnvBuilder::new()
+            .name_prefix("authenticate-ledger-store".to_string())
+            .build(),
+    );
+    let ledger_store_client = KeyImageStoreApiClient::new(
+        ChannelBuilder::default_channel_builder(grpc_env)
+            .connect_to_uri(&ledger_store_url, &logger),
+    );
+
+    let auth_unary_receiver = ledger_store_client.auth_async(&client_auth_request.into())?;
+    let auth_response = auth_unary_receiver.await?;
+
+    let result = enclave.ledger_store_connect(ledger_store_id, auth_response.into())?;
+
+    Ok(result)
+}

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -19,7 +19,6 @@ use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
 use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
-#[allow(dead_code)] //FIXME
 const RETRY_COUNT: usize = 3;
 
 /// Handles a series of requests sent by the Fog Ledger Router client,

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -178,7 +178,6 @@ where
     Ok(response)
 }
 
-#[allow(unused_variables)]
 /// Handles a client's query request.
 async fn handle_query_request<E>(
     query: attest::Message,


### PR DESCRIPTION
Implementation of the Key Image Router Service

### Motivation

This is the Key Image Router Service, which does the actual work of querying the Key Image Stores and obliviously collating the responses received.

### Future Work

The Key Image Router Service needs to be hosted inside of a Key Image Router Server, which itself needs to be hosted in the key image router binary. These will both be added in subsequent PRs.

It is known that the Key Image Router Service needs to be enhanced to keep track of the block ranges expected from shards, to guard against the case where a shard is mistakenly backed by a store with a different configured block range. This will also affect the loop termination logic, which (in this PR) assumes that a response from all shards is both necessary and sufficient to address a query.
