### PR TITLE
Ensure shards provide correct blocks

### DIFF
--- a/fog/types/src/common.rs
+++ b/fog/types/src/common.rs
@@ -5,6 +5,10 @@ use core::str::FromStr;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
+/// The string that delimits the start and end blocks in a string that
+/// represents a BlockRange.
+pub const BLOCK_RANGE_DELIMITER: &str = "-";
+
 /// A half-open [a, b) range of blocks
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Message, Serialize, Deserialize)]
 pub struct BlockRange {
@@ -70,7 +74,7 @@ impl FromStr for BlockRange {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let block_indices: Vec<u64> = s
-            .split(',')
+            .split(BLOCK_RANGE_DELIMITER)
             .map(|index_str| index_str.trim().parse())
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| "BlockRange index is not a number.")?;

--- a/fog/types/src/common.rs
+++ b/fog/types/src/common.rs
@@ -167,7 +167,9 @@ mod tests {
         let start_block = 0;
         let end_block = 10;
         let third_block = 10;
-        let block_range_str = format!("{start_block}{BLOCK_RANGE_DELIMITER}{end_block}{BLOCK_RANGE_DELIMITER}{third_block}");
+        let block_range_str = format!(
+            "{start_block}{BLOCK_RANGE_DELIMITER}{end_block}{BLOCK_RANGE_DELIMITER}{third_block}"
+        );
 
         let result = BlockRange::from_str(&block_range_str);
 

--- a/fog/types/src/common.rs
+++ b/fog/types/src/common.rs
@@ -138,7 +138,7 @@ mod tests {
     fn from_string_well_formatted_creates_block_range() {
         let start_block = 0;
         let end_block = 10;
-        let block_range_str = format!("{},{}", start_block, end_block);
+        let block_range_str = format!("{start_block}{BLOCK_RANGE_DELIMITER}{end_block}");
 
         let result = BlockRange::from_str(&block_range_str);
 
@@ -152,7 +152,7 @@ mod tests {
     fn from_string_well_formatted_with_whitespace_creates_block_range() {
         let start_block = 0;
         let end_block = 10;
-        let block_range_str = format!("     {} , {} ", start_block, end_block);
+        let block_range_str = format!("{start_block}{BLOCK_RANGE_DELIMITER}{end_block}");
 
         let result = BlockRange::from_str(&block_range_str);
 
@@ -167,7 +167,7 @@ mod tests {
         let start_block = 0;
         let end_block = 10;
         let third_block = 10;
-        let block_range_str = format!("{},{},{}", start_block, end_block, third_block);
+        let block_range_str = format!("{start_block}{BLOCK_RANGE_DELIMITER}{end_block}{BLOCK_RANGE_DELIMITER}{third_block}");
 
         let result = BlockRange::from_str(&block_range_str);
 
@@ -178,7 +178,7 @@ mod tests {
     fn from_string_non_numbers_errors() {
         let start_block = 'a';
         let end_block = 'b';
-        let block_range_str = format!("{},{}", start_block, end_block);
+        let block_range_str = format!("{start_block}{BLOCK_RANGE_DELIMITER}{end_block}");
 
         let result = BlockRange::from_str(&block_range_str);
 

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -8,12 +8,13 @@ use mc_common::{logger::log, time::SystemTimeProvider};
 use mc_fog_api::view_grpc::FogViewStoreApiClient;
 use mc_fog_view_enclave::{SgxViewEnclave, ENCLAVE_FILE};
 use mc_fog_view_server::{
-    config::FogViewRouterConfig, fog_view_router_server::FogViewRouterServer,
+    config::{FogViewRouterConfig, ShardingStrategy::Epoch},
+    fog_view_router_server::{FogViewRouterServer, Shard},
+    sharding_strategy::ShardingStrategy,
 };
 use mc_util_cli::ParserWithBuildInfo;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use std::{
-    collections::HashMap,
     env,
     sync::{Arc, RwLock},
 };
@@ -40,28 +41,39 @@ fn main() {
         logger.clone(),
     );
 
-    // TODO: Remove and get from a config.
-    let mut fog_view_store_grpc_clients = HashMap::new();
+    let mut shards = Vec::new();
     let grpc_env = Arc::new(
         grpcio::EnvBuilder::new()
             .name_prefix("Main-RPC".to_string())
             .build(),
     );
-    for shard_uri in config.shard_uris.clone() {
+    for (i, shard_uri) in config.shard_uris.clone().into_iter().enumerate() {
         let fog_view_store_grpc_client = FogViewStoreApiClient::new(
             ChannelBuilder::default_channel_builder(grpc_env.clone())
                 .connect_to_uri(&shard_uri, &logger),
         );
-        fog_view_store_grpc_clients.insert(shard_uri, Arc::new(fog_view_store_grpc_client));
+
+        let sharding_strategy = config
+            .sharding_strategies
+            .get(i)
+            .unwrap_or_else(|| panic!("Couldn't find shard at index {}", i));
+        let Epoch(epoch_sharding_strategy) = sharding_strategy;
+        let block_range = epoch_sharding_strategy.get_block_range();
+        let shard = Shard::new(
+            shard_uri.clone(),
+            Arc::new(fog_view_store_grpc_client),
+            block_range,
+        );
+        shards.push(shard);
     }
-    let fog_view_store_grpc_clients = Arc::new(RwLock::new(fog_view_store_grpc_clients));
+    let shards = Arc::new(RwLock::new(shards));
 
     let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
     let mut router_server = FogViewRouterServer::new(
         config,
         sgx_enclave,
         ias_client,
-        fog_view_store_grpc_clients,
+        shards,
         SystemTimeProvider::default(),
         logger,
     );

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -122,7 +122,7 @@ pub struct FogViewRouterConfig {
     pub client_listen_uri: RouterClientListenUri,
 
     /// gRPC listening URI for Fog View Stores. Should be indexed the same as
-    /// the `sharding_stratgies` field.
+    /// the `sharding_strategies` field.
     #[clap(long, env = "MC_VIEW_SHARD_URIS")]
     pub shard_uris: Vec<FogViewStoreUri>,
 

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -121,8 +121,14 @@ pub struct FogViewRouterConfig {
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
     pub client_listen_uri: RouterClientListenUri,
 
-    /// gRPC listening URI for Fog View Stores.
-    #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
+    /// Sharding Strategies for each Shard. Should be indexed the same as the
+    /// `shard_uris` field.
+    #[clap(long, env = "MC_VIEW_SHARDING_STRATEGIES")]
+    pub sharding_strategies: Vec<ShardingStrategy>,
+
+    /// gRPC listening URI for Fog View Stores. Should be indexed the same as
+    /// the `sharding_stratgies` field.
+    #[clap(long, env = "MC_VIEW_SHARD_URIS")]
     pub shard_uris: Vec<FogViewStoreUri>,
 
     /// PEM-formatted keypair to send with an Attestation Request.

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -121,11 +121,6 @@ pub struct FogViewRouterConfig {
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
     pub client_listen_uri: RouterClientListenUri,
 
-    /// Sharding Strategies for each Shard. Should be indexed the same as the
-    /// `shard_uris` field.
-    #[clap(long, env = "MC_VIEW_SHARDING_STRATEGIES")]
-    pub sharding_strategies: Vec<ShardingStrategy>,
-
     /// gRPC listening URI for Fog View Stores. Should be indexed the same as
     /// the `sharding_stratgies` field.
     #[clap(long, env = "MC_VIEW_SHARD_URIS")]

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -148,7 +148,7 @@ pub struct FogViewRouterConfig {
     pub omap_capacity: u64,
 
     /// Router admin listening URI.
-    #[clap(long)]
+    #[clap(long, env = "MC_ADMIN_LISTEN_URI")]
     pub admin_listen_uri: AdminUri,
 
     /// The chain id of the network we are a part of

--- a/fog/view/server/src/fog_view_router_service.rs
+++ b/fog/view/server/src/fog_view_router_service.rs
@@ -1,23 +1,19 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use crate::{router_request_handler, SVC_COUNTERS};
+use crate::{fog_view_router_server::Shard, router_request_handler, SVC_COUNTERS};
 use futures::{executor::block_on, FutureExt, TryFutureExt};
 use grpcio::{DuplexSink, RequestStream, RpcContext, UnarySink};
 use mc_attest_api::attest;
 use mc_common::logger::{log, Logger};
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse},
-    view_grpc::{FogViewApi, FogViewRouterApi, FogViewStoreApiClient},
+    view_grpc::{FogViewApi, FogViewRouterApi},
 };
-use mc_fog_uri::FogViewStoreUri;
 use mc_fog_view_enclave_api::ViewEnclaveProxy;
 use mc_util_grpc::{check_request_chain_id, rpc_logger, send_result, Authenticator};
 use mc_util_metrics::ServiceMetrics;
 use mc_util_telemetry::tracer;
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
 #[derive(Clone)]
 pub struct FogViewRouterService<E>
@@ -25,7 +21,7 @@ where
     E: ViewEnclaveProxy,
 {
     enclave: E,
-    shard_clients: Arc<RwLock<HashMap<FogViewStoreUri, Arc<FogViewStoreApiClient>>>>,
+    shards: Arc<RwLock<Vec<Shard>>>,
     chain_id: String,
     /// GRPC request authenticator.
     authenticator: Arc<dyn Authenticator + Send + Sync>,
@@ -40,14 +36,14 @@ impl<E: ViewEnclaveProxy> FogViewRouterService<E> {
     /// perform view store authentication on each one.
     pub fn new(
         enclave: E,
-        shard_clients: Arc<RwLock<HashMap<FogViewStoreUri, Arc<FogViewStoreApiClient>>>>,
+        shards: Arc<RwLock<Vec<Shard>>>,
         chain_id: String,
         authenticator: Arc<dyn Authenticator + Send + Sync>,
         logger: Logger,
     ) -> Self {
         Self {
             enclave,
-            shard_clients,
+            shards,
             chain_id,
             authenticator,
             logger,
@@ -69,11 +65,11 @@ where
             let logger = logger.clone();
             // TODO: Confirm that we don't need to perform the authenticator logic. I think
             // we don't  because of streaming...
-            let shard_clients = self.shard_clients.read().expect("RwLock poisoned");
+            let shards = self.shards.read().expect("RwLock poisoned");
             let method_name = ServiceMetrics::get_method_name(&ctx);
             let future = router_request_handler::handle_requests(
                 method_name,
-                shard_clients.values().cloned().collect(),
+                shards.clone(),
                 self.enclave.clone(),
                 requests,
                 responses,
@@ -134,12 +130,12 @@ where
             }
 
             // This will block the async API. We should use some sort of differentiator...
-            let shard_clients = self.shard_clients.read().expect("RwLock poisoned");
+            let shards = self.shards.read().expect("RwLock poisoned");
             let tracer = tracer!();
             let result = block_on(router_request_handler::handle_query_request(
                 request,
                 self.enclave.clone(),
-                shard_clients.values().cloned().collect(),
+                shards.clone(),
                 self.logger.clone(),
                 &tracer,
             ))

--- a/fog/view/server/src/router_admin_service.rs
+++ b/fog/view/server/src/router_admin_service.rs
@@ -1,9 +1,15 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use crate::SVC_COUNTERS;
+use crate::{
+    fog_view_router_server::Shard,
+    sharding_strategy::{EpochShardingStrategy, ShardingStrategy},
+    SVC_COUNTERS,
+};
 use grpcio::{ChannelBuilder, RpcContext, RpcStatus, UnarySink};
-use itertools::Itertools;
-use mc_common::logger::{log, Logger};
+use mc_common::{
+    logger::{log, Logger},
+    HashSet,
+};
 use mc_fog_api::{
     view::AddShardRequest,
     view_grpc::{FogViewRouterAdminApi, FogViewStoreApiClient},
@@ -14,26 +20,19 @@ use mc_util_grpc::{
     ConnectionUriGrpcioChannel, Empty,
 };
 use std::{
-    collections::HashMap,
     str::FromStr,
     sync::{Arc, RwLock},
 };
 
 #[derive(Clone)]
 pub struct FogViewRouterAdminService {
-    shard_clients: Arc<RwLock<HashMap<FogViewStoreUri, Arc<FogViewStoreApiClient>>>>,
+    shards: Arc<RwLock<Vec<Shard>>>,
     logger: Logger,
 }
 
 impl FogViewRouterAdminService {
-    pub fn new(
-        shard_clients: Arc<RwLock<HashMap<FogViewStoreUri, Arc<FogViewStoreApiClient>>>>,
-        logger: Logger,
-    ) -> Self {
-        Self {
-            shard_clients,
-            logger,
-        }
+    pub fn new(shards: Arc<RwLock<Vec<Shard>>>, logger: Logger) -> Self {
+        Self { shards, logger }
     }
 
     fn add_shard_impl(&mut self, shard_uri: &str, logger: &Logger) -> Result<Empty, RpcStatus> {
@@ -44,8 +43,13 @@ impl FogViewRouterAdminService {
                 logger,
             )
         })?;
-        let mut shard_clients = self.shard_clients.write().expect("RwLock Poisoned");
-        if shard_clients.keys().contains(&view_store_uri) {
+        let mut shards = self.shards.write().expect("RwLock Poisoned");
+        if shards
+            .iter()
+            .map(|shard| shard.uri.clone())
+            .collect::<HashSet<FogViewStoreUri>>()
+            .contains(&view_store_uri)
+        {
             let error = rpc_precondition_error(
                 "add_shard",
                 format!("Shard uri {} already exists in the shard list", shard_uri),
@@ -62,7 +66,11 @@ impl FogViewRouterAdminService {
             ChannelBuilder::default_channel_builder(grpc_env)
                 .connect_to_uri(&view_store_uri, logger),
         );
-        shard_clients.insert(view_store_uri, Arc::new(view_store_client));
+        // TODO: Add block range or sharding strategy to this...
+        // Check to make sure this block range isn't already covered...
+        let block_range = EpochShardingStrategy::default().get_block_range();
+        let shard = Shard::new(view_store_uri, Arc::new(view_store_client), block_range);
+        shards.push(shard);
 
         Ok(Empty::new())
     }

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -112,6 +112,9 @@ impl FromStr for EpochShardingStrategy {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq("default") {
+            return Ok(EpochShardingStrategy::default());
+        }
         if let Ok(block_range) = BlockRange::from_str(s) {
             return Ok(Self::new(block_range));
         }

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -484,6 +484,7 @@ class FogConformanceTest:
             admin_port = BASE_VIEW_STORE_ADMIN_PORT,
             admin_http_gateway_port = BASE_VIEW_STORE_ADMIN_HTTP_GATEWAY_PORT,
             release = self.release,
+            sharding_strategy= 'default'
         )
         self.fog_view_store.start()
 
@@ -495,6 +496,7 @@ class FogConformanceTest:
             admin_http_gateway_port = BASE_VIEW_ADMIN_HTTP_GATEWAY_PORT,
             release = self.release,
             shard_uris = [self.fog_view_store.get_client_listen_uri()],
+            sharding_strategies= [self.fog_view_store.get_sharding_strategy()]
         )
         self.fog_view_router.start()
 

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -496,7 +496,6 @@ class FogConformanceTest:
             admin_http_gateway_port = BASE_VIEW_ADMIN_HTTP_GATEWAY_PORT,
             release = self.release,
             shard_uris = [self.fog_view_store.get_client_listen_uri()],
-            sharding_strategies= [self.fog_view_store.get_sharding_strategy()]
         )
         self.fog_view_router.start()
 

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -97,6 +97,7 @@ class FogNetwork(Network):
             admin_port = BASE_VIEW_STORE_ADMIN_PORT,
             admin_http_gateway_port = BASE_VIEW_STORE_ADMIN_HTTP_GATEWAY_PORT,
             release = True,
+            sharding_strategy= 'default'
         )
         self.fog_view_store.start()
 
@@ -108,6 +109,7 @@ class FogNetwork(Network):
             admin_http_gateway_port = BASE_VIEW_ADMIN_HTTP_GATEWAY_PORT,
             release = True,
             shard_uris = [self.fog_view_store.get_client_listen_uri()],
+            sharding_strategies= [self.fog_view_store.get_sharding_strategy()],
         )
         self.fog_view_router.start()
 

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -109,7 +109,6 @@ class FogNetwork(Network):
             admin_http_gateway_port = BASE_VIEW_ADMIN_HTTP_GATEWAY_PORT,
             release = True,
             shard_uris = [self.fog_view_store.get_client_listen_uri()],
-            sharding_strategies= [self.fog_view_store.get_sharding_strategy()],
         )
         self.fog_view_router.start()
 

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -177,7 +177,7 @@ class FogIngest:
 
 
 class FogViewRouter:
-    def __init__(self, name, client_responder_id, client_port, admin_port, admin_http_gateway_port, shard_uris, release):
+    def __init__(self, name, client_responder_id, client_port, admin_port, admin_http_gateway_port, shard_uris, sharding_strategies, release):
         self.name = name
 
         self.client_responder_id = client_responder_id
@@ -189,6 +189,7 @@ class FogViewRouter:
         self.admin_http_gateway_port = admin_http_gateway_port
 
         self.shard_uris = shard_uris
+        self.sharding_strategies = sharding_strategies
 
         self.release = release
         self.target_dir = target_dir(self.release)
@@ -210,6 +211,7 @@ class FogViewRouter:
             f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--shard-uris={",".join(self.shard_uris)}',
+            f'--sharding-strategies={",".join(self.sharding_strategies)}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
         ])
@@ -228,12 +230,13 @@ class FogViewRouter:
             self.admin_http_gateway_process = None
 
 class FogViewStore:
-    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release):
+    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release, sharding_strategy):
         self.name = name
 
         self.client_port = client_port
         self.client_responder_id = f'{LISTEN_HOST}:{self.client_port}'
         self.client_listen_url = f'insecure-fog-view-store://{LISTEN_HOST}:{self.client_port}/'
+        self.sharding_strategy = sharding_strategy
 
         self.admin_port = admin_port
         self.admin_http_gateway_port = admin_http_gateway_port
@@ -249,6 +252,8 @@ class FogViewStore:
 
     def get_client_listen_uri(self):
         return self.client_listen_url
+    def get_sharding_strategy(self):
+        return self.sharding_strategy
 
     def start(self):
         self.stop()
@@ -259,6 +264,7 @@ class FogViewStore:
             f'exec {self.target_dir}/fog_view_server',
             f'--client-listen-uri={self.client_listen_url}',
             f'--client-responder-id={self.client_responder_id}',
+            f'--sharding-strategy={self.sharding_strategy}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -177,7 +177,7 @@ class FogIngest:
 
 
 class FogViewRouter:
-    def __init__(self, name, client_responder_id, client_port, admin_port, admin_http_gateway_port, shard_uris, sharding_strategies, release):
+    def __init__(self, name, client_responder_id, client_port, admin_port, admin_http_gateway_port, shard_uris, release):
         self.name = name
 
         self.client_responder_id = client_responder_id
@@ -189,7 +189,6 @@ class FogViewRouter:
         self.admin_http_gateway_port = admin_http_gateway_port
 
         self.shard_uris = shard_uris
-        self.sharding_strategies = sharding_strategies
 
         self.release = release
         self.target_dir = target_dir(self.release)
@@ -211,7 +210,6 @@ class FogViewRouter:
             f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--shard-uris={",".join(self.shard_uris)}',
-            f'--sharding-strategies={",".join(self.sharding_strategies)}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
         ])
@@ -235,7 +233,7 @@ class FogViewStore:
 
         self.client_port = client_port
         self.client_responder_id = f'{LISTEN_HOST}:{self.client_port}'
-        self.client_listen_url = f'insecure-fog-view-store://{LISTEN_HOST}:{self.client_port}/'
+        self.client_listen_url = f'insecure-fog-view-store://{LISTEN_HOST}:{self.client_port}/?sharding_strategy={self.sharding_strategy}'
         self.sharding_strategy = sharding_strategy
 
         self.admin_port = admin_port

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -233,6 +233,7 @@ class FogViewStore:
 
         self.client_port = client_port
         self.client_responder_id = f'{LISTEN_HOST}:{self.client_port}'
+        self.sharding_strategy = sharding_strategy
         self.client_listen_url = f'insecure-fog-view-store://{LISTEN_HOST}:{self.client_port}/?sharding_strategy={self.sharding_strategy}'
         self.sharding_strategy = sharding_strategy
 
@@ -250,8 +251,6 @@ class FogViewStore:
 
     def get_client_listen_uri(self):
         return self.client_listen_url
-    def get_sharding_strategy(self):
-        return self.sharding_strategy
 
     def start(self):
         self.stop()


### PR DESCRIPTION
### Motivation

As described in #2966, the Fog View Router (FVR) has no way of knowing if a shard provides the "correct" block range - i.e. the block range for which it was configured to process. This PR makes FVR aware of the shards' block ranges and throws an error if a shard provides an incorrect block range. 