### PR TITLE
Implement prometheus metrics for FVR

### DIFF
--- a/fog/view/server/src/fog_view_router_service.rs
+++ b/fog/view/server/src/fog_view_router_service.rs
@@ -64,7 +64,6 @@ where
         requests: RequestStream<FogViewRouterRequest>,
         responses: DuplexSink<FogViewRouterResponse>,
     ) {
-        log::info!(self.logger, "Request received in request fn");
         let _timer = SVC_COUNTERS.req(&ctx);
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let logger = logger.clone();

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -160,7 +160,6 @@ where
 
     /// Unwrap and forward to enclave
     pub fn query_impl(&mut self, request: attest::Message) -> Result<attest::Message, RpcStatus> {
-        log::trace!(self.logger, "Getting encrypted request");
         let tracer = tracer!();
 
         tracer.in_span("query_impl", |_cx| {
@@ -183,7 +182,6 @@ where
         &mut self,
         request: attest::NonceMessage,
     ) -> Result<attest::NonceMessage, RpcStatus> {
-        log::trace!(self.logger, "Getting encrypted request");
         let tracer = tracer!();
         tracer.in_span("query_nonce_impl", |_cx| {
             let untrusted_query_response =

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -47,7 +47,7 @@ where
 
         // Perform prometheus logic before the match statement to ensure that
         // this logic is executed.
-        let response_status = ResponseStatus::new(&result);
+        let response_status = ResponseStatus::from(&result);
         SVC_COUNTERS.resp_impl(&method_name, response_status.is_success);
         SVC_COUNTERS.status_code_impl(&method_name, response_status.code);
 

--- a/util/grpc/src/lib.rs
+++ b/util/grpc/src/lib.rs
@@ -82,7 +82,7 @@ pub fn send_result<T>(
     logger: &Logger,
 ) {
     let logger = logger.clone();
-    let response_status = ResponseStatus::new(&resp);
+    let response_status = ResponseStatus::from(&resp);
     let is_success = response_status.is_success;
     let code = response_status.code;
 
@@ -112,17 +112,15 @@ pub struct ResponseStatus {
     pub code: RpcStatusCode,
 }
 
-impl ResponseStatus {
-    /// Creates a `ResponseStatus` struct from a gRPC response.
-    #[inline]
-    pub fn new<T>(response: &Result<T, RpcStatus>) -> Self {
+impl<T> From<&Result<T, RpcStatus>> for ResponseStatus {
+    fn from(response: &Result<T, RpcStatus>) -> Self {
         let is_success = response.is_ok();
         let code = match response {
             Ok(_) => RpcStatusCode::OK,
             Err(e) => e.code(),
         };
 
-        ResponseStatus { is_success, code }
+        Self { is_success, code }
     }
 }
 

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -20,7 +20,7 @@ pub use prometheus::{
     register, register_histogram, Histogram, HistogramOpts, HistogramVec, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
-pub use service_metrics::ServiceMetrics;
+pub use service_metrics::{GrpcMethodName, ServiceMetrics};
 
 lazy_static! {
     pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered();

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -130,12 +130,10 @@ impl ServiceMetrics {
 
     /// Gets the method name from a gRPC RpcContext.
     pub fn get_method_name(ctx: &RpcContext) -> GrpcMethodName {
-        let mut method_name = "unknown_method".to_string();
-        if let Some(name) = path_from_ctx(ctx) {
-            method_name = name;
-        };
-
-        method_name
+        match path_from_ctx(ctx) {
+            Some(method_name) => method_name,
+            None => "unknown_method".to_string(),
+        }
     }
 
     /// Takes the RpcContext used during a gRPC method call to get the method

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -47,6 +47,10 @@ use std::str;
 /// from GRPC context.
 /// e.g., calc_service.req{method = "add"} = +1
 /// e.g., calc_service.duration_sum{method="add"} = 6
+
+/// Corresponds to which gRPC method is being called.
+pub type GrpcMethodName = String;
+
 #[derive(Clone)]
 pub struct ServiceMetrics {
     /// Count of requests made by each gRPC method tracked
@@ -107,11 +111,13 @@ impl ServiceMetrics {
     /// name and increments counters tracking the number of calls to and
     /// returns a counter to track the duration of the method
     pub fn req(&self, ctx: &RpcContext) -> Option<HistogramTimer> {
-        let mut method_name = "unknown_method".to_string();
-        if let Some(name) = path_from_ctx(ctx) {
-            method_name = name;
-        }
+        let method_name = Self::get_method_name(ctx);
+        self.req_impl(&method_name)
+    }
 
+    /// Increments counters tracking the number of calls to and
+    /// returns a counter to track the duration of the method
+    pub fn req_impl(&self, method_name: &GrpcMethodName) -> Option<HistogramTimer> {
         self.num_req
             .with_label_values(&[method_name.as_str()])
             .inc();
@@ -122,26 +128,42 @@ impl ServiceMetrics {
         )
     }
 
+    /// Gets the method name from a gRPC RpcContext.
+    pub fn get_method_name(ctx: &RpcContext) -> GrpcMethodName {
+        let mut method_name = "unknown_method".to_string();
+        if let Some(name) = path_from_ctx(ctx) {
+            method_name = name;
+        };
+
+        method_name
+    }
+
     /// Takes the RpcContext used during a gRPC method call to get the method
     /// name and increments an error counter if the method resulted in an
     /// error
     pub fn resp(&self, ctx: &RpcContext, success: bool) {
-        if let Some(name) = path_from_ctx(ctx) {
-            self.num_error
-                .with_label_values(&[name.as_str()])
-                .inc_by(if success { 0 } else { 1 });
-        }
+        let method_name = Self::get_method_name(ctx);
+        self.resp_impl(&method_name, success);
+    }
+
+    pub fn resp_impl(&self, method_name: &GrpcMethodName, success: bool) {
+        self.num_error
+            .with_label_values(&[method_name.as_str()])
+            .inc_by(if success { 0 } else { 1 });
     }
 
     /// Takes the RpcContext used during a gRPC method call to get the method
     /// name as well as the gRPC status code that method returned and
     /// increments a counter for the status code reported
     pub fn status_code(&self, ctx: &RpcContext, response_code: RpcStatusCode) {
-        if let Some(name) = path_from_ctx(ctx) {
-            self.num_status_code
-                .with_label_values(&[name.as_str(), response_code.to_string().as_str()])
-                .inc();
-        }
+        let method_name = Self::get_method_name(ctx);
+        self.status_code_impl(&method_name, response_code);
+    }
+
+    pub fn status_code_impl(&self, method_name: &GrpcMethodName, response_code: RpcStatusCode) {
+        self.num_status_code
+            .with_label_values(&[method_name.as_str(), response_code.to_string().as_str()])
+            .inc();
     }
 
     /// Tracks gRPC message name and size for aggregation into a Prometheus


### PR DESCRIPTION
### Motivation
Implements Prometheus metrics for Fog View Router (FVR). Previously, upon receiving a request, the router "opened" a Prometheus metrics session, but it never closed it. This PR closes the session and refactors some underlying util logic for cleanliness.