### PR TITLE
Updates to support SGX 2.18.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   build-dev:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -42,7 +42,7 @@ jobs:
 
   build-prod:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -63,7 +63,7 @@ jobs:
 
   build-and-test-wasm:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -78,7 +78,7 @@ jobs:
 
   lint-rust:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -95,7 +95,7 @@ jobs:
 
   build-and-test-go:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -135,7 +135,7 @@ jobs:
 
   docs:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -154,7 +154,7 @@ jobs:
 
   mc-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     strategy:
       matrix:
@@ -197,7 +197,7 @@ jobs:
 
   consensus-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     strategy:
       matrix:
@@ -230,7 +230,7 @@ jobs:
 
   fog-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     strategy:
       matrix:
@@ -281,7 +281,7 @@ jobs:
 
   fog-ingest-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -304,7 +304,7 @@ jobs:
 
   fog-conformance-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -344,7 +344,7 @@ jobs:
 
   fog-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code
@@ -531,7 +531,7 @@ jobs:
 
   minting-and-burning-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     steps:
       - name: Check out code

--- a/.github/workflows/dependent-repos.yml
+++ b/.github/workflows/dependent-repos.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   android-bindings:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     permissions:
       pull-requests: write
@@ -30,7 +30,7 @@ jobs:
 
   full-service:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.20
+    container: mobilecoin/builder-install:v0.0.21
 
     permissions:
       pull-requests: write

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -78,7 +78,7 @@ jobs:
     - generate-metadata
     runs-on: [self-hosted, Linux, large-cd]
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.20
+      image: mobilecoin/rust-sgx-base:v0.0.21
 
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem

--- a/.mobconf
+++ b/.mobconf
@@ -1,9 +1,9 @@
 [image]
 url = mobilecoin/builder-install
-tag = v0.0.20
+tag = v0.0.21
 [builder-install]
 url = mobilecoin/builder-install
-tag = v0.0.20
+tag = v0.0.21
 [signing-tools]
 url = mobilecoin/signing-tools
 tag = v0.0.1

--- a/consensus/enclave/build.rs
+++ b/consensus/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 7;

--- a/consensus/enclave/trusted/build.rs
+++ b/consensus/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/consensus/service/BUILD.md
+++ b/consensus/service/BUILD.md
@@ -97,8 +97,8 @@ Recommended SDK and package installation:
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin"
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.18.100.3.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 )
@@ -112,8 +112,8 @@ chmod +x ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 ./sgx_linux_x64_driver_2.11.054c9c4c.bin
 
 # Install the SDK to /opt/intel/sgxsdk
-chmod +x ./sgx_linux_x64_sdk_2.17.101.1.bin
-./sgx_linux_x64_sdk_2.17.101.1.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.18.100.3.bin
+./sgx_linux_x64_sdk_2.18.100.3.bin --prefix=/opt/intel
 
 apt install libsgx-uae-service sgx-aesm-service
 

--- a/docker/install_sgx.sh
+++ b/docker/install_sgx.sh
@@ -24,7 +24,7 @@ cd /tmp
 (
 	. /etc/os-release
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin"
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.18.100.3.bin"
 
 	echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 )
@@ -59,8 +59,8 @@ apt-get install -yq --no-install-recommends \
 
 # Install *after* pkg-config so that they get registered correctly.
 # pkg-config gets pulled in transitively via build-essential
-chmod +x ./sgx_linux_x64_sdk_2.17.101.1.bin
-./sgx_linux_x64_sdk_2.17.101.1.bin --prefix=/opt/intel
+chmod +x ./sgx_linux_x64_sdk_2.18.100.3.bin
+./sgx_linux_x64_sdk_2.18.100.3.bin --prefix=/opt/intel
 
 # Update .bashrc to source sgxsdk
 echo 'source /opt/intel/sgxsdk/environment' >> /root/.bashrc

--- a/fog/ingest/enclave/build.rs
+++ b/fog/ingest/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
 const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 6;

--- a/fog/ingest/enclave/trusted/build.rs
+++ b/fog/ingest/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/build.rs
+++ b/fog/ledger/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
 const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 6;

--- a/fog/ledger/enclave/trusted/build.rs
+++ b/fog/ledger/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/build.rs
+++ b/fog/view/enclave/build.rs
@@ -12,7 +12,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -10,7 +10,7 @@ use std::{env::var, path::PathBuf};
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
 const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 6;

--- a/fog/view/enclave/trusted/build.rs
+++ b/fog/view/enclave/trusted/build.rs
@@ -14,7 +14,7 @@ const SGX_SIMULATION_LIBS: &[&str] = &["libsgx_urts_sim", "libsgx_epid_sim"];
 
 // Changing this version is a breaking change, you must update the crate version
 // if you do.
-const SGX_VERSION: &str = "2.17.101.1";
+const SGX_VERSION: &str = "2.18.100.3";
 
 fn main() {
     let env = Environment::default();

--- a/ops/Dockerfile-consensus
+++ b/ops/Dockerfile-consensus
@@ -19,9 +19,9 @@ RUN apt-get update -q -q && \
 
 # Install SGX Ubuntu/Debian Repo
 RUN source /etc/os-release && \
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin" && \
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_driver_2.11.054c9c4c.bin" && \
 
-	wget "https://download.01.org/intel-sgx/sgx-linux/2.17.1/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.17.101.1.bin" && \
+	wget "https://download.01.org/intel-sgx/sgx-linux/2.18/distro/ubuntu${VERSION_ID}-server/sgx_linux_x64_sdk_2.18.100.3.bin" && \
 	echo "deb [arch=amd64 signed-by=/usr/local/share/apt-keyrings/intel-sgx-archive-keyring.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu/ ${UBUNTU_CODENAME} main" > /etc/apt/sources.list.d/intel-sgx.list
 
 RUN mkdir -p /usr/local/share/apt-keyrings && \


### PR DESCRIPTION
- Update scripts to use SGX SDK 2.18
- Update enclave build scripts to require 2.18 SDK

### Motivation

SGX 2.18 has been recently released, this PR updates our repository to use it.

### Future Work

- [x] Update builder container to one which uses SGX 2.18
