### PR TITLE
Fix shard response processing loop

### DIFF
--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -54,6 +54,7 @@ pub fn process_shard_responses(
                     "Received a response with status 'unknown' from store{}",
                     FogViewStoreUri::from_str(&response.store_uri)?
                 );
+                shard_clients_for_retry.push(shard_client);
             }
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::Success => {
                 new_query_responses.push(response.clone());


### PR DESCRIPTION
### Motivation
Currently, the `router_request_handler` can terminate its request loop if there are still view stores that need to be authenticated. The expected behavior is to: 

 (a) Return a success if all the ready shards (see note below0 have returned query_responses
 (b) After 3 retries, return an error if some shards returned errors that need to be retried.

This PR accomplishes this by adding shards that return responses with `UNKNOWN` status codes to the `shard_clients_for_retry` field (which it should have been doing before), and only decrementing the retry count if there are no stores that need authentication. 

NOTE: This is slightly different than the Fog Ledger Router implementation because that implementation breaks the loop once the number of `query_responses` equals the number of `shard_clients`. This doesn't work here because a shard that returns a `NOT_READY` code should not be retried AND we shouldn't add it's response to the `query_responses` field. Therefore, under that logic, if one ore more shards are`NOT_READY` the loop would return an error (`query_responses.len() < shard_clients.len()` will always be true), when it should just pass back what it was able to process with the  returned `SUCCESS` responses.