### PR TITLE
dont format Baidu code 

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,4 +5,5 @@ imports_granularity = "Crate"
 ignore = [
     "sgx/types",   # copy-pasta from rust-sgx-sdk
     "sgx/urts",    # came from Baidu
+    "sgx/sync",    # came from Baidu
 ]


### PR DESCRIPTION
I discovered that running `cargo fmt --all` tries to format Baidu-originated files. We should either format them or ignore them, and it seems like our solution for other Baidu code was to ignore it.

Cherrypick of #2987 