### PR TITLE
Derive Eq for SignedContingentInputError

### DIFF
--- a/transaction/extra/src/signed_contingent_input.rs
+++ b/transaction/extra/src/signed_contingent_input.rs
@@ -193,7 +193,7 @@ impl From<&UnmaskedAmount> for Amount {
 }
 
 /// An error which can occur when validating a signed contingent input
-#[derive(Display, Debug, Clone)]
+#[derive(Display, Debug, Clone, Eq, PartialEq)]
 pub enum SignedContingentInputError {
     /// The number of required outputs did not match to the number of amounts
     WrongNumberOfRequiredOutputAmounts,


### PR DESCRIPTION
### Motivation

Other error traits implement this and it makes some tests (that I am working on in a separate repository) easier.
