### PR TITLE
Fix blank query sealing issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,6 +2532,7 @@ dependencies = [
  "mc-attest-verifier",
  "mc-crypto-noise",
  "mc-sgx-compat",
+ "mc-util-serial",
  "serde",
 ]
 
@@ -3167,6 +3168,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
+ "mc-util-serial",
  "sha2 0.10.6",
 ]
 

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -13,6 +13,7 @@ mc-attest-core = { path = "../../attest/core", default-features = false }
 mc-attest-verifier = { path = "../../attest/verifier", default-features = false }
 mc-crypto-noise = { path = "../../crypto/noise", default-features = false }
 mc-sgx-compat = { path = "../../sgx/compat" }
+mc-util-serial = { path = "../../util/serial" }
 
 displaydoc = { version = "0.2", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }

--- a/attest/enclave-api/src/error.rs
+++ b/attest/enclave-api/src/error.rs
@@ -2,6 +2,7 @@
 
 //! Enclave API Errors
 
+use alloc::{format, string::String};
 use core::result::Result as StdResult;
 use displaydoc::Display;
 use mc_attest_ake::Error as AkeError;
@@ -70,6 +71,12 @@ pub enum Error {
     /// Too many IAS reports are already in-flight
     TooManyPendingReports,
 
+    /// Encoding error
+    Encode(String),
+
+    /// Decoding error
+    Decode(String),
+
     /// Connection not found by node ID or session
     NotFound,
 }
@@ -125,5 +132,17 @@ impl From<IntelSealingError> for Error {
 impl From<ParseSealedError> for Error {
     fn from(src: ParseSealedError) -> Error {
         Error::Unseal(src)
+    }
+}
+
+impl From<mc_util_serial::encode::Error> for Error {
+    fn from(src: mc_util_serial::encode::Error) -> Self {
+        Error::Encode(format!("{}", src))
+    }
+}
+
+impl From<mc_util_serial::decode::Error> for Error {
+    fn from(src: mc_util_serial::decode::Error) -> Self {
+        Error::Decode(format!("{}", src))
     }
 }

--- a/attest/enclave-api/src/error.rs
+++ b/attest/enclave-api/src/error.rs
@@ -2,7 +2,7 @@
 
 //! Enclave API Errors
 
-use alloc::{format, string::String};
+use alloc::string::{String, ToString};
 use core::result::Result as StdResult;
 use displaydoc::Display;
 use mc_attest_ake::Error as AkeError;
@@ -137,12 +137,12 @@ impl From<ParseSealedError> for Error {
 
 impl From<mc_util_serial::encode::Error> for Error {
     fn from(src: mc_util_serial::encode::Error) -> Self {
-        Error::Encode(format!("{}", src))
+        Error::Encode(src.to_string())
     }
 }
 
 impl From<mc_util_serial::decode::Error> for Error {
     fn from(src: mc_util_serial::decode::Error) -> Self {
-        Error::Decode(format!("{}", src))
+        Error::Decode(src.to_string())
     }
 }

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -97,7 +97,7 @@ pub struct SealedClientRequest {
     /// The channel_id associated with the QueryRequest. Since the channel_id
     /// will never be 0, this struct will never serialize into an empty byte
     /// array.
-    pub channel_id: Vec<u8>,
+    pub channel_id: ClientSession,
 }
 
 /// The response to a request for a new report. The enclave will expect the

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -87,6 +87,19 @@ pub struct SealedClientMessage {
     pub data: IntelSealed,
 }
 
+/// SealedClientRequest structure, which is used in the enclave during the Intel
+/// sealing process. Ensures that the data being passed to Intel is not empty.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct SealedClientRequest {
+    /// The decrypted client request bytes
+    pub client_request_bytes: Vec<u8>,
+
+    /// The channel_id associated with the QueryRequest. Since the channel_id
+    /// will never be 0, this struct will never serialize into an empty byte
+    /// array.
+    pub channel_id: Vec<u8>,
+}
+
 /// The response to a request for a new report. The enclave will expect the
 /// QuoteNonce to be used when the report is quoted, and both the quote and
 /// report to be returned to the enclave during the verify_quote() phase.

--- a/attest/enclave-api/src/lib.rs
+++ b/attest/enclave-api/src/lib.rs
@@ -87,10 +87,10 @@ pub struct SealedClientMessage {
     pub data: IntelSealed,
 }
 
-/// SealedClientRequest structure, which is used in the enclave during the Intel
-/// sealing process. Ensures that the data being passed to Intel is not empty.
+/// Helper struct that is used in the enclave during the Intel
+/// sealing process. Ensures that the data being sealed is not empty.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct SealedClientRequest {
+pub struct PlaintextClientRequest {
     /// The decrypted client request bytes
     pub client_request_bytes: Vec<u8>,
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -771,6 +771,7 @@ dependencies = [
  "mc-attest-verifier",
  "mc-crypto-noise",
  "mc-sgx-compat",
+ "mc-util-serial",
  "serde",
 ]
 
@@ -1017,6 +1018,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
+ "mc-util-serial",
  "sha2",
 ]
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -14,6 +14,7 @@ mc-common = { path = "../../../common", default-features = false }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-crypto-rand = { path = "../../../crypto/rand", default-features = false }
 mc-util-from-random = { path = "../../../util/from-random" }
+mc-util-serial = { path = "../../../util/serial" }
 mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 
 aes-gcm = "0.9.4"

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -545,7 +545,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let client_query_bytes = self.client_decrypt(incoming_client_message)?;
         let sealed_client_query = SealedClientRequest {
             client_request_bytes: client_query_bytes,
-            channel_id: channel_id.clone().into(),
+            channel_id: channel_id.clone(),
         };
         let sealed_client_query_bytes = mc_util_serial::serialize(&sealed_client_query)?;
         let sealed_data = IntelSealed::seal_raw(&sealed_client_query_bytes, &[])?;

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -16,8 +16,8 @@ use mc_attest_core::{
 };
 use mc_attest_enclave_api::{
     ClientAuthRequest, ClientAuthResponse, ClientSession, EnclaveMessage, Error, NonceAuthRequest,
-    NonceAuthResponse, NonceSession, PeerAuthRequest, PeerAuthResponse, PeerSession, Result,
-    SealedClientMessage, SealedClientRequest,
+    NonceAuthResponse, NonceSession, PeerAuthRequest, PeerAuthResponse, PeerSession,
+    PlaintextClientRequest, Result, SealedClientMessage,
 };
 use mc_attest_trusted::{EnclaveReport, SealAlgo};
 use mc_attest_verifier::{MrEnclaveVerifier, Verifier, DEBUG_ENCLAVE};
@@ -543,7 +543,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let aad = incoming_client_message.aad.clone();
         let channel_id = incoming_client_message.channel_id.clone();
         let client_query_bytes = self.client_decrypt(incoming_client_message)?;
-        let sealed_client_query = SealedClientRequest {
+        let sealed_client_query = PlaintextClientRequest {
             client_request_bytes: client_query_bytes,
             channel_id: channel_id.clone(),
         };
@@ -561,7 +561,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
     /// plaintext
     pub fn unseal(&self, sealed_message: &SealedClientMessage) -> Result<Vec<u8>> {
         let (sealed_client_request_bytes, _) = sealed_message.data.unseal_raw()?;
-        let sealed_client_request: SealedClientRequest =
+        let sealed_client_request: PlaintextClientRequest =
             mc_util_serial::deserialize(&sealed_client_request_bytes)?;
 
         Ok(sealed_client_request.client_request_bytes)

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "mc-attest-verifier",
  "mc-crypto-noise",
  "mc-sgx-compat",
+ "mc-util-serial",
  "serde",
 ]
 
@@ -944,6 +945,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
+ "mc-util-serial",
  "sha2",
 ]
 

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "mc-attest-verifier",
  "mc-crypto-noise",
  "mc-sgx-compat",
+ "mc-util-serial",
  "serde",
 ]
 
@@ -913,6 +914,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
+ "mc-util-serial",
  "sha2",
 ]
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "mc-attest-verifier",
  "mc-crypto-noise",
  "mc-sgx-compat",
+ "mc-util-serial",
  "serde",
 ]
 
@@ -954,6 +955,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-compat",
  "mc-util-from-random",
+ "mc-util-serial",
  "sha2",
 ]
 


### PR DESCRIPTION
### Motivation
The "classic" unary Fog View API supports blank `QueryRequest`s. (i.e. a `QueryRequest` without egress keys). When implementing FVR, we decided to not support blank QueryRequests to simplify the Intel sealing logic, but this was a mistake because we forgot that clients should be able to query Fog View without egress keys to get information like highest processed block count etc. 

This change makes the necessary changes to the Intel sealing logic to allow for blank FVR `QueryRequest`s. This PR's logic is tested in the follow up PR that removes the classic Fog View API from fog view service.

