### PR TITLE
feat: rate limit consensus client attest endpoint

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -385,7 +385,7 @@ jobs:
         chart_path: .internal-ci/helm/${{ matrix.chart }}
 
 ################################################
-# Bootstrap namespace to v1.1.3-dev from backup
+# Bootstrap namespace to v3.0.0-dev from backup
 ################################################
   bootstrap-v3-bv2:
     uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -92,6 +92,10 @@ jobs:
               intel.com/sgx: 2000
           persistence:
             enabled: false
+          client:
+            attest:
+              rateLimits:
+                enabled: false
         EOF
 
     - name: Deploy Consensus nodes

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
@@ -1,11 +1,15 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+# split out attest endpoint for client port so we can set rate limiting.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "consensusNode.fullname" . }}-client-grpc
+  name: {{ include "consensusNode.fullname" . }}-client-grpc-attest
   annotations:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
+    {{- end }}
+    {{- if .Values.node.client.attest.rateLimits.enabled }}
+    {{- toYaml .Values.node.client.attest.rateLimits.annotations | nindent 4 }}
     {{- end }}
     {{- toYaml .Values.node.client.ingress.annotations | nindent 4 }}
   labels:
@@ -19,21 +23,7 @@ spec:
   - host: {{ include "consensusNode.clientHostname" . }}
     http:
       paths:
-      - path: /build_info.BuildInfoApi
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "consensusNode.fullname" . }}
-            port:
-              number: 3223
-      - path: /consensus_common.BlockchainAPI
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "consensusNode.fullname" . }}
-            port:
-              number: 3223
-      - path: /consensus_client.ConsensusClientAPI
+      - path: /attest.AttestedApi
         pathType: Prefix
         backend:
           service:

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -101,6 +101,21 @@ node:
           storage: 512Gi
 
   client:
+    attest:
+      rateLimits:
+        enabled: true
+        # Assume 2 ingress controllers.
+        # Since this version of haproxy ingress doesn't have peering support we need to divide the
+        # total requests we want to allow by the number of nodes.  Its a little bit funky since
+        # we also need to assume that load-balancing between ingest nodes is even (or close enough).
+        # Another limitation is this stick-table is shared across all ingresses that use the same
+        # rate-limit-period.  Need to file a pr?
+        # rate limit attest endpoint to 20 requests/min from any single IP.
+        annotations:
+          haproxy.org/rate-limit-status-code: "429"
+          haproxy.org/rate-limit-requests: "10"
+          haproxy.org/rate-limit-period: 1m
+
     ingress:
       annotations:
         # HAProxy Ingress

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -113,7 +113,7 @@ node:
         # rate limit attest endpoint to 20 requests/min from any single IP.
         annotations:
           haproxy.org/rate-limit-status-code: "429"
-          haproxy.org/rate-limit-requests: "10"
+          haproxy.org/rate-limit-requests: "20"
           haproxy.org/rate-limit-period: 1m
 
     ingress:


### PR DESCRIPTION
### Motivation

Set up rate limits to the client attest endpoint to prevent abusive clients from pushing sessions out of the database.  
20 requests per minute per IP address.  

