### PR TITLE
Bump all version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ The crates in this repository do not adhere to [Semantic Versioning](https://sem
 
 - [MCIP 56]: Make the enclave enforce unique nonces per-token (improved fix for TOB-MCCT-4).
 - TOB-MCCT-5: Reject transactions where the client's fee map differs from the consensus enclave's.
+- Update SGX SDK to 2.18.
 
 [MCIP 42]: https://github.com/mobilecoinfoundation/mcips/blob/main/text/0042-partial-fill-rules.md
 [MCIP 43]: https://github.com/mobilecoinfoundation/mcips/blob/main/text/0043-block-metadata.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2454,14 +2454,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "grpcio",
@@ -2476,7 +2476,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead 0.4.3",
  "aes-gcm 0.9.4",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead 0.4.3",
  "cargo-emit",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bincode",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cookie",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cargo-emit",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -3042,7 +3042,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-common",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "chrono",
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "clap 4.0.29",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "digest 0.10.5",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead 0.4.3",
  "digest 0.10.5",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "displaydoc",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead 0.4.3",
  "aes-gcm 0.9.4",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.29",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3534,7 +3534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "crossbeam-channel",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "cookie",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "assert_cmd",
  "clap 4.0.29",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "dirs",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3913,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3960,7 +3960,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "grpcio",
@@ -4104,14 +4104,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes 0.7.5",
  "aligned-cmov",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "clap 4.0.29",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -4332,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.29",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "clap 4.0.29",
@@ -4486,7 +4486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "clap 4.0.29",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "digest 0.10.5",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "grpcio",
@@ -4729,7 +4729,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -4803,7 +4803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "dirs",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-api",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "lmdb-rkv",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm 0.9.4",
  "clap 4.0.29",
@@ -4983,7 +4983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "async-channel",
  "clap 4.0.29",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "grpcio",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "grpcio",
  "hex",
@@ -5168,7 +5168,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5186,7 +5186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "hex_fmt",
@@ -5212,21 +5212,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5263,18 +5263,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5316,7 +5316,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5353,7 +5353,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes 0.7.5",
  "assert_matches",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5485,7 +5485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5496,7 +5496,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "hex",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.1",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-util-build-info",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -5580,7 +5580,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5591,18 +5591,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-account-keys",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "clap 4.0.29",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "grpcio",
@@ -5666,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-common",
@@ -5677,11 +5677,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "clap 4.0.29",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5720,7 +5720,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "hex",
  "itertools",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5770,7 +5770,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "mc-crypto-keys",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "itertools",
@@ -5819,7 +5819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -5862,14 +5862,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "getrandom 0.2.8",
  "mc-account-keys",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "clap 4.0.29",
  "displaydoc",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bitflags",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "digest",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1095,7 +1095,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1264,11 +1264,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1299,29 +1299,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1350,14 +1350,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1365,11 +1365,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1450,14 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "../README.md"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-crypto-dalek"
 description = "MobileCoin Dalek Crypto Configurator Package"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -730,14 +730,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bitflags",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "digest",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1255,14 +1255,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1368,11 +1368,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1403,36 +1403,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1461,14 +1461,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1476,11 +1476,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1561,14 +1561,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -1587,14 +1587,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -734,14 +734,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bitflags",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "digest",
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "rand",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1219,14 +1219,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1316,11 +1316,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1351,36 +1351,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1409,14 +1409,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1424,11 +1424,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1509,14 +1509,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -1535,14 +1535,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -740,14 +740,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "bitflags",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "digest",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1180,14 +1180,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1378,11 +1378,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1422,36 +1422,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1480,14 +1480,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1495,11 +1495,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1580,14 +1580,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "serde",
@@ -1606,14 +1606,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Runtime gRPC Utilities"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A map object based on heapless Vec"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "4.0.0-pre0"
+version = "4.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
 


### PR DESCRIPTION
- Bump all crate versions to v4.0.0.

### Motivation

This is the last thing we need to do before building the 4.0 enclave.

