### PR TITLE
release/v4.0 - fix:  CD workflow issues #2941 and #2942

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -275,7 +275,7 @@ jobs:
 
 #########################################
 # Build/Publish public artifacts
-######################################### 1a94367
+#########################################
   docker:
     runs-on: [self-hosted, Linux, small]
     needs:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -11,10 +11,6 @@ env:
 
 on:
   pull_request:
-    branches:
-    - master
-    - main
-    - release/*
     paths-ignore:
     - '**.md'
   push:
@@ -279,7 +275,7 @@ jobs:
 
 #########################################
 # Build/Publish public artifacts
-#########################################
+######################################### 1a94367
   docker:
     runs-on: [self-hosted, Linux, small]
     needs:
@@ -332,12 +328,16 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Get short SHA
+      run: echo "sha7=sha-$(echo "${GITHUB_SHA}" | cut -c1-7)" >> "${GITHUB_ENV}"
+
     - name: Publish to DockerHub
       id: docker_publish_dockerhub
       uses: docker/build-push-action@v3
       with:
         build-args: |
           REPO_ORG=${{ env.DOCKER_ORG }}
+          BASE_TAG=${{ env.sha7 }}
           RUST_BIN_PATH=rust_build_artifacts
           GO_BIN_PATH=go_build_artifacts
         cache-from: type=registry,ref=${{ env.DOCKER_ORG }}/${{ matrix.image }}:buildcache-${{ needs.generate-metadata.outputs.namespace }}

--- a/.internal-ci/docker/Dockerfile.bootstrap-tools
+++ b/.internal-ci/docker/Dockerfile.bootstrap-tools
@@ -5,7 +5,8 @@
 # Multipurpose "toolbox" container for operations, testing and migrations.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
@@ -15,7 +16,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install updates
 RUN apt-get update \
- && apt-get upgrade -y \
  && apt-get install -y \
         ca-certificates \
         gettext \

--- a/.internal-ci/docker/Dockerfile.fog-ledger
+++ b/.internal-ci/docker/Dockerfile.fog-ledger
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin fog-ledger nodes.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.fog-test-client
+++ b/.internal-ci/docker/Dockerfile.fog-test-client
@@ -6,18 +6,13 @@
 # e2e testing.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 RUN addgroup --system --gid 1000 app \
   && addgroup --system --gid 2000 app-data \
   && adduser --system --ingroup app --uid 1000 app \
   && usermod -a -G 2000 app
-
-RUN apt-get update \
-  && apt-get upgrade -y \
-  && apt-get install -y ca-certificates \
-  && apt-get clean \
-  && rm -r /var/lib/apt/lists
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.fogingest
+++ b/.internal-ci/docker/Dockerfile.fogingest
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin fogingest nodes.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.fogreport
+++ b/.internal-ci/docker/Dockerfile.fogreport
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin fogreport nodes.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.fogview
+++ b/.internal-ci/docker/Dockerfile.fogview
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin fogview nodes.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.go-grpc-gateway
+++ b/.internal-ci/docker/Dockerfile.go-grpc-gateway
@@ -5,7 +5,8 @@
 # Runtime Image for the json -> grpc gateway service.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 ARG GO_BIN_PATH=go-grpc-gateway
 COPY ${GO_BIN_PATH}/grpc-proxy /usr/bin/go-grpc-gateway

--- a/.internal-ci/docker/Dockerfile.mobilecoind
+++ b/.internal-ci/docker/Dockerfile.mobilecoind
@@ -5,7 +5,8 @@
 # Runtime image for mobilecoind service.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release

--- a/.internal-ci/docker/Dockerfile.node_hw
+++ b/.internal-ci/docker/Dockerfile.node_hw
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin consensus nodes built in SGX hw mode.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Install logstash to ship logs when used as a standalone container.
 ARG LOGSTASH_VERSION=7.16.3

--- a/.internal-ci/docker/Dockerfile.runtime-base
+++ b/.internal-ci/docker/Dockerfile.runtime-base
@@ -3,7 +3,7 @@
 # Dockerfile.runtime-base
 #  A minimal base runtime image for mobilecoin applications.
 #
-FROM ubuntu:focal-20220404
+FROM ubuntu:focal-20221019
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.internal-ci/docker/Dockerfile.watcher
+++ b/.internal-ci/docker/Dockerfile.watcher
@@ -5,7 +5,8 @@
 # Runtime image for MobileCoin watcher service.
 
 ARG REPO_ORG=mobilecoin
-FROM ${REPO_ORG}/runtime-base:latest
+ARG BASE_TAG=latest
+FROM ${REPO_ORG}/runtime-base:${BASE_TAG}
 
 # Copy binaries
 ARG RUST_BIN_PATH=target/release


### PR DESCRIPTION
### Motivation

- fixes #2941 : Use docker sha tag instead of latest on FROM image for runtime containers.
- fixes #2942 : Run CD on all PRs to make sure graphite branch/merge chains get tested.


