### PR TITLE
Make the `Tx` object zeroize itself on drop

### DIFF
--- a/crypto/ring-signature/src/ring_signature/key_image.rs
+++ b/crypto/ring-signature/src/ring_signature/key_image.rs
@@ -8,6 +8,7 @@ use mc_util_repr_bytes::{
     derive_core_cmp_from_as_ref, derive_debug_and_display_hex_from_as_ref,
     derive_repr_bytes_from_as_ref_and_try_from, typenum::U32, LengthMismatch,
 };
+use zeroize::Zeroize;
 
 #[cfg(feature = "prost")]
 use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
@@ -15,7 +16,7 @@ use mc_util_repr_bytes::derive_prost_message_from_repr_bytes;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Copy, Clone, Default, Digestible)]
+#[derive(Copy, Clone, Default, Digestible, Zeroize)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[digestible(transparent)]
 /// The "image" of a private key `x`: I = x * Hp(x * G) = x * Hp(P).

--- a/crypto/ring-signature/src/ring_signature/mlsag.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag.rs
@@ -10,7 +10,7 @@ use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPubli
 use prost::Message;
 use rand_core::CryptoRngCore;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
     domain_separators::RING_MLSAG_CHALLENGE_DOMAIN_TAG,
@@ -34,7 +34,7 @@ pub struct ReducedTxOut {
 /// MLSAG for a ring of public keys and amount commitments.
 /// Note: Serialize and Deserialize appear to be cruft left over from
 /// sdk_json_interface.
-#[derive(Clone, Digestible, PartialEq, Eq, Serialize, Deserialize, Message)]
+#[derive(Clone, Deserialize, Digestible, Message, PartialEq, Eq, Serialize, Zeroize)]
 pub struct RingMLSAG {
     /// The initial challenge `c[0]`.
     #[prost(message, required, tag = "1")]

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -310,7 +310,7 @@ pub fn initialize_ledger(
                 );
 
                 let key_images = tx.key_images();
-                (tx.prefix.outputs, key_images)
+                (tx.prefix.outputs.clone(), key_images)
             }
             None => {
                 // Create an origin block.

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -102,7 +102,7 @@ pub struct SignedInputRing {
 /// having the view private key for a set of input TxOuts, and it can then be
 /// moved to a separate machine/service that then takes it + the spend private
 /// key and uses that to generate a fully signed transaction.
-#[derive(Clone, Debug, Deserialize, Digestible, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Digestible, Eq, PartialEq, Serialize, Zeroize)]
 pub struct SigningData {
     /// The bytes actually signed by MLSAG signatures.
     /// This is different depending on what block version we are in.
@@ -507,7 +507,7 @@ impl SigningData {
 }
 
 /// An RCT_TYPE_BULLETPROOFS_2 signature
-#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize, Zeroize)]
 pub struct SignatureRctBulletproofs {
     /// Signature for each input ring.
     #[prost(message, repeated, tag = "1")]

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -103,7 +103,8 @@ impl fmt::Debug for TxHash {
 }
 
 /// A CryptoNote-style transaction.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Message, Digestible)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Message, Digestible, Zeroize)]
+#[zeroize(drop)]
 pub struct Tx {
     /// The transaction contents.
     #[prost(message, required, tag = "1")]
@@ -160,7 +161,7 @@ impl Tx {
 ///
 /// Note: If you add something here, consider if it should be added to the
 /// TxSummary also for hardware wallet visibility.
-#[derive(Clone, Deserialize, Eq, PartialEq, Serialize, Message, Digestible)]
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize, Zeroize)]
 pub struct TxPrefix {
     /// List of inputs to the transaction.
     #[prost(message, repeated, tag = "1")]
@@ -244,7 +245,7 @@ impl TxPrefix {
 }
 
 /// An "input" to a transaction.
-#[derive(Clone, Deserialize, Eq, PartialEq, Serialize, Message, Digestible)]
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize, Zeroize)]
 pub struct TxIn {
     /// A "ring" of outputs containing the single output that is being spent.
     /// It would be nice to use [TxOut; RING_SIZE] here, but Prost only works


### PR DESCRIPTION
This is an experimental change to improve hygeine of memory in the consensus enclave (but also in the clients)

This makes a bunch of objects derive `Zeroize` in transaction-core, and makes the `Tx` object zeroize itself on drop.

For examples of why this is a good change, consider that, in the `mc-connection` ThickClient crate, after we serialize a Tx to protobuf and encrypt it for the enclave, we zeroize the plaintext. However, before this change, we do not zeroize the `Tx` object (since it would not have been possible), so another copy of the data that we zeroized continues to exist in memory. After this change, the `Tx` will zeroize itself automatically as well.

The main reason not to do this would be if it hurts the performance of the consensus nodes, but I consider this unlikely, because, the untrusted side never actually sees `Tx` objects so SCP should not be meaningfully impacted by this, only the transaction validation handles the decrypted `Tx`. And the elliptic curve operations done to validate a Tx should be many orders of magnitude more expensive than a zeroizing operation. So I expect no measurable performance difference as a result of this change.

See github issue #2717

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
