### PR TITLE
add account::ViewAccount, keys::{TxOutPublic, TxOutTargetPublic} to core, improve prost support for key types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
+ "prost",
  "serde",
  "zeroize",
 ]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,3 @@ pub mod consts;
 pub mod subaddress;
 
 pub mod slip10;
-
-#[cfg(feature = "protos")]
-pub mod protos;

--- a/core/src/protos.rs
+++ b/core/src/protos.rs
@@ -1,8 +1,0 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
-
-//! Generated rust objects from api/protos
-
-#![allow(missing_docs)]
-#![allow(non_snake_case)]
-
-include!(concat!(env!("OUT_DIR"), "/external.rs"));

--- a/core/src/subaddress.rs
+++ b/core/src/subaddress.rs
@@ -30,9 +30,9 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPrivate) {
     type Output = (SubaddressViewPrivate, SubaddressSpendPrivate);
 
     fn subaddress(&self, index: u64) -> Self::Output {
-        let (view_private, spend_private) = (&self.0, &self.1);
+        let (view_private, spend_private) = (self.0, self.1);
 
-        let a: &Scalar = view_private.as_ref();
+        let a = Scalar::from(view_private);
 
         // `Hs(a || n)`
         let Hs: Scalar = {
@@ -45,7 +45,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPrivate) {
         };
 
         // Return private subaddress keys
-        let b: &Scalar = spend_private.as_ref();
+        let b = Scalar::from(spend_private);
         (
             SubaddressViewPrivate::from(RistrettoPrivate::from(a * (Hs + b))),
             SubaddressSpendPrivate::from(RistrettoPrivate::from(Hs + b)),
@@ -58,10 +58,10 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPublic) {
     type Output = (SubaddressViewPublic, SubaddressSpendPublic);
 
     fn subaddress(&self, index: u64) -> Self::Output {
-        let (view_private, spend_public) = (&self.0, &self.1);
+        let (view_private, spend_public) = (self.0, self.1);
 
         // Generate spend public
-        let a: &Scalar = view_private.as_ref();
+        let a = Scalar::from(view_private);
 
         // `Hs(a || n)`
         let Hs: Scalar = {
@@ -77,7 +77,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPublic) {
         let B = RistrettoPublic::from(&b);
 
         // Return public subaddress keys
-        let C: RistrettoPoint = B.as_ref() + spend_public.as_ref();
+        let C: RistrettoPoint = B.as_ref() + &RistrettoPoint::from(spend_public);
         (
             SubaddressViewPublic::from(RistrettoPublic::from(a * C)),
             SubaddressSpendPublic::from(RistrettoPublic::from(C)),

--- a/core/src/subaddress.rs
+++ b/core/src/subaddress.rs
@@ -6,6 +6,7 @@
 
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 
+use mc_core_types::account::{PublicSubaddress, ViewAccount};
 use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 
@@ -84,6 +85,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPublic) {
     }
 }
 
+/// [Subaddress] implementation for base account
 impl Subaddress for Account {
     type Output = SpendSubaddress;
 
@@ -95,6 +97,22 @@ impl Subaddress for Account {
         SpendSubaddress {
             view_private,
             spend_private,
+        }
+    }
+}
+
+/// [Subaddress] implementation for view-only account
+impl Subaddress for ViewAccount {
+    type Output = PublicSubaddress;
+
+    /// Fetch private keys for the i^th subaddress
+    fn subaddress(&self, index: u64) -> Self::Output {
+        let (view_public, spend_public) =
+            (self.view_private_key(), self.spend_public_key()).subaddress(index);
+
+        PublicSubaddress {
+            view_public,
+            spend_public,
         }
     }
 }

--- a/core/src/subaddress.rs
+++ b/core/src/subaddress.rs
@@ -77,7 +77,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPublic) {
         let B = RistrettoPublic::from(&b);
 
         // Return public subaddress keys
-        let C: RistrettoPoint = B.as_ref() + &RistrettoPoint::from(spend_public);
+        let C: RistrettoPoint = B.as_ref() + RistrettoPoint::from(spend_public);
         (
             SubaddressViewPublic::from(RistrettoPublic::from(a * C)),
             SubaddressSpendPublic::from(RistrettoPublic::from(C)),

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -8,10 +8,12 @@ readme = "README.md"
 
 [features]
 serde = ["dep:serde"]
+prost = ["dep:prost", "mc-crypto-keys/prost"]
 
 [dependencies]
 # External dependencies
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
+prost = { version = "0.11.2", optional = true, default-features = false }
 serde = { version = "1.0.144", optional = true, default-features = false, features = [ "derive" ] }
 zeroize = { version = "1.5", default-features = false }
 

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -13,7 +13,7 @@ prost = ["dep:prost", "mc-crypto-keys/prost"]
 [dependencies]
 # External dependencies
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
-prost = { version = "0.11.2", optional = true, default-features = false }
+prost = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1.0.144", optional = true, default-features = false, features = [ "derive" ] }
 zeroize = { version = "1.5", default-features = false }
 

--- a/core/types/src/account.rs
+++ b/core/types/src/account.rs
@@ -60,6 +60,54 @@ impl Account {
     }
 }
 
+/// MobileCoin view only account object.
+///
+/// Derived from an [Account] object, used where spend key custody is external
+/// (offline or via hardware).
+#[derive(Zeroize)]
+pub struct ViewAccount {
+    /// Root view private key
+    view_private: RootViewPrivate,
+
+    /// Root spend public key
+    spend_public: RootSpendPublic,
+}
+
+impl ViewAccount {
+    /// Create an view-only account from existing private keys
+    pub fn new(view_private: RootViewPrivate, spend_public: RootSpendPublic) -> Self {
+        Self {
+            view_private,
+            spend_public,
+        }
+    }
+
+    /// Fetch account view public key
+    pub fn view_public_key(&self) -> RootViewPublic {
+        RootViewPublic::from(&self.view_private)
+    }
+
+    /// Fetch account spend public key
+    pub fn spend_public_key(&self) -> &RootSpendPublic {
+        &self.spend_public
+    }
+
+    /// Fetch account view private key
+    pub fn view_private_key(&self) -> &RootViewPrivate {
+        &self.view_private
+    }
+}
+
+/// Create a [ViewAccount] from a root [Account] object
+impl From<&Account> for ViewAccount {
+    fn from(a: &Account) -> Self {
+        Self {
+            view_private: a.view_private_key().clone(),
+            spend_public: a.spend_public_key(),
+        }
+    }
+}
+
 /// MobileCoin spend subaddress object.
 ///
 /// Contains view and spend private keys.
@@ -102,6 +150,7 @@ impl SpendSubaddress {
 pub struct ViewSubaddress {
     /// sub-address view private key
     pub view_private: SubaddressViewPrivate,
+
     /// sub-address spend private key
     pub spend_public: SubaddressSpendPublic,
 }

--- a/core/types/src/keys.rs
+++ b/core/types/src/keys.rs
@@ -37,9 +37,9 @@ pub type RootViewPublic = Key<Root, View, RistrettoPublic>;
 pub type RootSpendPublic = Key<Root, Spend, RistrettoPublic>;
 
 /// TxOut public key
-pub type TxOutPublic = Key<Tx, Public, RistrettoPublic>;
+pub type TxOutPublic = Key<TxOut, Public, RistrettoPublic>;
 /// TxOut target public key
-pub type TxOutTargetPublic = Key<Tx, Target, RistrettoPublic>;
+pub type TxOutTargetPublic = Key<TxOut, Target, RistrettoPublic>;
 
 /// Generic key object, see type aliases for use
 #[derive(Clone, Debug, Zeroize)]
@@ -158,10 +158,10 @@ impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// Access underlying [`RistrettoPoint`] for public keys using [`AsRef`]
-impl<ADDR, KIND> AsRef<RistrettoPoint> for Key<ADDR, KIND, RistrettoPublic> {
-    fn as_ref(&self) -> &RistrettoPoint {
-        self.key.as_ref()
+/// Access underlying [`RistrettoPoint`] for public key containers
+impl<ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPublic>> for RistrettoPoint {
+    fn from(k: &Key<ADDR, KIND, RistrettoPublic>) -> Self {
+        *k.key.as_ref()
     }
 }
 
@@ -186,7 +186,7 @@ impl<ADDR, KIND> PartialEq<Key<ADDR, KIND, RistrettoPublic>> for RistrettoPublic
     }
 }
 
-/// [`core::fmt::Display`] for public key objects
+/// [core::fmt::Display] for public key objects
 impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
@@ -197,7 +197,7 @@ impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// [`core::fmt::LowerHex`] for public key objects
+/// [core::fmt::LowerHex] for public key objects
 impl<ADDR, KIND> core::fmt::LowerHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
@@ -208,7 +208,7 @@ impl<ADDR, KIND> core::fmt::LowerHex for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// [`core::fmt::UpperHex`] for public key objects
+/// [core::fmt::UpperHex] for public key objects
 impl<ADDR, KIND> core::fmt::UpperHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
@@ -251,7 +251,7 @@ impl<ADDR, KIND> From<Key<ADDR, KIND, RistrettoPrivate>> for Key<ADDR, KIND, Ris
 }
 
 /// Attempt to create a private key from a compressed point, wrapping
-/// [`RistrettoPrivate::try_from`]
+/// [RistrettoPrivate::try_from]
 impl<ADDR, KIND> TryFrom<&[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
     type Error = KeyError;
 
@@ -266,7 +266,7 @@ impl<ADDR, KIND> TryFrom<&[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
 }
 
 /// Attempt to create a private key from a compressed point, wrapping
-/// [`RistrettoPrivate::try_from`]
+/// [RistrettoPrivate::try_from]
 impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
     type Error = KeyError;
 
@@ -275,14 +275,14 @@ impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// Access underlying [`Scalar`] for private keys using [`AsRef`]
-impl<ADDR, KIND> AsRef<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
-    fn as_ref(&self) -> &Scalar {
-        self.key.as_ref()
+/// Access underlying [Scalar] for private key objects
+impl <ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPrivate>> for Scalar {
+    fn from(k: &Key<ADDR, KIND, RistrettoPrivate>) -> Self {
+        *k.key.as_ref()
     }
 }
 
-/// Create private keys from raw [`Scalar`]
+/// Create a private key from raw [Scalar]
 impl<ADDR, KIND> From<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
     fn from(s: Scalar) -> Self {
         Self {
@@ -293,35 +293,35 @@ impl<ADDR, KIND> From<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// [`PartialEq`] via public key conversion for Private key objects
+/// [PartialEq] via public key conversion for Private key objects
 impl<ADDR, KIND> PartialEq for Key<ADDR, KIND, RistrettoPrivate> {
     fn eq(&self, other: &Self) -> bool {
         RistrettoPublic::from(&self.key) == RistrettoPublic::from(&other.key)
     }
 }
 
-/// PartialEq for backwards compatibility with private key objects
+/// [PartialEq] for backwards compatibility with private key objects
 impl<ADDR, KIND> PartialEq<RistrettoPrivate> for Key<ADDR, KIND, RistrettoPrivate> {
     fn eq(&self, other: &RistrettoPrivate) -> bool {
         RistrettoPublic::from(&self.key) == RistrettoPublic::from(other)
     }
 }
 
-/// PartialEq for backwards compatibility with private key objects
+/// [PartialEq] for backwards compatibility with private key objects
 impl<ADDR, KIND> PartialEq<Key<ADDR, KIND, RistrettoPrivate>> for RistrettoPrivate {
     fn eq(&self, other: &Key<ADDR, KIND, RistrettoPrivate>) -> bool {
         RistrettoPublic::from(self) == RistrettoPublic::from(&other.key)
     }
 }
 
-/// [`core::fmt::Display`] for private key objects
+/// [core::fmt::Display] for private key objects
 impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPrivate> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "pub({})", RistrettoPublic::from(&self.key))
     }
 }
 
-/// [`serde::Serialize`] implementation for private key types
+/// [serde::Serialize] implementation for private key types
 #[cfg(feature = "serde")]
 impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPrivate> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -329,7 +329,7 @@ impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// [`serde::Serialize`] implementation for public key types
+/// [serde::Serialize] implementation for public key types
 #[cfg(feature = "serde")]
 impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPublic> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -337,7 +337,7 @@ impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// [`serde::Deserialize`] implementation for all key types
+/// [serde::Deserialize] implementation for all key types
 #[cfg(feature = "serde")]
 impl<'de, ADDR, KIND, KEY> serde::de::Deserialize<'de> for Key<ADDR, KIND, KEY>
 where
@@ -362,7 +362,7 @@ where
 #[cfg(feature = "serde")]
 struct KeyVisitor<KEY>(PhantomData<KEY>);
 
-/// Visitor implementation for [`Key`] types supporting `TryFrom<&[u8]>`
+/// Visitor implementation for [Key] types supporting `TryFrom<&[u8]>`
 #[cfg(feature = "serde")]
 impl<'de, KEY> serde::de::Visitor<'de> for KeyVisitor<KEY>
 where
@@ -386,7 +386,7 @@ where
     }
 }
 
-/// Expose [`prost::Message`] for internal `KEY` types implementing this
+/// [Key] implementation of [prost::Message] when its inner `KEY` type implements [prost::Message].
 #[cfg(feature = "prost")]
 impl<ADDR, KIND, KEY> prost::Message for Key<ADDR, KIND, KEY>
 where

--- a/core/types/src/keys.rs
+++ b/core/types/src/keys.rs
@@ -276,7 +276,7 @@ impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
 }
 
 /// Access underlying [Scalar] for private key objects
-impl <ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPrivate>> for Scalar {
+impl<ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPrivate>> for Scalar {
     fn from(k: &Key<ADDR, KIND, RistrettoPrivate>) -> Self {
         *k.key.as_ref()
     }
@@ -386,7 +386,8 @@ where
     }
 }
 
-/// [Key] implementation of [prost::Message] when its inner `KEY` type implements [prost::Message].
+/// [Key] implementation of [prost::Message] when its inner `KEY` type
+/// implements [prost::Message].
 #[cfg(feature = "prost")]
 impl<ADDR, KIND, KEY> prost::Message for Key<ADDR, KIND, KEY>
 where

--- a/core/types/src/markers.rs
+++ b/core/types/src/markers.rs
@@ -17,3 +17,15 @@ pub struct View;
 /// Spend key marker type
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Spend;
+
+/// Transaction key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Tx;
+
+/// Transaction public key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Public;
+
+/// Transaction target key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Target;

--- a/core/types/src/markers.rs
+++ b/core/types/src/markers.rs
@@ -18,9 +18,9 @@ pub struct View;
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Spend;
 
-/// Transaction key marker type
+/// TxOut key marker type
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Tx;
+pub struct TxOut;
 
 /// Transaction public key marker type
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/crypto/ring-signature/src/onetime_keys.rs
+++ b/crypto/ring-signature/src/onetime_keys.rs
@@ -104,12 +104,12 @@ pub fn create_tx_out_target_key(
     let Hs: Scalar = {
         let r = tx_private_key.as_ref();
         let view_public = recipient.view_public_key();
-        let C: &RistrettoPoint = view_public.as_ref();
+        let C: &RistrettoPoint = &RistrettoPoint::from(&view_public);
         hash_to_scalar(r * C)
     };
 
     let spend_public = recipient.spend_public_key();
-    let D: &RistrettoPoint = spend_public.as_ref();
+    let D: &RistrettoPoint = &RistrettoPoint::from(&spend_public);
     RistrettoPublic::from(Hs * G + D)
 }
 


### PR DESCRIPTION
some smol improvements extracted from the ledger adventure branch

- add new `account::ViewAccount`, `keys::{TxOutPublic, TxOutTargetPublic}` types to core
- add `TryFrom<[u8; 32]>` key constructors alongside existing `TryFrom<&[u8; 32]>` impls for `Key` container to smooth over some type constraint challenges 
- passthrough `prost::Message` and `ReprBytes` for `Key` container types to improve compatibility when replacing `RistrettoPublic` and `RistrettoPrivate` types in serializable objects
