### PR TITLE
mint-client generate-mint-tx can now get tombstone block from consensus

### DIFF
--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -359,6 +359,11 @@ pub enum Commands {
         #[clap(long, env = "MC_CHAIN_ID")]
         chain_id: Option<String>,
 
+        /// Optional URI of consensus node to query for current block index and
+        /// calculate a default tombstone block from.
+        #[clap(long, env = "MC_CONSENSUS_URI")]
+        tombstone_from_node: Option<ConsensusClientUri>,
+
         #[clap(flatten)]
         params: MintTxParams,
     },


### PR DESCRIPTION
added --tombstone-from-node <nodespec> to mc-consensus-mint-client's generate-mint-tx command

### Motivation

When generating a mint-tx file, a tombstone block for the mint-tx needs to be assigned. Previously, we required the user to independently look up the index of the last block of the blockchain, increment that by some amount, and pass it to the command using the --tombstone argument.

This PR adds an optional --tombstone-from-node argument which takes a node spec, asks the node for the current last block index, adds MAX_TOMBSTONE_BLOCKS - 1, and uses that for the mint-tx's tombstone block.