### PR TITLE
fix(ci/cd): break out cleanup for cleaner logic

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -528,19 +528,34 @@ jobs:
 ###############################################################
 # Clean up deployments
 ###############################################################
-# we want to clean up on everything but master and feature/*
-# run on pr, run on tag. run on branch that's not master or feature/*
-  cleanup-after-run:
-    if: |
-      github.event_name == 'pull_request' ||
-      github.ref_type == 'tag' ||
-      (
-        github.ref_type == 'branch' &&
-        ! (
-          github.ref_name == 'master' ||
-          startsWith('feature/', github.ref_name)
-        )
-      )
+# we keep master and feature/*
+# run on pr, run on tag, run on release/*.
+# break this up because 4 or 5 part boolean logic is hard with GHA basic statements.
+# Yes this is less DRY, but way more readable and easier to follow.
+  cleanup-after-pr:
+    if: github.event_name == 'pull_request'
+    needs:
+    - test-current-bv3-release
+    - generate-metadata
+    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
+    with:
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      delete_namespace: true
+    secrets: inherit
+
+  cleanup-after-tag:
+    if: github.ref_type == 'tag'
+    needs:
+    - test-current-bv3-release
+    - generate-metadata
+    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
+    with:
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      delete_namespace: true
+    secrets: inherit
+
+  cleanup-after-release-branch:
+    if: github.ref_type == 'branch' && startsWith('release/', github.ref_name)
     needs:
     - test-current-bv3-release
     - generate-metadata


### PR DESCRIPTION
### Motivation

Small fix for the CD workflow to break up some buggy logic on when to clean up a development deploy. This is technically less DRY, but in my opinion much easier to follow and probably more importantly, should actually work :grin: 



