### PR TITLE
Oblivious collation of key image store responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,6 +3905,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "mc-watcher-api",
+ "yare",
 ]
 
 [[package]]

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -35,3 +35,4 @@ mc-fog-types = { path = "../../../types" }
 
 [dev-dependencies]
 mc-common = { path = "../../../../common", features = ["loggers"] }
+yare = "1.0.2"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -33,3 +33,5 @@ mc-oblivious-traits = "2.2"
 mc-fog-ledger-enclave-api = { path = "../api", default-features = false }
 mc-fog-types = { path = "../../../types" }
 
+[dev-dependencies]
+mc-common = { path = "../../../../common", features = ["loggers"] }

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -29,7 +29,8 @@ use mc_common::{
 use mc_crypto_ake_enclave::{AkeEnclaveState, NullIdentity};
 use mc_crypto_keys::X25519Public;
 use mc_fog_ledger_enclave_api::{
-    Error, KeyImageData, LedgerEnclave, OutputContext, Result, UntrustedKeyImageQueryResponse,
+    Error, KeyImageData, KeyImageResult, LedgerEnclave, OutputContext, Result,
+    UntrustedKeyImageQueryResponse,
 };
 use mc_fog_types::ledger::{
     CheckKeyImagesRequest, CheckKeyImagesResponse, GetOutputsRequest, GetOutputsResponse,
@@ -280,14 +281,14 @@ where
             .max()
             .expect("this is only None when the iterator is empty but we early-exit in that case");
 
-        let plaintext_results = shard_query_responses
+        let plaintext_results: Vec<KeyImageResult> = shard_query_responses
             .into_iter()
             .flat_map(|query_response| query_response.results)
             .collect();
 
         let oblivious_results = oblivious_utils::collate_shard_key_image_search_results(
             client_query_request.queries,
-            plaintext_results,
+            &plaintext_results,
         );
 
         let max_block_version = max(latest_block_version, *MAX_BLOCK_VERSION);

--- a/fog/ledger/enclave/impl/src/oblivious_utils.rs
+++ b/fog/ledger/enclave/impl/src/oblivious_utils.rs
@@ -1,0 +1,454 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Contains methods that allow a Fog View Router enclave to combine all of the
+//! Fog View Shard's query responses into one query response that'll be returned
+//! for the client.
+
+use aligned_cmov::{
+    subtle::{Choice, ConstantTimeEq},
+    CMov,
+};
+use alloc::vec::Vec;
+use mc_fog_types::ledger::{KeyImageQuery, KeyImageResult, KeyImageResultCode};
+use mc_watcher_api::TimestampResultCode;
+
+/// The default KeyImageResultCode used when collating the shard responses.
+const DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE: KeyImageResultCode = KeyImageResultCode::NotSpent;
+
+pub fn collate_shard_key_image_search_results(
+    client_queries: Vec<KeyImageQuery>,
+    shard_key_image_search_results: Vec<KeyImageResult>,
+) -> Vec<KeyImageResult> {
+    let mut client_key_image_search_results: Vec<KeyImageResult> = client_queries
+        .iter()
+        .map(|client_query| KeyImageResult {
+            key_image: client_query.key_image,
+            spent_at: 1, // not 0 because it's defined to be >0 in the .proto file
+            timestamp: u64::MAX,
+            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+            key_image_result_code: DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32,
+        })
+        .collect();
+
+    for shard_key_image_search_result in shard_key_image_search_results.iter() {
+        for client_key_image_search_result in client_key_image_search_results.iter_mut() {
+            maybe_overwrite_key_image_search_result(
+                client_key_image_search_result,
+                shard_key_image_search_result,
+            );
+        }
+    }
+
+    client_key_image_search_results
+}
+
+fn maybe_overwrite_key_image_search_result(
+    client_key_image_search_result: &mut KeyImageResult,
+    shard_key_image_search_result: &KeyImageResult,
+) {
+    let should_overwrite_key_image_search_result = should_overwrite_key_image_search_result(
+        client_key_image_search_result,
+        shard_key_image_search_result,
+    );
+
+    client_key_image_search_result.key_image_result_code.cmov(
+        should_overwrite_key_image_search_result,
+        &shard_key_image_search_result.key_image_result_code,
+    );
+
+    client_key_image_search_result.spent_at.cmov(
+        should_overwrite_key_image_search_result,
+        &shard_key_image_search_result.spent_at,
+    );
+
+    client_key_image_search_result.timestamp.cmov(
+        should_overwrite_key_image_search_result,
+        &shard_key_image_search_result.timestamp,
+    );
+
+    client_key_image_search_result.timestamp_result_code.cmov(
+        should_overwrite_key_image_search_result,
+        &shard_key_image_search_result.timestamp_result_code,
+    );
+}
+
+fn should_overwrite_key_image_search_result(
+    client_key_image_search_result: &KeyImageResult,
+    shard_key_image_search_result: &KeyImageResult,
+) -> Choice {
+    let client_key_image: &[u8] = client_key_image_search_result.key_image.as_ref();
+    let shard_key_image: &[u8] = shard_key_image_search_result.key_image.as_ref();
+    let do_key_images_match = client_key_image.ct_eq(shard_key_image);
+
+    let client_key_image_search_result_code = client_key_image_search_result.key_image_result_code;
+    let shard_key_image_search_result_code = shard_key_image_search_result.key_image_result_code;
+
+    let client_code_is_not_spent: Choice =
+        client_key_image_search_result_code.ct_eq(&(KeyImageResultCode::NotSpent as u32));
+
+    let shard_code_is_spent: Choice =
+        shard_key_image_search_result_code.ct_eq(&(KeyImageResultCode::Spent as u32));
+    let shard_code_is_error: Choice =
+        shard_key_image_search_result_code.ct_eq(&(KeyImageResultCode::KeyImageError as u32));
+
+    //   We make the same query to several shards and get several responses, and
+    // this logic determines how we fill the one client response.
+    //   At a high level, we want to prioritize "spent" responses.
+    // Error responses are "retriable" errors that the client will retry
+    // after a backoff. The "not spent" response is the default response and
+    // gets overwritten by any other response.
+    // spent > error > not spent
+    do_key_images_match
+           // Always write a Found code
+        & (shard_code_is_spent
+            // Write an error code IFF the client code is NotFound.
+            | ((shard_code_is_error) & client_code_is_not_spent))
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use std::vec;
+
+    #[test]
+    fn should_overwrite_tests() {
+        let test_cases = vec![
+            // Images don't match
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::NotSpent,
+                654321,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::Spent,
+                false,
+                "key images don't match, but overwritten anyway!",
+            ),
+            // Spent beats not spent
+            (
+                123456,
+                1,
+                u64::MAX,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::NotSpent,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::Spent,
+                true,
+                "Shard key is spent but doesn't overwrite unspent client!",
+            ),
+            // Spent beats error
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::KeyImageError,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::Spent,
+                true,
+                "Shard key is spent but doesn't overwrite error client!",
+            ),
+            // Error beats not spent
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::NotSpent,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::KeyImageError,
+                true,
+                "Shard result is error but doesn't overwrite unspent client!",
+            ),
+            // Error doesn't beat spent
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::Spent,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::KeyImageError,
+                false,
+                "Shard result is error but overwrites spent client!",
+            ),
+            // Unspent doesn't beat error
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::KeyImageError,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::NotSpent,
+                false,
+                "Shard result is unspent but overwrites client error!",
+            ),
+            // Unspent doesn't beat spent
+            (
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::Spent,
+                123456,
+                1,
+                123456,
+                TimestampResultCode::TimestampFound,
+                KeyImageResultCode::NotSpent,
+                false,
+                "Shard result is unspent but overwrites spent client!",
+            ),
+        ];
+
+        for (
+            client_key_image,
+            client_spent_at,
+            client_timestamp,
+            client_timestamp_result_code,
+            client_key_image_result_code,
+            shard_key_image,
+            shard_spent_at,
+            shard_timestamp,
+            shard_timestamp_result_code,
+            shard_key_image_result_code,
+            expected_result,
+            panic_message,
+        ) in test_cases.into_iter()
+        {
+            let client_result = KeyImageResult {
+                key_image: client_key_image.into(),
+                spent_at: client_spent_at,
+                timestamp: client_timestamp,
+                timestamp_result_code: client_timestamp_result_code as u32,
+                key_image_result_code: client_key_image_result_code as u32,
+            };
+            let shard_result = KeyImageResult {
+                key_image: shard_key_image.into(),
+                spent_at: shard_spent_at,
+                timestamp: shard_timestamp,
+                timestamp_result_code: shard_timestamp_result_code as u32,
+                key_image_result_code: shard_key_image_result_code as u32,
+            };
+            let result: bool =
+                should_overwrite_key_image_search_result(&client_result, &shard_result).into();
+            assert_eq!(result, expected_result, "{}", panic_message);
+        }
+    }
+
+    fn collate(
+        client_queries: Vec<KeyImageQuery>,
+        shard_key_image_search_results: Vec<KeyImageResult>,
+    ) -> Vec<KeyImageResult> {
+        let queries_count = client_queries.len();
+        let result =
+            collate_shard_key_image_search_results(client_queries, shard_key_image_search_results);
+
+        let results_count = result.len();
+        assert_eq!(
+            results_count, queries_count,
+            "{}",
+            "results length does not match number of queries"
+        );
+
+        result
+    }
+
+    #[test]
+    fn collation_tests() {
+        // All results available, no dupes
+        let client_queries = vec![KeyImageQuery {
+            key_image: 1.into(),
+            start_block: 0,
+        }];
+
+        let shard_results = vec![KeyImageResult {
+            key_image: 1.into(),
+            spent_at: 1,
+            timestamp: 123,
+            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+            key_image_result_code: KeyImageResultCode::Spent as u32,
+        }];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_found = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
+        });
+
+        assert!(
+            all_images_found,
+            "{}",
+            "all images are present but some were not collated"
+        );
+
+        // All results available, one duplicate
+        let client_queries = vec![KeyImageQuery {
+            key_image: 1.into(),
+            start_block: 0,
+        }];
+
+        let shard_results = vec![
+            KeyImageResult {
+                key_image: 1.into(),
+                spent_at: 1,
+                timestamp: 123,
+                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+                key_image_result_code: KeyImageResultCode::Spent as u32,
+            },
+            KeyImageResult {
+                key_image: 1.into(),
+                spent_at: 1,
+                timestamp: 123,
+                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+                key_image_result_code: KeyImageResultCode::Spent as u32,
+            },
+        ];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_found = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
+        });
+
+        assert!(
+            all_images_found,
+            "{}",
+            "all images are present but some were not collated"
+        );
+
+        // All results available, one error
+        let client_queries = vec![KeyImageQuery {
+            key_image: 1.into(),
+            start_block: 0,
+        }];
+
+        let shard_results = vec![
+            KeyImageResult {
+                key_image: 1.into(),
+                spent_at: 1,
+                timestamp: 123,
+                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+                key_image_result_code: KeyImageResultCode::Spent as u32,
+            },
+            KeyImageResult {
+                key_image: 1.into(),
+                spent_at: 1,
+                timestamp: 123,
+                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+                key_image_result_code: KeyImageResultCode::KeyImageError as u32,
+            },
+        ];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_found = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
+        });
+
+        assert!(
+            all_images_found,
+            "{}",
+            "all images are present but some were not collated"
+        );
+
+        // No results available
+        let client_queries = vec![KeyImageQuery {
+            key_image: 1.into(),
+            start_block: 0,
+        }];
+
+        let shard_results = vec![];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_found = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
+        });
+
+        assert!(
+            !all_images_found,
+            "{}",
+            "all images show results but no result provided"
+        );
+
+        // Result is error
+        let client_queries = vec![KeyImageQuery {
+            key_image: 1.into(),
+            start_block: 0,
+        }];
+
+        let shard_results = vec![KeyImageResult {
+            key_image: 1.into(),
+            spent_at: 1,
+            timestamp: 123,
+            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+            key_image_result_code: KeyImageResultCode::KeyImageError as u32,
+        }];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_error = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::KeyImageError as u32
+        });
+
+        assert!(
+            all_images_error,
+            "{}",
+            "an image reported no error despite an error result"
+        );
+
+        // Only some queries answered
+        let client_queries = vec![
+            KeyImageQuery {
+                key_image: 1.into(),
+                start_block: 0,
+            },
+            KeyImageQuery {
+                key_image: 2.into(),
+                start_block: 0,
+            },
+        ];
+
+        let shard_results = vec![KeyImageResult {
+            key_image: 1.into(),
+            spent_at: 1,
+            timestamp: 123,
+            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+            key_image_result_code: KeyImageResultCode::Spent as u32,
+        }];
+
+        let result = collate(client_queries, shard_results);
+
+        let all_images_found = result.iter().all(|key_image_result| {
+            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
+        });
+
+        assert!(
+            !all_images_found,
+            "{}",
+            "all images show results but some had no result provided"
+        );
+    }
+}

--- a/fog/ledger/enclave/impl/src/oblivious_utils.rs
+++ b/fog/ledger/enclave/impl/src/oblivious_utils.rs
@@ -260,17 +260,13 @@ mod tests {
             timestamp_result_code: TimestampResultCode::TimestampFound as u32,
             key_image_result_code: KeyImageResultCode::Spent as u32,
         };
-        let shard_results = vec![key_image_result];
+        let shard_results = vec![key_image_result.clone()];
 
-        let results = collate_shard_key_image_search_results(client_queries, &shard_results);
-
+        let mut results = collate_shard_key_image_search_results(client_queries, &shard_results);
+        results.sort_by_key(|r| r.key_image);
         assert_eq!(
-            results[0].key_image_result_code,
-            KeyImageResultCode::Spent as u32
-        );
-        assert_eq!(
-            results[1].key_image_result_code,
-            DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32
+            results,
+            vec![key_image_result, default_client_key_image(2.into())]
         );
     }
 }

--- a/fog/ledger/enclave/impl/src/oblivious_utils.rs
+++ b/fog/ledger/enclave/impl/src/oblivious_utils.rs
@@ -10,24 +10,29 @@ use aligned_cmov::{
 };
 use alloc::vec::Vec;
 use mc_fog_types::ledger::{KeyImageQuery, KeyImageResult, KeyImageResultCode};
+use mc_transaction_core::ring_signature::KeyImage;
 use mc_watcher_api::TimestampResultCode;
 
 /// The default KeyImageResultCode used when collating the shard responses.
 const DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE: KeyImageResultCode = KeyImageResultCode::NotSpent;
 
+fn default_client_key_image(key_image: KeyImage) -> KeyImageResult {
+    KeyImageResult {
+        key_image,
+        spent_at: 1, // not 0 because it's defined to be >0 in the .proto file
+        timestamp: u64::MAX,
+        timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+        key_image_result_code: DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32,
+    }
+}
+
 pub fn collate_shard_key_image_search_results(
     client_queries: Vec<KeyImageQuery>,
-    shard_key_image_search_results: Vec<KeyImageResult>,
+    shard_key_image_search_results: &[KeyImageResult],
 ) -> Vec<KeyImageResult> {
     let mut client_key_image_search_results: Vec<KeyImageResult> = client_queries
         .iter()
-        .map(|client_query| KeyImageResult {
-            key_image: client_query.key_image,
-            spent_at: 1, // not 0 because it's defined to be >0 in the .proto file
-            timestamp: u64::MAX,
-            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
-            key_image_result_code: DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32,
-        })
+        .map(|client_query| default_client_key_image(client_query.key_image))
         .collect();
 
     for shard_key_image_search_result in shard_key_image_search_results.iter() {
@@ -78,31 +83,32 @@ fn should_overwrite_key_image_search_result(
 ) -> Choice {
     let client_key_image: &[u8] = client_key_image_search_result.key_image.as_ref();
     let shard_key_image: &[u8] = shard_key_image_search_result.key_image.as_ref();
-    let do_key_images_match = client_key_image.ct_eq(shard_key_image);
+    let key_images_match = client_key_image.ct_eq(shard_key_image);
 
     let client_key_image_search_result_code = client_key_image_search_result.key_image_result_code;
     let shard_key_image_search_result_code = shard_key_image_search_result.key_image_result_code;
 
-    let client_code_is_not_spent: Choice =
-        client_key_image_search_result_code.ct_eq(&(KeyImageResultCode::NotSpent as u32));
+    let client_code_is_default: Choice =
+        client_key_image_search_result_code.ct_eq(&(DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32));
 
     let shard_code_is_spent: Choice =
         shard_key_image_search_result_code.ct_eq(&(KeyImageResultCode::Spent as u32));
     let shard_code_is_error: Choice =
         shard_key_image_search_result_code.ct_eq(&(KeyImageResultCode::KeyImageError as u32));
 
-    //   We make the same query to several shards and get several responses, and
-    // this logic determines how we fill the one client response.
-    //   At a high level, we want to prioritize "spent" responses.
-    // Error responses are "retriable" errors that the client will retry
-    // after a backoff. The "not spent" response is the default response and
-    // gets overwritten by any other response.
-    // spent > error > not spent
-    do_key_images_match
-           // Always write a Found code
-        & (shard_code_is_spent
-            // Write an error code IFF the client code is NotFound.
-            | ((shard_code_is_error) & client_code_is_not_spent))
+    // We make the same query to several shards and get several responses, and
+    //   this logic determines how we fill the one client response.
+    // First, we only update the client response if the shard's key image for this
+    // result matches   the key image for the client result we're considering
+    // updating. At a high level, we want to prioritize "spent" responses.
+    //   Error responses are "retriable" errors that the client will retry
+    //   after a backoff. The "not spent" response is the default response and
+    //   gets overwritten by any other response.
+    // "Overwrite key image search result if the key images match and either the
+    // shard's response is Spent or there is a new KeyImageError result"
+    let new_error = shard_code_is_error & client_code_is_default;
+    let should_update = shard_code_is_spent | new_error;
+    key_images_match & should_update
 }
 
 #[cfg(test)]
@@ -111,269 +117,96 @@ mod tests {
 
     use super::*;
     use std::vec;
+    use yare::parameterized;
 
     #[test]
-    fn should_overwrite_tests() {
-        let test_cases = vec![
-            // Images don't match
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::NotSpent,
-                654321,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::Spent,
-                false,
-                "key images don't match, but overwritten anyway!",
-            ),
-            // Spent beats not spent
-            (
-                123456,
-                1,
-                u64::MAX,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::NotSpent,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::Spent,
-                true,
-                "Shard key is spent but doesn't overwrite unspent client!",
-            ),
-            // Spent beats error
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::KeyImageError,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::Spent,
-                true,
-                "Shard key is spent but doesn't overwrite error client!",
-            ),
-            // Error beats not spent
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::NotSpent,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::KeyImageError,
-                true,
-                "Shard result is error but doesn't overwrite unspent client!",
-            ),
-            // Error doesn't beat spent
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::Spent,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::KeyImageError,
-                false,
-                "Shard result is error but overwrites spent client!",
-            ),
-            // Unspent doesn't beat error
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::KeyImageError,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::NotSpent,
-                false,
-                "Shard result is unspent but overwrites client error!",
-            ),
-            // Unspent doesn't beat spent
-            (
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::Spent,
-                123456,
-                1,
-                123456,
-                TimestampResultCode::TimestampFound,
-                KeyImageResultCode::NotSpent,
-                false,
-                "Shard result is unspent but overwrites spent client!",
-            ),
-        ];
-
-        for (
-            client_key_image,
-            client_spent_at,
-            client_timestamp,
-            client_timestamp_result_code,
-            client_key_image_result_code,
-            shard_key_image,
-            shard_spent_at,
-            shard_timestamp,
-            shard_timestamp_result_code,
-            shard_key_image_result_code,
-            expected_result,
-            panic_message,
-        ) in test_cases.into_iter()
-        {
-            let client_result = KeyImageResult {
-                key_image: client_key_image.into(),
-                spent_at: client_spent_at,
-                timestamp: client_timestamp,
-                timestamp_result_code: client_timestamp_result_code as u32,
-                key_image_result_code: client_key_image_result_code as u32,
-            };
-            let shard_result = KeyImageResult {
-                key_image: shard_key_image.into(),
-                spent_at: shard_spent_at,
-                timestamp: shard_timestamp,
-                timestamp_result_code: shard_timestamp_result_code as u32,
-                key_image_result_code: shard_key_image_result_code as u32,
-            };
-            let result: bool =
-                should_overwrite_key_image_search_result(&client_result, &shard_result).into();
-            assert_eq!(result, expected_result, "{}", panic_message);
-        }
+    fn differing_key_images_do_not_update() {
+        let client_result = default_client_key_image(1.into());
+        let shard_result = default_client_key_image(2.into());
+        let result: bool =
+            should_overwrite_key_image_search_result(&client_result, &shard_result).into();
+        assert!(!result);
     }
 
-    fn collate(
-        client_queries: Vec<KeyImageQuery>,
-        shard_key_image_search_results: Vec<KeyImageResult>,
-    ) -> Vec<KeyImageResult> {
-        let queries_count = client_queries.len();
-        let result =
-            collate_shard_key_image_search_results(client_queries, shard_key_image_search_results);
+    #[parameterized(
+    client_default_shard_is_spent = { KeyImageResultCode::NotSpent, KeyImageResultCode::Spent},
+    client_default_shard_is_error = { KeyImageResultCode::NotSpent, KeyImageResultCode::KeyImageError},
+    client_error_shard_is_spent = { KeyImageResultCode::KeyImageError, KeyImageResultCode::Spent},
+    client_spent_shard_is_spent = { KeyImageResultCode::Spent, KeyImageResultCode::Spent},
+    )]
+    fn should_update(client_code: KeyImageResultCode, shard_code: KeyImageResultCode) {
+        let mut client_result = default_client_key_image(1.into());
+        let mut shard_result = client_result.clone();
+        client_result.key_image_result_code = client_code as u32;
+        shard_result.key_image_result_code = shard_code as u32;
+        let result: bool =
+            should_overwrite_key_image_search_result(&client_result, &shard_result).into();
+        assert!(result);
+    }
 
-        let results_count = result.len();
-        assert_eq!(
-            results_count, queries_count,
-            "{}",
-            "results length does not match number of queries"
-        );
-
-        result
+    #[parameterized(
+    client_default_shard_is_not_spent = { KeyImageResultCode::NotSpent, KeyImageResultCode::NotSpent},
+    client_error_shard_is_not_spent = { KeyImageResultCode::KeyImageError, KeyImageResultCode::NotSpent},
+    client_error_shard_is_error = { KeyImageResultCode::KeyImageError, KeyImageResultCode::KeyImageError},
+    client_spent_shard_is_not_spent = { KeyImageResultCode::Spent, KeyImageResultCode::NotSpent},
+    client_spent_shard_is_error = { KeyImageResultCode::Spent, KeyImageResultCode::KeyImageError},
+    )]
+    fn should_not_update(client_code: KeyImageResultCode, shard_code: KeyImageResultCode) {
+        let mut client_result = default_client_key_image(1.into());
+        let mut shard_result = client_result.clone();
+        client_result.key_image_result_code = client_code as u32;
+        shard_result.key_image_result_code = shard_code as u32;
+        let result: bool =
+            should_overwrite_key_image_search_result(&client_result, &shard_result).into();
+        assert!(!result);
     }
 
     #[test]
-    fn collation_tests() {
-        // All results available, no dupes
+    fn all_available() {
+        let range = 1..=3;
+        let client_queries = range
+            .clone()
+            .map(|key_image| KeyImageQuery {
+                key_image: key_image.into(),
+                start_block: 0,
+            })
+            .collect::<Vec<_>>();
+        let mut shard_results = range
+            .map(|key_image| KeyImageResult {
+                key_image: key_image.into(),
+                spent_at: key_image + 1,
+                timestamp: key_image + 10,
+                timestamp_result_code: TimestampResultCode::WatcherBehind as u32,
+                key_image_result_code: KeyImageResultCode::Spent as u32,
+            })
+            .collect::<Vec<_>>();
+        let mut results = collate_shard_key_image_search_results(client_queries, &shard_results);
+        results.sort_by_key(|r| r.key_image);
+        shard_results.sort_by_key(|r| r.key_image);
+        assert_eq!(results, shard_results);
+    }
+
+    #[test]
+    fn duplicate_shard_results_returns_one_result() {
         let client_queries = vec![KeyImageQuery {
             key_image: 1.into(),
             start_block: 0,
         }];
-
-        let shard_results = vec![KeyImageResult {
+        let key_image_result = KeyImageResult {
             key_image: 1.into(),
-            spent_at: 1,
-            timestamp: 123,
-            timestamp_result_code: TimestampResultCode::TimestampFound as u32,
+            spent_at: 2,
+            timestamp: 3,
+            timestamp_result_code: TimestampResultCode::WatcherBehind as u32,
             key_image_result_code: KeyImageResultCode::Spent as u32,
-        }];
+        };
+        let shard_results = vec![key_image_result.clone(), key_image_result.clone()];
+        let mut results = collate_shard_key_image_search_results(client_queries, &shard_results);
+        results.sort_by_key(|r| r.key_image);
+        assert_eq!(results, vec![key_image_result]);
+    }
 
-        let result = collate(client_queries, shard_results);
-
-        let all_images_found = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
-        });
-
-        assert!(
-            all_images_found,
-            "{}",
-            "all images are present but some were not collated"
-        );
-
-        // All results available, one duplicate
-        let client_queries = vec![KeyImageQuery {
-            key_image: 1.into(),
-            start_block: 0,
-        }];
-
-        let shard_results = vec![
-            KeyImageResult {
-                key_image: 1.into(),
-                spent_at: 1,
-                timestamp: 123,
-                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
-                key_image_result_code: KeyImageResultCode::Spent as u32,
-            },
-            KeyImageResult {
-                key_image: 1.into(),
-                spent_at: 1,
-                timestamp: 123,
-                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
-                key_image_result_code: KeyImageResultCode::Spent as u32,
-            },
-        ];
-
-        let result = collate(client_queries, shard_results);
-
-        let all_images_found = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
-        });
-
-        assert!(
-            all_images_found,
-            "{}",
-            "all images are present but some were not collated"
-        );
-
-        // All results available, one error
-        let client_queries = vec![KeyImageQuery {
-            key_image: 1.into(),
-            start_block: 0,
-        }];
-
-        let shard_results = vec![
-            KeyImageResult {
-                key_image: 1.into(),
-                spent_at: 1,
-                timestamp: 123,
-                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
-                key_image_result_code: KeyImageResultCode::Spent as u32,
-            },
-            KeyImageResult {
-                key_image: 1.into(),
-                spent_at: 1,
-                timestamp: 123,
-                timestamp_result_code: TimestampResultCode::TimestampFound as u32,
-                key_image_result_code: KeyImageResultCode::KeyImageError as u32,
-            },
-        ];
-
-        let result = collate(client_queries, shard_results);
-
-        let all_images_found = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
-        });
-
-        assert!(
-            all_images_found,
-            "{}",
-            "all images are present but some were not collated"
-        );
-
-        // No results available
+    #[test]
+    fn none_available() {
         let client_queries = vec![KeyImageQuery {
             key_image: 1.into(),
             start_block: 0,
@@ -381,45 +214,34 @@ mod tests {
 
         let shard_results = vec![];
 
-        let result = collate(client_queries, shard_results);
+        let result = collate_shard_key_image_search_results(client_queries, &shard_results);
 
-        let all_images_found = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
-        });
+        assert_eq!(result, vec![default_client_key_image(1.into())]);
+    }
 
-        assert!(
-            !all_images_found,
-            "{}",
-            "all images show results but no result provided"
-        );
-
-        // Result is error
+    #[test]
+    fn error_result() {
         let client_queries = vec![KeyImageQuery {
             key_image: 1.into(),
             start_block: 0,
         }];
 
-        let shard_results = vec![KeyImageResult {
+        let key_image_result = KeyImageResult {
             key_image: 1.into(),
             spent_at: 1,
             timestamp: 123,
             timestamp_result_code: TimestampResultCode::TimestampFound as u32,
             key_image_result_code: KeyImageResultCode::KeyImageError as u32,
-        }];
+        };
+        let shard_results = vec![key_image_result.clone()];
 
-        let result = collate(client_queries, shard_results);
+        let results = collate_shard_key_image_search_results(client_queries, &shard_results);
 
-        let all_images_error = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::KeyImageError as u32
-        });
+        assert_eq!(results, vec![key_image_result]);
+    }
 
-        assert!(
-            all_images_error,
-            "{}",
-            "an image reported no error despite an error result"
-        );
-
-        // Only some queries answered
+    #[test]
+    fn partial_responses() {
         let client_queries = vec![
             KeyImageQuery {
                 key_image: 1.into(),
@@ -431,24 +253,24 @@ mod tests {
             },
         ];
 
-        let shard_results = vec![KeyImageResult {
+        let key_image_result = KeyImageResult {
             key_image: 1.into(),
             spent_at: 1,
             timestamp: 123,
             timestamp_result_code: TimestampResultCode::TimestampFound as u32,
             key_image_result_code: KeyImageResultCode::Spent as u32,
-        }];
+        };
+        let shard_results = vec![key_image_result];
 
-        let result = collate(client_queries, shard_results);
+        let results = collate_shard_key_image_search_results(client_queries, &shard_results);
 
-        let all_images_found = result.iter().all(|key_image_result| {
-            key_image_result.key_image_result_code == KeyImageResultCode::Spent as u32
-        });
-
-        assert!(
-            !all_images_found,
-            "{}",
-            "all images show results but some had no result provided"
+        assert_eq!(
+            results[0].key_image_result_code,
+            KeyImageResultCode::Spent as u32
+        );
+        assert_eq!(
+            results[1].key_image_result_code,
+            DEFAULT_KEY_IMAGE_SEARCH_RESULT_CODE as u32
         );
     }
 }


### PR DESCRIPTION
Obliviously collates responses from Key Image Stores, to maintain security properties under the new router/store model.

### Motivation

We want to maintain our security properties even though we are splitting out the Fog Ledger service into a router/store model. In order to do this, we obliviously collate the responses from Key Image Stores in encrypted SGX memory so that an attacker cannot determine which shard a given response came from.

### Future Work

