### PR TITLE
Update versions to 4.0.0-pre0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2381,14 +2381,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "grpcio",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead 0.4.3",
  "aes-gcm 0.9.4",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead 0.4.3",
  "cargo-emit",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "bincode",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cookie",
@@ -2746,7 +2746,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cargo-emit",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-common",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "chrono",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "clap 4.0.18",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "digest 0.10.5",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead 0.4.3",
  "digest 0.10.5",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "displaydoc",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead 0.4.3",
  "aes-gcm 0.9.4",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.18",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "crossbeam-channel",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cookie",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "assert_cmd",
  "clap 4.0.18",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "dirs",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3826,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3917,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "grpcio",
@@ -4017,14 +4017,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes 0.7.5",
  "aligned-cmov",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "clap 4.0.18",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4199,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.18",
@@ -4318,7 +4318,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "clap 4.0.18",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "clap 4.0.18",
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "digest 0.10.5",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4588,7 +4588,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "grpcio",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "dirs",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-api",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "lmdb-rkv",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm 0.9.4",
  "clap 4.0.18",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "async-channel",
  "clap 4.0.18",
@@ -4947,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "grpcio",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "grpcio",
  "hex",
@@ -5081,7 +5081,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "hex_fmt",
@@ -5125,21 +5125,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5176,18 +5176,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes 0.7.5",
  "assert_matches",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5395,7 +5395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "hex",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.1",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5447,7 +5447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-util-build-info",
@@ -5477,7 +5477,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -5490,7 +5490,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5501,18 +5501,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-account-keys",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "clap 4.0.18",
@@ -5565,7 +5565,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "grpcio",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-common",
@@ -5587,11 +5587,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "clap 4.0.18",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5630,7 +5630,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5660,7 +5660,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "hex",
  "itertools",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "mc-crypto-keys",
@@ -5693,7 +5693,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5716,7 +5716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "itertools",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -5772,14 +5772,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "getrandom 0.2.8",
  "mc-account-keys",
@@ -5794,7 +5794,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "clap 4.0.18",
  "displaydoc",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -708,14 +708,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -734,7 +734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1262,11 +1262,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1297,29 +1297,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1348,14 +1348,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1363,11 +1363,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1448,14 +1448,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "../README.md"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-crypto-dalek"
 description = "MobileCoin Dalek Crypto Configurator Package"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -728,14 +728,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1253,14 +1253,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1366,11 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1401,36 +1401,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1459,14 +1459,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1474,11 +1474,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1537,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1559,14 +1559,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1585,14 +1585,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -732,14 +732,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if",
  "rand",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1122,7 +1122,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1217,14 +1217,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1314,11 +1314,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1349,36 +1349,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1407,14 +1407,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1422,11 +1422,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1507,14 +1507,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1533,14 +1533,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -738,14 +738,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1178,14 +1178,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1376,11 +1376,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1420,36 +1420,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1478,14 +1478,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1493,11 +1493,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1578,14 +1578,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1604,14 +1604,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A map object based on heapless Vec"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "2.1.0-pre0"
+version = "4.0.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 


### PR DESCRIPTION
- Bump versions of all crates to 4.0.0-pre0.

### Motivation

Preparation for releasing 4.0.0 to alpha.

