### PR TITLE
Cleanup in preparation for 2023-01-04 rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,9 +6326,9 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -93,7 +93,7 @@ impl fmt::Display for PublicAddress {
             .iter()
             .chain(self.view_public_key().to_bytes().iter())
         {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         if !self.fog_report_url.is_empty() {
             write!(f, ":'{}'", self.fog_report_url)?;

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -84,7 +84,7 @@ fn info(state: &rocket::State<State>) -> Result<Json<JsonInfoResponse>, String> 
     let info = state
         .admin_api_client
         .get_info(&Empty::new())
-        .map_err(|err| format!("Failed getting info: {}", err))?;
+        .map_err(|err| format!("Failed getting info: {err}"))?;
 
     Ok(Json(JsonInfoResponse::try_from(&info)?))
 }
@@ -105,7 +105,7 @@ fn set_rust_log(
     let _resp = state
         .admin_api_client
         .set_rust_log(&req)
-        .map_err(|err| format!("failed setting rust_log: {}", err))?;
+        .map_err(|err| format!("failed setting rust_log: {err}"))?;
 
     Ok(Redirect::to("/"))
 }
@@ -115,7 +115,7 @@ fn metrics(state: &rocket::State<State>) -> Result<String, String> {
     let resp = state
         .admin_api_client
         .get_prometheus_metrics(&Empty::new())
-        .map_err(|err| format!("failed getting metrics: {}", err))?;
+        .map_err(|err| format!("failed getting metrics: {err}"))?;
     Ok(resp.metrics)
 }
 

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -64,7 +64,7 @@ use std::path::PathBuf;
 /// Helper method for getting the suggested path/filename for a given block
 /// index.
 pub fn block_num_to_s3block_path(block_index: BlockIndex) -> PathBuf {
-    let filename = format!("{:016x}.pb", block_index);
+    let filename = format!("{block_index:016x}.pb");
     let mut path = PathBuf::new();
     for i in 0..7 {
         path.push(&filename[i * 2..i * 2 + 2]);
@@ -81,7 +81,7 @@ pub fn merged_block_num_to_s3block_path(
     bucket_size: u64,
     first_block_index: BlockIndex,
 ) -> PathBuf {
-    let base_dir = format!("merged-{}", bucket_size);
+    let base_dir = format!("merged-{bucket_size}");
     let mut path = PathBuf::new();
     path.push(base_dir);
     path.push(block_num_to_s3block_path(first_block_index));

--- a/attest/core/src/ias/json.rs
+++ b/attest/core/src/ias/json.rs
@@ -162,6 +162,6 @@ impl From<JsonObject> for JsonValue {
 pub(crate) fn parse(src: &str) -> (usize, Option<JsonValue>) {
     let data: Vec<char> = src.chars().collect();
     let mut idx = 0;
-    let retval = rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data, &mut idx);
+    let retval = rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&data, &mut idx);
     (idx, retval)
 }

--- a/attest/core/src/nonce.rs
+++ b/attest/core/src/nonce.rs
@@ -232,7 +232,7 @@ mod test {
             [2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64],
             ias_nonce.0
         );
-        let decoded = hex::decode(&s).unwrap();
+        let decoded = hex::decode(s).unwrap();
         assert_eq!(decoded, ias_nonce.0);
     }
 }

--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -76,7 +76,7 @@ impl Display for QuoteSignType {
             QuoteSignType::Unlinkable => "Unlinkable",
             QuoteSignType::Linkable => "Linkable",
         };
-        write!(formatter, "{}", text)
+        write!(formatter, "{text}")
     }
 }
 

--- a/attest/core/src/types/epid_group_id.rs
+++ b/attest/core/src/types/epid_group_id.rs
@@ -59,7 +59,7 @@ impl Hash for EpidGroupId {
 
 impl Ord for EpidGroupId {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.0[..]).cmp(&other.0[..])
+        self.0[..].cmp(&other.0[..])
     }
 }
 
@@ -134,6 +134,6 @@ mod test {
     fn test_display() {
         let gid: sgx_epid_group_id_t = [0x2eu8, 0x0b, 0, 0];
         let epid_gid = EpidGroupId::from(gid);
-        assert_eq!("00000b2e", format!("{}", epid_gid));
+        assert_eq!("00000b2e", format!("{epid_gid}"));
     }
 }

--- a/attest/core/src/types/measurement.rs
+++ b/attest/core/src/types/measurement.rs
@@ -96,8 +96,8 @@ impl PartialEq<MrSigner> for Measurement {
 impl Display for Measurement {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            Measurement::MrEnclave(e) => write!(f, "MRENCLAVE: {}", e),
-            Measurement::MrSigner(s) => write!(f, "MRSIGNER: {}", s),
+            Measurement::MrEnclave(e) => write!(f, "MRENCLAVE: {e}"),
+            Measurement::MrSigner(s) => write!(f, "MRSIGNER: {s}"),
         }
     }
 }

--- a/attest/core/src/types/report_body.rs
+++ b/attest/core/src/types/report_body.rs
@@ -223,7 +223,7 @@ impl Ord for ReportBody {
     /// Attributes, Misc Select, ConfigId, ConfigSVN, CPU SVN, and
     /// ReportData, in that order
     fn cmp(&self, other: &Self) -> Ordering {
-        match (&self.0.isv_family_id[..]).cmp(&other.0.isv_family_id[..]) {
+        match self.0.isv_family_id[..].cmp(&other.0.isv_family_id[..]) {
             Ordering::Equal => match self.0.isv_prod_id.cmp(&other.0.isv_prod_id) {
                 Ordering::Equal => match self.0.isv_ext_prod_id.cmp(&other.0.isv_ext_prod_id) {
                     Ordering::Equal => match self.0.isv_svn.cmp(&other.0.isv_svn) {

--- a/attest/core/src/types/update_info.rs
+++ b/attest/core/src/types/update_info.rs
@@ -30,8 +30,7 @@ impl Debug for UpdateInfo {
         let psw_update = self.0.pswUpdate;
         write!(
             f,
-            "UpdateInfo {{ ucodeUpdate: i32({}), csmeFwUpdate: i32({}), pswUpdate: i32({}) }}",
-            ucode_update, csme_fw_update, psw_update,
+            "UpdateInfo {{ ucodeUpdate: i32({ucode_update}), csmeFwUpdate: i32({csme_fw_update}), pswUpdate: i32({psw_update}) }}",
         )
     }
 }
@@ -43,8 +42,7 @@ impl Display for UpdateInfo {
         let psw_update = self.0.pswUpdate;
         write!(
             f,
-            "Microcode {}, Management Engine Firmware {}, Platform Services {}",
-            ucode_update, csme_fw_update, psw_update
+            "Microcode {ucode_update}, Management Engine Firmware {csme_fw_update}, Platform Services {psw_update}"
         )
     }
 }

--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -104,15 +104,14 @@ fn purge_expired_cert(path: &Path) {
             // regenerated.
             if utc_now + Duration::hours(24) > not_after {
                 remove_file(path)
-                    .unwrap_or_else(|e| panic!("failed deleting expired cert {:?}: {:?}", path, e));
+                    .unwrap_or_else(|e| panic!("failed deleting expired cert {path:?}: {e:?}"));
             }
         }
         Err(_) => {
             // Failed getting expiration date from certificate, delete it so it gets
             // regenerated.
-            remove_file(path).unwrap_or_else(|e| {
-                panic!("failed deleting non-parseable cert {:?}: {:?}", path, e)
-            });
+            remove_file(path)
+                .unwrap_or_else(|e| panic!("failed deleting non-parseable cert {path:?}: {e:?}"));
         }
     }
 }
@@ -275,7 +274,7 @@ fn main() {
             .write_pem_string(&mut csprng)
             .expect("Could not create PEM string of certificate");
 
-        write(chain_path, &(root_cert_pem + &signer_cert_pem)).expect("Unable to write cert chain");
+        write(chain_path, root_cert_pem + &signer_cert_pem).expect("Unable to write cert chain");
     }
 
     let env = Environment::default();

--- a/blockchain/validators/src/metadata/key_range/config.rs
+++ b/blockchain/validators/src/metadata/key_range/config.rs
@@ -122,7 +122,7 @@ fn parse_pem_or_hex(
 
     let base_path = base_path.into().or_else(|| std::env::current_dir().ok());
     let path = if let Some(base) = base_path {
-        base.join(&value)
+        base.join(value)
     } else {
         value.into()
     };

--- a/common/src/logger/loggers/mod.rs
+++ b/common/src/logger/loggers/mod.rs
@@ -187,7 +187,7 @@ pub fn create_root_logger() -> Logger {
             if !key_val_str.is_empty() {
                 let key_val = key_val_str.split('=').collect::<Vec<&str>>();
                 if key_val.len() != 2 {
-                    panic!("invalid MC_LOG_EXTRA key/val: {}", key_val_str)
+                    panic!("invalid MC_LOG_EXTRA key/val: {key_val_str}")
                 }
 
                 let k = key_val[0].to_string();

--- a/common/src/logger/loggers/sentry_logger.rs
+++ b/common/src/logger/loggers/sentry_logger.rs
@@ -76,7 +76,7 @@ pub struct KeyValueList(pub Vec<(Key, String)>);
 
 impl Serializer for KeyValueList {
     fn emit_arguments(&mut self, key: Key, val: &std::fmt::Arguments) -> slog::Result {
-        self.0.push((key, format!("{}", val)));
+        self.0.push((key, format!("{val}")));
         Ok(())
     }
 }

--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -98,7 +98,7 @@ cfg_if::cfg_if! {
                     + (self.start.elapsed().subsec_nanos() as f64 / 1_000_000.0);
 
                 let time = match time_in_ms as u64 {
-                    0..=3000 => format!("{}ms", time_in_ms),
+                    0..=3000 => format!("{time_in_ms}ms"),
                     3001..=60000 => format!("{:.2}s", time_in_ms / 1000.0),
                     _ => format!("{:.2}m", time_in_ms / 1000.0 / 60.0),
                 };
@@ -119,7 +119,7 @@ cfg_if::cfg_if! {
             fn basic_trace_time() {
                 let logger = create_test_logger("basic_trace_time".to_string());
 
-                slog_scope::scope(&logger.clone(), || {
+                slog_scope::scope(&logger, || {
                     trace_time!(global_logger(), "test global");
 
                     {

--- a/common/src/panic_handler.rs
+++ b/common/src/panic_handler.rs
@@ -16,18 +16,15 @@ pub fn setup_panic_handler() {
 }
 
 fn handle_panic(panic_info: &PanicInfo<'_>) {
-    let details = format!("{}", panic_info);
+    let details = format!("{panic_info}");
     let backtrace = format!("{:#?}", Backtrace::new());
     let thread_name = thread::current().name().unwrap_or("?").to_string();
     let process_name = env::args().next().unwrap_or_else(|| "?".to_string());
 
     // First, print the crash details.
-    println!(
-        "OH NO, WE CRASHED :( thread {} on {}",
-        thread_name, process_name
-    );
-    println!("Details: {}", details);
-    println!("{}", backtrace);
+    println!("OH NO, WE CRASHED :( thread {thread_name} on {process_name}");
+    println!("Details: {details}");
+    println!("{backtrace}");
 
     // Also attempt to log using the logger.
     logger::global_log::crit!(

--- a/connection/src/credentials.rs
+++ b/connection/src/credentials.rs
@@ -63,7 +63,7 @@ impl HardcodedCredentialsProvider {
 
 impl<URI: ConnectionUri> From<&URI> for HardcodedCredentialsProvider {
     fn from(src: &URI) -> Self {
-        Self::new(&src.username(), &src.password())
+        Self::new(src.username(), src.password())
     }
 }
 

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -104,7 +104,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
         real_range
             .map(|block_index| {
                 self.ledger
-                    .get_block(block_index as u64)
+                    .get_block(block_index)
                     .or(Err(ConnectionError::NotFound))
             })
             .collect::<Result<Vec<Block>, ConnectionError>>()
@@ -164,7 +164,7 @@ mod tests {
             // Get blocks 25,26,27. These are entirely out of range, so should return an
             // error.
             if let Ok(blocks) = mock_peer.fetch_blocks(25..28) {
-                println!("Blocks: {:?}", blocks);
+                println!("Blocks: {blocks:?}");
                 panic!();
             }
         }

--- a/connection/test-utils/src/lib.rs
+++ b/connection/test-utils/src/lib.rs
@@ -10,8 +10,7 @@ mod user_tx;
 
 pub fn test_client_uri(node_id: u32) -> ConsensusClientUri {
     ConsensusClientUri::from_str(&format!(
-        "mc://node{}.test.com?responder-id=loadbalancer.foo.com:4882",
-        node_id
+        "mc://node{node_id}.test.com?responder-id=loadbalancer.foo.com:4882"
     ))
     .expect("Could not construct client uri from string")
 }

--- a/consensus/enclave/impl/build.rs
+++ b/consensus/enclave/impl/build.rs
@@ -47,13 +47,13 @@ fn main() {
     // Check for env var and override
     fee_spend_public_key[..].copy_from_slice(
         &hex::decode(
-            &var("FEE_SPEND_PUBLIC_KEY").unwrap_or_else(|_| default_fee_spend_pub.to_string()),
+            var("FEE_SPEND_PUBLIC_KEY").unwrap_or_else(|_| default_fee_spend_pub.to_string()),
         )
         .expect("Failed parsing public spend key."),
     );
     fee_view_public_key[..].copy_from_slice(
         &hex::decode(
-            &var("FEE_VIEW_PUBLIC_KEY").unwrap_or_else(|_| default_fee_view_pub.to_string()),
+            var("FEE_VIEW_PUBLIC_KEY").unwrap_or_else(|_| default_fee_view_pub.to_string()),
         )
         .expect("Failed parsing public view key."),
     );
@@ -76,7 +76,7 @@ fn main() {
     };
 
     let parsed_pem =
-        pem::parse(&pem_bytes).expect("Failed parsing minting trust root public key PEM file");
+        pem::parse(pem_bytes).expect("Failed parsing minting trust root public key PEM file");
     let minting_trust_root_public_key = Ed25519Public::try_from_der(&parsed_pem.contents[..])
         .expect("Failed parsing minting trust root public key DER");
     let minting_trust_root_public_key_bytes = minting_trust_root_public_key.to_bytes();
@@ -85,16 +85,13 @@ fn main() {
         "// Copyright (c) 2018-2022 The MobileCoin Foundation\n\n// Auto-generated file\n\n"
             .to_string();
     constants.push_str(&format!(
-        "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {:?};\n\n",
-        fee_spend_public_key
+        "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {fee_spend_public_key:?};\n\n"
     ));
     constants.push_str(&format!(
-        "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {:?};\n",
-        fee_view_public_key
+        "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {fee_view_public_key:?};\n"
     ));
     constants.push_str(&format!(
-        "pub const MINTING_TRUST_ROOT_PUBLIC_KEY: [u8; 32] = {:?};\n",
-        minting_trust_root_public_key_bytes
+        "pub const MINTING_TRUST_ROOT_PUBLIC_KEY: [u8; 32] = {minting_trust_root_public_key_bytes:?};\n"
     ));
 
     // Output directory for generated constants.

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1553,9 +1553,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -19,7 +19,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for the business logic / implementation state
     static ref ENCLAVE: SgxConsensusEnclave = SgxConsensusEnclave::new(mc_sgx_slog::default_logger());

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -54,7 +54,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_config_tx_opt(&(&tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -141,7 +141,7 @@ fn main() {
                     common_headers_call_option(&chain_id),
                 )
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -183,7 +183,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_tx_opt(&(&tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -227,7 +227,7 @@ fn main() {
         }
 
         Commands::HashTxFile { tx_file } => {
-            println!("{}", hex::encode(&tx_file.hash_tx_prefix()));
+            println!("{}", hex::encode(tx_file.hash_tx_prefix()));
         }
 
         Commands::HashMintTx { params } => {
@@ -279,7 +279,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_tx_opt(&(&merged_tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -340,7 +340,7 @@ fn main() {
                     .map(|signer| {
                         Ed25519Pair::from(Ed25519Private::from(signer))
                             .try_sign(message.as_ref())
-                            .map_err(|e| format!("Failed to sign: {}", e))
+                            .map_err(|e| format!("Failed to sign: {e}"))
                     })
                     .collect::<Result<Vec<_>, _>>()
                     .expect("failed signing"),
@@ -378,7 +378,7 @@ fn main() {
             match pubkey.verify(&hash, &signature) {
                 Ok(()) => println!("signature Ok"),
                 Err(e) => {
-                    println!("{:?}", e);
+                    println!("{e:?}");
                     exit(1)
                 }
             }

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -64,7 +64,7 @@ impl MintConfigTxPrefixParams {
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintConfigTxPrefix, String> {
         let mut mint_config_tx_prefix = MintConfigTxPrefix::try_from(&self.mint_config_tx_file)
-            .map_err(|err| format!("Failed to parse mint config tx file: {}", err))?;
+            .map_err(|err| format!("Failed to parse mint config tx file: {err}"))?;
 
         // Override tombstone block if provided.
         if let Some(tombstone) = self.tombstone {
@@ -138,7 +138,7 @@ impl MintConfigTxParams {
             .map(|signer| {
                 Ed25519Pair::from(Ed25519Private::from(signer))
                     .try_sign(message.as_ref())
-                    .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {}", e))
+                    .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {e}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         signatures.extend(self.signatures);
@@ -183,8 +183,7 @@ impl MintTxPrefixParams {
         let mut tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
         let e_fog_hint = self.recipient.fog_report_url().map(|fog_url| -> Result<_, String> {
             let fog_bits = fog_bits.ok_or_else(|| format!(
-                "This recipient has a fog url, but a CSS to validate fog public keys was not supplied: '{}'",
-                fog_url,
+                "This recipient has a fog url, but a CSS to validate fog public keys was not supplied: '{fog_url}'",
             ))?;
             let (e_fog_hint, pubkey_expiry) = fog_bits.get_e_fog_hint(&self.recipient)?;
             tombstone_block = tombstone_block.min(pubkey_expiry);
@@ -243,7 +242,7 @@ impl MintTxParams {
             .map(|signer| {
                 Ed25519Pair::from(Ed25519Private::from(signer))
                     .try_sign(message.as_ref())
-                    .map_err(|e| format!("Failed to sign MintTxPrefix: {}", e))
+                    .map_err(|e| format!("Failed to sign MintTxPrefix: {e}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         signatures.extend(self.signatures);
@@ -496,25 +495,25 @@ pub struct Config {
 // trait for use with clap
 pub fn load_mint_private_key_from_pem(filename: &str) -> Result<MintPrivateKey, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
 
-    let parsed_pem = pem::parse(&bytes)
-        .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
+    let parsed_pem =
+        pem::parse(bytes).map_err(|err| format!("Failed parsing PEM file '{filename}': {err}"))?;
 
     let key = Ed25519Private::try_from_der(&parsed_pem.contents[..])
-        .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing DER from PEM file '{filename}': {err}"))?;
     Ok(MintPrivateKey(key))
 }
 
 pub fn load_key_from_pem<K: DistinguishedEncoding>(filename: &str) -> Result<K, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
 
-    let parsed_pem = pem::parse(&bytes)
-        .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
+    let parsed_pem =
+        pem::parse(bytes).map_err(|err| format!("Failed parsing PEM file '{filename}': {err}"))?;
 
     let key = K::try_from_der(&parsed_pem.contents[..])
-        .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing DER from PEM file '{filename}': {err}"))?;
     Ok(key)
 }
 
@@ -523,44 +522,37 @@ pub fn load_or_parse_ed25519_signature(
 ) -> Result<Ed25519Signature, String> {
     // Check if the signature provided is a filename.
     let bytes = if Path::new(filename_or_hex_signature).exists() {
-        let bytes = fs::read(filename_or_hex_signature).map_err(|err| {
-            format!(
-                "Failed reading file '{}': {}",
-                filename_or_hex_signature, err
-            )
-        })?;
+        let bytes = fs::read(filename_or_hex_signature)
+            .map_err(|err| format!("Failed reading file '{filename_or_hex_signature}': {err}"))?;
 
-        let parsed_pem = pem::parse(&bytes).map_err(|err| {
-            format!(
-                "Failed parsing PEM file '{}': {}",
-                filename_or_hex_signature, err
-            )
+        let parsed_pem = pem::parse(bytes).map_err(|err| {
+            format!("Failed parsing PEM file '{filename_or_hex_signature}': {err}")
         })?;
 
         parsed_pem.contents
     } else if filename_or_hex_signature.len() == Ed25519Signature::BYTE_SIZE * 2 {
         // *2 due to hex encoding
         hex::decode(filename_or_hex_signature)
-            .map_err(|err| format!("Failed decoding hex signature: {}", err))?
+            .map_err(|err| format!("Failed decoding hex signature: {err}"))?
     } else {
         return Err("Signature must either be a PEM file or a hex-encoded string".to_string());
     };
 
     Ed25519Signature::try_from(&bytes[..])
-        .map_err(|err| format!("Failed parsing Ed25519 signature: {}", err))
+        .map_err(|err| format!("Failed parsing Ed25519 signature: {err}"))
 }
 
 fn parse_public_address(b58: &str) -> Result<PublicAddress, String> {
     let printable_wrapper = PrintableWrapper::b58_decode(b58.into())
-        .map_err(|err| format!("failed parsing b58 address '{}': {}", b58, err))?;
+        .map_err(|err| format!("failed parsing b58 address '{b58}': {err}"))?;
 
     if printable_wrapper.has_public_address() {
         let public_address = PublicAddress::try_from(printable_wrapper.get_public_address())
-            .map_err(|err| format!("failed converting b58 public address '{}': {}", b58, err))?;
+            .map_err(|err| format!("failed converting b58 public address '{b58}': {err}"))?;
 
         Ok(public_address)
     } else {
-        Err(format!("b58 address '{}' is not a public address", b58))
+        Err(format!("b58 address '{b58}' is not a public address"))
     }
 }
 
@@ -582,10 +574,9 @@ fn get_or_generate_nonce(nonce: Option<[u8; NONCE_LENGTH]>) -> Vec<u8> {
 }
 
 fn load_tx_file_from_path(path: &str) -> Result<TxFile, String> {
-    TxFile::from_json_file(path).map_err(|e| format!("failed loading file {:?}: {}", path, e))
+    TxFile::from_json_file(path).map_err(|e| format!("failed loading file {path:?}: {e}"))
 }
 
 fn load_mint_config_tx_file_from_path(path: &str) -> Result<MintConfigTxFile, String> {
-    MintConfigTxFile::from_json_file(path)
-        .map_err(|e| format!("failed loading file {:?}: {}", path, e))
+    MintConfigTxFile::from_json_file(path).map_err(|e| format!("failed loading file {path:?}: {e}"))
 }

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -61,7 +61,7 @@ impl FogContext {
         public_address: &PublicAddress,
     ) -> Result<FullyValidatedFogPubkey, String> {
         let fog_uri = FogUri::from_str(public_address.fog_report_url().ok_or("Missing fog url")?)
-            .map_err(|err| format!("Invalid fog uri: {}", err))?;
+            .map_err(|err| format!("Invalid fog uri: {err}"))?;
 
         let conn = GrpcFogReportConnection::new(
             self.chain_id.clone(),
@@ -71,14 +71,14 @@ impl FogContext {
 
         let responses = conn
             .fetch_fog_reports([fog_uri].into_iter())
-            .map_err(|err| format!("Error fetching fog reports: {}", err))?;
+            .map_err(|err| format!("Error fetching fog reports: {err}"))?;
 
         let verifier = get_fog_ingest_verifier(self.css_signature.clone());
         let resolver = FogResolver::new(responses, &verifier)
-            .map_err(|err| format!("Error building FogResolver: {}", err))?;
+            .map_err(|err| format!("Error building FogResolver: {err}"))?;
         resolver
             .get_fog_pubkey(public_address)
-            .map_err(|err| format!("Could not validate fog pubkey: {}", err))
+            .map_err(|err| format!("Could not validate fog pubkey: {err}"))
     }
 }
 

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -17,14 +17,14 @@ const PEM_TAG_PUBLIC_KEY: &str = "PUBLIC KEY";
 
 pub fn print_mint_config_tx(tx: &MintConfigTx, indent: usize) {
     let indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfigTx:", indent_str);
+    println!("{indent_str}MintConfigTx:");
     print_mint_config_tx_prefix(&tx.prefix, indent + 1);
     print_multi_sig(&tx.signature, indent + 1);
 }
 
 pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfigTxPrefix:", indent_str);
+    println!("{indent_str}MintConfigTxPrefix:");
 
     indent_str.push_str(INDENT_STR);
     println!(
@@ -45,7 +45,7 @@ pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
 
 pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfig:", indent_str);
+    println!("{indent_str}MintConfig:");
 
     indent_str.push_str(INDENT_STR);
     println!("{}Token id: {}", indent_str, mint_config.token_id);
@@ -55,7 +55,7 @@ pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
 
 pub fn print_mint_tx(tx: &MintTx, indent: usize) {
     let indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintTx:", indent_str);
+    println!("{indent_str}MintTx:");
     print_mint_tx_prefix(&tx.prefix, indent + 1);
     print_multi_sig(&tx.signature, indent + 1);
 }
@@ -67,7 +67,7 @@ pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
     let b58_recipient = wrapper.b58_encode().expect("failed encoding b58 address");
 
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintTxPrefix:", indent_str);
+    println!("{indent_str}MintTxPrefix:");
     indent_str.push_str(INDENT_STR);
     println!("{}Token id: {}", indent_str, prefix.token_id);
     println!("{}Mint amount: {}", indent_str, prefix.amount);
@@ -76,7 +76,7 @@ pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
         "{}Spend public key: {}",
         indent_str, prefix.spend_public_key
     );
-    println!("{}Recipient B58 address: {}", indent_str, b58_recipient);
+    println!("{indent_str}Recipient B58 address: {b58_recipient}");
     println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
     println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
 }
@@ -118,6 +118,6 @@ pub fn print_pem(obj: &impl DistinguishedEncoding, tag: &str, indent: usize) {
         contents: obj.to_der(),
     });
     for line in pem_str.lines() {
-        println!("{}{}", indent_str, line);
+        println!("{indent_str}{line}");
     }
 }

--- a/consensus/scp/play/src/main.rs
+++ b/consensus/scp/play/src/main.rs
@@ -43,10 +43,10 @@ pub struct Config {
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet, String> {
     let quorum_set: QuorumSet = serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+        .map_err(|err| format!("Error parsing quorum set {src}: {err:?}"))?;
 
     if !quorum_set.is_valid() {
-        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+        return Err(format!("Invalid quorum set: {quorum_set:?}"));
     }
 
     Ok(quorum_set)
@@ -54,7 +54,7 @@ fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet, String> {
 
 fn parse_node_id_from_uri(src: &str) -> Result<NodeID, String> {
     let uri = PeerUri::from_str(src)
-        .map_err(|err| format!("Could not get URI from param {}: {:?}", src, err))?;
+        .map_err(|err| format!("Could not get URI from param {src}: {err:?}"))?;
     Ok(NodeID::from(&uri))
 }
 

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -305,7 +305,7 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
 
         let validate_nominate = |payload: &NominatePayload<V>| -> Result<(), String> {
             if payload.X.intersection(&payload.Y).next().is_some() {
-                Err(format!("X intersects Y, msg: {}", self))
+                Err(format!("X intersects Y, msg: {self}"))
             } else {
                 Ok(())
             }
@@ -314,21 +314,21 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
         let validate_prepare = |payload: &PreparePayload<V>| -> Result<(), String> {
             if let Some(P) = &payload.P {
                 if payload.B < *P {
-                    return Err(format!("B < P, msg: {}", self));
+                    return Err(format!("B < P, msg: {self}"));
                 }
 
                 if let Some(PP) = &payload.PP {
                     if *PP >= *P {
-                        return Err(format!("PP >= P, msg: {}", self));
+                        return Err(format!("PP >= P, msg: {self}"));
                     }
                 }
             }
 
             if payload.CN > payload.HN {
-                return Err(format!("CN > HN, msg: {}", self));
+                return Err(format!("CN > HN, msg: {self}"));
             }
             if payload.HN > payload.B.N {
-                return Err(format!("HN > BN, msg: {}", self));
+                return Err(format!("HN > BN, msg: {self}"));
             }
 
             Ok(())
@@ -350,7 +350,7 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
 
             Commit(ref payload) => {
                 if payload.CN > payload.HN {
-                    return Err(format!("CN > HN, msg: {}", self));
+                    return Err(format!("CN > HN, msg: {self}"));
                 }
             }
 
@@ -607,7 +607,7 @@ impl<V: Value, ID: GenericNodeId> fmt::Display for Msg<V, ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let format_opt_ballot = |b: &Option<Ballot<V>>| match b {
             None => "<>".to_string(),
-            Some(b) => format!("{}", b),
+            Some(b) => format!("{b}"),
         };
 
         // Returns "<set.len, hash(set)>".
@@ -759,7 +759,7 @@ mod msg_tests {
                 QuorumSet::empty(),
                 1,
                 Prepare(PreparePayload {
-                    B: ballot.clone(),
+                    B: ballot,
                     P: Some(prepared.clone()),
                     PP: Some(prepared_prime.clone()),
                     CN: 0, /* c_counter -> if h_counter > 0, and ballot is confirmed prepared,

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -467,7 +467,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_from_self.clone(), msg_from_self.clone()]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -502,7 +502,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_future_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -537,7 +537,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_old_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -587,7 +587,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_current_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 1), // Should return a message.
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -638,7 +638,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_recent_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 1), // Should return a message.
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -747,7 +747,7 @@ mod tests {
             Arc::new(trivial_validity_fn),
             Arc::new(trivial_combine_fn),
             slot_index,
-            logger.clone(),
+            logger,
         );
 
         // Client(s) submits some values to node 2.

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -753,7 +753,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 
         // Invariants: p' is less-than-and-incompatible-with p.
         if let (Some(p), Some(pp)) = (&self.P, &self.PP) {
-            assert!(pp < p, "p: {:?}, pp: {:?}", p, pp);
+            assert!(pp < p, "p: {p:?}, pp: {pp:?}");
             assert_ne!(p.X, pp.X);
         }
 
@@ -2626,7 +2626,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // When the timer fires, we should advance to a new ballot with all 4 values.
         {
@@ -2758,7 +2758,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // When the timer fires, we should advance to a new ballot with all 4 values.
         // The prepared value should not change.
@@ -2869,7 +2869,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // The next higher ballot should **not** include the latest confirmed nominated
         // values.

--- a/consensus/scp/tests/mock_network/cyclic_topology.rs
+++ b/consensus/scp/tests/mock_network/cyclic_topology.rs
@@ -29,12 +29,12 @@ pub fn directed_cycle(num_nodes: usize) -> mock_network::NetworkConfig {
             .collect::<Vec<NodeID>>();
 
         nodes.push(mock_network::NodeConfig::new(
-            format!("c{}", node_index),
+            format!("c{node_index}"),
             test_utils::test_node_id(node_index as u32),
             peers_vector.iter().cloned().collect::<HashSet<NodeID>>(),
             QuorumSet::new_with_node_ids(1, vec![next_node_id]),
         ));
     }
 
-    mock_network::NetworkConfig::new(format!("cyclic{}", num_nodes), nodes)
+    mock_network::NetworkConfig::new(format!("cyclic{num_nodes}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/mesh_topology.rs
+++ b/consensus/scp/tests/mock_network/mesh_topology.rs
@@ -26,12 +26,12 @@ pub fn dense_mesh(
             .collect::<Vec<NodeID>>();
 
         nodes.push(mock_network::NodeConfig::new(
-            format!("m{}", node_index),
+            format!("m{node_index}"),
             test_utils::test_node_id(node_index as u32),
             peers_vector.iter().cloned().collect::<HashSet<NodeID>>(),
             QuorumSet::new_with_node_ids(k as u32, peers_vector),
         ));
     }
 
-    mock_network::NetworkConfig::new(format!("m{}k{}", n, k), nodes)
+    mock_network::NetworkConfig::new(format!("m{n}k{k}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/metamesh_topology.rs
+++ b/consensus/scp/tests/mock_network/metamesh_topology.rs
@@ -87,7 +87,7 @@ pub fn metamesh(
                 .collect::<HashSet<NodeID>>();
 
             nodes.push(mock_network::NodeConfig::new(
-                format!("mm{}-{}", org_index, server_index),
+                format!("mm{org_index}-{server_index}"),
                 node_id,
                 peers,
                 QuorumSet::new_with_inner_sets(k_n as u32, inner_quorum_sets),
@@ -95,5 +95,5 @@ pub fn metamesh(
         }
     }
 
-    mock_network::NetworkConfig::new(format!("{}k{}-{}k{}", n, k_n, m, k_m), nodes)
+    mock_network::NetworkConfig::new(format!("{n}k{k_n}-{m}k{k_m}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -449,7 +449,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_value failed: {:?}", err);
+                    panic!("send_value failed: {err:?}");
                 }
             },
         }
@@ -462,7 +462,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_msg failed: {:?}", err);
+                    panic!("send_msg failed: {err:?}");
                 }
             },
         }
@@ -474,7 +474,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_stop failed: {:?}", err);
+                    panic!("send_stop failed: {err:?}");
                 }
             },
         }

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -15,7 +15,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     test_options.values_to_submit = 10000;
 
     let network_config = mock_network::cyclic_topology::directed_cycle(num_nodes);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -20,7 +20,7 @@ fn mesh_test_helper(
     let mut test_options = mock_network::TestOptions::new();
     test_options.values_to_submit = 10000;
     let network_config = mock_network::mesh_topology::dense_mesh(n, k);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -28,29 +28,29 @@ fn metamesh_test_helper(
     test_options.scp_timebase = Duration::from_millis(100);
 
     let network_config = mock_network::metamesh_topology::metamesh(n, k_n, m, k_m);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_3k1(logger: Logger) {
-    metamesh_test_helper(3, 2, 3, 1, logger.clone());
+    metamesh_test_helper(3, 2, 3, 1, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_3k2(logger: Logger) {
-    metamesh_test_helper(3, 2, 3, 2, logger.clone());
+    metamesh_test_helper(3, 2, 3, 2, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_4k3(logger: Logger) {
-    metamesh_test_helper(3, 2, 4, 3, logger.clone());
+    metamesh_test_helper(3, 2, 4, 3, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_5k4(logger: Logger) {
-    metamesh_test_helper(3, 2, 5, 4, logger.clone());
+    metamesh_test_helper(3, 2, 5, 4, logger);
 }

--- a/consensus/scp/types/src/test_utils.rs
+++ b/consensus/scp/types/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn test_node_id_and_signer(node_id: u32) -> (NodeID, Ed25519Pair) {
     let signer_keypair = Ed25519Pair::from_random(&mut seeded_rng);
     (
         NodeID {
-            responder_id: ResponderId::from_str(&format!("node{}.test.com:8443", node_id)).unwrap(),
+            responder_id: ResponderId::from_str(&format!("node{node_id}.test.com:8443")).unwrap(),
             public_key: signer_keypair.public_key(),
         },
         signer_keypair,

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -153,7 +153,7 @@ impl Config {
     pub fn tokens(&self) -> TokensConfig {
         if let Some(tokens_path) = &self.tokens_path {
             TokensConfig::load_from_path(tokens_path).unwrap_or_else(|_| {
-                panic!("failed loading tokens configuration from {:?}", tokens_path)
+                panic!("failed loading tokens configuration from {tokens_path:?}")
             })
         } else {
             TokensConfig::default()
@@ -167,10 +167,10 @@ impl Config {
 /// * `private_key` - A DER formatted, Base64 encoded Ed25519 private key.
 fn keypair_from_base64(private_key: &str) -> Result<Arc<Ed25519Pair>, String> {
     let privkey_bytes = base64::decode_config(private_key, base64::STANDARD)
-        .map_err(|err| format!("Could not decode private key from base64 {:?}", err))?;
+        .map_err(|err| format!("Could not decode private key from base64 {err:?}"))?;
 
     let secret_key = Ed25519Private::try_from_der(privkey_bytes.as_slice())
-        .map_err(|err| format!("Could not get Ed25519Private from der {:?}", err))?;
+        .map_err(|err| format!("Could not get Ed25519Private from der {err:?}"))?;
     Ok(Arc::new(Ed25519Pair::from(secret_key)))
 }
 

--- a/consensus/service/config/src/network.rs
+++ b/consensus/service/config/src/network.rs
@@ -89,11 +89,10 @@ impl NetworkConfig {
             .cloned()
             .map(|uri| {
                 (
-                    uri.responder_id().unwrap_or_else(|e| {
-                        panic!("unable to get responder_id for {}: {:?}", uri, e)
-                    }),
+                    uri.responder_id()
+                        .unwrap_or_else(|e| panic!("unable to get responder_id for {uri}: {e:?}")),
                     uri.node_id()
-                        .unwrap_or_else(|e| panic!("unable to get node_id for {}: {:?}", uri, e)),
+                        .unwrap_or_else(|e| panic!("unable to get node_id for {uri}: {e:?}")),
                 )
             })
             .collect();
@@ -102,12 +101,12 @@ impl NetworkConfig {
             for uri in known_peers.iter() {
                 let responder_id = uri
                     .responder_id()
-                    .unwrap_or_else(|e| panic!("unable to get responder_id for {}: {:?}", uri, e));
+                    .unwrap_or_else(|e| panic!("unable to get responder_id for {uri}: {e:?}"));
                 let node_id = uri
                     .node_id()
-                    .unwrap_or_else(|e| panic!("unable to get node_id for {}: {:?}", uri, e));
+                    .unwrap_or_else(|e| panic!("unable to get node_id for {uri}: {e:?}"));
                 if peer_map.get(&responder_id).unwrap_or(&node_id) != &node_id {
-                    panic!("node id mismatch for {}", responder_id);
+                    panic!("node id mismatch for {responder_id}");
                 } else {
                     peer_map.insert(responder_id, node_id);
                 }
@@ -137,7 +136,7 @@ impl NetworkConfig {
                         peer_map
                             .get(responder_id)
                             .unwrap_or_else(|| {
-                                panic!("Unknown responder_id {} in quorum set", responder_id)
+                                panic!("Unknown responder_id {responder_id} in quorum set")
                             })
                             .clone(),
                     ),

--- a/consensus/service/config/src/signer_identity.rs
+++ b/consensus/service/config/src/signer_identity.rs
@@ -23,9 +23,9 @@ impl FromStr for PemEd25519Public {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pem = pem::parse(s).map_err(|e| format!("Failed to parse PEM {:?}: {}", s, e))?;
+        let pem = pem::parse(s).map_err(|e| format!("Failed to parse PEM {s:?}: {e}"))?;
         let public_key = Ed25519Public::try_from_der(&pem.contents)
-            .map_err(|e| format!("Failed to parse public key {:?}: {}", s, e))?;
+            .map_err(|e| format!("Failed to parse public key {s:?}: {e}"))?;
         Ok(PemEd25519Public(public_key))
     }
 }

--- a/consensus/service/src/api/attested_api_service.rs
+++ b/consensus/service/src/api/attested_api_service.rs
@@ -159,7 +159,7 @@ mod peer_tests {
             .unwrap();
         server.start();
         let (_, port) = server.bind_addrs().next().unwrap();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = AttestedApiClient::new(ch);
         (client, server)
     }
@@ -186,13 +186,13 @@ mod peer_tests {
 
         match client.auth(&AuthMessage::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }
@@ -223,7 +223,7 @@ mod client_tests {
             .unwrap();
         server.start();
         let (_, port) = server.bind_addrs().next().unwrap();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = AttestedApiClient::new(ch);
         (client, server)
     }
@@ -250,13 +250,13 @@ mod client_tests {
 
         match client.auth(&AuthMessage::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -96,7 +96,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
         // Get "persistence type" blocks.
         let mut blocks: Vec<mc_blockchain_types::Block> = Vec::new();
         for block_index in start_index..end_index {
-            match self.ledger.get_block(block_index as u64) {
+            match self.ledger.get_block(block_index) {
                 Ok(block) => blocks.push(block),
                 Err(mc_ledger_db::Error::NotFound) => {
                     // This is okay - it means we have reached the last block in the ledger in the
@@ -204,7 +204,7 @@ mod tests {
             .unwrap();
         server.start();
         let (_, port) = server.bind_addrs().next().unwrap();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = BlockchainApiClient::new(ch);
         (client, server)
     }
@@ -265,13 +265,13 @@ mod tests {
 
         match client.get_last_block_info(&Empty::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }
@@ -419,13 +419,13 @@ mod tests {
 
         match client.get_blocks(&BlocksRequest::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -87,7 +87,7 @@ impl ClientApiService {
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {
             if let TxManagerError::TransactionValidation(cause) = &err {
-                counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
+                counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{cause:?}"));
             }
             err
         })?;
@@ -116,7 +116,7 @@ impl ClientApiService {
     ) -> Result<ProposeMintConfigTxResponse, ConsensusGrpcError> {
         counters::PROPOSE_MINT_CONFIG_TX_INITIATED.inc();
         let mint_config_tx = MintConfigTx::try_from(&grpc_tx)
-            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{err:?}")))?;
         let response = ProposeMintConfigTxResponse::new();
 
         // Validate the transaction.
@@ -142,7 +142,7 @@ impl ClientApiService {
     ) -> Result<ProposeMintTxResponse, ConsensusGrpcError> {
         counters::PROPOSE_MINT_TX_INITIATED.inc();
         let mint_tx = MintTx::try_from(&grpc_tx)
-            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{err:?}")))?;
         let response = ProposeMintTxResponse::new();
 
         // Validate the transaction.
@@ -395,14 +395,14 @@ mod client_api_tests {
             .unwrap();
         server.start();
         let (_, port) = server.bind_addrs().next().unwrap();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = ConsensusClientApiClient::new(ch);
         (client, server)
     }
 
     /// Get a dummy config object
     fn get_config() -> Config {
-        Config::try_parse_from(&[
+        Config::try_parse_from([
             "foo",
             "--chain-id=local",
             "--peer-responder-id=localhost:8081",
@@ -504,7 +504,7 @@ mod client_api_tests {
                 assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -575,7 +575,7 @@ mod client_api_tests {
                 assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -626,7 +626,7 @@ mod client_api_tests {
             Ok(_) => {
                 panic!("Got success, but failure was expected");
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -704,7 +704,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -764,7 +764,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -832,7 +832,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -874,12 +874,12 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -929,12 +929,12 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         // This is a global variable. It affects other unit tests, so must be reset :(
@@ -978,13 +978,13 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         };
     }
@@ -1045,7 +1045,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert_eq!(
@@ -1114,7 +1114,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1159,12 +1159,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1217,12 +1217,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1274,12 +1274,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1346,7 +1346,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert_eq!(
@@ -1420,7 +1420,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1470,12 +1470,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1533,12 +1533,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1595,12 +1595,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -85,7 +85,7 @@ impl From<TxManagerError> for ConsensusGrpcError {
             TxManagerError::Enclave(err) => Self::from(err),
             TxManagerError::TransactionValidation(err) => Self::from(err),
             TxManagerError::LedgerDb(err) => Self::from(err),
-            _ => Self::Other(format!("tx manager error: {}", src)),
+            _ => Self::Other(format!("tx manager error: {src}")),
         }
     }
 }
@@ -110,7 +110,7 @@ impl From<ConsensusGrpcError> for RpcStatus {
         match src {
             ConsensusGrpcError::RpcStatus(rpc_status) => rpc_status,
             ConsensusGrpcError::Ledger(err) => {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Ledger error: {}", err))
+                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Ledger error: {err}"))
             }
             ConsensusGrpcError::OverCapacity => RpcStatus::with_message(
                 RpcStatusCode::UNAVAILABLE,
@@ -132,12 +132,10 @@ impl From<ConsensusGrpcError> for RpcStatus {
                 global_log::error!("Attempting to convert a ConsensusGrpcError::TransactionValidation into RpcStatus, this should not happen! Error is: {}", err);
                 RpcStatus::with_message(
                     RpcStatusCode::INTERNAL,
-                    format!("Unexpected transaction validation error: {}", err),
+                    format!("Unexpected transaction validation error: {err}"),
                 )
             }
-            _ => {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Internal error: {}", src))
-            }
+            _ => RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Internal error: {src}")),
         }
     }
 }

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -162,9 +162,9 @@ impl PeerApiService {
                         logger,
                         "Error validating transaction {tx_hash}: {err}",
                         tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
+                        err = format!("{err:?}")
                     );
-                    counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", err));
+                    counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{err:?}"));
                 }
 
                 Err(err) => {
@@ -172,7 +172,7 @@ impl PeerApiService {
                         logger,
                         "tx_propose failed for {tx_hash}: {err}",
                         tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
+                        err = format!("{err:?}")
                     );
                 }
             };
@@ -459,7 +459,7 @@ mod tests {
             .unwrap();
         server.start();
         let (_, port) = server.bind_addrs().next().unwrap();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = ConsensusPeerApiClient::new(ch);
         (client, server)
     }
@@ -528,7 +528,7 @@ mod tests {
                     ConsensusMsgResult::UnknownPeer
                 );
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -599,7 +599,7 @@ mod tests {
             Ok(consensus_msg_response) => {
                 assert_eq!(consensus_msg_response.get_result(), ConsensusMsgResult::Ok);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         // TODO: Should pass the message to incoming_consensus_msgs_sender
@@ -637,12 +637,12 @@ mod tests {
         message.set_payload(vec![240, 159, 146, 150]); // UTF-8 "sparkle heart".
 
         match client.send_consensus_msg(&message) {
-            Ok(response) => panic!("Unexpected response: {:?}", response),
+            Ok(response) => panic!("Unexpected response: {response:?}"),
             Err(RpcFailure(_rpc_status)) => {
                 // This is expected.
                 // TODO: check status code.
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -714,12 +714,12 @@ mod tests {
         message.set_payload(mc_util_serial::serialize(&payload).unwrap());
 
         match client.send_consensus_msg(&message) {
-            Ok(response) => panic!("Unexpected response: {:?}", response),
+            Ok(response) => panic!("Unexpected response: {response:?}"),
             Err(RpcFailure(_rpc_status)) => {
                 // This is expected.
                 // TODO: check status code.
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 

--- a/consensus/service/src/background_work_queue.rs
+++ b/consensus/service/src/background_work_queue.rs
@@ -94,7 +94,7 @@ impl<T: Send + 'static> BackgroundWorkQueue<T> {
         if let Some(join_handle) = self.join_handle.take() {
             return join_handle
                 .join()
-                .map_err(|e| BackgroundWorkQueueError::JoinFailed(format!("{:?}", e)))?;
+                .map_err(|e| BackgroundWorkQueueError::JoinFailed(format!("{e:?}")))?;
         }
 
         Ok(())

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -236,7 +236,7 @@ impl ByzantineLedger {
                 peer_manager,
                 tx_manager,
                 mint_tx_manager,
-                broadcaster.clone(),
+                broadcaster,
                 task_receiver,
                 is_behind.clone(),
                 highest_peer_block.clone(),
@@ -479,7 +479,7 @@ mod tests {
             msg_signer_key,
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, byzantine_ledger is not behind.
@@ -572,7 +572,7 @@ mod tests {
             local_signer_key.clone(),
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, there should be no messages to the network.
@@ -706,8 +706,7 @@ mod tests {
                 .msgs;
             assert!(
                 msgs.contains(&expected_msg),
-                "Nominate msg not found. msgs={:#?}",
-                msgs,
+                "Nominate msg not found. msgs={msgs:#?}",
             );
         }
 
@@ -954,7 +953,7 @@ mod tests {
             local_signer_key.clone(),
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, there should be no messages to the network.
@@ -1044,8 +1043,7 @@ mod tests {
                 .msgs;
             assert!(
                 msgs.contains(&expected_msg),
-                "Nominate msg not found. msgs={:#?}",
-                msgs,
+                "Nominate msg not found. msgs={msgs:#?}",
             );
         }
 

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -841,13 +841,13 @@ impl<
         let well_formed_encrypted_txs_with_proofs = self
             .tx_manager
             .tx_hashes_to_well_formed_encrypted_txs_and_proofs(&tx_hashes)
-            .unwrap_or_else(|e| panic!("failed resolving tx_hashes {:?}: {:?}", tx_hashes, e));
+            .unwrap_or_else(|e| panic!("failed resolving tx_hashes {tx_hashes:?}: {e:?}"));
 
         // Bundle mint_txs with the matching configuration that allows the minting.
         let mint_txs_with_config = self
             .mint_tx_manager
             .mint_txs_with_config(&mint_txs)
-            .unwrap_or_else(|e| panic!("failed resolving mint txs {:?}: {:?}", mint_txs, e));
+            .unwrap_or_else(|e| panic!("failed resolving mint txs {mint_txs:?}: {e:?}"));
 
         // Get the root membership element, which is needed for validating the
         // membership proofs (and also storing in the block for bookkeeping
@@ -881,10 +881,7 @@ impl<
 
     fn get_block_metadata(&self, block_id: &BlockID) -> BlockMetadata {
         let verification_report = self.enclave.get_ias_report().unwrap_or_else(|err| {
-            panic!(
-                "Failed to fetch verification report after forming block {:?}: {}",
-                block_id, err
-            )
+            panic!("Failed to fetch verification report after forming block {block_id:?}: {err}")
         });
         let contents = BlockMetadataContents::new(
             block_id.clone(),
@@ -894,12 +891,7 @@ impl<
         );
 
         BlockMetadata::from_contents_and_keypair(contents, &self.msg_signer_key).unwrap_or_else(
-            |err| {
-                panic!(
-                    "Failed to sign block metadata for block {:?}: {}",
-                    block_id, err
-                )
-            },
+            |err| panic!("Failed to sign block metadata for block {block_id:?}: {err}"),
         )
     }
 }
@@ -1170,7 +1162,7 @@ mod tests {
                 attempt_sync_at: now,
                 num_sync_attempts: 0,
             },
-            logger.clone(),
+            logger,
         );
     }
 

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -297,8 +297,7 @@ impl<
 
         self.consensus_msgs_from_network.stop().map_err(|e| {
             ConsensusServiceError::BackgroundWorkQueueStop(format!(
-                "consensus_msgs_from_network: {:?}",
-                e
+                "consensus_msgs_from_network: {e:?}"
             ))
         })?;
 
@@ -650,7 +649,7 @@ impl<
                             // If a value was submitted to `scp_client_value_sender` that means it
                             // should've found it's way into the cache. Suddenly not having it there
                             // indicates something is broken, so for the time being we will panic.
-                            panic!("tx hash {} expected to be in cache but wasn't", tx_hash);
+                            panic!("tx hash {tx_hash} expected to be in cache but wasn't");
                         }
                     }
                 }
@@ -749,7 +748,7 @@ impl<
                     "public_key": config.node_id().public_key,
                     "peer_responder_id": config.peer_responder_id,
                     "client_responder_id": config.client_responder_id,
-                    "message_pubkey": encode_config(&config.msg_signer_key.public_key().to_der(), URL_SAFE),
+                    "message_pubkey": encode_config(config.msg_signer_key.public_key().to_der(), URL_SAFE),
                     "network": config.network_path,
                     "peer_listen_uri": config.peer_listen_uri,
                     "client_listen_uri": config.client_listen_uri,

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -220,7 +220,7 @@ pub mod well_formed_tests {
                 assert_eq!(current_block_index, num_blocks - 1);
                 assert_eq!(highest_index_proofs.len(), 3)
             }
-            Err(e) => panic!("Unexpected error {}", e),
+            Err(e) => panic!("Unexpected error {e}"),
         }
     }
 

--- a/consensus/tool/src/main.rs
+++ b/consensus/tool/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
                         }
                     }
                     Err(err) => {
-                        eprintln!("{}: get_last_block_info(): {}", uri, err);
+                        eprintln!("{uri}: get_last_block_info(): {err}");
                         needs_retry = true;
                     }
                 };
@@ -147,7 +147,7 @@ fn main() {
                             }
                         }
                         Err(err) => {
-                            eprintln!("{}: get_last_block_info(): {}", uri, err);
+                            eprintln!("{uri}: get_last_block_info(): {err}");
                             was_updated = true;
                         }
                     };
@@ -164,7 +164,7 @@ fn main() {
                 std::thread::sleep(Duration::from_secs(period));
             };
             // Print the stopping point on STDOUT so that scripts can capture this easily
-            print!("{}", last_block_index)
+            print!("{last_block_index}")
         }
     }
 }

--- a/core/types/src/keys.rs
+++ b/core/types/src/keys.rs
@@ -150,7 +150,7 @@ impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02x}", d)?;
+            write!(f, "{d:02x}")?;
         }
         Ok(())
     }
@@ -161,7 +161,7 @@ impl<ADDR, KIND> core::fmt::LowerHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02x}", d)?;
+            write!(f, "{d:02x}")?;
         }
         Ok(())
     }
@@ -172,7 +172,7 @@ impl<ADDR, KIND> core::fmt::UpperHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02X}", d)?;
+            write!(f, "{d:02X}")?;
         }
         Ok(())
     }

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -621,7 +621,7 @@ fn try_digestible_enum_transparent(
             };
 
             if ith_type == jth_type {
-                panic!("The types of the {}'th and {}'th variants of {} appear to be the same. When using digestible(transparent), this is highly suspect", j, i, ident);
+                panic!("The types of the {j}'th and {i}'th variants of {ident} appear to be the same. When using digestible(transparent), this is highly suspect");
             }
         }
     }

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -246,7 +246,7 @@ impl Digestible for u16 {
         transcript: &mut DT,
     ) {
         // Note: encoding of the size of the uint is implicit in merlin's framing
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -257,7 +257,7 @@ impl Digestible for u32 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -268,7 +268,7 @@ impl Digestible for u64 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -279,7 +279,7 @@ impl Digestible for i8 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -290,7 +290,7 @@ impl Digestible for i16 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -301,7 +301,7 @@ impl Digestible for i32 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -312,7 +312,7 @@ impl Digestible for i64 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 

--- a/crypto/digestible/test-utils/src/inspect_ast.rs
+++ b/crypto/digestible/test-utils/src/inspect_ast.rs
@@ -521,8 +521,8 @@ impl From<&ASTNode> for serde_json::Value {
 impl From<&ASTPrimitive> for serde_json::Value {
     fn from(src: &ASTPrimitive) -> Self {
         json!({
-            utf8(&src.context): "primitive",
-            "type_name": utf8(&src.type_name),
+            utf8(src.context): "primitive",
+            "type_name": utf8(src.type_name),
             "data": pretty_bytes(&src.data)
         })
     }
@@ -531,7 +531,7 @@ impl From<&ASTPrimitive> for serde_json::Value {
 impl From<&ASTNone> for serde_json::Value {
     fn from(src: &ASTNone) -> Self {
         json!({
-            utf8(&src.context): "",
+            utf8(src.context): "",
         })
     }
 }
@@ -539,7 +539,7 @@ impl From<&ASTNone> for serde_json::Value {
 impl From<&ASTSequence> for serde_json::Value {
     fn from(src: &ASTSequence) -> Self {
         let mut result = json!({
-            utf8(&src.context): "sequence",
+            utf8(src.context): "sequence",
             "len": src.len,
         });
         result.as_object_mut().unwrap().insert(
@@ -553,7 +553,7 @@ impl From<&ASTSequence> for serde_json::Value {
 impl From<&ASTAggregate> for serde_json::Value {
     fn from(src: &ASTAggregate) -> Self {
         let mut result = json!({
-            utf8(&src.context): "aggregate",
+            utf8(src.context): "aggregate",
             "name": utf8(&src.name),
         });
         result.as_object_mut().unwrap().insert(
@@ -572,7 +572,7 @@ impl From<&ASTVariant> for serde_json::Value {
             serde_json::Value::String("**incomplete**".to_string())
         };
         json!({
-            utf8(&src.context): "variant",
+            utf8(src.context): "variant",
             "name": utf8(&src.name),
             "which": src.which,
             "value": value_json,

--- a/crypto/digestible/test-utils/src/lib.rs
+++ b/crypto/digestible/test-utils/src/lib.rs
@@ -19,9 +19,9 @@ pub fn digestible_test_case<D: Digestible>(
     let mut transcript = MockMerlin::new();
     obj.append_to_transcript(context.as_bytes(), &mut transcript);
     if &transcript.append_bytes_calls[..] != expected_append_bytes {
+        let append_bytes_calls = transcript.append_bytes_calls;
         panic!(
-            "Digestible test case failed: context = {}\nExpected:\n{:?}\nFound:\n{:?}",
-            context, expected_append_bytes, transcript.append_bytes_calls
+            "Digestible test case failed: context = {context}\nExpected:\n{expected_append_bytes:?}\nFound:\n{append_bytes_calls:?}",
         );
     }
 }
@@ -34,8 +34,7 @@ pub fn digestible_test_case_ast<D: Digestible>(
     let ast = calculate_digest_ast(context.as_bytes(), obj);
     if ast != expected_ast {
         panic!(
-            "Digestible AST test case failed: context = {}\nExpected:\n{}\nFound:\n{}",
-            context, expected_ast, ast
+            "Digestible AST test case failed: context = {context}\nExpected:\n{expected_ast}\nFound:\n{ast}",
         );
     }
 }

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -447,7 +447,7 @@ impl Digestible for Ed25519Signature {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"ed25519-sig", &self);
+        transcript.append_primitive(context, b"ed25519-sig", self);
     }
 }
 
@@ -610,15 +610,15 @@ mod ed25519_tests {
     fn openssl_version() {
         run_and_log("openssl", &["version"]);
 
-        let output = Command::new("openssl").args(&["version"]).output().unwrap();
+        let output = Command::new("openssl").args(["version"]).output().unwrap();
         let output_string = String::from_utf8(output.stdout).unwrap();
         let mut iter = output_string.split(' ');
         iter.next();
         let ver_string = iter.next().unwrap();
-        eprintln!("version: {}", ver_string);
+        eprintln!("version: {ver_string}");
         let ver = Version::parse(ver_string).unwrap();
         let ver_req = VersionReq::parse(">= 1.1").unwrap();
-        assert!(ver_req.matches(&ver), "Version of openssl should be {}, install a better one and put it in path (or run in docker)", ver_req);
+        assert!(ver_req.matches(&ver), "Version of openssl should be {ver_req}, install a better one and put it in path (or run in docker)");
     }
 
     // This test is only run in nightly, because it has a dependency on host version

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -115,7 +115,7 @@ pub struct Fingerprint<D: digest::OutputSizeUser>(
 /// Debug impl for fingerprint objects
 impl<D: digest::OutputSizeUser> core::fmt::Debug for Fingerprint<D> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Fingerprint({})", self)
+        write!(f, "Fingerprint({self})")
     }
 }
 
@@ -142,7 +142,7 @@ impl<T: PublicKey + DistinguishedEncoding> Fingerprintable for T {
         let der = self.to_der_slice(&mut buff);
 
         // Get the hash of the DER bytes
-        let hash = D::digest(&der);
+        let hash = D::digest(der);
 
         // Return fingerprint
         Fingerprint(hash)

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -259,8 +259,7 @@ impl Debug for X25519Public {
 
         write!(
             f,
-            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
-            b64_str
+            "-----BEGIN PUBLIC KEY-----\n{b64_str}\n-----END PUBLIC KEY-----\n",
         )
     }
 }

--- a/crypto/ring-signature/src/amount/commitment.rs
+++ b/crypto/ring-signature/src/amount/commitment.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for Commitment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Commitment(")?;
         for i in self.to_bytes() {
-            write!(f, "{:02x}", i)?;
+            write!(f, "{i:02x}")?;
         }
         write!(f, ")")
     }

--- a/crypto/ring-signature/src/onetime_keys.rs
+++ b/crypto/ring-signature/src/onetime_keys.rs
@@ -84,7 +84,7 @@ const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 /// Hashes a curve point to a Scalar.
 fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_SCALAR_DOMAIN_TAG);
+    hasher.update(HASH_TO_SCALAR_DOMAIN_TAG);
     hasher.update(point.compress().as_bytes());
     Scalar::from_hash(hasher)
 }

--- a/crypto/ring-signature/src/ring_signature/mlsag.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag.rs
@@ -333,7 +333,7 @@ fn challenge(
     L1: &RistrettoPoint,
 ) -> Scalar {
     let mut hasher = Blake2b512::new();
-    hasher.update(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
+    hasher.update(RING_MLSAG_CHALLENGE_DOMAIN_TAG);
     hasher.update(message);
     hasher.update(key_image);
     hasher.update(L0.compress().as_bytes());

--- a/crypto/ring-signature/src/ring_signature/mod.rs
+++ b/crypto/ring-signature/src/ring_signature/mod.rs
@@ -59,7 +59,7 @@ impl PedersenGens {
 /// For amounts, H varies based on the token id.
 pub fn generators(token_id: u64) -> PedersenGens {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(HASH_TO_POINT_DOMAIN_TAG);
 
     // This step xors the token id bytes on top of the "base point" bytes
     // used prior to the introduction of token ids.
@@ -91,8 +91,8 @@ pub fn generators(token_id: u64) -> PedersenGens {
 /// Applies a hash function and returns a RistrettoPoint.
 pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
-    hasher.update(&ristretto_public.to_bytes());
+    hasher.update(HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(ristretto_public.to_bytes());
     RistrettoPoint::from_hash(hasher)
 }
 

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -287,7 +287,7 @@ fn main() {
         let fog_resolver = build_fog_resolver(&fog_uri, &env2, &logger);
 
         thread::Builder::new()
-            .name(format!("worker{}", i))
+            .name(format!("worker{i}"))
             .spawn(move || {
                 worker_thread_entry(
                     spendable_txouts_receiver2,
@@ -413,8 +413,7 @@ fn select_spendable_tx_outs(
                     .get_value(&shared_secret)
                     .unwrap_or_else(|err| {
                         panic!(
-                        "TX ownership is not as expected: tx #{} not owned by account_index {}: {}",
-                        index, account_index, err
+                        "TX ownership is not as expected: tx #{index} not owned by account_index {account_index}: {err}"
                     )
                     });
 

--- a/fog/distribution/tests/bootstrap.rs
+++ b/fog/distribution/tests/bootstrap.rs
@@ -15,11 +15,11 @@ use tempfile::TempDir;
 fn test_find_spendable_tx_outs() {
     let me = PathBuf::from(args().next().unwrap());
     let bin = me.parent().unwrap().parent().unwrap();
-    println!("bin = {:?}", bin);
+    println!("bin = {bin:?}");
 
     let dir = TempDir::new().unwrap();
     set_current_dir(dir.path()).unwrap();
-    println!("dir = {:?}", dir);
+    println!("dir = {dir:?}");
 
     assert!(Command::new(bin.join("sample-keys"))
         .args([

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -28,7 +28,7 @@ pub struct IngestConfig {
 fn parse_ristretto_hex(src: &str) -> Result<CompressedRistrettoPublic, String> {
     let mut key_bytes = [0u8; 32];
     hex::decode_to_slice(src.as_bytes(), &mut key_bytes[..])
-        .map_err(|err| format!("Hex decode error: {:?}", err))?;
+        .map_err(|err| format!("Hex decode error: {err:?}"))?;
     Ok(CompressedRistrettoPublic::from(&key_bytes))
 }
 

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -287,8 +287,7 @@ fn test_ingest_enclave_malformed_txos(logger: Logger) {
                 assert_eq!(some_rows.len(), 3);
                 assert_eq!(
                     some_rows[0].search_key, bob_search_key,
-                    "unexpected search key for {}'th tx for Bob",
-                    index3
+                    "unexpected search key for {index3}'th tx for Bob"
                 );
                 assert_ne!(some_rows[1].search_key, bob_search_key);
                 assert_ne!(some_rows[2].search_key, bob_search_key);
@@ -512,51 +511,39 @@ fn test_ingest_enclave_overflow(logger: Logger) {
 
             assert!(
                 alice_found || bob_found,
-                "Could not match {}'th tx row to Alice's or Bob's RNG's",
-                idx
+                "Could not match {idx}'th tx row to Alice's or Bob's RNG's"
             );
             assert!(
                 !alice_found || !bob_found,
-                "Matched {}'th tx row to BOTH Alice and to Bob",
-                idx
+                "Matched {idx}'th tx row to BOTH Alice and to Bob"
             );
 
             match alice_fog_credential.decrypt_tx_out_result(tx_row.payload.clone()) {
                 Ok(tx_out_record) => {
                     assert_eq!(
                         tx_out_record.tx_out_global_index, idx as u64,
-                        "{:?} {:?} alice:{} bob:{}",
-                        tx_out_record, tx_row, alice_found, bob_found,
+                        "{tx_out_record:?} {tx_row:?} alice:{alice_found} bob:{bob_found}",
                     );
                     let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,
-                        "{:?} {:?}",
-                        tx_out_record,
-                        tx_row,
+                        "{tx_out_record:?} {tx_row:?}",
                     );
-                    assert_eq!(
-                        tx_out_record.block_index, 1,
-                        "{:?} {:?}",
-                        tx_out_record, tx_row
-                    );
+                    assert_eq!(tx_out_record.block_index, 1, "{tx_out_record:?} {tx_row:?}");
                     assert!(
                         alice_found,
-                        "Alice wasn't supposed to be able to decrypt {}'th tx row. bob_found = {}: {:?} {:?}",
-                        idx, bob_found, tx_out_record, tx_row,
+                        "Alice wasn't supposed to be able to decrypt {idx}'th tx row. bob_found = {bob_found}: {tx_out_record:?} {tx_row:?}",
                     );
                 }
                 Err(err @ TxOutRecoveryError::MacCheckFailed) => {
                     assert!(
                         !alice_found,
-                        "Alice was supposed to be able to decrypt {}'th tx row: {}",
-                        idx, err
+                        "Alice was supposed to be able to decrypt {idx}'th tx row: {err}"
                     );
                 }
                 Err(err) => {
-                    panic!("Alice got an unexpected error when attempting to decrypt {}'th tx row: {}. alice_found = {}",
-                        idx, err, alice_found
+                    panic!("Alice got an unexpected error when attempting to decrypt {idx}'th tx row: {err}. alice_found = {alice_found}"
                     );
                 }
             };
@@ -565,38 +552,28 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                 Ok(tx_out_record) => {
                     assert_eq!(
                         tx_out_record.tx_out_global_index, idx as u64,
-                        "{:?} {:?} alice:{} bob:{}",
-                        tx_out_record, tx_row, alice_found, bob_found,
+                        "{tx_out_record:?} {tx_row:?} alice:{alice_found} bob:{bob_found}",
                     );
                     let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,
-                        "{:?} {:?}",
-                        tx_out_record,
-                        tx_row,
+                        "{tx_out_record:?} {tx_row:?}",
                     );
-                    assert_eq!(
-                        tx_out_record.block_index, 1,
-                        "{:?} {:?}",
-                        tx_out_record, tx_row
-                    );
+                    assert_eq!(tx_out_record.block_index, 1, "{tx_out_record:?} {tx_row:?}");
                     assert!(
                         bob_found,
-                        "Bob wasn't supposed to be able to decrypt {}'th tx row. alice_found = {}: {:?} {:?}",
-                        idx, alice_found, tx_out_record, tx_row,
+                        "Bob wasn't supposed to be able to decrypt {idx}'th tx row. alice_found = {alice_found}: {tx_out_record:?} {tx_row:?}",
                     );
                 }
                 Err(err @ TxOutRecoveryError::MacCheckFailed) => {
                     assert!(
                         !bob_found,
-                        "Bob was supposed to be able to decrypt {}'th tx row: {}",
-                        idx, err
+                        "Bob was supposed to be able to decrypt {idx}'th tx row: {err}"
                     );
                 }
                 Err(err) => {
-                    panic!("Bob got an unexpected error when attempting to decrypt {}'th tx row: {}. bob_found = {}",
-                        idx, err, bob_found
+                    panic!("Bob got an unexpected error when attempting to decrypt {idx}'th tx row: {err}. bob_found = {bob_found}"
                     );
                 }
             };

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1672,9 +1672,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/fog/ingest/enclave/trusted/src/lib.rs
+++ b/fog/ingest/enclave/trusted/src/lib.rs
@@ -21,7 +21,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for the business logic / implementation state
     static ref ENCLAVE: SgxIngestEnclave<OcallORAMStorageCreator> = SgxIngestEnclave::new(default_logger());

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -59,10 +59,7 @@ fn main() {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-ingest cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-ingest cannot connect to database '{database_url}': {err:?}")
     });
 
     let ledger_db = LedgerDB::open(&config.ledger_db).expect("Could not read ledger DB");

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn ingest_server_config_example() {
         let config = IngestConfig::try_parse_from(
-         &["/usr/bin/fog_ingest_server",
+         ["/usr/bin/fog_ingest_server",
       "--ledger-db", "/fog-data/ledger",
       "--watcher-db", "/fog-data/watcher",
      "--ias-spid", "00000000000000000000000000000000", "--ias-api-key", "00000000000000000000000000000000",

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -153,7 +153,7 @@ where
         ) {
             Ok(enclave) => enclave,
             Err(NewEnclaveError::Create(err)) => {
-                panic!("Could not create new enclave: {}", err);
+                panic!("Could not create new enclave: {err}");
             }
             Err(NewEnclaveError::Init(err)) => {
                 log::error!(
@@ -1107,10 +1107,10 @@ where
                     // wrong set to false.
                     Err(err @ PeerBackupError::FailedRemoteKeyBackup(_))
                     | Err(err @ PeerBackupError::FailedRemoteSetPeers(_)) => {
-                        panic!("Should not have attempted remote modification during confirm backup. Logic Error: {}", err);
+                        panic!("Should not have attempted remote modification during confirm backup. Logic Error: {err}");
                     }
                     Err(err @ PeerBackupError::CreatingNewIngressKey) => {
-                        panic!("Should not have attempted creating new ingress key during confirm backup. Logic Error. {}", err);
+                        panic!("Should not have attempted creating new ingress key during confirm backup. Logic Error. {err}");
                     }
                     //Nonretriable errors that can occur normally during confirm backup.
                     Err(err @ PeerBackupError::AnotherActivePeer(_))

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -148,8 +148,7 @@ impl IngestControllerState {
     pub fn increment_next_block_index(&mut self) {
         assert!(
             !self.is_idle(),
-            "next_block_index should not be incremented if we are idle: {}",
-            self
+            "next_block_index should not be incremented if we are idle: {self}"
         );
         // Perform the increment
         self.next_block_index += 1;
@@ -295,7 +294,7 @@ impl Display for IngestControllerState {
             self.mode, self.next_block_index, self.pubkey_expiry_window
         )?;
         if let Some(iid) = self.ingest_invocation_id {
-            write!(f, "ingest_invocation_id: {}, ", iid)?;
+            write!(f, "ingest_invocation_id: {iid}, ")?;
         }
         write!(f, "peers: {} }}", SeqDisplay(self.peers.iter()))
     }

--- a/fog/ingest/server/src/state_file.rs
+++ b/fog/ingest/server/src/state_file.rs
@@ -50,7 +50,7 @@ impl StateFile {
         let proto_data = state_data.write_to_bytes().map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed serializing state data: {}", e),
+                format!("failed serializing state data: {e}"),
             )
         })?;
         let mut file = fs::File::create(&self.file_path)?;
@@ -62,7 +62,7 @@ impl StateFile {
     /// fails, in order to prevent a crash loop.
     pub fn move_to_bak(&self) -> Result<()> {
         let bak = self.file_path.with_extension("bak");
-        std::fs::rename(&self.file_path, &bak)?;
+        std::fs::rename(&self.file_path, bak)?;
         Ok(())
     }
 }

--- a/fog/ingest/server/test-utils/src/lib.rs
+++ b/fog/ingest/server/test-utils/src/lib.rs
@@ -36,7 +36,7 @@ const OMAP_CAPACITY: u64 = 4096;
 fn make_uris(base_port: u16, idx: u8) -> (FogIngestUri, IngestPeerUri) {
     let port = base_port + 5 * (idx as u16 + 1);
     let client_listen_uri =
-        FogIngestUri::from_str(&format!("insecure-fog-ingest://0.0.0.0:{}/", port)).unwrap();
+        FogIngestUri::from_str(&format!("insecure-fog-ingest://0.0.0.0:{port}/")).unwrap();
     let peer_listen_uri =
         IngestPeerUri::from_str(&format!("insecure-igp://0.0.0.0:{}/", port + 1)).unwrap();
 
@@ -72,9 +72,7 @@ impl TestIngestNode {
             }
             assert!(
                 start.elapsed() <= timeout,
-                "Timed out waiting for ingest node to process blocks; ingested {} blocks, target is {}",
-                ingest_height,
-                height,
+                "Timed out waiting for ingest node to process blocks; ingested {ingest_height} blocks, target is {height}",
             );
             sleep(Duration::from_millis(100));
         }
@@ -193,7 +191,7 @@ impl IngestServerTestHelper {
         let state_file_path = TempDir::new("ingest_state")
             .expect("Could not make tempdir for ingest state")
             .into_path()
-            .join(format!("mc-fog-ingest-state-{}", idx));
+            .join(format!("mc-fog-ingest-state-{idx}"));
         self.make_node_with_state(idx, peer_idxs, state_file_path)
     }
 
@@ -313,9 +311,7 @@ impl IngestServerTestHelper {
             }
             assert!(
                 start.elapsed() <= *timeout,
-                "Timed out waiting for active node to process data; recovery_db has {} blocks, target is {}",
-                recovery_db_count,
-                target,
+                "Timed out waiting for active node to process data; recovery_db has {recovery_db_count} blocks, target is {target}",
             );
             sleep(Duration::from_millis(100));
         }

--- a/fog/ingest/server/tests/key_sharing_on_activate.rs
+++ b/fog/ingest/server/tests/key_sharing_on_activate.rs
@@ -8,7 +8,7 @@ const BASE_PORT: u16 = 3997;
 
 #[test_with_logger]
 fn test_key_sharing_on_activate(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
 
     let nodes = helper.make_nodes(5);
@@ -32,8 +32,7 @@ fn test_key_sharing_on_activate(logger: Logger) {
     nodes.iter().skip(1).enumerate().for_each(|(i, node)| {
         assert!(
             node.activate().is_err(),
-            "node{} should not be able to activate",
-            i
+            "node{i} should not be able to activate"
         )
     });
 

--- a/fog/ingest/server/tests/peer_key_sharing.rs
+++ b/fog/ingest/server/tests/peer_key_sharing.rs
@@ -150,8 +150,7 @@ fn test_ingest_pool_integration(db_test_context: Arc<SqlRecoveryDbTestContext>, 
             let result = primary_ingest_client.new_keys();
             assert!(
                 result.is_err(),
-                "new_keys should return an error code when the server is active: {:?}",
-                result
+                "new_keys should return an error code when the server is active: {result:?}"
             );
             let final_primary_key = primary_ingest_client
                 .get_status()

--- a/fog/ingest/server/tests/sealed_key.rs
+++ b/fog/ingest/server/tests/sealed_key.rs
@@ -7,7 +7,7 @@ const BASE_PORT: u16 = 3457;
 
 #[test_with_logger]
 fn test_ingest_sealed_key_recovery(logger: Logger) {
-    let helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let helper = IngestServerTestHelper::new(BASE_PORT, logger);
 
     let node = helper.make_node(1, 1..=1);
     let original_key = node.get_ingress_key();

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -18,7 +18,7 @@ const BASE_PORT: u16 = 4997;
 // to idle because the key is retired in the DB.
 #[test_with_logger]
 fn three_node_cluster_activation_retiry(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
 
     // Do three repetitions of the whole thing
@@ -103,7 +103,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node0, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node0, should have got KeyAlreadyRetired: {err}");
             }
         };
 
@@ -115,7 +115,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node1, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node1, should have got KeyAlreadyRetired: {err}");
             }
         };
 
@@ -127,7 +127,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node2, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node2, should have got KeyAlreadyRetired: {err}");
             }
         };
 

--- a/fog/ingest/server/tests/tx_recovery.rs
+++ b/fog/ingest/server/tests/tx_recovery.rs
@@ -111,7 +111,7 @@ fn test_ingest_polling_integration(base_port: u16, mut rng: RngType, logger: Log
 // Function for generating the random number of txs to put in a block
 fn gen_num_tx_for_block(rng: &mut impl RngCore) -> usize {
     loop {
-        let n = (rng.next_u64() % NUM_TX_PER_BLOCK as u64) as usize;
+        let n = (rng.next_u64() % NUM_TX_PER_BLOCK) as usize;
         if n != 0 {
             break n;
         }

--- a/fog/ledger/enclave/impl/src/key_image_store.rs
+++ b/fog/ledger/enclave/impl/src/key_image_store.rs
@@ -182,8 +182,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> KeyImageStore<OS
                 oram_result_code == OMAP_FOUND
                     || oram_result_code == OMAP_NOT_FOUND
                     || oram_result_code == OMAP_INVALID_KEY,
-                "oram_result_code had an unexpected value: {}",
-                oram_result_code
+                "oram_result_code had an unexpected value: {oram_result_code}"
             );
         }
 

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -107,7 +107,7 @@ impl LedgerSgxEnclave {
 
         sgx_enclave
             .enclave_init(self_id, desired_capacity)
-            .unwrap_or_else(|e| panic!("enclave_init({}) failed: {:?}", self_id, e));
+            .unwrap_or_else(|e| panic!("enclave_init({self_id}) failed: {e:?}"));
 
         sgx_enclave
     }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1620,9 +1620,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -21,7 +21,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for business logic / implementation state of ledger enclave
     static ref ENCLAVE: SgxLedgerEnclave<OcallORAMStorageCreator> = SgxLedgerEnclave::new(default_logger());

--- a/fog/ledger/server/src/bin/main.rs
+++ b/fog/ledger/server/src/bin/main.rs
@@ -68,7 +68,7 @@ fn main() {
     let config2 = config.clone();
     let get_config_json = Arc::new(move || {
         serde_json::to_string(&config2)
-            .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{:?}", err)))
+            .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{err:?}")))
     });
     let _admin_server = config.admin_listen_uri.as_ref().map(|admin_listen_uri| {
         AdminServer::start(

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -302,7 +302,7 @@ mod test {
             mock_ledger.clone(),
             enclave,
             authenticator,
-            logger.clone(),
+            logger,
         );
 
         let request = OutputContext {
@@ -361,7 +361,7 @@ mod test {
             mock_ledger,
             enclave,
             authenticator,
-            logger.clone(),
+            logger,
         );
 
         let request = OutputContext {

--- a/fog/ledger/server/src/server.rs
+++ b/fog/ledger/server/src/server.rs
@@ -129,7 +129,7 @@ impl<E: LedgerEnclaveProxy, R: RaClient + Send + Sync + 'static> LedgerServer<E,
             config.chain_id.clone(),
             ledger,
             watcher,
-            client_authenticator.clone(),
+            client_authenticator,
             logger.clone(),
         );
 

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -247,14 +247,13 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
                         assert_eq!(status.message(), expected);
                     }
                     _ => {
-                        panic!("unexpected grpcio error: {}", err);
+                        panic!("unexpected grpcio error: {err}");
                     }
                 }
             } else {
                 panic!("Expected an error when chain-id is wrong");
             }
         }
-
         // grpcio detaches all its threads and does not join them :(
         // we opened a PR here: https://github.com/tikv/grpc-rs/pull/455
         // in the meantime we can just sleep after grpcio env and all related
@@ -588,12 +587,8 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
             .expect("Failed starting ledger server");
 
         // Make unattested ledger client
-        let client = FogUntrustedLedgerGrpcClient::new(
-            client_uri,
-            GRPC_RETRY_CONFIG,
-            grpc_env,
-            logger.clone(),
-        );
+        let client =
+            FogUntrustedLedgerGrpcClient::new(client_uri, GRPC_RETRY_CONFIG, grpc_env, logger);
 
         // Try to get a block
         let queries = [0..1];
@@ -750,12 +745,8 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
             .expect("Failed starting ledger server");
 
         // Make unattested ledger client
-        let client = FogUntrustedLedgerGrpcClient::new(
-            client_uri,
-            GRPC_RETRY_CONFIG,
-            grpc_env,
-            logger.clone(),
-        );
+        let client =
+            FogUntrustedLedgerGrpcClient::new(client_uri, GRPC_RETRY_CONFIG, grpc_env, logger);
 
         // Get a tx_out that is actually in the ledger
         let real_tx_out0 = { ledger.get_tx_out_by_index(0).unwrap() };
@@ -830,7 +821,7 @@ fn add_block_to_ledger(
                 src_url,
                 block_index,
                 signature.clone(),
-                format!("00/{}", block_index),
+                format!("00/{block_index}"),
             )
             .expect("Could not add block signature");
     }

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -129,11 +129,11 @@ impl AutoKillChild {
     pub fn assert_not_stopped(&mut self) {
         match self.0.try_wait() {
             Ok(Some(stat)) => {
-                panic!("child stopped unexpectedly: status: {}", stat)
+                panic!("child stopped unexpectedly: status: {stat}")
             }
             Ok(None) => {}
             Err(err) => {
-                panic!("error getting child status: {}", err)
+                panic!("error getting child status: {err}")
             }
         }
     }
@@ -145,7 +145,7 @@ impl Drop for AutoKillChild {
             // Invalid input means the process is already dead, and we don't have to kill
             // it. Anything else means that killing it failed somehow
             if err.kind() != std::io::ErrorKind::InvalidInput {
-                panic!("Could not send SIGKILL to child: {}", err)
+                panic!("Could not send SIGKILL to child: {err}")
             }
         }
 
@@ -174,12 +174,11 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         let ingest_client_port = base_port + 4;
         let ingest_peer_port = base_port + 5;
         let client_listen_uri = FogIngestUri::from_str(&format!(
-            "insecure-fog-ingest://127.0.0.1:{}",
-            ingest_client_port
+            "insecure-fog-ingest://127.0.0.1:{ingest_client_port}"
         ))
         .unwrap();
         let peer_listen_uri =
-            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{}", ingest_peer_port))
+            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{ingest_peer_port}"))
                 .unwrap();
         let local_node_id = peer_listen_uri.responder_id().unwrap();
 
@@ -230,17 +229,17 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         // Maybe we should take ias-spid from env also
         let mut command = std::process::Command::new(ingest_server_binary.to_str().unwrap());
         command
-            .args(&["--ledger-db", ledger_db_path.path().to_str().unwrap()])
-            .args(&["--watcher-db", watcher_db_path.path().to_str().unwrap()])
-            .args(&["--client-listen-uri", &client_listen_uri.to_string()])
-            .args(&["--peer-listen-uri", &peer_listen_uri.to_string()])
-            .args(&["--ias-spid", &"0".repeat(32)])
-            .args(&["--ias-api-key", &"0".repeat(32)])
-            .args(&["--local-node-id", &local_node_id.to_string()])
-            .args(&["--peers", &peer_listen_uri.to_string()])
-            .args(&["--state-file", state_file_path.to_str().unwrap()])
-            .args(&["--admin-listen-uri", &admin_listen_uri.to_string()])
-            .args(&["--user-capacity", &test_params.user_capacity.to_string()]);
+            .args(["--ledger-db", ledger_db_path.path().to_str().unwrap()])
+            .args(["--watcher-db", watcher_db_path.path().to_str().unwrap()])
+            .args(["--client-listen-uri", client_listen_uri.as_ref()])
+            .args(["--peer-listen-uri", peer_listen_uri.as_ref()])
+            .args(["--ias-spid", &"0".repeat(32)])
+            .args(["--ias-api-key", &"0".repeat(32)])
+            .args(["--local-node-id", &local_node_id.to_string()])
+            .args(["--peers", peer_listen_uri.as_ref()])
+            .args(["--state-file", state_file_path.to_str().unwrap()])
+            .args(["--admin-listen-uri", admin_listen_uri.as_ref()])
+            .args(["--user-capacity", &test_params.user_capacity.to_string()]);
 
         log::info!(logger, "Spawning ingest server: {:?}", command);
 
@@ -446,6 +445,6 @@ fn main() {
     // XXX: Write results to a results file or something?
     println!("Load testing results\n================");
     for result in results.iter() {
-        println!("{}", result);
+        println!("{result}");
     }
 }

--- a/fog/ocall_oram_storage/trusted/src/lib.rs
+++ b/fog/ocall_oram_storage/trusted/src/lib.rs
@@ -340,8 +340,7 @@ where
             let (last_idx, last_hash) = last_hash.expect("should not be empty at this point");
             assert!(
                 bool::from(self.trusted_merkle_roots[last_idx as usize].ct_eq(&last_hash)),
-                "authentication failed, trusted merkle root mismatch at {}",
-                last_idx
+                "authentication failed, trusted merkle root mismatch at {last_idx}"
             );
         }
     }
@@ -691,11 +690,9 @@ mod helpers {
 
         for (x, idx) in idx.iter().enumerate() {
             let byte_index = (idx * DataSize::U64) as usize;
-            (&mut data[x])
-                .copy_from_slice(&allocation.data[byte_index..byte_index + DataSize::USIZE]);
+            data[x].copy_from_slice(&allocation.data[byte_index..byte_index + DataSize::USIZE]);
             let byte_index = (idx * MetaSize::U64) as usize;
-            (&mut meta[x])
-                .copy_from_slice(&allocation.meta[byte_index..byte_index + MetaSize::USIZE]);
+            meta[x].copy_from_slice(&allocation.meta[byte_index..byte_index + MetaSize::USIZE]);
         }
     }
 

--- a/fog/ocall_oram_storage/untrusted/src/lib.rs
+++ b/fog/ocall_oram_storage/untrusted/src/lib.rs
@@ -92,13 +92,11 @@ impl UntrustedAllocation {
         global_log::info!("Untrusted is allocating oram storage: count = {}, data_size = {}, meta_size = {}, mem = {} KB. Total mem allocated this way = {} KB", count, data_item_size, meta_item_size, mem_kb, total_mem_kb);
         assert!(
             data_item_size % 8 == 0,
-            "data item size is not good: {}",
-            data_item_size
+            "data item size is not good: {data_item_size}"
         );
         assert!(
             meta_item_size % 8 == 0,
-            "meta item size is not good: {}",
-            meta_item_size
+            "meta item size is not good: {meta_item_size}"
         );
 
         let data_pointer = unsafe {
@@ -181,7 +179,7 @@ pub unsafe extern "C" fn allocate_oram_storage(
 /// id must be a valid id previously returned by allocate_oram_storage
 #[no_mangle]
 pub unsafe extern "C" fn release_oram_storage(id: u64) {
-    let ptr: *mut UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *mut UntrustedAllocation = id as *mut UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when releasing storage"
@@ -219,7 +217,7 @@ pub unsafe extern "C" fn checkout_oram_storage(
 ) {
     #[cfg(debug_assertions)]
     debug_checks::check_id(id);
-    let ptr: *const UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *const UntrustedAllocation = id as *const UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when checking out storage"
@@ -291,7 +289,7 @@ pub unsafe extern "C" fn checkin_oram_storage(
 ) {
     #[cfg(debug_assertions)]
     debug_checks::check_id(id);
-    let ptr: *const UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *const UntrustedAllocation = id as *const UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when checking in storage"

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -29,10 +29,7 @@ async fn main() -> Result<(), rocket::Error> {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-overseer cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-overseer cannot connect to database '{database_url}': {err:?}")
     });
 
     let mut overseer_service =

--- a/fog/overseer/server/src/config.rs
+++ b/fog/overseer/server/src/config.rs
@@ -40,7 +40,7 @@ mod tests {
     use mc_fog_uri::ConnectionUri;
     #[test]
     fn ingest_server_config_example() {
-        let config = OverseerConfig::try_parse_from(&[
+        let config = OverseerConfig::try_parse_from([
             "/usr/bin/fog_overseer_server",
             "--overseer-listen-host",
             "www.mycoolhost.com",

--- a/fog/overseer/server/src/service.rs
+++ b/fog/overseer/server/src/service.rs
@@ -141,7 +141,7 @@ where
         encoder.encode(&metric_families, &mut buffer).unwrap();
 
         String::from_utf8(buffer)
-            .map_err(|err| format!("Get prometheus metrics from_utf8 failed: {}", err))
+            .map_err(|err| format!("Get prometheus metrics from_utf8 failed: {err}"))
     }
 
     /// Try and fetch summaries from all ingest clients.
@@ -161,16 +161,14 @@ where
                         );
                         IngestSummary::try_from(&proto_ingest_summary).map_err(|err| {
                             format!(
-                                "Could not parse ingest summary for node with URI '{}': {}",
-                                uri, err
+                                "Could not parse ingest summary for node with URI '{uri}': {err}"
                             )
                         })
                     }
 
                     Err(err) => {
                         let error_message = format!(
-                            "Unable to retrieve ingest summary for node with URI '{}': {}",
-                            uri, err
+                            "Unable to retrieve ingest summary for node with URI '{uri}': {err}"
                         );
                         log::trace!(self.logger, "{}", error_message);
                         Err(error_message)

--- a/fog/overseer/server/src/worker.rs
+++ b/fog/overseer/server/src/worker.rs
@@ -234,7 +234,7 @@ where
                             })
                             .collect();
                     let error_message =
-                        format!("Active ingress keys: {:?}", active_node_ingress_pubkeys);
+                        format!("Active ingress keys: {active_node_ingress_pubkeys:?}");
                     let error = OverseerError::MultipleActiveNodes(error_message);
                     log::error!(self.logger, "{}", error);
                 }
@@ -276,10 +276,8 @@ where
                     }
 
                     Err(err) => {
-                        let error_message = format!(
-                            "Unable to retrieve ingest summary for node ({}): {}",
-                            uri, err
-                        );
+                        let error_message =
+                            format!("Unable to retrieve ingest summary for node ({uri}): {err}");
                         log::trace!(logger, "{}", error_message);
                         unresponsive_node_urls.insert(uri.clone());
                         Err(OverseerError::UnresponsiveNodeError(error_message))
@@ -338,7 +336,7 @@ where
             }
             _ => {
                 self.is_enabled.store(false, Ordering::SeqCst);
-                let error_message = format!("This is unexpected and requires manual intervention. As such, we've disabled overseer. Take the appropriate action and then re-enable overseer by calling the /enable endpoint. Inactive oustanding keys: {:?}", inactive_outstanding_keys);
+                let error_message = format!("This is unexpected and requires manual intervention. As such, we've disabled overseer. Take the appropriate action and then re-enable overseer by calling the /enable endpoint. Inactive oustanding keys: {inactive_outstanding_keys:?}");
                 Err(OverseerError::MultipleInactiveOutstandingKeys(
                     error_message,
                 ))
@@ -468,7 +466,7 @@ where
                 }
                 Err(err) => {
                     let number_of_remaining_tries = Self::NUMBER_OF_TRIES - current_try as usize;
-                    let error_message = format!("The following key was not successfully reported as lost: {}. Will try {} more times. Underlying error: {}", inactive_outstanding_key, number_of_remaining_tries, err);
+                    let error_message = format!("The following key was not successfully reported as lost: {inactive_outstanding_key}. Will try {number_of_remaining_tries} more times. Underlying error: {err}");
                     OperationResult::Retry(OverseerError::ReportLostKey(error_message))
                 }
             },

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -13,7 +13,7 @@ const BASE_PORT: u16 = 8850;
 // cluster has one active node.
 #[test_with_logger]
 fn one_active_node_produces_ingest_summaries(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -35,7 +35,6 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
     assert_eq!(
         active_pattern.captures_len(),
         1,
-        "JSON body should have exactly 1 ACTIVE: {}",
-        body
+        "JSON body should have exactly 1 ACTIVE: {body}"
     );
 }

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -19,7 +19,7 @@ const BASE_PORT: u16 = 8550;
 fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_and_original_key_is_reported_lost(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let mut nodes = VecDeque::from(helper.make_nodes(3));
 

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -19,7 +19,7 @@ const BASE_PORT: u16 = 8600;
 fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_is_not_reported_lost_or_retired(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let mut nodes = VecDeque::from(helper.make_nodes(3));
 

--- a/fog/overseer/server/tests/one_active_node.rs
+++ b/fog/overseer/server/tests/one_active_node.rs
@@ -14,7 +14,7 @@ const BASE_PORT: u16 = 8650;
 // Fog Overseer shouldn't take any action.
 #[test_with_logger]
 fn one_active_node_cluster_state_does_not_change(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -17,7 +17,7 @@ const BASE_PORT: u16 = 8700;
 // original active key as lost.
 #[test_with_logger]
 fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -35,35 +35,30 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
     let correct_active_node_count = Regex::new(r#"active_node_count"} 1"#).unwrap();
     assert!(
         correct_active_node_count.is_match(&body),
-        "Body does not have expected active_node_count: {}",
-        body
+        "Body does not have expected active_node_count: {body}"
     );
 
     let correct_egress_key_count = Regex::new(r#"egress_key_count"} 3"#).unwrap();
     assert!(
         correct_egress_key_count.is_match(&body),
-        "Body does not have expected egress_key_count: {}",
-        body
+        "Body does not have expected egress_key_count: {body}"
     );
 
     let correct_idle_node_count = Regex::new(r#"idle_node_count"} 2"#).unwrap();
     assert!(
         correct_idle_node_count.is_match(&body),
-        "Body does not have expected idle_node_count: {}",
-        body
+        "Body does not have expected idle_node_count: {body}"
     );
 
     let correct_ingress_key_count = Regex::new(r#"ingress_key_count"} 1"#).unwrap();
     assert!(
         correct_ingress_key_count.is_match(&body),
-        "Body does not have expected ingress_key_count: {}",
-        body
+        "Body does not have expected ingress_key_count: {body}"
     );
 
     let correct_unresponsive_node_count_name = Regex::new(r#"unresponsive_node_count"#).unwrap();
     assert!(
         !correct_unresponsive_node_count_name.is_match(&body),
-        "Body should not have unresponsive_node_count: {}",
-        body
+        "Body should not have unresponsive_node_count: {body}"
     );
 }

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -18,7 +18,7 @@ const BASE_PORT: u16 = 8750;
 fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_is_set_node_activated(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -17,7 +17,7 @@ const BASE_PORT: u16 = 8800;
 // activate it.
 #[test_with_logger]
 fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -60,7 +60,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
         .zip(new_ingress_keys.iter())
         .enumerate()
         .for_each(|(index, (original, new))| {
-            assert_ne!(original, new, "node{} ingress key did not change", index)
+            assert_ne!(original, new, "node{index} ingress key did not change")
         });
 
     // Ensure that the old active key is retired.

--- a/fog/report/api/tests/fog_types.rs
+++ b/fog/report/api/tests/fog_types.rs
@@ -41,9 +41,9 @@ where
 
 fn prost_verification_report(name: &str) -> ProstVerificationReport {
     ProstVerificationReport {
-        sig: format!("{} sig", name).into_bytes().into(),
+        sig: format!("{name} sig").into_bytes().into(),
         chain: Default::default(),
-        http_body: format!("{} body", name),
+        http_body: format!("{name} body"),
     }
 }
 
@@ -70,7 +70,7 @@ fn prost_test_cases() -> Vec<ProstReport> {
 
 fn protobuf_verification_signature(name: &str) -> ProtobufVerificationSignature {
     let mut sig = ProtobufVerificationSignature::new();
-    sig.set_contents(format!("{} sig", name).into_bytes());
+    sig.set_contents(format!("{name} sig").into_bytes());
     sig
 }
 
@@ -78,7 +78,7 @@ fn protobuf_verification_report(name: &str) -> ProtobufVerificationReport {
     let mut report = ProtobufVerificationReport::new();
     report.set_sig(protobuf_verification_signature(name));
     report.set_chain(RepeatedField::from_vec(make_chain()));
-    report.set_http_body(format!("{} body", name));
+    report.set_http_body(format!("{name} body"));
     report
 }
 
@@ -112,7 +112,7 @@ fn round_trip_prost_report() {
 #[test]
 fn round_trip_protobuf_report() {
     for case in protobuf_test_cases() {
-        eprintln!("report = {:?}", case);
+        eprintln!("report = {case:?}");
         round_trip_protobuf::<ProtobufReport, ProstReport>(case);
     }
 }

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -115,12 +115,12 @@ fn get_fog_response_with_retries(
             Err(Error::NoReports(_)) => {
                 std::thread::sleep(Duration::from_millis(500));
                 if Instant::now() > deadline {
-                    eprintln!("No reports after {:?} time retrying", retry_duration);
+                    eprintln!("No reports after {retry_duration:?} time retrying");
                     exit(1)
                 }
             }
             Err(err) => {
-                eprintln!("Could not get fog response ({}): {}", fog_uri, err);
+                eprintln!("Could not get fog response ({fog_uri}): {err}");
                 exit(1);
             }
         }
@@ -281,11 +281,8 @@ fn main() {
     // if show-expiry is selected, we show key and expiry, formatted as json
     // else just print the hex bytes of key
     if config.show_expiry {
-        print!(
-            "{{ \"pubkey\": \"{}\", \"pubkey_expiry\": {} }}",
-            hex_str, pubkey_expiry
-        );
+        print!("{{ \"pubkey\": \"{hex_str}\", \"pubkey_expiry\": {pubkey_expiry} }}");
     } else {
-        print!("{}", hex_str);
+        print!("{hex_str}");
     }
 }

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -26,10 +26,7 @@ fn main() {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-report cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-report cannot connect to database '{database_url}': {err:?}")
     });
 
     let mut server = Server::new(

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -353,7 +353,7 @@ impl CachedTxData {
 
         let tx_values: Vec<u64> = available.iter().map(|txo| txo.amount.value).collect();
 
-        let selected = input_selection_heuristic(&tx_values, amount.value, max_inputs)?;
+        let selected = input_selection_heuristic(tx_values, amount.value, max_inputs)?;
 
         Ok(selected
             .into_iter()
@@ -855,7 +855,7 @@ impl CachedTxData {
             self.rng_set.get_rngs().len()
         ));
         for owned_tx_out in self.owned_tx_outs.values() {
-            lines.push(format!("{:?}\n", owned_tx_out));
+            lines.push(format!("{owned_tx_out:?}\n"));
         }
         lines.join("\n")
     }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -276,8 +276,7 @@ impl Client {
                                     }
                                     MALFORMED_REQUEST => {
                                         panic!(
-                                            "Server reported our request {:?} was malformed",
-                                            public_key
+                                            "Server reported our request {public_key:?} was malformed"
                                         );
                                     }
                                     DATABASE_ERROR => {
@@ -294,7 +293,7 @@ impl Client {
                                         }
                                     }
                                     other => {
-                                        panic!("Server returned an unknown status code: {}", other);
+                                        panic!("Server returned an unknown status code: {other}");
                                     }
                                 };
                             }
@@ -370,7 +369,7 @@ impl Client {
         let fee_map = self.get_fee_map(true)?;
 
         // Make fog resolver
-        let fog_uris = (&[&self.account_key.change_subaddress(), target_address])
+        let fog_uris = [&self.account_key.change_subaddress(), target_address]
             .iter()
             .filter_map(|addr| addr.fog_report_url())
             .map(FogUri::from_str)
@@ -423,8 +422,8 @@ impl Client {
         assert_eq!(inputs.len(), 1);
         assert_eq!(rings.len(), 1);
 
-        let (input, input_proof) = (&inputs[0]).clone();
-        let ring = (&rings[0]).clone();
+        let (input, input_proof) = inputs[0].clone();
+        let ring = rings[0].clone();
 
         // Check amount found, calculate change
         let input_amount = input.amount;
@@ -556,8 +555,7 @@ impl Client {
             match result.status() {
                 Err(err) => {
                     return Err(Error::FogMerkleProof(format!(
-                        "Server failed to compute a merkle proof: {}",
-                        err
+                        "Server failed to compute a merkle proof: {err}"
                     )))
                 }
                 Ok(None) => {
@@ -788,8 +786,7 @@ impl Client {
                 }
                 match result.status() {
                     Err(err) => Err(Error::FogMerkleProof(format!(
-                        "Server failed to compute a merkle proof: {}",
-                        err
+                        "Server failed to compute a merkle proof: {err}"
                     ))),
                     Ok(None) => Err(Error::FogMerkleProof(
                         "Server did not find one of the outputs we need".to_string(),
@@ -881,10 +878,9 @@ impl Client {
                     panic!("unhandled: Server returned indices in an unexpected order");
                 }
                 match result.status() {
-                    Err(err) => panic!(
-                        "unhandled: Server failed to computer a merkle proof: {}",
-                        err
-                    ),
+                    Err(err) => {
+                        panic!("unhandled: Server failed to computer a merkle proof: {err}")
+                    }
                     Ok(None) => panic!("unhandled: Server did not find one of the outputs we need"),
                     Ok(Some(res)) => res,
                 }

--- a/fog/sig/authority/src/ristretto.rs
+++ b/fog/sig/authority/src/ristretto.rs
@@ -25,7 +25,7 @@ impl Verifier for RistrettoPublic {
 
     fn verify_authority(&self, spki_bytes: &[u8], sig: &Self::Sig) -> Result<(), String> {
         self.verify_schnorrkel(super::context(), spki_bytes, sig)
-            .map_err(|e| format!("{:#}", e))
+            .map_err(|e| format!("{e:#}"))
     }
 }
 

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -251,8 +251,7 @@ impl SqlRecoveryDb {
             }))
         } else {
             Err(Error::IngressKeysSchemaViolation(format!(
-                "Found multiple entries for key: {:?}",
-                key
+                "Found multiple entries for key: {key:?}"
             )))
         }
     }
@@ -347,8 +346,7 @@ impl SqlRecoveryDb {
                     Ok(accepted_start_block_count)
                 } else {
                     Err(Error::IngressKeyUnsuccessfulInsert(format!(
-                        "Unable to insert ingress key: {:?}",
-                        key
+                        "Unable to insert ingress key: {key:?}"
                     )))
                 }
             })
@@ -662,8 +660,7 @@ impl SqlRecoveryDb {
                 }
             } else {
                 return Err(Error::IngressKeysSchemaViolation(format!(
-                    "Found multiple entries for key: {:?}",
-                    lost_ingress_key
+                    "Found multiple entries for key: {lost_ingress_key:?}"
                 )));
             };
 
@@ -1100,8 +1097,7 @@ impl SqlRecoveryDb {
                 Ok(Some(cumulative_txo_count as u64))
             } else {
                 Err(Error::IngestedBlockSchemaViolation(format!(
-                    "Found multiple cumulative_txo_count values for block {}: {:?}",
-                    block_index, data
+                    "Found multiple cumulative_txo_count values for block {block_index}: {data:?}"
                 )))
             }
         }
@@ -2581,9 +2577,9 @@ mod tests {
             .collect();
 
         VerificationReport {
-            sig: format!("{} sig", name).into_bytes().into(),
+            sig: format!("{name} sig").into_bytes().into(),
             chain,
-            http_body: format!("{} body", name),
+            http_body: format!("{name} body"),
         }
     }
 
@@ -3664,7 +3660,7 @@ mod tests {
 
     #[test_with_logger]
     fn get_expired_invocations_multiple_expired(logger: Logger) {
-        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger.clone());
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
 
         let mut rng = thread_rng();
@@ -3699,7 +3695,7 @@ mod tests {
 
     #[test_with_logger]
     fn get_expired_invocations_mixed(logger: Logger) {
-        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger.clone());
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
 
         let mut rng = thread_rng();

--- a/fog/sql_recovery_db/src/test_utils.rs
+++ b/fog/sql_recovery_db/src/test_utils.rs
@@ -42,17 +42,17 @@ impl SqlRecoveryDbTestContext {
 
         // First, connect to postgres db to be able to create our test
         // database.
-        let postgres_url = format!("{}/postgres", base_url);
+        let postgres_url = format!("{base_url}/postgres");
         log::info!(&logger, "Connecting to root PG DB {}", postgres_url);
         let conn = SqlRecoveryDbTestContext::establish_connection(&postgres_url);
         // Create a new database for the test
-        let query = diesel::sql_query(format!("CREATE DATABASE {};", db_name).as_str());
+        let query = diesel::sql_query(format!("CREATE DATABASE {db_name};").as_str());
         let _ = query
             .execute(&conn)
-            .unwrap_or_else(|err| panic!("Could not create database {}: {:?}", db_name, err));
+            .unwrap_or_else(|err| panic!("Could not create database {db_name}: {err:?}"));
 
         // Now we can connect to the database and run the migrations
-        let db_url = format!("{}/{}", base_url, db_name);
+        let db_url = format!("{base_url}/{db_name}");
         log::info!(&logger, "Connecting to newly created PG DB '{}'", db_url);
 
         let conn = SqlRecoveryDbTestContext::establish_connection(&db_url);
@@ -90,7 +90,7 @@ impl SqlRecoveryDbTestContext {
     pub fn new_conn(&self) -> PgConnection {
         let db_url = self.db_url();
         PgConnection::establish(&db_url)
-            .unwrap_or_else(|err| panic!("Cannot connect to database {}: {}", db_url, err))
+            .unwrap_or_else(|err| panic!("Cannot connect to database {db_url}: {err}"))
     }
 
     fn establish_connection(url: &str) -> PgConnection {
@@ -100,7 +100,7 @@ impl SqlRecoveryDbTestContext {
                 .take(TOTAL_RETRY_COUNT),
             || PgConnection::establish(url),
         )
-        .unwrap_or_else(|err| panic!("Cannot connect to PG database '{}: {}'", url, err))
+        .unwrap_or_else(|err| panic!("Cannot connect to PG database '{url}: {err}'"))
     }
 }
 

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -56,9 +56,8 @@ fn main() {
         };
 
         let get_config_json = Arc::new(move || {
-            serde_json::to_string(&json_data).map_err(|err| {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{:?}", err))
-            })
+            serde_json::to_string(&json_data)
+                .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{err:?}")))
         });
         AdminServer::start(
             None,
@@ -108,7 +107,7 @@ fn main() {
                 "Transactions could not clear in {:?} seconds",
                 config.consensus_wait
             ),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -950,7 +950,7 @@ impl TestClient {
     /// * token_id: The token id to use
     /// * num_transactions: The number of transactions to run
     pub fn run_test(&self, num_transactions: usize) -> Result<(), TestClientError> {
-        let client_count = self.account_keys.len() as usize;
+        let client_count = self.account_keys.len();
         assert!(client_count > 1);
         log::info!(self.logger, "Creating {} clients", client_count);
         let clients = self.build_clients(client_count);
@@ -1062,7 +1062,7 @@ impl TestClient {
     /// but it should be equal in most cases where the period is sufficiently
     /// larger than the expected transfer duration.
     pub fn run_continuously(&self, period: Duration) {
-        let client_count = self.account_keys.len() as usize;
+        let client_count = self.account_keys.len();
         assert!(client_count > 1);
         log::debug!(self.logger, "Creating {} clients", client_count);
         let clients = self.build_clients(client_count);
@@ -1432,7 +1432,7 @@ impl core::fmt::Display for TxInfo {
             )?;
         }
         if let Some(appeared) = &guard.tx_appeared {
-            write!(f, "Appeared in block index {}, ", appeared)?;
+            write!(f, "Appeared in block index {appeared}, ")?;
         }
         if let Some(tx) = &guard.tx {
             write!(

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -111,7 +111,7 @@ fn main() {
     let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
         &config.watcher,
         &[tx_source_url.clone()],
-        logger.clone(),
+        logger,
     )
     .expect("Could not create watcher_db");
 

--- a/fog/test_infra/src/db_tests.rs
+++ b/fog/test_infra/src/db_tests.rs
@@ -82,8 +82,7 @@ pub fn recovery_db_smoke_tests_new_apis<DB: RecoveryDb>(
                 .count();
             assert_eq!(
                 num_rng_events, SEEDS_PER_ROUND,
-                "unexpected number of rng events: found {} expected {}",
-                num_rng_events, SEEDS_PER_ROUND
+                "unexpected number of rng events: found {num_rng_events} expected {SEEDS_PER_ROUND}"
             );
 
             assert_rng_record_rows_were_recovered(
@@ -134,8 +133,7 @@ pub fn recovery_db_smoke_tests_new_apis<DB: RecoveryDb>(
             assert_eq!(user_events.len(), 0);
             assert_eq!(
                 next_start_from_user_event_id, start_from_user_event_id,
-                "expected next_start_from_user_event_id not to be different: found {} expected {}",
-                next_start_from_user_event_id, start_from_user_event_id
+                "expected next_start_from_user_event_id not to be different: found {next_start_from_user_event_id} expected {start_from_user_event_id}"
             );
         }
     }

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -127,7 +127,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
                     src_url,
                     block_index,
                     block_signature,
-                    format!("00/{}", block_index),
+                    format!("00/{block_index}"),
                 )
                 .expect("Could not add block signature");
         }
@@ -182,10 +182,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
         return global_txo_count + num_new_txos;
     }
 
-    panic!(
-        "polling failed to yield expected result {:?}, obtained {:?}",
-        expected_result, result
-    );
+    panic!("polling failed to yield expected result {expected_result:?}, obtained {result:?}");
 }
 
 /// Throw all the user phones in the pool and see if they can recover them via

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -107,7 +107,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         key.clone_from_slice(search_key);
         value[0] = (ValueSize::USIZE - 1 - ciphertext.len()) as u8;
         let data_end = ValueSize::USIZE - value[0] as usize;
-        (&mut value[1..data_end]).clone_from_slice(ciphertext);
+        value[1..data_end].clone_from_slice(ciphertext);
         self.last_ciphertext_size_byte = value[0];
 
         // Note: Passing true means we allow overwrite, which seems fine since
@@ -177,8 +177,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
                 oram_result_code == OMAP_FOUND
                     || oram_result_code == OMAP_NOT_FOUND
                     || oram_result_code == OMAP_INVALID_KEY,
-                "oram_result_code had an unexpected value: {}",
-                oram_result_code
+                "oram_result_code had an unexpected value: {oram_result_code}"
             );
         }
 

--- a/fog/view/enclave/tests/basic.rs
+++ b/fog/view/enclave/tests/basic.rs
@@ -17,7 +17,7 @@ fn get_enclave(logger: Logger) -> SgxViewEnclave {
         get_enclave_path(mc_fog_view_enclave::ENCLAVE_FILE),
         ResponderId::from_str("abc:123").unwrap(),
         VIEW_OMAP_CAPACITY,
-        logger.clone(),
+        logger,
     )
 }
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1691,9 +1691,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -19,7 +19,7 @@ use mc_sgx_types::{c_void, sgx_is_outside_enclave, sgx_status_t};
 use mc_util_serial::{deserialize, serialize};
 
 lazy_static::lazy_static! {
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 }
 
 /// The entry point implementation for test_enclave_api

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -138,7 +138,7 @@ fn build_fog_view_conn(
     log::debug!(logger, "Fog view attestation verifier: {:?}", verifier);
 
     let client_uri = FogViewUri::from_str(uri)
-        .unwrap_or_else(|e| panic!("Could not parse client uri: {}: {:?}", uri, e));
+        .unwrap_or_else(|e| panic!("Could not parse client uri: {uri}: {e:?}"));
 
     // TODO: Supply chain-id to the load-test binary?
     FogViewGrpcClient::new(

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -24,12 +24,7 @@ fn main() {
         config.postgres_config.clone(),
         logger.clone(),
     )
-    .unwrap_or_else(|err| {
-        panic!(
-            "fog-view cannot connect to database '{}': {:?}",
-            database_url, err
-        )
-    });
+    .unwrap_or_else(|err| panic!("fog-view cannot connect to database '{database_url}': {err:?}"));
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/fog/view/server/src/block_tracker.rs
+++ b/fog/view/server/src/block_tracker.rs
@@ -177,8 +177,8 @@ impl BlockTracker {
     /// Get the highest block count we have encountered.
     pub fn highest_known_block_count(&self) -> u64 {
         self.processed_block_per_ingress_key
-            .iter()
-            .map(|(_key, block_index)| *block_index + 1)
+            .values()
+            .map(|block_index| *block_index + 1)
             .max()
             .unwrap_or(0)
     }
@@ -195,7 +195,7 @@ mod tests {
 
     #[test_with_logger]
     fn next_blocks_empty(logger: Logger) {
-        let block_tracker = BlockTracker::new(logger.clone());
+        let block_tracker = BlockTracker::new(logger);
         assert_eq!(block_tracker.next_blocks(&[]).len(), 0);
     }
 
@@ -232,8 +232,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -314,8 +313,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -364,8 +362,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -434,8 +431,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -509,7 +505,7 @@ mod tests {
     // highest_fully_processed_block_count behaves as expected
     #[test_with_logger]
     fn highest_fully_processed_block_count_all_empty(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         assert_eq!(
             block_tracker.highest_fully_processed_block_count(&[]),
@@ -520,7 +516,7 @@ mod tests {
     // Check with a key that hasn't yet processed anything.
     #[test_with_logger]
     fn highest_fully_processed_block_missing_blocks_nothing_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -543,7 +539,7 @@ mod tests {
     // are processed when the start block is 0.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
@@ -578,7 +574,7 @@ mod tests {
     // when the start block is greater than zero
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
@@ -614,7 +610,7 @@ mod tests {
     // then the key is reported lost
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed3(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec = IngressPublicKeyRecord {
@@ -661,7 +657,7 @@ mod tests {
     // When the slow one is marked lost, that unblocks progress.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -728,8 +724,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -741,8 +736,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -760,7 +754,7 @@ mod tests {
     // key is loaded
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs_some_lost2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -830,8 +824,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -843,8 +836,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -876,7 +868,7 @@ mod tests {
     /// key, makes progress
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_followed_by_gap(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -899,8 +891,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -911,8 +902,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -949,8 +939,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Make the block "exist" and "load" it
@@ -962,8 +951,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }
@@ -975,7 +963,7 @@ mod tests {
     /// when everything works.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -998,8 +986,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1010,8 +997,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1027,8 +1013,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1039,8 +1024,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1066,8 +1050,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1080,8 +1063,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1095,8 +1077,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec2.last_scanned_block = Some(index);
@@ -1107,8 +1088,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }
@@ -1123,7 +1103,7 @@ mod tests {
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active_both_lost(
         logger: Logger,
     ) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -1146,8 +1126,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1158,8 +1137,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1175,8 +1153,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1187,8 +1164,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1214,8 +1190,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1228,8 +1203,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1273,8 +1247,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone(), rec3.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec3.last_scanned_block = Some(index);
@@ -1289,8 +1262,7 @@ mod tests {
                     rec3.clone()
                 ]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -750,9 +750,9 @@ mod tests {
             .collect();
 
         VerificationReport {
-            sig: format!("{} sig", name).into_bytes().into(),
+            sig: format!("{name} sig").into_bytes().into(),
             chain,
-            http_body: format!("{} body", name),
+            http_body: format!("{name} body"),
         }
     }
 }

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -70,7 +70,7 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewService<E, DB> {
                 .map_err(|err| {
                     RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("AAD deserialization error: {}", err),
+                        format!("AAD deserialization error: {err}"),
                     )
                 })?;
 
@@ -172,7 +172,7 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewApi for FogViewSe
                         sink,
                         Err(rpc_permissions_error(
                             "client_auth",
-                            format!("Permission denied: {}", client_error),
+                            format!("Permission denied: {client_error}"),
                             logger,
                         )),
                         logger,

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -56,7 +56,7 @@ fn get_test_environment(
     let db = db_test_context.get_db_instance();
 
     let port = portpicker::pick_unused_port().expect("pick_unused_port");
-    let uri = FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{}", port)).unwrap();
+    let uri = FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{port}")).unwrap();
 
     let server = {
         let config = ViewConfig {
@@ -277,8 +277,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
         let server_num_blocks = server.highest_processed_block_count();
         if server_num_blocks > db_num_blocks {
             panic!(
-                "Server num blocks should never be larger than db num blocks: {} > {}",
-                server_num_blocks, db_num_blocks
+                "Server num blocks should never be larger than db num blocks: {server_num_blocks} > {db_num_blocks}"
             );
         }
         if server_num_blocks == db_num_blocks {

--- a/go-grpc-gateway/testing/src/bin/main.rs
+++ b/go-grpc-gateway/testing/src/bin/main.rs
@@ -13,11 +13,7 @@ fn main() {
 
     let config = Config::parse();
 
-    let mut server = Server::new(
-        &config.client_listen_uri,
-        config.chain_id.clone(),
-        logger.clone(),
-    );
+    let mut server = Server::new(&config.client_listen_uri, config.chain_id.clone(), logger);
     server.start();
 
     loop {

--- a/ledger/db/src/ledger_db.rs
+++ b/ledger/db/src/ledger_db.rs
@@ -2158,12 +2158,12 @@ mod ledger_db_test {
         let n_blocks = 43;
         let expected_blocks = populate_db(&mut ledger_db, n_blocks, 1);
 
-        for block_index in 0..n_blocks {
+        for (block_index, _) in expected_blocks.iter().enumerate().take(n_blocks) {
             let block = ledger_db
                 .get_block(block_index as u64)
-                .unwrap_or_else(|_| panic!("Could not get block {:?}", block_index));
+                .unwrap_or_else(|_| panic!("Could not get block {block_index:?}"));
 
-            assert_eq!(&block, expected_blocks[block_index as usize].block());
+            assert_eq!(&block, expected_blocks[block_index].block());
         }
     }
 
@@ -2175,12 +2175,12 @@ mod ledger_db_test {
         let n_blocks = 43;
         let expected_blocks = populate_db(&mut ledger_db, n_blocks, 1);
 
-        for block_index in 0..n_blocks {
+        for (block_index, _) in expected_blocks.iter().enumerate().take(n_blocks) {
             let block_contents = ledger_db
                 .get_block_contents(block_index as u64)
-                .unwrap_or_else(|_| panic!("Could not get block contents {:?}", block_index));
+                .unwrap_or_else(|_| panic!("Could not get block contents {block_index:?}"));
 
-            let expected_block_contents = expected_blocks[block_index as usize].contents();
+            let expected_block_contents = expected_blocks[block_index].contents();
             assert_eq!(&block_contents, expected_block_contents);
         }
     }
@@ -2200,7 +2200,7 @@ mod ledger_db_test {
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -2242,7 +2242,7 @@ mod ledger_db_test {
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -651,7 +651,7 @@ mod tests {
                 ]
                 .contains(&mint_limit));
             }
-            Err(err) => panic!("Unexpected error {}", err),
+            Err(err) => panic!("Unexpected error {err}"),
         }
     }
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -68,8 +68,7 @@ impl MockLedger {
         for ki in &contents.key_images {
             assert!(
                 inner.key_images.insert(*ki, block.index).is_none(),
-                "duplicate key image: {:?}",
-                ki
+                "duplicate key image: {ki:?}"
             );
         }
 

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -326,7 +326,7 @@ pub fn initialize_ledger(
         let block_data =
             add_txos_and_key_images_to_ledger(ledger, block_version, outputs, key_images, rng)
                 .unwrap_or_else(|err| {
-                    panic!("failed to append block with index {}: {}", block_index, err)
+                    panic!("failed to append block with index {block_index}: {err}")
                 });
 
         to_spend = Some(block_data.contents().outputs[0].clone());
@@ -335,7 +335,7 @@ pub fn initialize_ledger(
     }
 
     // Verify that db now contains n transactions.
-    assert_eq!(ledger.num_blocks().unwrap(), n_blocks as u64);
+    assert_eq!(ledger.num_blocks().unwrap(), { n_blocks });
 
     results
 }

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -379,7 +379,7 @@ pub fn containing_ranges(index: u64, num_leaves: u64) -> Result<Vec<(u64, u64)>,
 
     if let Some(num_leaves_full_tree) = num_leaves.checked_next_power_of_two() {
         // The depth of a full binary tree large enough to contain num_leaves.
-        let depth: u32 = 64 - (num_leaves_full_tree as u64).leading_zeros() - 1;
+        let depth: u32 = 64 - num_leaves_full_tree.leading_zeros() - 1;
         let ranges: Vec<(u64, u64)> = (0..=depth).map(|d| containing_range(index, d)).collect();
         Ok(ranges)
     } else {
@@ -886,11 +886,11 @@ pub mod tx_out_store_tests {
         // unrecognized hash.
         let unrecognized_hash: Hash = [0u8; 32];
         match tx_out_store.get_tx_out_index_by_hash(&unrecognized_hash, &ro_transaction) {
-            Ok(index) => panic!("Returned index {:?} for unrecognized hash.", index),
+            Ok(index) => panic!("Returned index {index:?} for unrecognized hash."),
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected Error {:?}", e),
+            Err(e) => panic!("Unexpected Error {e:?}"),
         }
     }
 
@@ -932,11 +932,11 @@ pub mod tx_out_store_tests {
         let unrecognized_public_key = CompressedRistrettoPublic::from(&[0; 32]);
         match tx_out_store.get_tx_out_index_by_public_key(&unrecognized_public_key, &ro_transaction)
         {
-            Ok(index) => panic!("Returned index {:?} for unrecognized public key.", index),
+            Ok(index) => panic!("Returned index {index:?} for unrecognized public key."),
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected Error {:?}", e),
+            Err(e) => panic!("Unexpected Error {e:?}"),
         }
     }
 
@@ -980,7 +980,7 @@ pub mod tx_out_store_tests {
                 Err(Error::NotFound) => {
                     // This is expected.
                 }
-                Err(e) => panic!("Unexpected Error {:?}", e),
+                Err(e) => panic!("Unexpected Error {e:?}"),
             }
         }
         ro_transaction.commit().unwrap();
@@ -1091,7 +1091,7 @@ pub mod tx_out_store_tests {
     #[test]
     fn test_containing_ranges() {
         let ranges: Vec<(u64, u64)> = containing_ranges(5, 13).unwrap();
-        println!("{:?}", ranges);
+        println!("{ranges:?}");
 
         assert_eq!(5, ranges.len());
 
@@ -1102,7 +1102,7 @@ pub mod tx_out_store_tests {
         assert!(ranges.contains(&(0, 15)));
 
         // Ranges must be in order from smallest to largest.
-        assert_eq!((5, 5), *ranges.get(0).unwrap());
+        assert_eq!((5, 5), *ranges.first().unwrap());
         assert_eq!((4, 5), *ranges.get(1).unwrap());
         assert_eq!((4, 7), *ranges.get(2).unwrap());
         assert_eq!((0, 7), *ranges.get(3).unwrap());
@@ -1303,7 +1303,7 @@ pub mod tx_out_store_tests {
 
             let ranges: Vec<Range> = proof.elements.iter().map(|e| e.range).collect();
 
-            println!("{:?}", ranges);
+            println!("{ranges:?}");
             assert_eq!(ranges[0], Range::new(5, 5).unwrap());
             assert_eq!(ranges[1], Range::new(4, 4).unwrap());
             assert_eq!(ranges[2], Range::new(6, 7).unwrap());
@@ -1343,7 +1343,7 @@ pub mod tx_out_store_tests {
             Err(Error::TxOutIndexOutOfBounds(43)) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 }

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -240,7 +240,7 @@ impl BlockHandler for LocalBlockWriter {
         let dir = dest.as_path().parent().expect("failed getting parent");
 
         fs::create_dir_all(dir)
-            .unwrap_or_else(|e| panic!("failed creating directory {:?}: {:?}", dir, e));
+            .unwrap_or_else(|e| panic!("failed creating directory {dir:?}: {e:?}"));
         fs::write(&dest, bytes).unwrap_or_else(|err| {
             panic!(
                 "failed writing block #{} to {:?}: {}",
@@ -281,11 +281,10 @@ impl BlockHandler for LocalBlockWriter {
         let dir = dest.as_path().parent().expect("failed getting parent");
 
         fs::create_dir_all(dir)
-            .unwrap_or_else(|e| panic!("failed creating directory {:?}: {:?}", dir, e));
+            .unwrap_or_else(|e| panic!("failed creating directory {dir:?}: {e:?}"));
         fs::write(&dest, bytes).unwrap_or_else(|err| {
             panic!(
-                "failed writing merged block #{}-{} to {:?}: {}",
-                first_block_index, last_block_index, dest, err,
+                "failed writing merged block #{first_block_index}-{last_block_index} to {dest:?}: {err}",
             )
         });
     }
@@ -336,10 +335,10 @@ fn main() {
             // See if the state file exists and read it if it does.
             if state_file_path.as_path().exists() {
                 let file_data = fs::read_to_string(&state_file_path).unwrap_or_else(|e| {
-                    panic!("Failed reading state file {:?}: {:?}", state_file_path, e)
+                    panic!("Failed reading state file {state_file_path:?}: {e:?}")
                 });
                 let state_data: StateData = serde_json::from_str(&file_data).unwrap_or_else(|e| {
-                    panic!("Failed parsing state file {:?}: {:?}", state_file_path, e)
+                    panic!("Failed parsing state file {state_file_path:?}: {e:?}")
                 });
                 state_data.next_block
             } else {
@@ -355,9 +354,8 @@ fn main() {
         }
 
         Destination::Local { path } => {
-            fs::create_dir_all(&path).unwrap_or_else(|_| {
-                panic!("Failed creating local destination directory {:?}", path)
-            });
+            fs::create_dir_all(&path)
+                .unwrap_or_else(|_| panic!("Failed creating local destination directory {path:?}"));
             Box::new(LocalBlockWriter::new(path, logger.clone()))
         }
     };
@@ -410,9 +408,9 @@ fn main() {
                     // the ledger due to block_index <= next_block_num (which we
                     // successfully fetched or otherwise this code wouldn't be
                     // running).
-                    let block_data = ledger_db.get_block_data(block_index).unwrap_or_else(|err| {
-                        panic!("failed getting block #{}: {}", block_index, err)
-                    });
+                    let block_data = ledger_db
+                        .get_block_data(block_index)
+                        .unwrap_or_else(|err| panic!("failed getting block #{block_index}: {err}"));
                     blocks_data.push(block_data);
                 }
 

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
                 // Append new data to the ledger
                 local_ledger
                     .append_block_data(&block_data)
-                    .unwrap_or_else(|_| panic!("Could not append block {:?}", block_index))
+                    .unwrap_or_else(|_| panic!("Could not append block {block_index:?}"))
             }
             Err(err) => {
                 log::info!(

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -135,7 +135,7 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
             }
             // Don't know how to migrate.
             Err(err) => {
-                panic!("Error while migrating: {:?}", err);
+                panic!("Error while migrating: {err:?}");
             }
         };
     }

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let config = Config::parse();
 
-    migrate(&config.ledger_db, &logger);
+    migrate(config.ledger_db, &logger);
 
     // Give logger a moment to flush.
     sleep(Duration::from_secs(1));

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -85,11 +85,11 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
             let thread_logger = self.logger.clone();
             let thread_results_and_condvar = results_and_condvar.clone();
             thread::Builder::new()
-                .name(format!("Poll:{}", responder_id))
+                .name(format!("Poll:{responder_id}"))
                 .spawn(move || {
                     log::debug!(thread_logger, "Getting last block from {}", conn);
 
-                    let &(ref lock, ref condvar) = &*thread_results_and_condvar;
+                    let (lock, condvar) = &*thread_results_and_condvar;
 
                     let block_info_result = conn.fetch_block_info(Self::get_retry_iterator());
 
@@ -121,7 +121,7 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
         }
 
         // Wait until we get all results.
-        let &(ref lock, ref condvar) = &*results_and_condvar;
+        let (lock, condvar) = &*results_and_condvar;
         let num_peers = self.manager.len();
         let results = condvar //.wait(lock.lock().unwrap()).unwrap();
             .wait_while(lock.lock().unwrap(), |ref mut results| {

--- a/ledger/sync/src/reqwest_transactions_fetcher.rs
+++ b/ledger/sync/src/reqwest_transactions_fetcher.rs
@@ -190,7 +190,7 @@ impl ReqwestTransactionsFetcher {
         let obj = M::parse_from_bytes(&bytes).map_err(|err| {
             ReqwestTransactionsFetcherError::InvalidBlockReceived(
                 url.to_string(),
-                format!("protobuf parse failed: {:?}", err),
+                format!("protobuf parse failed: {err:?}"),
             )
         })?;
 

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -74,7 +74,7 @@ fn main() {
 
     std::fs::copy(
         "../../target/sample_data/ledger/data.mdb",
-        format!("{}/data.mdb", ledger_path_str),
+        format!("{ledger_path_str}/data.mdb"),
     )
     .expect("failed copying ledger");
 
@@ -107,7 +107,7 @@ fn main() {
         .into_iter()
         .map(|node_id| {
             let node_uri =
-                ClientUri::from_str(&format!("mc://node{}.{}.mobilecoin.com/", node_id, NETWORK))
+                ClientUri::from_str(&format!("mc://node{node_id}.{NETWORK}.mobilecoin.com/"))
                     .expect("failed parsing URI");
 
             ThickClient::new(

--- a/mobilecoind-dev-faucet/src/bin/main.rs
+++ b/mobilecoind-dev-faucet/src/bin/main.rs
@@ -4,6 +4,7 @@
 
 #![deny(missing_docs)]
 #![feature(proc_macro_hygiene, decl_macro)]
+#![allow(clippy::let_unit_value)]
 
 use clap::Parser;
 use mc_common::logger::{create_app_logger, log, o};

--- a/mobilecoind-dev-faucet/src/data_types.rs
+++ b/mobilecoind-dev-faucet/src/data_types.rs
@@ -116,10 +116,10 @@ impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
     fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
-            tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
-            tx_out_hash: hex::encode(&src.get_tx_out_hash()),
+            tx_public_key: hex::encode(src.get_tx_public_key().get_data()),
+            tx_out_hash: hex::encode(src.get_tx_out_hash()),
             tombstone: src.get_tombstone(),
-            confirmation_number: hex::encode(&src.get_confirmation_number()),
+            confirmation_number: hex::encode(src.get_confirmation_number()),
         }
     }
 }
@@ -146,11 +146,11 @@ pub struct JsonPublicAddress {
 impl From<&PublicAddress> for JsonPublicAddress {
     fn from(src: &PublicAddress) -> Self {
         Self {
-            view_public_key: hex::encode(&src.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&src.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(src.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(src.get_spend_public_key().get_data()),
             fog_report_url: src.get_fog_report_url().into(),
             fog_report_id: src.get_fog_report_id().into(),
-            fog_authority_sig: hex::encode(&src.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(src.get_fog_authority_sig()),
         }
     }
 }
@@ -240,7 +240,7 @@ impl TryFrom<&JsonSlamRequest> for SlamParams {
                 .iter()
                 .map(|uri| FromStr::from_str(uri.as_str()))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|err| format!("Invalid uri: {}", err))?;
+                .map_err(|err| format!("Invalid uri: {err}"))?;
         }
         Ok(result)
     }

--- a/mobilecoind-dev-faucet/src/lib.rs
+++ b/mobilecoind-dev-faucet/src/lib.rs
@@ -196,7 +196,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .add_monitor(&req)
-                .map_err(|err| format!("Failed adding a monitor: {}", err))?;
+                .map_err(|err| format!("Failed adding a monitor: {err}"))?;
 
             resp.monitor_id
         };
@@ -208,7 +208,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .get_public_address(&req)
-                .map_err(|err| format!("Failed getting public address: {}", err))?;
+                .map_err(|err| format!("Failed getting public address: {err}"))?;
 
             resp.b58_code
         };
@@ -224,7 +224,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .get_network_status(&Default::default())
-                .map_err(|err| format!("Failed getting network status: {}", err))?;
+                .map_err(|err| format!("Failed getting network status: {err}"))?;
 
             for (k, v) in resp.get_last_block_info().minimum_fees.iter() {
                 result.insert(k.into(), *v);
@@ -248,7 +248,7 @@ impl State {
         req: &JsonFaucetRequest,
     ) -> Result<api::SubmitTxResponse, String> {
         let printable_wrapper = PrintableWrapper::b58_decode(req.b58_address.clone())
-            .map_err(|err| format!("Could not decode b58 address: {}", err))?;
+            .map_err(|err| format!("Could not decode b58 address: {err}"))?;
 
         let public_address = if printable_wrapper.has_public_address() {
             printable_wrapper.get_public_address()
@@ -279,9 +279,9 @@ impl State {
         let resp = self
             .mobilecoind_api_client
             .generate_tx_from_tx_out_list_async(&req)
-            .map_err(|err| format!("Failed to build Tx: {}", err))?
+            .map_err(|err| format!("Failed to build Tx: {err}"))?
             .await
-            .map_err(|err| format!("Build Tx ended in error: {}", err))?;
+            .map_err(|err| format!("Build Tx ended in error: {err}"))?;
 
         // Submit the tx proposal
         let mut req = api::SubmitTxRequest::new();
@@ -290,9 +290,9 @@ impl State {
         let resp = self
             .mobilecoind_api_client
             .submit_tx_async(&req)
-            .map_err(|err| format!("Failed to submit Tx: {}", err))?
+            .map_err(|err| format!("Failed to submit Tx: {err}"))?
             .await
-            .map_err(|err| format!("Submit Tx ended in error: {}", err))?;
+            .map_err(|err| format!("Submit Tx ended in error: {err}"))?;
 
         // Tell the worker that this utxo was submitted, so that it can track and
         // recycle the utxo if this payment fails
@@ -318,18 +318,10 @@ impl State {
             let resp = self
                 .mobilecoind_api_client
                 .get_balance_async(&req)
-                .map_err(|err| {
-                    format!(
-                        "Failed to check balance for token id '{}': {}",
-                        token_id, err
-                    )
-                })?
+                .map_err(|err| format!("Failed to check balance for token id '{token_id}': {err}"))?
                 .await
                 .map_err(|err| {
-                    format!(
-                        "Balance check request for token id '{}' ended in error: {}",
-                        token_id, err
-                    )
+                    format!("Balance check request for token id '{token_id}' ended in error: {err}")
                 })?;
             balances.insert(*token_id, resp.balance);
         }

--- a/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
+++ b/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
@@ -86,7 +86,7 @@ impl PreparedUtxo {
                 ))
             })
             .collect::<Result<Vec<_>, ConversionError>>()
-            .map_err(|err| format!("Conversion error: {}", err))?
+            .map_err(|err| format!("Conversion error: {err}"))?
             .into_iter()
             .unzip();
 
@@ -110,9 +110,9 @@ impl PreparedUtxo {
 
         let proofs_resp = mobilecoind_api_client
             .get_membership_proofs_async(&req)
-            .map_err(|err| format!("Failed to request membership proofs: {}", err))?
+            .map_err(|err| format!("Failed to request membership proofs: {err}"))?
             .await
-            .map_err(|err| format!("Request membership proofs ended in error: {}", err))?;
+            .map_err(|err| format!("Request membership proofs ended in error: {err}"))?;
 
         // Get mixins for this utxo
         let mut req = api::GetMixinsRequest::new();
@@ -122,9 +122,9 @@ impl PreparedUtxo {
 
         let mixins_resp = mobilecoind_api_client
             .get_mixins_async(&req)
-            .map_err(|err| format!("Failed to request mixins: {}", err))?
+            .map_err(|err| format!("Failed to request mixins: {err}"))?
             .await
-            .map_err(|err| format!("Request mixins ended in error: {}", err))?;
+            .map_err(|err| format!("Request mixins ended in error: {err}"))?;
 
         Ok((proofs_resp, mixins_resp))
     }
@@ -141,10 +141,7 @@ impl PreparedUtxo {
         // Get block version to target
         let block_version = network_state.get_last_block_info().network_block_version;
         let block_version = BlockVersion::try_from(block_version).map_err(|err| {
-            format!(
-                "Got invalid block version {} from network ({})",
-                block_version, err
-            )
+            format!("Got invalid block version {block_version} from network ({err})")
         })?;
 
         // Get minimum fee for this token id
@@ -154,7 +151,7 @@ impl PreparedUtxo {
             .get_last_block_info()
             .minimum_fees
             .get(&token_id)
-            .ok_or_else(|| format!("Missing fee for token id: {}", token_id))?;
+            .ok_or_else(|| format!("Missing fee for token id: {token_id}"))?;
         let token_id = TokenId::from(token_id);
         let fee_amount = Amount::new(fee_value, token_id);
 
@@ -165,7 +162,7 @@ impl PreparedUtxo {
             let report_verifier = Verifier::default();
 
             FogResolver::new(responses, &report_verifier)
-                .map_err(|err| format!("Fog resolver: {}", err))?
+                .map_err(|err| format!("Fog resolver: {err}"))?
         };
 
         // Create tx_builder.
@@ -175,7 +172,7 @@ impl PreparedUtxo {
             fog_resolver,
             EmptyMemoBuilder::default(),
         )
-        .map_err(|err| format!("Transaction builder new: {}", err))?;
+        .map_err(|err| format!("Transaction builder new: {err}"))?;
 
         tx_builder.set_tombstone_block(tombstone_block);
         tx_builder.add_input(self.get_input_credentials(account_key)?);
@@ -185,11 +182,11 @@ impl PreparedUtxo {
                 recipient,
                 &mut rng,
             )
-            .map_err(|err| format!("Add output: {}", err))?;
+            .map_err(|err| format!("Add output: {err}"))?;
 
         tx_builder
             .build(&LocalRingSigner::from(account_key), &mut rng)
-            .map_err(|err| format!("Build Tx: {}", err))
+            .map_err(|err| format!("Build Tx: {err}"))
     }
 
     fn get_input_credentials(&self, account_key: &AccountKey) -> Result<InputCredentials, String> {
@@ -202,6 +199,6 @@ impl PreparedUtxo {
             onetime_key_derive_data,
             *account_key.view_private_key(),
         )
-        .map_err(|err| format!("InputCredentials: {}", err))
+        .map_err(|err| format!("InputCredentials: {err}"))
     }
 }

--- a/mobilecoind-dev-faucet/src/slam/tx_submitter.rs
+++ b/mobilecoind-dev-faucet/src/slam/tx_submitter.rs
@@ -28,7 +28,7 @@ impl TxSubmitter {
             return Err("No consensus uris".to_owned());
         }
         let conns = Self::get_connections(&uris, env, logger)
-            .map_err(|err| format!("consensus connection: {}", err))?;
+            .map_err(|err| format!("consensus connection: {err}"))?;
         Ok(Self { conns })
     }
 

--- a/mobilecoind-dev-faucet/src/worker.rs
+++ b/mobilecoind-dev-faucet/src/worker.rs
@@ -235,7 +235,7 @@ impl Worker {
         for (token_id, value) in target_amounts.iter() {
             let minimum_fee_value = minimum_fees
                 .get(token_id)
-                .unwrap_or_else(|| panic!("Missing minimum fee for {}", token_id));
+                .unwrap_or_else(|| panic!("Missing minimum fee for {token_id}"));
             let (state, receiver) = WorkerTokenState::new(*token_id, *minimum_fee_value, *value);
             worker_token_states.push(state);
             receivers.insert(*token_id, receiver);
@@ -564,7 +564,7 @@ impl WorkerTokenState {
             let key_image: KeyImage = utxo
                 .get_key_image()
                 .try_into()
-                .map_err(|err| format!("invalid key image: {}", err))?;
+                .map_err(|err| format!("invalid key image: {err}"))?;
             if let Entry::Vacant(e) = self.known_utxos.entry(key_image) {
                 // We found a utxo not in the cache, let's queue and add to cache
                 log::trace!(
@@ -823,14 +823,14 @@ impl WorkerTokenState {
 
             let mut resp = client
                 .generate_tx(&req)
-                .map_err(|err| format!("Failed to generate rebalancing tx: {}", err))?;
+                .map_err(|err| format!("Failed to generate rebalancing tx: {err}"))?;
 
             // Submit the Tx
             let mut req = api::SubmitTxRequest::new();
             req.set_tx_proposal(resp.take_tx_proposal());
             let submit_tx_response = client
                 .submit_tx(&req)
-                .map_err(|err| format!("Failed to submit rebalancing tx: {}", err))?;
+                .map_err(|err| format!("Failed to submit rebalancing tx: {err}"))?;
 
             // This lets us keep tabs on when this split payment has resolved, so that we
             // can avoid sending another payment until it does

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -52,12 +52,12 @@ fn set_password(
     let mut req = api::SetDbPasswordRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
-            .map_err(|err| format!("Failed decoding password hex: {}", err))?,
+            .map_err(|err| format!("Failed decoding password hex: {err}"))?,
     );
     let _resp = state
         .mobilecoind_api_client
         .set_db_password(&req)
-        .map_err(|err| format!("Failed setting password: {}", err))?;
+        .map_err(|err| format!("Failed setting password: {err}"))?;
     Ok(Json(JsonPasswordResponse { success: true }))
 }
 
@@ -70,12 +70,12 @@ fn unlock_db(
     let mut req = api::UnlockDbRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
-            .map_err(|err| format!("Failed decoding password hex: {}", err))?,
+            .map_err(|err| format!("Failed decoding password hex: {err}"))?,
     );
     let _resp = state
         .mobilecoind_api_client
         .unlock_db(&req)
-        .map_err(|err| format!("Failed unlocking database: {}", err))?;
+        .map_err(|err| format!("Failed unlocking database: {err}"))?;
     Ok(Json(JsonUnlockDbResponse { success: true }))
 }
 
@@ -85,7 +85,7 @@ fn version(state: &rocket::State<State>) -> Result<Json<JsonMobilecoindVersionRe
     let resp = state
         .mobilecoind_api_client
         .get_version(&api::Empty::new())
-        .map_err(|err| format!("Failed getting version: {}", err))?;
+        .map_err(|err| format!("Failed getting version: {err}"))?;
     Ok(Json(JsonMobilecoindVersionResponse::from(&resp)))
 }
 
@@ -95,7 +95,7 @@ fn entropy(state: &rocket::State<State>) -> Result<Json<JsonRootEntropyResponse>
     let resp = state
         .mobilecoind_api_client
         .generate_root_entropy(&api::Empty::new())
-        .map_err(|err| format!("Failed getting entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting entropy: {err}"))?;
     Ok(Json(JsonRootEntropyResponse::from(&resp)))
 }
 
@@ -105,7 +105,7 @@ fn account_key_from_root_entropy(
     root_entropy: String,
 ) -> Result<Json<JsonAccountKeyResponse>, String> {
     let entropy =
-        hex::decode(root_entropy).map_err(|err| format!("Failed to decode hex key: {}", err))?;
+        hex::decode(root_entropy).map_err(|err| format!("Failed to decode hex key: {err}"))?;
 
     let mut req = api::GetAccountKeyFromRootEntropyRequest::new();
     req.set_root_entropy(entropy.to_vec());
@@ -113,7 +113,7 @@ fn account_key_from_root_entropy(
     let resp = state
         .mobilecoind_api_client
         .get_account_key_from_root_entropy(&req)
-        .map_err(|err| format!("Failed getting account key for root entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting account key for root entropy: {err}"))?;
 
     Ok(Json(JsonAccountKeyResponse::from(&resp)))
 }
@@ -124,7 +124,7 @@ fn mnemonic(state: &rocket::State<State>) -> Result<Json<JsonMnemonicResponse>, 
     let resp = state
         .mobilecoind_api_client
         .generate_mnemonic(&api::Empty::new())
-        .map_err(|err| format!("Failed getting entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting entropy: {err}"))?;
     Ok(Json(JsonMnemonicResponse::from(&resp)))
 }
 
@@ -139,7 +139,7 @@ fn account_key_from_mnemonic(
     let resp = state
         .mobilecoind_api_client
         .get_account_key_from_mnemonic(&req)
-        .map_err(|err| format!("Failed getting account key for mnemonic: {}", err))?;
+        .map_err(|err| format!("Failed getting account key for mnemonic: {err}"))?;
 
     Ok(Json(JsonAccountKeyResponse::from(&resp)))
 }
@@ -155,12 +155,12 @@ fn add_monitor(
     let mut view_private_key = RistrettoPrivate::new();
     view_private_key.set_data(
         hex::decode(&monitor.account_key.view_private_key)
-            .map_err(|err| format!("Failed to decode hex key: {}", err))?,
+            .map_err(|err| format!("Failed to decode hex key: {err}"))?,
     );
     let mut spend_private_key = RistrettoPrivate::new();
     spend_private_key.set_data(
         hex::decode(&monitor.account_key.spend_private_key)
-            .map_err(|err| format!("Failed to decode hex key: {}", err))?,
+            .map_err(|err| format!("Failed to decode hex key: {err}"))?,
     );
     account_key.set_view_private_key(view_private_key);
     account_key.set_spend_private_key(spend_private_key);
@@ -174,7 +174,7 @@ fn add_monitor(
     let monitor_response = state
         .mobilecoind_api_client
         .add_monitor(&req)
-        .map_err(|err| format!("Failed adding monitor: {}", err))?;
+        .map_err(|err| format!("Failed adding monitor: {err}"))?;
 
     Ok(Json(JsonMonitorResponse::from(&monitor_response)))
 }
@@ -183,7 +183,7 @@ fn add_monitor(
 #[delete("/monitors/<monitor_hex>")]
 fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(), String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::RemoveMonitorRequest::new();
     req.set_monitor_id(monitor_id);
@@ -191,7 +191,7 @@ fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(
     let _resp = state
         .mobilecoind_api_client
         .remove_monitor(&req)
-        .map_err(|err| format!("Failed removing monitor: {}", err))?;
+        .map_err(|err| format!("Failed removing monitor: {err}"))?;
 
     Ok(())
 }
@@ -202,7 +202,7 @@ fn monitors(state: &rocket::State<State>) -> Result<Json<JsonMonitorListResponse
     let resp = state
         .mobilecoind_api_client
         .get_monitor_list(&api::Empty::new())
-        .map_err(|err| format!("Failed getting monitor list: {}", err))?;
+        .map_err(|err| format!("Failed getting monitor list: {err}"))?;
     Ok(Json(JsonMonitorListResponse::from(&resp)))
 }
 
@@ -213,7 +213,7 @@ fn monitor_status(
     monitor_hex: String,
 ) -> Result<Json<JsonMonitorStatusResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetMonitorStatusRequest::new();
     req.set_monitor_id(monitor_id);
@@ -221,7 +221,7 @@ fn monitor_status(
     let resp = state
         .mobilecoind_api_client
         .get_monitor_status(&req)
-        .map_err(|err| format!("Failed getting monitor status: {}", err))?;
+        .map_err(|err| format!("Failed getting monitor status: {err}"))?;
 
     Ok(Json(JsonMonitorStatusResponse::from(&resp)))
 }
@@ -234,7 +234,7 @@ fn balance(
     subaddress_index: u64,
 ) -> Result<Json<JsonBalanceResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetBalanceRequest::new();
     req.set_monitor_id(monitor_id);
@@ -243,7 +243,7 @@ fn balance(
     let resp = state
         .mobilecoind_api_client
         .get_balance(&req)
-        .map_err(|err| format!("Failed getting balance: {}", err))?;
+        .map_err(|err| format!("Failed getting balance: {err}"))?;
 
     Ok(Json(JsonBalanceResponse::from(&resp)))
 }
@@ -255,7 +255,7 @@ fn utxos(
     subaddress_index: u64,
 ) -> Result<Json<JsonUtxosResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetUnspentTxOutListRequest::new();
     req.set_monitor_id(monitor_id);
@@ -264,7 +264,7 @@ fn utxos(
     let resp = state
         .mobilecoind_api_client
         .get_unspent_tx_out_list(&req)
-        .map_err(|err| format!("Failed getting utxos: {}", err))?;
+        .map_err(|err| format!("Failed getting utxos: {err}"))?;
 
     Ok(Json(JsonUtxosResponse::from(&resp)))
 }
@@ -277,7 +277,7 @@ fn public_address(
     subaddress_index: u64,
 ) -> Result<Json<JsonPublicAddressResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     // Get our public address.
     let mut req = api::GetPublicAddressRequest::new();
@@ -287,7 +287,7 @@ fn public_address(
     let resp = state
         .mobilecoind_api_client
         .get_public_address(&req)
-        .map_err(|err| format!("Failed getting public address: {}", err))?;
+        .map_err(|err| format!("Failed getting public address: {err}"))?;
 
     Ok(Json(JsonPublicAddressResponse::from(&resp)))
 }
@@ -299,7 +299,7 @@ fn create_request_code(
     request: Json<JsonCreateRequestCodeRequest>,
 ) -> Result<Json<JsonCreateRequestCodeResponse>, String> {
     let receiver = api::external::PublicAddress::try_from(&request.receiver)
-        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+        .map_err(|err| format!("Failed to parse receiver's public address: {err}"))?;
 
     // Generate b58 code
     let mut req = api::CreateRequestCodeRequest::new();
@@ -314,7 +314,7 @@ fn create_request_code(
     let resp = state
         .mobilecoind_api_client
         .create_request_code(&req)
-        .map_err(|err| format!("Failed creating request code: {}", err))?;
+        .map_err(|err| format!("Failed creating request code: {err}"))?;
 
     Ok(Json(JsonCreateRequestCodeResponse::from(&resp)))
 }
@@ -330,7 +330,7 @@ fn parse_request_code(
     let resp = state
         .mobilecoind_api_client
         .parse_request_code(&req)
-        .map_err(|err| format!("Failed parsing request code: {}", err))?;
+        .map_err(|err| format!("Failed parsing request code: {err}"))?;
 
     // The response contains the public keys encoded in the read request, as well as
     // a memo and requested value. This can be used as-is in the transfer call
@@ -345,7 +345,7 @@ fn create_address_code(
     request: Json<JsonCreateAddressCodeRequest>,
 ) -> Result<Json<JsonCreateAddressCodeResponse>, String> {
     let receiver = api::external::PublicAddress::try_from(&request.receiver)
-        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+        .map_err(|err| format!("Failed to parse receiver's public address: {err}"))?;
 
     // Generate b58 code
     let mut req = api::CreateAddressCodeRequest::new();
@@ -354,7 +354,7 @@ fn create_address_code(
     let resp = state
         .mobilecoind_api_client
         .create_address_code(&req)
-        .map_err(|err| format!("Failed creating address code: {}", err))?;
+        .map_err(|err| format!("Failed creating address code: {err}"))?;
 
     Ok(Json(JsonCreateAddressCodeResponse::from(&resp)))
 }
@@ -370,7 +370,7 @@ fn parse_address_code(
     let resp = state
         .mobilecoind_api_client
         .parse_address_code(&req)
-        .map_err(|err| format!("Failed parding address code: {}", err))?;
+        .map_err(|err| format!("Failed parding address code: {err}"))?;
 
     // The response contains the public keys encoded in the read request
     Ok(Json(JsonParseAddressCodeResponse::from(&resp)))
@@ -390,7 +390,7 @@ fn build_and_submit(
     transfer: Json<JsonSendPaymentRequest>,
 ) -> Result<Json<JsonSendPaymentResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let public_address = PublicAddress::try_from(&transfer.request_data.receiver)?;
 
@@ -420,7 +420,7 @@ fn build_and_submit(
     let resp = state
         .mobilecoind_api_client
         .send_payment(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSendPaymentResponse::from(&resp)))
@@ -440,7 +440,7 @@ fn pay_address_code(
     transfer: Json<JsonPayAddressCodeRequest>,
 ) -> Result<Json<JsonSendPaymentResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     // Get amount.
     let amount = u64::from(transfer.value);
@@ -467,7 +467,7 @@ fn pay_address_code(
     let resp = state
         .mobilecoind_api_client
         .pay_address_code(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSendPaymentResponse::from(&resp)))
@@ -488,7 +488,7 @@ fn generate_request_code_transaction(
     request: Json<JsonCreateTxProposalRequest>,
 ) -> Result<Json<JsonCreateTxProposalResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let public_address = PublicAddress::try_from(&request.transfer.receiver)?;
 
@@ -502,7 +502,7 @@ fn generate_request_code_transaction(
         .iter()
         .map(|input| {
             api::UnspentTxOut::try_from(input)
-                .map_err(|err| format!("Failed to convert input: {}", err))
+                .map_err(|err| format!("Failed to convert input: {err}"))
         })
         .collect::<Result<_, String>>()?;
 
@@ -516,7 +516,7 @@ fn generate_request_code_transaction(
     let resp = state
         .mobilecoind_api_client
         .generate_tx(&req)
-        .map_err(|err| format!("Failed to generate tx: {}", err))?;
+        .map_err(|err| format!("Failed to generate tx: {err}"))?;
 
     Ok(Json(JsonCreateTxProposalResponse::from(&resp)))
 }
@@ -531,13 +531,13 @@ fn submit_tx(
     let mut req = api::SubmitTxRequest::new();
     req.set_tx_proposal(
         api::TxProposal::try_from(&proposal.tx_proposal)
-            .map_err(|err| format!("Failed to convert tx proposal: {}", err))?,
+            .map_err(|err| format!("Failed to convert tx proposal: {err}"))?,
     );
 
     let resp = state
         .mobilecoind_api_client
         .submit_tx(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSubmitTxResponse::from(&resp)))
@@ -553,9 +553,9 @@ fn check_transfer_status(
         .mobilecoind_api_client
         .get_tx_status_as_sender(
             &api::SubmitTxResponse::try_from(&submit_response.0)
-                .map_err(|err| format!("Could not convert JsonSubmitTxResponse: {}", err))?,
+                .map_err(|err| format!("Could not convert JsonSubmitTxResponse: {err}"))?,
         )
-        .map_err(|err| format!("Failed getting status: {}", err))?;
+        .map_err(|err| format!("Failed getting status: {err}"))?;
 
     Ok(Json(JsonStatusResponse::from(&resp)))
 }
@@ -578,17 +578,17 @@ fn check_receiver_transfer_status(
     receipt: Json<JsonReceiverTxReceipt>,
 ) -> Result<Json<JsonStatusResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut receiver_receipt = api::ReceiverTxReceipt::new();
     let mut tx_public_key = CompressedRistretto::new();
-    tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{}", err))?);
+    tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{err}"))?);
     receiver_receipt.set_tx_public_key(tx_public_key);
     receiver_receipt
-        .set_tx_out_hash(hex::decode(&receipt.tx_out_hash).map_err(|err| format!("{}", err))?);
+        .set_tx_out_hash(hex::decode(&receipt.tx_out_hash).map_err(|err| format!("{err}"))?);
     receiver_receipt.set_tombstone(receipt.tombstone);
     receiver_receipt.set_confirmation_number(
-        hex::decode(&receipt.confirmation_number).map_err(|err| format!("{}", err))?,
+        hex::decode(&receipt.confirmation_number).map_err(|err| format!("{err}"))?,
     );
 
     let mut req = api::GetTxStatusAsReceiverRequest::new();
@@ -598,7 +598,7 @@ fn check_receiver_transfer_status(
     let resp = state
         .mobilecoind_api_client
         .get_tx_status_as_receiver(&req)
-        .map_err(|err| format!("Failed getting status: {}", err))?;
+        .map_err(|err| format!("Failed getting status: {err}"))?;
 
     Ok(Json(JsonStatusResponse::from(&resp)))
 }
@@ -609,7 +609,7 @@ fn ledger_info(state: &rocket::State<State>) -> Result<Json<JsonLedgerInfoRespon
     let resp = state
         .mobilecoind_api_client
         .get_ledger_info(&api::Empty::new())
-        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+        .map_err(|err| format!("Failed getting ledger info: {err}"))?;
 
     Ok(Json(JsonLedgerInfoResponse::from(&resp)))
 }
@@ -626,7 +626,7 @@ fn block_info(
     let resp = state
         .mobilecoind_api_client
         .get_block_info(&req)
-        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+        .map_err(|err| format!("Failed getting ledger info: {err}"))?;
 
     Ok(Json(JsonBlockInfoResponse::from(&resp)))
 }
@@ -643,7 +643,7 @@ fn block_details(
     let resp = state
         .mobilecoind_api_client
         .get_block(&req)
-        .map_err(|err| format!("Failed getting block details: {}", err))?;
+        .map_err(|err| format!("Failed getting block details: {err}"))?;
 
     Ok(Json(JsonBlockDetailsResponse::from(&resp)))
 }
@@ -655,7 +655,7 @@ fn processed_block(
     block_num: u64,
 ) -> Result<Json<JsonProcessedBlockResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetProcessedBlockRequest::new();
     req.set_monitor_id(monitor_id);
@@ -664,7 +664,7 @@ fn processed_block(
     let resp = state
         .mobilecoind_api_client
         .get_processed_block(&req)
-        .map_err(|err| format!("Failed getting processed block: {}", err))?;
+        .map_err(|err| format!("Failed getting processed block: {err}"))?;
 
     Ok(Json(JsonProcessedBlockResponse::from(&resp)))
 }
@@ -676,7 +676,7 @@ fn tx_out_get_block_index_by_public_key(
     public_key_hex: String,
 ) -> Result<Json<JsonBlockIndexByTxPubKeyResponse>, String> {
     let tx_out_public_key = hex::decode(public_key_hex)
-        .map_err(|err| format!("Failed to decode hex public key: {}", err))?;
+        .map_err(|err| format!("Failed to decode hex public key: {err}"))?;
 
     let mut tx_out_public_key_proto = CompressedRistretto::new();
     tx_out_public_key_proto.set_data(tx_out_public_key);
@@ -687,7 +687,7 @@ fn tx_out_get_block_index_by_public_key(
     let resp = state
         .mobilecoind_api_client
         .get_block_index_by_tx_pub_key(&req)
-        .map_err(|err| format!("Failed getting block index: {}", err))?;
+        .map_err(|err| format!("Failed getting block index: {err}"))?;
 
     Ok(Json(JsonBlockIndexByTxPubKeyResponse::from(&resp)))
 }
@@ -712,7 +712,7 @@ fn get_proof_of_membership(
     let get_membership_proofs_response = state
         .mobilecoind_api_client
         .get_membership_proofs(&get_membership_proofs_request)
-        .map_err(|err| format!("Failed getting membership proofs: {}", err))?;
+        .map_err(|err| format!("Failed getting membership proofs: {err}"))?;
 
     // Return JSON response
     let (outputs, membership_proofs): (Vec<JsonTxOut>, Vec<JsonTxOutMembershipProof>) =
@@ -755,7 +755,7 @@ fn get_mixins(
     let get_mixins_response = state
         .mobilecoind_api_client
         .get_mixins(&get_mixins_request)
-        .map_err(|err| format!("Failed getting mixins: {}", err))?;
+        .map_err(|err| format!("Failed getting mixins: {err}"))?;
 
     let (mixins, membership_proofs): (Vec<JsonTxOut>, Vec<JsonTxOutMembershipProof>) =
         get_mixins_response

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -67,9 +67,9 @@ pub struct JsonAccountKeyResponse {
 impl From<&api::GetAccountKeyResponse> for JsonAccountKeyResponse {
     fn from(src: &api::GetAccountKeyResponse) -> Self {
         Self {
-            view_private_key: hex::encode(&src.get_account_key().get_view_private_key().get_data()),
+            view_private_key: hex::encode(src.get_account_key().get_view_private_key().get_data()),
             spend_private_key: hex::encode(
-                &src.get_account_key().get_spend_private_key().get_data(),
+                src.get_account_key().get_spend_private_key().get_data(),
             ),
         }
     }
@@ -160,11 +160,11 @@ impl From<&api::UnspentTxOut> for JsonUnspentTxOut {
         Self {
             tx_out: src.get_tx_out().into(),
             subaddress_index: src.get_subaddress_index(),
-            key_image: hex::encode(&src.get_key_image().get_data()),
+            key_image: hex::encode(src.get_key_image().get_data()),
             value: JsonU64(src.value),
             attempted_spend_height: src.get_attempted_spend_height(),
             attempted_spend_tombstone: src.get_attempted_spend_tombstone(),
-            monitor_id: hex::encode(&src.get_monitor_id()),
+            monitor_id: hex::encode(src.get_monitor_id()),
         }
     }
 }
@@ -177,14 +177,14 @@ impl TryFrom<&JsonUnspentTxOut> for api::UnspentTxOut {
         let mut key_image = KeyImage::new();
         key_image.set_data(
             hex::decode(&src.key_image)
-                .map_err(|err| format!("Failed to decode key image hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode key image hex: {err}"))?,
         );
 
         // Reconstruct the public address as a protobuf
         let mut utxo = api::UnspentTxOut::new();
         utxo.set_tx_out(
             mc_api::external::TxOut::try_from(&src.tx_out)
-                .map_err(|err| format!("Failed to get TxOut: {}", err))?,
+                .map_err(|err| format!("Failed to get TxOut: {err}"))?,
         );
         utxo.set_subaddress_index(src.subaddress_index);
         utxo.set_key_image(key_image);
@@ -193,7 +193,7 @@ impl TryFrom<&JsonUnspentTxOut> for api::UnspentTxOut {
         utxo.set_attempted_spend_tombstone(src.attempted_spend_tombstone);
         utxo.set_monitor_id(
             hex::decode(&src.monitor_id)
-                .map_err(|err| format!("Failed to decode monitor id hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode monitor id hex: {err}"))?,
         );
 
         Ok(utxo)
@@ -258,11 +258,11 @@ pub struct JsonPublicAddress {
 impl From<&PublicAddress> for JsonPublicAddress {
     fn from(src: &PublicAddress) -> Self {
         Self {
-            view_public_key: hex::encode(&src.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&src.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(src.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(src.get_spend_public_key().get_data()),
             fog_report_url: String::from(src.get_fog_report_url()),
             fog_report_id: String::from(src.get_fog_report_id()),
-            fog_authority_sig: hex::encode(&src.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(src.get_fog_authority_sig()),
         }
     }
 }
@@ -292,11 +292,11 @@ impl From<&api::GetPublicAddressResponse> for JsonPublicAddressResponse {
     fn from(src: &api::GetPublicAddressResponse) -> Self {
         let public_address = src.get_public_address();
         Self {
-            view_public_key: hex::encode(&public_address.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&public_address.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(public_address.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(public_address.get_spend_public_key().get_data()),
             fog_report_url: String::from(public_address.get_fog_report_url()),
             fog_report_id: String::from(public_address.get_fog_report_id()),
-            fog_authority_sig: hex::encode(&public_address.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(public_address.get_fog_authority_sig()),
             b58_address_code: src.get_b58_code().to_string(),
         }
     }
@@ -311,12 +311,12 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
         let mut view_public_key = CompressedRistretto::new();
         view_public_key.set_data(
             hex::decode(&src.view_public_key)
-                .map_err(|err| format!("Failed to decode view key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode view key hex: {err}"))?,
         );
         let mut spend_public_key = CompressedRistretto::new();
         spend_public_key.set_data(
             hex::decode(&src.spend_public_key)
-                .map_err(|err| format!("Failed to decode spend key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode spend key hex: {err}"))?,
         );
 
         // Reconstruct the public address as a protobuf
@@ -327,7 +327,7 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
         public_address.set_fog_report_id(src.fog_report_id.clone());
         public_address.set_fog_authority_sig(
             hex::decode(&src.fog_authority_sig)
-                .map_err(|err| format!("Failed to decode fog authority sig hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode fog authority sig hex: {err}"))?,
         );
 
         Ok(public_address)
@@ -414,10 +414,10 @@ impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
     fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
-            tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
-            tx_out_hash: hex::encode(&src.get_tx_out_hash()),
+            tx_public_key: hex::encode(src.get_tx_public_key().get_data()),
+            tx_out_hash: hex::encode(src.get_tx_out_hash()),
             tombstone: src.get_tombstone(),
-            confirmation_number: hex::encode(&src.get_confirmation_number()),
+            confirmation_number: hex::encode(src.get_confirmation_number()),
         }
     }
 }
@@ -479,7 +479,7 @@ impl TryFrom<&JsonOutlay> for api::Outlay {
         outlay.set_value(src.value.into());
         outlay.set_receiver(
             PublicAddress::try_from(&src.receiver)
-                .map_err(|err| format!("Could not convert receiver: {}", err))?,
+                .map_err(|err| format!("Could not convert receiver: {err}"))?,
         );
 
         Ok(outlay)
@@ -523,14 +523,14 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
         let mut commitment = CompressedRistretto::new();
         commitment.set_data(
             hex::decode(&src.commitment)
-                .map_err(|err| format!("Failed to decode commitment hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode commitment hex: {err}"))?,
         );
         let mut masked_amount = MaskedAmount::new();
         masked_amount.set_commitment(commitment);
         masked_amount.set_masked_value(src.masked_value.into());
         masked_amount.set_masked_token_id(
             hex::decode(&src.masked_token_id)
-                .map_err(|err| format!("Failed to decode masked token id hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode masked token id hex: {err}"))?,
         );
 
         match src.version {
@@ -540,7 +540,7 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
             Some(2) => {
                 Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(masked_amount))
             }
-            Some(other) => Err(format!("Unknown masked amount version: {}", other)),
+            Some(other) => Err(format!("Unknown masked amount version: {other}")),
         }
     }
 }
@@ -574,22 +574,22 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
         let mut target_key = CompressedRistretto::new();
         target_key.set_data(
             hex::decode(&src.target_key)
-                .map_err(|err| format!("Failed to decode target key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode target key hex: {err}"))?,
         );
         let mut public_key = CompressedRistretto::new();
         public_key.set_data(
             hex::decode(&src.public_key)
-                .map_err(|err| format!("Failed to decode public key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode public key hex: {err}"))?,
         );
         let mut e_fog_hint = EncryptedFogHint::new();
         e_fog_hint.set_data(
             hex::decode(&src.e_fog_hint)
-                .map_err(|err| format!("Failed to decode e_fog_hint hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode e_fog_hint hex: {err}"))?,
         );
         let mut e_memo = EncryptedMemo::new();
         e_memo.set_data(
             hex::decode(&src.e_memo)
-                .map_err(|err| format!("Failed to decode e_memo hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode e_memo hex: {err}"))?,
         );
 
         let mut txo = mc_api::external::TxOut::new();
@@ -667,7 +667,7 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
             let mut hash = TxOutMembershipHash::new();
             hash.set_data(
                 hex::decode(&element.hash)
-                    .map_err(|err| format!("Could not decode elem hash: {}", err))?,
+                    .map_err(|err| format!("Could not decode elem hash: {err}"))?,
             );
 
             let mut elem = TxOutMembershipElement::new();
@@ -747,7 +747,7 @@ impl TryFrom<&JsonInputRules> for InputRules {
                 .iter()
                 .map(|out| {
                     mc_api::external::TxOut::try_from(out)
-                        .map_err(|err| format!("Could not get TxOut: {}", err))
+                        .map_err(|err| format!("Could not get TxOut: {err}"))
                 })
                 .collect::<Result<_, String>>()?,
         );
@@ -784,14 +784,14 @@ impl TryFrom<&JsonTxIn> for TxIn {
         let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
         for output in &src.ring {
             let p_output = mc_api::external::TxOut::try_from(output)
-                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+                .map_err(|err| format!("Could not get TxOut: {err}"))?;
             outputs.push(p_output);
         }
 
         let mut proofs: Vec<TxOutMembershipProof> = Vec::new();
         for proof in &src.proofs {
             let p_proof = TxOutMembershipProof::try_from(proof)
-                .map_err(|err| format!("Could not get proof: {}", err))?;
+                .map_err(|err| format!("Could not get proof: {err}"))?;
             proofs.push(p_proof);
         }
 
@@ -838,14 +838,14 @@ impl TryFrom<&JsonTxPrefix> for TxPrefix {
         let mut inputs: Vec<TxIn> = Vec::new();
         for input in &src.inputs {
             let p_input =
-                TxIn::try_from(input).map_err(|err| format!("Could not get TxIn: {}", err))?;
+                TxIn::try_from(input).map_err(|err| format!("Could not get TxIn: {err}"))?;
             inputs.push(p_input);
         }
 
         let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
         for output in &src.outputs {
             let p_output = mc_api::external::TxOut::try_from(output)
-                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+                .map_err(|err| format!("Could not get TxOut: {err}"))?;
             outputs.push(p_output);
         }
 
@@ -920,15 +920,14 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             let mut c_zero = mc_api::external::CurveScalar::new();
             c_zero.set_data(
                 hex::decode(&sig.c_zero)
-                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    .map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
 
             let mut responses: Vec<mc_api::external::CurveScalar> = Vec::new();
             for resp in &sig.responses {
                 let mut response = mc_api::external::CurveScalar::new();
                 response.set_data(
-                    hex::decode(resp)
-                        .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    hex::decode(resp).map_err(|err| format!("Could not decode from hex: {err}"))?,
                 );
                 responses.push(response);
             }
@@ -936,7 +935,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             let mut key_image = KeyImage::new();
             key_image.set_data(
                 hex::decode(&sig.key_image)
-                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    .map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
 
             let mut ring_sig = RingMLSAG::new();
@@ -951,7 +950,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
         for comm in &src.pseudo_output_commitments {
             let mut compressed = CompressedRistretto::new();
             compressed.set_data(
-                hex::decode(&comm).map_err(|err| format!("Could not decode from hex: {}", err))?,
+                hex::decode(comm).map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
             commitments.push(compressed);
         }
@@ -971,10 +970,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             .iter()
             .map(|hex_str| {
                 hex::decode(hex_str).map_err(|err| {
-                    format!(
-                        "Could not decode range proof from hex '{}': {}",
-                        hex_str, err
-                    )
+                    format!("Could not decode range proof from hex '{hex_str}': {err}")
                 })
             })
             .collect::<Result<_, _>>()?;
@@ -1012,11 +1008,11 @@ impl TryFrom<&JsonTx> for Tx {
 
         tx.set_prefix(
             TxPrefix::try_from(&src.prefix)
-                .map_err(|err| format!("Could not convert TxPrefix: {}", err))?,
+                .map_err(|err| format!("Could not convert TxPrefix: {err}"))?,
         );
         tx.set_signature(
             SignatureRctBulletproofs::try_from(&src.signature)
-                .map_err(|err| format!("Could not convert signature: {}", err))?,
+                .map_err(|err| format!("Could not convert signature: {err}"))?,
         );
 
         Ok(tx)
@@ -1063,14 +1059,14 @@ impl TryFrom<&JsonTxProposal> for api::TxProposal {
         let mut inputs: Vec<api::UnspentTxOut> = Vec::new();
         for input in src.input_list.iter() {
             let utxo = api::UnspentTxOut::try_from(input)
-                .map_err(|err| format!("Failed to convert input: {}", err))?;
+                .map_err(|err| format!("Failed to convert input: {err}"))?;
             inputs.push(utxo);
         }
 
         let mut outlays: Vec<api::Outlay> = Vec::new();
         for outlay in src.outlay_list.iter() {
             let out = api::Outlay::try_from(outlay)
-                .map_err(|err| format!("Failed to convert outlay: {}", err))?;
+                .map_err(|err| format!("Failed to convert outlay: {err}"))?;
             outlays.push(out);
         }
 
@@ -1079,7 +1075,7 @@ impl TryFrom<&JsonTxProposal> for api::TxProposal {
         proposal.set_input_list(RepeatedField::from_vec(inputs));
         proposal.set_outlay_list(RepeatedField::from_vec(outlays));
         proposal
-            .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
+            .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {err}"))?);
         proposal.set_fee(src.fee);
         proposal.set_outlay_index_to_tx_out_index(
             src.outlay_index_to_tx_out_index
@@ -1149,11 +1145,8 @@ impl TryFrom<&JsonSubmitTxResponse> for api::SubmitTxResponse {
             .key_images
             .iter()
             .map(|k| {
-                hex::decode(&k).map(KeyImage::from).map_err(|err| {
-                    format!(
-                        "Failed to decode hex for sender_tx_receipt.key_images: {}",
-                        err
-                    )
+                hex::decode(k).map(KeyImage::from).map_err(|err| {
+                    format!("Failed to decode hex for sender_tx_receipt.key_images: {err}")
                 })
             })
             .collect::<Result<Vec<KeyImage>, String>>()?;
@@ -1166,22 +1159,22 @@ impl TryFrom<&JsonSubmitTxResponse> for api::SubmitTxResponse {
             let mut receiver_receipt = api::ReceiverTxReceipt::new();
             receiver_receipt.set_recipient(
                 PublicAddress::try_from(&r.recipient)
-                    .map_err(|err| format!("Failed to convert recipient: {}", err))?,
+                    .map_err(|err| format!("Failed to convert recipient: {err}"))?,
             );
             let mut pubkey = mc_api::external::CompressedRistretto::new();
             pubkey.set_data(
                 hex::decode(&r.tx_public_key)
-                    .map_err(|err| format!("Failed to decode hex for tx_public_key: {}", err))?,
+                    .map_err(|err| format!("Failed to decode hex for tx_public_key: {err}"))?,
             );
             receiver_receipt.set_tx_public_key(pubkey);
             receiver_receipt.set_tx_out_hash(
                 hex::decode(&r.tx_out_hash)
-                    .map_err(|err| format!("Failed to decode hex for tx_out_hash: {}", err))?,
+                    .map_err(|err| format!("Failed to decode hex for tx_out_hash: {err}"))?,
             );
             receiver_receipt.set_tombstone(r.tombstone);
             receiver_receipt.set_confirmation_number(
                 hex::decode(&r.confirmation_number).map_err(|err| {
-                    format!("Failed to decode hex for confirmation_number: {}", err)
+                    format!("Failed to decode hex for confirmation_number: {err}")
                 })?,
             );
             receiver_receipts.push(receiver_receipt);
@@ -1291,12 +1284,12 @@ impl From<&api::GetBlockResponse> for JsonBlockDetailsResponse {
         let block = src.get_block();
 
         Self {
-            block_id: hex::encode(&block.get_id().get_data()),
+            block_id: hex::encode(block.get_id().get_data()),
             version: block.get_version(),
-            parent_id: hex::encode(&block.get_parent_id().get_data()),
+            parent_id: hex::encode(block.get_parent_id().get_data()),
             index: JsonU64(block.get_index()),
             cumulative_txo_count: JsonU64(block.get_cumulative_txo_count()),
-            contents_hash: hex::encode(&block.get_contents_hash().get_data()),
+            contents_hash: hex::encode(block.get_contents_hash().get_data()),
             key_images: src
                 .get_key_images()
                 .iter()
@@ -1326,10 +1319,10 @@ impl From<&api::ProcessedTxOut> for JsonProcessedTxOut {
         };
 
         Self {
-            monitor_id: hex::encode(&src.get_monitor_id()),
+            monitor_id: hex::encode(src.get_monitor_id()),
             subaddress_index: src.subaddress_index,
-            public_key: hex::encode(&src.get_public_key().get_data()),
-            key_image: hex::encode(&src.get_key_image().get_data()),
+            public_key: hex::encode(src.get_public_key().get_data()),
+            key_image: hex::encode(src.get_key_image().get_data()),
             value: JsonU64(src.value),
             direction: direction_str.to_owned(),
         }

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -218,7 +218,7 @@ fn create_or_open_ledger_db(
                     .unwrap_or_else(|_| panic!("Failed creating directory {:?}", config.ledger_db));
             }
 
-            let src = format!("{}/data.mdb", ledger_db_bootstrap);
+            let src = format!("{ledger_db_bootstrap}/data.mdb");
             std::fs::copy(src.clone(), &ledger_db_file).unwrap_or_else(|_| {
                 panic!(
                     "Failed copying ledger from {} into directory {}",

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -102,10 +102,10 @@ pub struct Config {
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {
     let quorum_set: QuorumSet<ResponderId> = serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+        .map_err(|err| format!("Error parsing quorum set {src}: {err:?}"))?;
 
     if !quorum_set.is_valid() {
-        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+        return Err(format!("Invalid quorum set: {quorum_set:?}"));
     }
 
     Ok(quorum_set)
@@ -211,9 +211,9 @@ impl Config {
             } else if let Some(verifier) = verifier.as_ref() {
                 let report_responses = conn
                     .fetch_fog_reports(fog_uris.iter().cloned())
-                    .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
+                    .map_err(|err| format!("Failed fetching fog reports: {err}"))?;
                 Ok(FogResolver::new(report_responses, verifier)
-                    .map_err(|err| format!("Invalid fog url: {}", err))?)
+                    .map_err(|err| format!("Invalid fog url: {err}"))?)
             } else {
                 Err(
                     "Some recipients have fog, but no fog ingest report verifier was configured"
@@ -310,7 +310,7 @@ impl PeersConfig {
             .iter()
             .map(|peer| {
                 peer.responder_id().unwrap_or_else(|err| {
-                    panic!("Could not get responder_id from peer URI {}: {}", peer, err)
+                    panic!("Could not get responder_id from peer URI {peer}: {err}")
                 })
             })
             .collect()

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -526,7 +526,7 @@ mod test {
 
         // Set up a db with 3 random recipients and 10 blocks.
         let (_ledger_db, mobilecoind_db) =
-            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger, &mut rng);
 
         // A test accouunt.
         let account_key = AccountKey::random(&mut rng);
@@ -558,7 +558,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::MonitorIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with overlapping subaddresses should fail.
@@ -574,7 +574,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::SubaddressSPKIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with overlapping subaddresses and a different
@@ -591,7 +591,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::SubaddressSPKIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with non overlapping subaddresses should succeed.

--- a/mobilecoind/src/db_crypto.rs
+++ b/mobilecoind/src/db_crypto.rs
@@ -175,9 +175,9 @@ impl DbCryptoProvider {
     /// Change the password that will be used for all future
     /// encryption/decryption operations. This should only be called after
     /// all existing data has been re-encrypted to the new password!
-    pub fn change_password<'env>(
+    pub fn change_password(
         &self,
-        mut db_txn: RwTransaction<'env>,
+        mut db_txn: RwTransaction<'_>,
         password: &[u8],
     ) -> Result<(), DbCryptoError> {
         let mut state = self.state.lock().expect("muted poisoned");
@@ -303,8 +303,8 @@ impl DbCryptoProvider {
         // Hash the password hash with Blake2b to get 64 bytes, first 32 for aeskey,
         // second 32 for nonce
         let mut hasher = Blake2b512::new();
-        hasher.update(&MOBILECOIND_DB_KEY_DOMAIN_TAG);
-        hasher.update(&password);
+        hasher.update(MOBILECOIND_DB_KEY_DOMAIN_TAG);
+        hasher.update(password);
         let result = hasher.finalize();
 
         let (key, remainder) = Split::<u8, <Aes256Gcm as NewAead>::KeySize>::split(result);

--- a/mobilecoind/src/monitor_store.rs
+++ b/mobilecoind/src/monitor_store.rs
@@ -186,9 +186,9 @@ impl MonitorStore {
     }
 
     /// Add a new monitor.
-    pub fn add<'env>(
+    pub fn add(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         data: &MonitorData,
     ) -> Result<MonitorId, Error> {
         let monitor_id = MonitorId::from(data);
@@ -213,9 +213,9 @@ impl MonitorStore {
     }
 
     /// Delete data for a given monitor.
-    pub fn remove<'env>(
+    pub fn remove(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
     ) -> Result<(), Error> {
         db_txn.del(self.monitor_id_to_monitor_data, monitor_id, None)?;
@@ -279,9 +279,9 @@ impl MonitorStore {
     }
 
     /// Set the MonitorData for an existing monitor
-    pub fn set_data<'env>(
+    pub fn set_data(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         data: &MonitorData,
     ) -> Result<(), Error> {
@@ -308,9 +308,9 @@ impl MonitorStore {
     /// This will fail if the current password is not set in the crypto_provider
     /// since part of the re-encryption process relies on being able to
     /// decrypt the existing data.
-    pub fn re_encrypt<'env>(
+    pub fn re_encrypt(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         new_password: &[u8],
     ) -> Result<(), Error> {
         let mut cursor = db_txn.open_rw_cursor(self.monitor_id_to_monitor_data)?;
@@ -396,9 +396,7 @@ pKZkdp8MQU5TLFOE9qjNeVsCAwEAAQ==
         assert_eq!(
             fog_expected,
             fog_id.as_bytes().to_vec(),
-            "{}/{}",
-            FOG_HEXPECTED,
-            HEXPECTED
+            "{FOG_HEXPECTED}/{HEXPECTED}"
         );
     }
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -247,14 +247,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         opt_tombstone: u64,
         opt_memo_builder: Option<Box<dyn MemoBuilder + 'static + Send + Sync>>,
     ) -> Result<TxProposal, Error> {
-        let logger = self.logger.new(o!("sender_monitor_id" => sender_monitor_id.to_string(), "outlays" => format!("{:?}", outlays)));
+        let logger = self.logger.new(o!("sender_monitor_id" => sender_monitor_id.to_string(), "outlays" => format!("{outlays:?}")));
         log::trace!(logger, "Building pending transaction...");
 
         // All inputs must be of the correct token id.
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -501,7 +501,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -696,7 +696,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -898,7 +898,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_builder =
             TransactionBuilder::new_with_box(block_version, fee_amount, fog_resolver, memo_builder)
                 .map_err(|err| {
-                    Error::TxBuild(format!("Error creating transaction builder: {}", err))
+                    Error::TxBuild(format!("Error creating transaction builder: {err}"))
                 })?;
         tx_builder.set_fee_map(fee_map);
 
@@ -996,7 +996,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 ..
             } = tx_builder
                 .add_output(amount, &outlay.receiver, rng)
-                .map_err(|err| Error::TxBuild(format!("failed adding output: {}", err)))?;
+                .map_err(|err| Error::TxBuild(format!("failed adding output: {err}")))?;
 
             tx_out_to_outlay_index.insert(tx_out, i);
             outlay_confirmation_numbers.push(confirmation);
@@ -1032,7 +1032,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
             tx_builder
                 .add_change_output(change_amount, &change_dest, rng)
-                .map_err(|err| Error::TxBuild(format!("failed adding output (change): {}", err)))?;
+                .map_err(|err| Error::TxBuild(format!("failed adding output (change): {err}")))?;
         }
 
         // Set tombstone block.
@@ -1041,7 +1041,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // Build tx.
         let tx = tx_builder
             .build(&NoKeysRingSigner {}, rng)
-            .map_err(|err| Error::TxBuild(format!("build tx failed: {}", err)))?;
+            .map_err(|err| Error::TxBuild(format!("build tx failed: {err}")))?;
 
         // Map each TxOut in the constructed transaction to its respective outlay.
         let outlay_index_to_tx_out_index = tx
@@ -1064,7 +1064,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .get(&i)
                 .expect("index not in map");
             if !found_tx_out_indices.insert(tx_out_index) {
-                panic!("duplicate index {} found in map", tx_out_index);
+                panic!("duplicate index {tx_out_index} found in map");
             }
         }
 
@@ -1089,7 +1089,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 fn extract_fog_uri(addr: &PublicAddress) -> Result<Option<FogUri>, Error> {
     if let Some(string) = addr.fog_report_url() {
         Ok(Some(FogUri::from_str(string).map_err(|err| {
-            Error::Fog(format!("Could not parse recipient Fog Url: {}", err))
+            Error::Fog(format!("Could not parse recipient Fog Url: {err}"))
         })?))
     } else {
         Ok(None)

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -182,9 +182,9 @@ impl ProcessedBlockStore {
     }
 
     /// Remove the data associated with a given monitor id.
-    pub fn remove<'env>(
+    pub fn remove(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
     ) -> Result<(), Error> {
         let start_key = ProcessedBlockKey::new(monitor_id, 0);
@@ -205,9 +205,9 @@ impl ProcessedBlockStore {
     }
 
     /// Feed data processed from a given block.
-    pub fn block_processed<'env>(
+    pub fn block_processed(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         block_index: u64,
         discovered_utxos: &[UnspentTxOut],
@@ -292,7 +292,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().expect("failed getting num blocks");
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -857,7 +857,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if utxo.token_id != request.token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -876,7 +876,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if subaddress_id.monitor_id != sender_monitor_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list.{}", i),
+                        format!("input_list.{i}"),
                     ));
                 }
 
@@ -978,7 +978,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if utxo.token_id != *token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -1047,14 +1047,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map(|(i, proto_utxo)| {
                 // Proto -> Rust struct conversion.
                 let utxo = UnspentTxOut::try_from(proto_utxo).map_err(|err| {
-                    rpc_internal_error(format!("unspent_tx_out[{}].try_from", i), err, &self.logger)
+                    rpc_internal_error(format!("unspent_tx_out[{i}].try_from"), err, &self.logger)
                 })?;
 
                 // Verify token id matches.
                 if utxo.token_id != request.token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -1073,7 +1073,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if subaddress_id.monitor_id != sender_monitor_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].monitor_id", i),
+                        format!("input_list[{i}].monitor_id"),
                     ));
                 }
 
@@ -1195,7 +1195,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .ok_or_else(|| {
                     RpcStatus::with_message(
                         RpcStatusCode::INTERNAL,
-                        format!("tx out index {} not found", tx_out_index),
+                        format!("tx out index {tx_out_index} not found"),
                     )
                 })?;
 
@@ -1814,10 +1814,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if balance > u64::max_value().into() {
             return Err(RpcStatus::with_message(
                 RpcStatusCode::INTERNAL,
-                format!(
-                    "balance of {} won't fit in u64, fetch utxo list instead",
-                    balance
-                ),
+                format!("balance of {balance} won't fit in u64, fetch utxo list instead"),
             ));
         }
 
@@ -2212,7 +2209,7 @@ mod test {
 
         // 10 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger, &mut rng);
 
         let monitors_map = mobilecoind_db.get_monitor_map().unwrap();
         assert_eq!(0, monitors_map.len());
@@ -2242,7 +2239,7 @@ mod test {
             request.set_monitor_id(id.to_vec());
             client
                 .remove_monitor(&request)
-                .unwrap_or_else(|_| panic!("failed to remove monitor {}", id));
+                .unwrap_or_else(|_| panic!("failed to remove monitor {id}"));
         }
 
         // Check that no monitors remain.
@@ -2440,7 +2437,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().unwrap();
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.
@@ -2516,7 +2513,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // call get entropy
         let response = client
@@ -2533,7 +2530,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // call get entropy
         let response = client.generate_mnemonic(&api::Empty::default()).unwrap();
@@ -2554,7 +2551,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Use mnemonic to construct AccountKey.
         let mnemonic_str =
@@ -2592,7 +2589,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Use root entropy to construct AccountKey.
         let root_entropy = [123u8; 32];
@@ -2634,7 +2631,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Insert into database.
         let id = mobilecoind_db.add_monitor(&data).unwrap();
@@ -2682,7 +2679,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get ledger info.
         let response = client.get_ledger_info(&api::Empty::new()).unwrap();
@@ -2696,7 +2693,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get block info for a valid block.
         let mut request = api::GetBlockInfoRequest::new();
@@ -2719,7 +2716,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get block info for a valid block.
         let mut request = api::GetBlockRequest::new();
@@ -2742,7 +2739,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Insert a block with some key images in it.
         let recipient = AccountKey::random(&mut rng).default_subaddress();
@@ -2826,7 +2823,7 @@ mod test {
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
-            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
+            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() + 1);
 
             let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
@@ -2847,7 +2844,7 @@ mod test {
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
-            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
+            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap());
 
             let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
@@ -2973,7 +2970,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // A call with an invalid hash should fail
         {
@@ -3009,7 +3006,7 @@ mod test {
 
             let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
-            receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
+            receipt.set_tombstone(ledger_db.num_blocks().unwrap() + 1);
 
             let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -3025,7 +3022,7 @@ mod test {
 
             let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
-            receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
+            receipt.set_tombstone(ledger_db.num_blocks().unwrap());
 
             let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -3144,7 +3141,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().expect("failed getting num blocks");
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.
@@ -3361,7 +3358,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 
@@ -3484,7 +3481,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 
@@ -4069,7 +4066,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Grab the first TxOut of each block in the database and verify its index.
         for block_index in 0..test_utils::GET_TESTING_ENVIRONMENT_NUM_BLOCKS as u64 {
@@ -4207,7 +4204,7 @@ mod test {
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
             get_testing_environment(
                 BLOCK_VERSION,
-                num_random_recipients as u32,
+                num_random_recipients,
                 &[sender_default_subaddress.clone()],
                 &[],
                 logger.clone(),
@@ -4261,7 +4258,7 @@ mod test {
             tx_proposal.outlays[0].value,
             // Each UTXO we have has PER_RECIPIENT_AMOUNT coins. We will be merging MAX_INPUTS of
             // those into a single output, minus the fee.
-            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - Mob::MINIMUM_FEE,
+            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS) - Mob::MINIMUM_FEE,
         );
 
         assert_eq!(tx_proposal.outlay_index_to_tx_out_index.len(), 1);
@@ -4888,7 +4885,7 @@ mod test {
                     "transactions_manager.build_transaction: Insufficient funds".to_owned()
                 );
             }
-            Err(err) => panic!("Unexpected error: {:?}", err),
+            Err(err) => panic!("Unexpected error: {err:?}"),
         };
 
         // Trying with a higher limit should work.
@@ -4953,8 +4950,8 @@ mod test {
         );
         let port = test_utils::get_free_port();
 
-        let uri = MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{}/", port))
-            .unwrap();
+        let uri =
+            MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{port}/")).unwrap();
 
         log::debug!(logger, "Setting up server {:?}", port);
         let (_server, server_conn_manager) = test_utils::setup_server::<MockFogPubkeyResolver>(
@@ -5261,7 +5258,7 @@ mod test {
             .get_tx_proposal()
             .get_input_list()
             .iter()
-            .map(|utxo| utxo.value as u64)
+            .map(|utxo| utxo.value)
             .sum::<u64>();
 
         let mut opt_submitted_tx: Option<Tx> = None;
@@ -5330,7 +5327,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Random receiver address.
         let receiver = AccountKey::random(&mut rng).default_subaddress();
@@ -5669,7 +5666,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         {
             // Random receiver address.
@@ -5736,7 +5733,7 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
 
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         let network_status = client.get_network_status(&api::Empty::new()).unwrap();
 
@@ -5900,7 +5897,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 

--- a/mobilecoind/src/subaddress_store.rs
+++ b/mobilecoind/src/subaddress_store.rs
@@ -110,9 +110,9 @@ impl SubaddressStore {
     }
 
     /// Insert a new subaddress spend public key into the database.
-    pub fn insert<'env>(
+    pub fn insert(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         data: &MonitorData,
         index: u64,
@@ -158,9 +158,9 @@ impl SubaddressStore {
     }
 
     /// deletes the SubaddressId stored for a subaddress spend public key
-    pub fn delete<'env>(
+    pub fn delete(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         data: &MonitorData,
         index: u64,
     ) -> Result<(), Error> {

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -101,7 +101,7 @@ impl SyncThread {
             let thread_queued_monitor_ids = queued_monitor_ids.clone();
             let thread_logger = logger.clone();
             let join_handle = thread::Builder::new()
-                .name(format!("sync_worker_{}", idx))
+                .name(format!("sync_worker_{idx}"))
                 .spawn(move || {
                     sync_thread_entry_point(
                         thread_ledger_db,

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -228,7 +228,7 @@ pub fn get_testing_environment(
     let port = get_free_port();
 
     let uri =
-        MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{}/", port)).unwrap();
+        MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{port}/")).unwrap();
 
     log::debug!(logger, "Setting up server {:?}", port);
     let (server, server_conn_manager) = setup_server::<MockFogResolver>(

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -133,9 +133,9 @@ impl UtxoStore {
 
     /// Append a discovered transaction to the list stored for a given
     /// subaddress.
-    pub fn append_utxo<'env>(
+    pub fn append_utxo(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         index: u64,
         utxo: &UnspentTxOut,
@@ -188,9 +188,9 @@ impl UtxoStore {
     }
 
     /// Removes all utxos associated with a given address.
-    pub fn remove_utxos<'env>(
+    pub fn remove_utxos(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         index: u64,
     ) -> Result<(), Error> {
@@ -231,9 +231,9 @@ impl UtxoStore {
     /// Removes utxos based on a list of key images.
     /// This method silently ignores key images that were not found in the
     /// database. It returns the list of utxos that were removed.
-    pub fn remove_utxos_by_key_images<'env>(
+    pub fn remove_utxos_by_key_images(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         key_images: &[KeyImage],
     ) -> Result<Vec<UnspentTxOut>, Error> {
@@ -348,9 +348,9 @@ impl UtxoStore {
 
     /// Update a list of UnspentTxOuts attempted_spend_height and
     /// attempted_spend_tombstone.
-    pub fn update_attempted_spend<'env>(
+    pub fn update_attempted_spend(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         utxo_ids: &[UtxoId],
         attempted_spend_height: u64,
         attempted_spend_tombstone: u64,
@@ -393,7 +393,7 @@ impl UtxoStore {
     ) -> Result<Vec<UtxoId>, Error> {
         let mut cursor = db_txn.open_ro_cursor(self.subaddress_id_to_utxo_id)?;
         cursor
-            .iter_dup_of(&subaddress_id.to_vec())
+            .iter_dup_of(subaddress_id.to_vec())
             .map(|result| {
                 result
                     .map_err(Error::from)
@@ -586,7 +586,7 @@ mod test {
                     ) {
                         Ok(_) => panic!("unexpected success"),
                         Err(Error::DuplicateUnspentTxOut) => {}
-                        Err(err) => panic!("unexpected error {:?}", err),
+                        Err(err) => panic!("unexpected error {err:?}"),
                     }
                 }
             }

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -248,7 +248,7 @@ mod tests {
         match msg.verify_signature() {
             Ok(_) => panic!("Signature verification should fail"),
             Err(ConsensusMsgError::SignatureError(_)) => {}
-            Err(e) => panic!("Sigature failed with unexpected error {:?}", e),
+            Err(e) => panic!("Sigature failed with unexpected error {e:?}"),
         }
     }
 
@@ -298,7 +298,7 @@ mod tests {
         match VerifiedConsensusMsg::try_from(msg) {
             Ok(_) => panic!("Signature verification should fail"),
             Err(ConsensusMsgError::SignatureError(_)) => {}
-            Err(e) => panic!("Sigature failed with unexpected error {:?}", e),
+            Err(e) => panic!("Sigature failed with unexpected error {e:?}"),
         }
     }
 }

--- a/peers/src/threaded_broadcaster.rs
+++ b/peers/src/threaded_broadcaster.rs
@@ -274,7 +274,7 @@ impl PeerThread {
 
         let join_handle = Some(
             thread::Builder::new()
-                .name(format!("{}", conn))
+                .name(format!("{conn}"))
                 .spawn(move || {
                     Self::thread_entrypoint(conn, retry_policy, receiver, logger);
                 })
@@ -397,7 +397,7 @@ impl PeerThread {
 
         let retry_iterator = retry_policy.get_delay_iterator().with_deadline(deadline);
 
-        match conn.send_consensus_msg(&*arc_msg, retry_iterator) {
+        match conn.send_consensus_msg(&arc_msg, retry_iterator) {
             Ok(resp) => match resp.get_result() {
                 ConsensusMsgResult::Ok => {}
                 ConsensusMsgResult::UnknownPeer => log::info!(

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -294,7 +294,7 @@ mod peer_manager_tests {
             // Get blocks 25,26,27. These are entirely out of range, so should return an
             // error.
             if let Ok(blocks) = mock_peer.fetch_blocks(25..28) {
-                println!("Blocks: {:?}", blocks);
+                println!("Blocks: {blocks:?}");
                 panic!();
             }
         }
@@ -407,11 +407,8 @@ mod threaded_broadcaster_tests {
         let peer_manager =
             ConnectionManager::new(vec![peer2.clone(), peer3.clone()], logger.clone());
 
-        let mut broadcaster = ThreadedBroadcaster::new(
-            &peer_manager,
-            &FibonacciRetryPolicy::default(),
-            logger.clone(),
-        );
+        let mut broadcaster =
+            ThreadedBroadcaster::new(&peer_manager, &FibonacciRetryPolicy::default(), logger);
 
         // Initially, nothing is broadcasted to either of our nodes.
         {
@@ -496,11 +493,8 @@ mod threaded_broadcaster_tests {
             logger.clone(),
         );
 
-        let mut broadcaster = ThreadedBroadcaster::new(
-            &peer_manager,
-            &FibonacciRetryPolicy::default(),
-            logger.clone(),
-        );
+        let mut broadcaster =
+            ThreadedBroadcaster::new(&peer_manager, &FibonacciRetryPolicy::default(), logger);
 
         // Initially, nothing is broadcasted to either of our nodes.
         {
@@ -581,7 +575,7 @@ mod threaded_broadcaster_tests {
         let mut broadcaster = ThreadedBroadcaster::new(
             &peer_manager,
             FibonacciRetryPolicy::default().initial_delay(Duration::from_millis(10)),
-            logger.clone(),
+            logger,
         );
 
         // Initially, nothing is broadcasted to either of our nodes.

--- a/sgx/panic/src/lib.rs
+++ b/sgx/panic/src/lib.rs
@@ -11,8 +11,6 @@
 // and rethrowing them, because in Rust those APIs use the Box type.
 #![feature(lang_items)] // for eh_personality
 #![feature(thread_local)]
-// Enable "untagged unions" when we have alloc feature, used in panicking::try
-#![cfg_attr(feature = "alloc", feature(untagged_unions))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/test-vectors/account-keys/build.rs
+++ b/test-vectors/account-keys/build.rs
@@ -131,7 +131,7 @@ fn main() {
                     .map(move |(entropy_hex, mnemonic_text)| {
                         let entropy =
                             hex::decode(*entropy_hex).expect("Could not parse entropy hex");
-                        let mnemonic = Mnemonic::from_phrase(*mnemonic_text, Language::English)
+                        let mnemonic = Mnemonic::from_phrase(mnemonic_text, Language::English)
                             .expect("Could not parse mnemonic string");
 
                         assert_eq!(mnemonic.entropy(), entropy.as_slice());

--- a/test-vectors/tx-out-records/build.rs
+++ b/test-vectors/tx-out-records/build.rs
@@ -85,7 +85,7 @@ fn generate_tx_out_record_data() -> TxOutRecordData {
 
     let recipient_account = AccountKey::random_with_fog(&mut rng);
     let spurious_account = AccountKey::random_with_fog(&mut rng);
-    let enclave = SgxIngestEnclave::<HeapORAMStorageCreator>::new(logger.clone());
+    let enclave = SgxIngestEnclave::<HeapORAMStorageCreator>::new(logger);
 
     let params = IngestEnclaveInitParams {
         responder_id: ResponderId::default(),

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -2845,7 +2845,7 @@ pub mod transaction_builder_tests {
             // Signing should fail if value is not conserved.
             match result {
                 Err(TxBuilderError::RingSignatureFailed(_)) => {} // Expected.
-                _ => panic!("Unexpected result {:?}", result),
+                _ => panic!("Unexpected result {result:?}"),
             }
         }
     }

--- a/transaction/core/src/amount/v1.rs
+++ b/transaction/core/src/amount/v1.rs
@@ -206,8 +206,8 @@ impl MaskedAmountV1 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_VALUE_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_VALUE_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     let scalar = Scalar::from_hash(hasher);
     let mut temp = [0u8; 8];
     temp.copy_from_slice(&scalar.as_bytes()[0..8]);
@@ -222,8 +222,8 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_token_id_mask(shared_secret: &RistrettoPublic) -> u64 {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_TOKEN_ID_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_TOKEN_ID_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     u64::from_le_bytes(hasher.finalize()[0..8].try_into().unwrap())
 }
 
@@ -233,8 +233,8 @@ fn get_token_id_mask(shared_secret: &RistrettoPublic) -> u64 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_BLINDING_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_BLINDING_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }
 

--- a/transaction/core/src/amount/v2.rs
+++ b/transaction/core/src/amount/v2.rs
@@ -113,8 +113,8 @@ impl MaskedAmountV2 {
     /// Get the amount shared secret from the tx out shared secret
     pub fn compute_amount_shared_secret(tx_out_shared_secret: &RistrettoPublic) -> [u8; 32] {
         let mut hasher = Blake2b512::new();
-        hasher.update(&AMOUNT_SHARED_SECRET_DOMAIN_TAG);
-        hasher.update(&tx_out_shared_secret.to_bytes());
+        hasher.update(AMOUNT_SHARED_SECRET_DOMAIN_TAG);
+        hasher.update(tx_out_shared_secret.to_bytes());
         // Safety: Blake2b is a 512-bit (64-byte) hash.
         hasher.finalize()[0..32].try_into().unwrap()
     }

--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -32,15 +32,15 @@ lazy_static! {
 /// Merkle tree hash function for a leaf node.
 pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_LEAF_DOMAIN_TAG);
-    hasher.update(&tx_out.hash());
+    hasher.update(TXOUT_MERKLE_LEAF_DOMAIN_TAG);
+    hasher.update(tx_out.hash());
     hasher.finalize().try_into().unwrap()
 }
 
 /// Merkle tree hash function for an internal node.
 pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_NODE_DOMAIN_TAG);
+    hasher.update(TXOUT_MERKLE_NODE_DOMAIN_TAG);
     hasher.update(left);
     hasher.update(right);
     hasher.finalize().try_into().unwrap()
@@ -49,7 +49,7 @@ pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
 /// Merkle tree Hash function for hashing a "nil" value.
 fn hash_nil() -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_NIL_DOMAIN_TAG);
+    hasher.update(TXOUT_MERKLE_NIL_DOMAIN_TAG);
     hasher.finalize().try_into().unwrap()
 }
 

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -142,7 +142,7 @@ pub mod tests {
 
         match check_range_proofs(&proof, &commitments, &generators(0), &mut rng) {
             Ok(_) => {} // This is expected.
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
     }
 

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -1520,7 +1520,7 @@ mod rct_bulletproofs_tests {
             ) {
                 Err(Error::ValueNotConserved) => {} // Expected
                 Err(e) => {
-                    panic!("Unexpected error {}", e);
+                    panic!("Unexpected error {e}");
                 }
                 _ => panic!("Unexpected success")
             }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -98,7 +98,7 @@ impl fmt::Display for TxHash {
 
 impl fmt::Debug for TxHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Tx#{}", self)
+        write!(f, "Tx#{self}")
     }
 }
 

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -107,8 +107,7 @@ impl From<MemoError> for NewMemoError {
         match src {
             MemoError::Utf8Decoding => Self::Utf8Decoding,
             MemoError::BadLength(byte_len) => Self::BadInputs(format!(
-                "Input of length: {} exceeded max byte length",
-                byte_len
+                "Input of length: {byte_len} exceeded max byte length"
             )),
             MemoError::MaxFeeExceeded(max_fee, attempted_fee) => {
                 Self::MaxFeeExceeded(max_fee, attempted_fee)

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -38,8 +38,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 ) -> TransactionValidationResult<()> {
     if BlockVersion::MAX < block_version {
         return Err(TransactionValidationError::Ledger(format!(
-            "Invalid block version: {}",
-            block_version
+            "Invalid block version: {block_version}"
         )));
     }
 

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -535,8 +535,7 @@ fn test_validate_signature_ok() {
         assert_eq!(
             validate_signature(block_version, &tx, &mut rng),
             Ok(()),
-            "failed at block version: {}",
-            block_version
+            "failed at block version: {block_version}"
         );
     }
 }
@@ -555,7 +554,7 @@ fn test_transaction_signature_err_modified_input() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -577,7 +576,7 @@ fn test_transaction_signature_err_modified_output() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -597,7 +596,7 @@ fn test_transaction_signature_err_modified_fee() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -617,7 +616,7 @@ fn test_transaction_signature_err_modified_token_id() {
         match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -635,7 +634,7 @@ fn test_transaction_signature_err_version_one_as_two() {
         match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -653,7 +652,7 @@ fn test_transaction_signature_err_version_two_as_one() {
         match validate_signature(BlockVersion::ONE, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }

--- a/transaction/extra/src/tx_out_confirmation_number.rs
+++ b/transaction/extra/src/tx_out_confirmation_number.rs
@@ -62,7 +62,7 @@ impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
 impl core::convert::From<&RistrettoPublic> for TxOutConfirmationNumber {
     fn from(shared_secret: &RistrettoPublic) -> Self {
         let mut hasher = Blake2b256::new();
-        hasher.update(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.update(TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
         hasher.update(shared_secret.to_bytes());
         Self(hasher.finalize().into())
     }

--- a/transaction/extra/src/tx_summary_unblinding/report.rs
+++ b/transaction/extra/src/tx_summary_unblinding/report.rs
@@ -87,10 +87,10 @@ impl Display for TxSummaryUnblindingReport {
         let mut current_entity = None;
         for ((entity, tok), val) in self.balance_changes.iter() {
             if Some(entity) != current_entity.as_ref() {
-                writeln!(formatter, "{}:", entity)?;
+                writeln!(formatter, "{entity}:")?;
                 current_entity = Some(entity.clone());
             }
-            writeln!(formatter, "\t{}: {}", *tok, val)?;
+            writeln!(formatter, "\t{}: {val}", *tok)?;
         }
         writeln!(
             formatter,

--- a/transaction/extra/tests/verifier.rs
+++ b/transaction/extra/tests/verifier.rs
@@ -123,7 +123,7 @@ fn test_max_size_tx_payload_sizes() {
     };
 
     assert_eq!(tx.prefix.inputs.len(), MAX_INPUTS as usize);
-    assert_eq!(tx.prefix.inputs[0].proofs.len(), RING_SIZE as usize);
+    assert_eq!(tx.prefix.inputs[0].proofs.len(), { RING_SIZE });
     assert_eq!(tx.prefix.inputs[0].proofs[0].elements.len(), 32);
 
     let tx_wire = encode(&tx);
@@ -165,7 +165,7 @@ fn test_min_size_tx_payload_sizes() {
     };
 
     assert_eq!(tx.prefix.inputs.len(), 1_usize);
-    assert_eq!(tx.prefix.inputs[0].proofs.len(), RING_SIZE as usize);
+    assert_eq!(tx.prefix.inputs[0].proofs.len(), { RING_SIZE });
     assert_eq!(tx.prefix.inputs[0].proofs[0].elements.len(), 32);
 
     let tx_wire = encode(&tx);

--- a/util/b58-decoder/src/bin/main.rs
+++ b/util/b58-decoder/src/bin/main.rs
@@ -57,7 +57,7 @@ fn main() {
         }
 
         Err(err) => {
-            println!("Failed decoding b58 into a known object: {}", err);
+            println!("Failed decoding b58 into a known object: {err}");
             std::process::exit(1);
         }
     }

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -697,14 +697,14 @@ impl Builder {
         let mut command = Command::new(&self.linker);
 
         command
-            .args(&[
+            .args([
                 "-o",
                 unsigned_enclave
                     .to_str()
                     .expect("Invalid UTF-8 in unsigned enclave path"),
             ])
-            .args(&["-z", "relro", "-z", "now", "-z", "noexecstack"])
-            .args(&["--no-undefined", "-nostdlib"]);
+            .args(["-z", "relro", "-z", "now", "-z", "noexecstack"])
+            .args(["--no-undefined", "-nostdlib"]);
 
         let mut config = Config::new();
         config
@@ -736,25 +736,25 @@ impl Builder {
         }
 
         command
-            .args(&[
+            .args([
                 "--whole-archive",
-                &format!("-lsgx_trts{}", sim_postfix),
+                &format!("-lsgx_trts{sim_postfix}"),
                 "--no-whole-archive",
             ])
-            .args(&[
+            .args([
                 "--start-group",
                 "-lsgx_tstdc",
                 "-lsgx_tcxx",
                 "-lsgx_tcrypto",
-                &format!("-lsgx_tservice{}", sim_postfix),
+                &format!("-lsgx_tservice{sim_postfix}"),
                 static_archive
                     .to_str()
                     .expect("Invalid UTF-8 in enclave staticlib filename"),
                 "--end-group",
             ])
-            .args(&["-Bstatic", "-Bsymbolic", "--no-undefined"])
-            .args(&["-pie", "-eenclave_entry", "--export-dynamic"])
-            .args(&["--defsym", "__ImageBase=0"])
+            .args(["-Bstatic", "-Bsymbolic", "--no-undefined"])
+            .args(["-pie", "-eenclave_entry", "--export-dynamic"])
+            .args(["--defsym", "__ImageBase=0"])
             .arg("--gc-sections")
             .arg(format!(
                 "--version-script={}",

--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -10,12 +10,12 @@ use std::{
 /// Get git revision by running `git describe` in a given directory.
 fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
     match Command::new("git")
-        .args(&["describe", "--always", "--dirty=-modified"])
+        .args(["describe", "--always", "--dirty=-modified"])
         .current_dir(current_dir)
         .output()
     {
         Err(err) => {
-            eprintln!("Couldn't run git: {}", err);
+            eprintln!("Couldn't run git: {err}");
             "??????".to_string()
         }
         Ok(proc_output) => {
@@ -40,7 +40,7 @@ fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
 /// Use the GIT_COMMIT environment variable to override this.
 fn get_root_git_commit() -> String {
     if let Ok(result) = env::var("GIT_COMMIT") {
-        eprintln!("GIT_COMMIT from env: {}", result);
+        eprintln!("GIT_COMMIT from env: {result}");
         return result;
     }
 
@@ -115,32 +115,20 @@ fn main() {
     let gen_contents = format!(
         r###"
 // This file is generated
-pub fn git_commit() -> &'static str {{ "{}" }}
-pub fn mobilecoin_git_commit() -> &'static str {{ "{}" }}
-pub fn profile() -> &'static str {{ "{}" }}
-pub fn debug() -> &'static str {{ "{}" }}
-pub fn opt_level() -> &'static str {{ "{}" }}
-pub fn debug_assertions() -> &'static str {{ "{}" }}
-pub fn target_arch() -> &'static str {{ "{}" }}
-pub fn target_os() -> &'static str {{ "{}" }}
-pub fn target_feature() -> &'static str {{ "{}" }}
-pub fn rustflags() -> &'static str {{ "{}" }}
-pub fn sgx_mode() -> &'static str {{ "{}" }}
-pub fn ias_mode() -> &'static str {{ "{}" }}
+pub fn git_commit() -> &'static str {{ "{root_git_commit}" }}
+pub fn mobilecoin_git_commit() -> &'static str {{ "{mobilecoin_git_commit}" }}
+pub fn profile() -> &'static str {{ "{profile}" }}
+pub fn debug() -> &'static str {{ "{debug}" }}
+pub fn opt_level() -> &'static str {{ "{opt_level}" }}
+pub fn debug_assertions() -> &'static str {{ "{debug_assertions}" }}
+pub fn target_arch() -> &'static str {{ "{target_arch}" }}
+pub fn target_os() -> &'static str {{ "{target_os}" }}
+pub fn target_feature() -> &'static str {{ "{target_feature}" }}
+pub fn rustflags() -> &'static str {{ "{rustflags}" }}
+pub fn sgx_mode() -> &'static str {{ "{sgx_mode}" }}
+pub fn ias_mode() -> &'static str {{ "{ias_mode}" }}
 // Note: Please update `build-info/src/lib.rs` if you add more stuff
 "###,
-        root_git_commit,
-        mobilecoin_git_commit,
-        profile,
-        debug,
-        opt_level,
-        debug_assertions,
-        target_arch,
-        target_os,
-        target_feature,
-        rustflags,
-        sgx_mode,
-        ias_mode
     );
 
     // Check the current contents and see if they are different
@@ -151,8 +139,8 @@ pub fn ias_mode() -> &'static str {{ "{}" }}
         out_file.clone().into_os_string().into_string().unwrap()
     );
     if let Ok(current_contents) = fs::read_to_string(out_file.clone()) {
-        eprintln!("current contents:\n{}", current_contents);
-        eprintln!("gen contents:\n{}", gen_contents);
+        eprintln!("current contents:\n{current_contents}");
+        eprintln!("gen contents:\n{gen_contents}");
         if current_contents == gen_contents {
             // Early return, don't cause make to rerun everything
             return;
@@ -162,5 +150,5 @@ pub fn ias_mode() -> &'static str {{ "{}" }}
     // rewrite the file
     let mut file = fs::File::create(out_file).expect("File creation");
     use std::io::Write;
-    write!(&mut file, "{}", gen_contents).expect("File I/O");
+    write!(&mut file, "{gen_contents}").expect("File I/O");
 }

--- a/util/build/info/src/bin/main.rs
+++ b/util/build/info/src/bin/main.rs
@@ -28,7 +28,7 @@ fn main() {
         } else if args[1] == "--all" {
             let mut result = String::new();
             mc_util_build_info::write_report(&mut result).unwrap();
-            print!("{}", result);
+            print!("{result}");
             return;
         }
     }

--- a/util/build/sgx/src/edger8r.rs
+++ b/util/build/sgx/src/edger8r.rs
@@ -163,7 +163,7 @@ impl Edger8r {
         let mut command = Command::new(&self.edger8r_path);
 
         for path in &self.search_paths {
-            command.args(&[
+            command.args([
                 "--search-path",
                 path.as_os_str()
                     .to_str()
@@ -173,16 +173,16 @@ impl Edger8r {
 
         if self.output_kind == OutputKind::Trusted {
             command
-                .arg(&"--trusted")
+                .arg("--trusted")
                 .arg(&self.edl_path)
-                .arg(&"--trusted-dir");
+                .arg("--trusted-dir");
         } else {
             command
-                .arg(&"--untrusted")
+                .arg("--untrusted")
                 .arg(&self.edl_path)
-                .arg(&"--untrusted-dir");
+                .arg("--untrusted-dir");
         }
-        command.arg(&self.out_dir.to_str().expect("Invalid UTF-8 in out dir"));
+        command.arg(self.out_dir.to_str().expect("Invalid UTF-8 in out dir"));
 
         let output = command.output()?;
 
@@ -190,7 +190,7 @@ impl Edger8r {
             Ok(self)
         } else {
             Err(Error::Generate(
-                format!("{:?}", command),
+                format!("{command:?}"),
                 String::from_utf8(output.stdout)?,
                 String::from_utf8(output.stderr)?,
             ))

--- a/util/build/sgx/src/sign.rs
+++ b/util/build/sgx/src/sign.rs
@@ -66,7 +66,7 @@ impl SgxSign {
             .arg("-enclave")
             .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-key")
             .arg(private_key)
             .arg("-out")
@@ -100,7 +100,7 @@ impl SgxSign {
             .arg("-enclave")
             .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-out")
             .arg(output_datfile);
 
@@ -133,17 +133,17 @@ impl SgxSign {
         let mut cmd = Command::new(self.sgx_sign_path.clone());
         cmd.arg("catsig")
             .arg("-enclave")
-            .arg(&unsigned_enclave)
+            .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-key")
-            .arg(&public_key_pem)
+            .arg(public_key_pem)
             .arg("-unsigned")
-            .arg(&gendata_output)
+            .arg(gendata_output)
             .arg("-sig")
-            .arg(&signature)
+            .arg(signature)
             .arg("-out")
-            .arg(&output_enclave);
+            .arg(output_enclave);
 
         if self.ignore_rel_error {
             cmd.arg("-ignore-rel-error");

--- a/util/dump-ledger/src/bin/dump_ledger.rs
+++ b/util/dump-ledger/src/bin/dump_ledger.rs
@@ -29,5 +29,5 @@ fn main() {
 
     let json = dump_ledger(&ledger_db, config.params).expect("failed to dump LedgerDB");
 
-    println!("{}", json);
+    println!("{json}");
 }

--- a/util/ffi/src/ffi_owned_ptr.rs
+++ b/util/ffi/src/ffi_owned_ptr.rs
@@ -55,7 +55,7 @@ impl<T: ?Sized> Drop for FfiOwnedPtr<T> {
         // misuse in unsafe Rust, in C, or a bug in the library.
         debug_assert!(!self.0.is_null());
         unsafe {
-            Box::from_raw(self.0);
+            drop(Box::from_raw(self.0));
         }
     }
 }
@@ -182,7 +182,7 @@ impl<T: ?Sized> Drop for FfiOptOwnedPtr<T> {
     fn drop(&mut self) {
         if !self.0.is_null() {
             unsafe {
-                Box::from_raw(self.0);
+                drop(Box::from_raw(self.0));
             }
         }
     }

--- a/util/generate-sample-ledger/tests/bootstrap.rs
+++ b/util/generate-sample-ledger/tests/bootstrap.rs
@@ -21,11 +21,11 @@ use tempfile::TempDir;
 fn test_exercise_bootstrap() {
     let me = PathBuf::from(args().next().unwrap());
     let bin = me.parent().unwrap().parent().unwrap();
-    println!("bin = {:?}", bin);
+    println!("bin = {bin:?}");
 
     let dir = TempDir::new().unwrap();
     set_current_dir(dir.path()).unwrap();
-    println!("dir = {:?}", dir);
+    println!("dir = {dir:?}");
 
     assert!(Command::new(bin.join("sample-keys"))
         .args(["--num", "5"])

--- a/util/grpc/src/admin_service.rs
+++ b/util/grpc/src/admin_service.rs
@@ -76,10 +76,7 @@ impl AdminService {
 
         let mut response = GetPrometheusMetricsResponse::new();
         response.set_metrics(String::from_utf8(buffer).map_err(|err| {
-            RpcStatus::with_message(
-                RpcStatusCode::INTERNAL,
-                format!("from_utf8 failed: {}", err),
-            )
+            RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("from_utf8 failed: {err}"))
         })?);
         Ok(response)
     }
@@ -95,7 +92,7 @@ impl AdminService {
         mc_util_build_info::write_report(&mut build_info_json).map_err(|err| {
             RpcStatus::with_message(
                 RpcStatusCode::INTERNAL,
-                format!("write_report failed: {}", err),
+                format!("write_report failed: {err}"),
             )
         })?;
 

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -231,7 +231,7 @@ mod test {
                 .authenticate_metadata(&metadata_builder.build())
                 .is_ok()
             {
-                panic!("Unexpected success with header {:?}", test_header_value);
+                panic!("Unexpected success with header {test_header_value:?}");
             }
         }
 
@@ -276,7 +276,7 @@ mod test {
                 .authenticate_metadata(&metadata_builder.build())
                 .is_ok()
             {
-                panic!("Unexpected success with header {:?}", test_header_value);
+                panic!("Unexpected success with header {test_header_value:?}");
             }
         }
 

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -59,7 +59,7 @@ impl<TP: TimeProvider> Authenticator for TokenAuthenticator<TP> {
         if !self.is_valid_time(timestamp)? {
             return Err(AuthenticatorError::ExpiredAuthorizationToken);
         }
-        if !self.is_valid_signature(&format!("{}:{}", username, timestamp), signature)? {
+        if !self.is_valid_signature(&format!("{username}:{timestamp}"), signature)? {
             return Err(AuthenticatorError::InvalidAuthorizationToken);
         }
         Ok(credentials.username)
@@ -154,7 +154,7 @@ impl<TP: TimeProvider> TokenBasicCredentialsGenerator<TP> {
             .since_epoch()
             .map_err(|_| TokenBasicCredentialsGeneratorError::TimeProvider)?
             .as_secs();
-        let prefix = format!("{}:{}", user_id, current_time_seconds);
+        let prefix = format!("{user_id}:{current_time_seconds}");
 
         let mut mac = Hmac::<Sha256>::new_from_slice(&self.shared_secret)
             .map_err(|_| TokenBasicCredentialsGeneratorError::InvalidHmacKey)?;

--- a/util/grpc/src/chain_id.rs
+++ b/util/grpc/src/chain_id.rs
@@ -15,7 +15,7 @@ pub fn check_request_chain_id(server_chain_id: &str, ctx: &RpcContext) -> Result
         if header == CHAIN_ID_GRPC_HEADER && server_chain_id.as_bytes() != value {
             return Err(RpcStatus::with_message(
                 RpcStatusCode::FAILED_PRECONDITION,
-                format!("{} '{}'", CHAIN_ID_MISMATCH_ERR_MSG, server_chain_id),
+                format!("{CHAIN_ID_MISMATCH_ERR_MSG} '{server_chain_id}'"),
             ));
         }
     }

--- a/util/grpc/src/server_cert_reloader.rs
+++ b/util/grpc/src/server_cert_reloader.rs
@@ -182,7 +182,7 @@ mod tests {
             .build();
         let ch = ChannelBuilder::new(env)
             .override_ssl_target(ssl_target)
-            .secure_connect(&format!("localhost:{}", port), cred);
+            .secure_connect(&format!("localhost:{port}"), cred);
         HealthClient::new(ch)
     }
 
@@ -198,10 +198,10 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC server.
-        let (_server, port) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server, port) = create_test_server(&cert_file, &key_file, logger);
 
         // Connect the server whose CN is "www.server1.com" with the correct
         // certificate.
@@ -235,7 +235,7 @@ mod tests {
         // Replace server1 certificates with server2. This should trigger the reloading
         // mechanism.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {
@@ -275,10 +275,10 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC server.
-        let (_server, port) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server, port) = create_test_server(&cert_file, &key_file, logger);
 
         // Sanity that the server works.
         let client1 = create_test_client(&server1_cert, "www.server1.com", port);
@@ -318,11 +318,11 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC servers.
         let (_server1, port1) = create_test_server(&cert_file, &key_file, logger.clone());
-        let (_server2, port2) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server2, port2) = create_test_server(&cert_file, &key_file, logger);
 
         // Sanity that the servers works.
         let client1 = create_test_client(&server1_cert, "www.server1.com", port1);
@@ -339,7 +339,7 @@ mod tests {
 
         // Replace server1 certificates with server2.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {
@@ -375,7 +375,7 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Create a listener URI.
         let port: u16 = 6544;
@@ -407,7 +407,7 @@ mod tests {
 
         // Replace server1 certificates with server2.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {

--- a/util/host-cert/src/lib.rs
+++ b/util/host-cert/src/lib.rs
@@ -39,7 +39,7 @@ const SSL_CERT_EXTENSIONS: &[&str] = &["pem", "crt"];
 /// would be used.
 fn read_cert_dir_contents(dirname: OsString) -> Result<Vec<u8>, String> {
     let entries = fs::read_dir(&dirname)
-        .map_err(|e| format!("Failed reading directory {:?}: {:?}", dirname, e))?;
+        .map_err(|e| format!("Failed reading directory {dirname:?}: {e:?}"))?;
 
     let mut retval = Vec::<u8>::with_capacity(INITIAL_BUNDLE_CAPACITY);
     let mut errors = Vec::<String>::new();
@@ -135,25 +135,22 @@ pub fn read_ca_bundle(ca_bundle: Option<PathBuf>) -> Result<Vec<u8>, String> {
                             }
 
                             Err(format!(
-                                "No certificate found in {:?} or {:?}",
-                                SSL_CERT_FILES, SSL_CERT_DIRS
+                                "No certificate found in {SSL_CERT_FILES:?} or {SSL_CERT_DIRS:?}"
                             ))
                         },
                         read_cert_dir_contents,
                     )
                 },
-                |path| {
-                    fs::read(path.clone()).map_err(|e| format!("Error reading {:?}: {:?}", path, e))
-                },
+                |path| fs::read(path.clone()).map_err(|e| format!("Error reading {path:?}: {e:?}")),
             )
         },
         |path| {
             if path.is_dir() {
                 read_cert_dir_contents(OsString::from(path))
             } else if path.is_file() {
-                fs::read(path.clone()).map_err(|e| format!("Error reading {:?}: {:?}", path, e))
+                fs::read(path.clone()).map_err(|e| format!("Error reading {path:?}: {e:?}"))
             } else {
-                Err(format!("{:?} is not a file or directory", path))
+                Err(format!("{path:?} is not a file or directory"))
             }
         },
     )

--- a/util/keyfile/src/bin/keygen_main.rs
+++ b/util/keyfile/src/bin/keygen_main.rs
@@ -42,7 +42,7 @@ fn main() {
     let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)
         .expect("Could not create mnemonic from entropy");
 
-    println!("Writing to {:?}", path);
+    println!("Writing to {path:?}");
 
     keygen::write_keyfiles(
         path,

--- a/util/keyfile/src/bin/main.rs
+++ b/util/keyfile/src/bin/main.rs
@@ -14,21 +14,21 @@ use std::{
 fn print_keyfile_bytes(bytes: &[u8]) {
     let acct_key =
         if let Ok(identity) = mc_util_keyfile::read_root_entropy_keyfile_data(Cursor::new(bytes)) {
-            println!("Identity: {:?}", identity);
+            println!("Identity: {identity:?}");
             AccountKey::from(&identity)
         } else {
             mc_util_keyfile::read_keyfile_data(Cursor::new(bytes))
                 .expect("Could not parse key file as either mnemonic or legacy entropy")
         };
 
-    println!("{:?}", acct_key);
+    println!("{acct_key:?}");
 }
 
 fn main() {
     let mut n_files = 0usize;
     for path in env::args().skip(1) {
         print_keyfile_bytes(
-            &fs::read(path.clone()).unwrap_or_else(|_| panic!("Could not read file '{}'", path)),
+            &fs::read(path.clone()).unwrap_or_else(|_| panic!("Could not read file '{path}'")),
         );
         n_files += 1;
     }

--- a/util/keyfile/src/config.rs
+++ b/util/keyfile/src/config.rs
@@ -42,7 +42,7 @@ fn load_spki_from_pemfile(src: &str) -> Result<Vec<u8>, String> {
             .map_err(|e| e.to_string())?
             .contents,
     )
-    .map_err(|e| format!("{:?}", e))
+    .map_err(|e| format!("{e:?}"))
     .map(|cert| cert.subject_public_key_info().spki().to_vec())
 }
 

--- a/util/keyfile/src/error.rs
+++ b/util/keyfile/src/error.rs
@@ -39,25 +39,25 @@ impl From<AccountKeyError> for Error {
 
 impl From<ProstEncodeError> for Error {
     fn from(src: ProstEncodeError) -> Error {
-        Error::Encode(format!("{}", src))
+        Error::Encode(format!("{src}"))
     }
 }
 
 impl From<ProstDecodeError> for Error {
     fn from(src: ProstDecodeError) -> Error {
-        Error::Encode(format!("{}", src))
+        Error::Encode(format!("{src}"))
     }
 }
 
 impl From<IoError> for Error {
     fn from(src: IoError) -> Error {
-        Error::Io(format!("{}", src))
+        Error::Io(format!("{src}"))
     }
 }
 
 impl From<JsonError> for Error {
     fn from(src: JsonError) -> Error {
-        Error::Json(format!("{}", src))
+        Error::Json(format!("{src}"))
     }
 }
 

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -60,7 +60,7 @@ pub fn write_keyfiles<P: AsRef<Path>>(
 
 /// Helper: Make i'th user's keyfiles' names
 fn keyfile_name(i: usize) -> String {
-    format!("account_keys_{}", i)
+    format!("account_keys_{i}")
 }
 
 /// Write the sequence of default user key files used in tests and demos

--- a/util/keyfile/src/mnemonic_acct.rs
+++ b/util/keyfile/src/mnemonic_acct.rs
@@ -52,7 +52,7 @@ impl TryFrom<UncheckedMnemonicAccount> for AccountKey {
             src.mnemonic.ok_or(Error::NoMnemonic)?.as_str(),
             Language::English,
         )
-        .map_err(|e| Error::InvalidMnemonic(format!("{}", e)))?;
+        .map_err(|e| Error::InvalidMnemonic(format!("{e}")))?;
         let slip10 = mnemonic.derive_slip10_key(src.account_index.ok_or(Error::NoAccountIndex)?);
         Ok(AccountKey::from(slip10).with_fog(
             src.fog_report_url.unwrap_or_default().as_str(),

--- a/util/keyfile/tests/b58-length.rs
+++ b/util/keyfile/tests/b58-length.rs
@@ -47,11 +47,10 @@ fn test_b58_pub_length() {
         for domain_len in 0..DOMAIN_LIMIT {
             assert!(
                 !test_b58pub_length(domain_len, 10, &mut rng),
-                "B58 address limit exceeded for domain length = {}",
-                domain_len
+                "B58 address limit exceeded for domain length = {domain_len}"
             );
         }
 
-        assert!(test_b58pub_length(DOMAIN_LIMIT, 10, &mut rng), "Domain limit is not computed correctly, we didn't exceed the limit with urls of length {}", DOMAIN_LIMIT);
+        assert!(test_b58pub_length(DOMAIN_LIMIT, 10, &mut rng), "Domain limit is not computed correctly, we didn't exceed the limit with urls of length {DOMAIN_LIMIT}");
     })
 }

--- a/util/keyfile/tests/bin-determinism.rs
+++ b/util/keyfile/tests/bin-determinism.rs
@@ -37,7 +37,7 @@ fn sample_keys_determinism() {
     let tempdir_path = tempdir.path().to_str().expect("tempdir was not UTF-8");
 
     assert!(Command::new(sample_keys_bin.clone())
-        .args(&[
+        .args([
             "--output-dir",
             tempdir_path,
             "--num",
@@ -56,7 +56,7 @@ fn sample_keys_determinism() {
     let tempdir2 = tempfile::tempdir().expect("Could not create tempdir2");
     let tempdir2_path = tempdir2.path().to_str().expect("tempdir2 was not UTF-8");
     assert!(Command::new(sample_keys_bin)
-        .args(&[
+        .args([
             "--output-dir",
             tempdir2_path,
             "--num",
@@ -73,7 +73,7 @@ fn sample_keys_determinism() {
         .success());
 
     assert!(Command::new("diff")
-        .args(&["-rq", tempdir_path, tempdir2_path])
+        .args(["-rq", tempdir_path, tempdir2_path])
         .status()
         .expect("Diff reported unexpected differences, this indicates nondeterminism")
         .success());
@@ -104,7 +104,7 @@ fn sample_keys_determinism2() {
     let tempdir_path = tempdir.path().to_str().expect("tempdir was not UTF-8");
 
     assert!(Command::new(sample_keys_bin.clone())
-        .args(&[
+        .args([
             "--output-dir",
             tempdir_path,
             "--num",
@@ -123,7 +123,7 @@ fn sample_keys_determinism2() {
     let tempdir2 = tempfile::tempdir().expect("Could not create tempdir2");
     let tempdir2_path = tempdir2.path().to_str().expect("tempdir2 was not UTF-8");
     assert!(Command::new(sample_keys_bin)
-        .args(&[
+        .args([
             "--output-dir",
             tempdir2_path,
             "--num",
@@ -140,7 +140,7 @@ fn sample_keys_determinism2() {
         .success());
     // exclude 1, any character, ., in order to exclude numbers 10 - 19
     assert!(Command::new("diff")
-        .args(&[
+        .args([
             "-rq",
             "--exclude=*1[0123456789].*",
             tempdir_path,

--- a/util/metrics/src/json_encoder.rs
+++ b/util/metrics/src/json_encoder.rs
@@ -45,11 +45,11 @@ impl Encoder for JsonEncoder {
                         // write the sum and counts
                         let h = m.get_histogram();
                         export_me.insert(
-                            flatten_metric_with_labels(&format!("{}_count", name), m),
+                            flatten_metric_with_labels(&format!("{name}_count"), m),
                             h.get_sample_count() as f64,
                         );
                         export_me.insert(
-                            flatten_metric_with_labels(&format!("{}_sum", name), m),
+                            flatten_metric_with_labels(&format!("{name}_sum"), m),
                             h.get_sample_sum(),
                         );
                     }
@@ -96,7 +96,7 @@ fn flatten_metric_with_labels(name: &str, metric: &Metric) -> String {
             .collect();
         let values = values.join(".");
         if !values.is_empty() {
-            format!("{}.{}", res, values)
+            format!("{res}.{values}")
         } else {
             res
         }

--- a/util/metrics/src/op_counters.rs
+++ b/util/metrics/src/op_counters.rs
@@ -26,38 +26,38 @@ impl OpMetrics {
         let name_str = name.into();
         OpMetrics {
             counters: IntCounterVec::new(
-                Opts::new(name_str.clone(), format!("Counters for {}", name_str)),
+                Opts::new(name_str.clone(), format!("Counters for {name_str}")),
                 &["op"],
             )
             .unwrap(),
             peer_counters: IntCounterVec::new(
                 Opts::new(
-                    format!("{}_peer_counter", name_str),
-                    format!("Counters for each remote peer of {}", name_str),
+                    format!("{name_str}_peer_counter"),
+                    format!("Counters for each remote peer of {name_str}"),
                 ),
                 &["op", "remote_responder_id"],
             )
             .unwrap(),
             gauges: IntGaugeVec::new(
                 Opts::new(
-                    format!("{}_gauge", name_str),
-                    format!("Gauges for {}", name_str),
+                    format!("{name_str}_gauge"),
+                    format!("Gauges for {name_str}"),
                 ),
                 &["op"],
             )
             .unwrap(),
             peer_gauges: IntGaugeVec::new(
                 Opts::new(
-                    format!("{}_peer_gauge", name_str),
-                    format!("Gauges for each remote peer of {}", name_str),
+                    format!("{name_str}_peer_gauge"),
+                    format!("Gauges for each remote peer of {name_str}"),
                 ),
                 &["op", "remote_responder_id"],
             )
             .unwrap(),
             histograms: HistogramVec::new(
                 HistogramOpts::new(
-                    format!("{}_duration", name_str),
-                    format!("Histogram values for {}", name_str),
+                    format!("{name_str}_duration"),
+                    format!("Histogram values for {name_str}"),
                 ),
                 &["op"],
             )

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -95,7 +95,9 @@ impl ServiceMetrics {
             .unwrap(),
         }
     }
+}
 
+impl ServiceMetrics {
     /// Register Prometheus metrics family
     pub fn new_and_registered() -> ServiceMetrics {
         let svc = ServiceMetrics::default();

--- a/util/parse/src/lib.rs
+++ b/util/parse/src/lib.rs
@@ -24,9 +24,9 @@ pub fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseI
 /// as other stuff.
 pub fn load_css_file(filename: &str) -> Result<CssSignature, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
     let signature = CssSignature::try_from(&bytes[..])
-        .map_err(|err| format!("Failed parsing CSS file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing CSS file '{filename}': {err}"))?;
     Ok(signature)
 }
 

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -576,7 +576,7 @@ mod tests {
     fn twenty_bytes_debug_hex() {
         let value = TwentyBytes { bytes: [0xBA; 20] };
         assert_eq!(
-            format!("{:?}", value),
+            format!("{value:?}"),
             "TwentyBytes(babababababababababababababababababababa)"
         );
     }
@@ -585,7 +585,7 @@ mod tests {
     fn twenty_bytes_display_hex() {
         let value = TwentyBytes { bytes: [0xBA; 20] };
         assert_eq!(
-            format!("{}", value),
+            format!("{value}"),
             "babababababababababababababababababababa"
         );
     }

--- a/util/seeded-ed25519-key-gen/src/main.rs
+++ b/util/seeded-ed25519-key-gen/src/main.rs
@@ -30,5 +30,5 @@ fn main() {
         tag: String::from("PRIVATE KEY"),
         contents: der_bytes,
     });
-    println!("{}", pem);
+    println!("{pem}");
 }

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -140,8 +140,7 @@ pub fn round_trip_message<SRC: Message + Eq + Default, DEST: protobuf::Message>(
 
     assert_eq!(
         *prost_val, final_val,
-        "Round-trip check failed!\nprost: {:?}\nprotobuf: {:?}",
-        prost_val, final_val
+        "Round-trip check failed!\nprost: {prost_val:?}\nprotobuf: {final_val:?}"
     );
 }
 
@@ -193,7 +192,7 @@ mod json_u64_tests {
     #[test]
     fn test_serialize_jsonu64_struct() {
         let the_struct = TestStruct {
-            nums: (&[0, 1, 2, u64::MAX]).iter().map(Into::into).collect(),
+            nums: [0, 1, 2, u64::MAX].iter().map(Into::into).collect(),
             block: JsonU64(u64::MAX - 1),
         };
         let serialized = serialize(&the_struct).unwrap();

--- a/util/test-helper/src/bin/generate_account_keys.rs
+++ b/util/test-helper/src/bin/generate_account_keys.rs
@@ -45,8 +45,8 @@ fn main() {
         } else {
             print!(" ");
         }
-        println!("{{\"vpk\":{:?},", vpk);
-        println!("   \"spk\":{:?}}}", spk);
+        println!("{{\"vpk\":{vpk:?},");
+        println!("   \"spk\":{spk:?}}}");
         remaining -= 1;
         i += 1;
     }

--- a/util/test-vector/src/lib.rs
+++ b/util/test-vector/src/lib.rs
@@ -15,16 +15,16 @@ pub trait TestVector: Sized {
     {
         let filename = format!("{}/{}/{}.jsonl", dir, Self::MODULE_SUBDIR, Self::FILE_NAME);
         let file = File::open(filename.clone())
-            .unwrap_or_else(|_| panic!("cannot read file '{}'", filename));
+            .unwrap_or_else(|_| panic!("cannot read file '{filename}'"));
 
         BufReader::new(file)
             .lines()
             .enumerate()
             .map(|(i, line)| {
-                let line = line
-                    .unwrap_or_else(|_| panic!("cannot read line {} of file '{}'", i, filename));
+                let line =
+                    line.unwrap_or_else(|_| panic!("cannot read line {i} of file '{filename}'"));
                 serde_json::from_str(&line)
-                    .unwrap_or_else(|_| panic!("cannot parse line {} of file '{}'", i, filename))
+                    .unwrap_or_else(|_| panic!("cannot parse line {i} of file '{filename}'"))
             })
             .collect()
     }

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -335,10 +335,9 @@ mod consensus_peer_uri_tests {
 
         let mut seeded_rng: FixedRng = SeedableRng::from_seed([0u8; 32]);
         let signer_key = Ed25519Pair::from_random(&mut seeded_rng);
-        let hex_pubkey = hex::encode(&signer_key.public_key());
+        let hex_pubkey = hex::encode(signer_key.public_key());
         let uri = PeerUri::from_str(&format!(
-            "mcp://node1.test.mobilecoin.com/?consensus-msg-key={}",
-            hex_pubkey
+            "mcp://node1.test.mobilecoin.com/?consensus-msg-key={hex_pubkey}"
         ))
         .unwrap();
         assert_eq!(

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -175,7 +175,7 @@ pub trait ConnectionUri:
     fn tls_chain(&self) -> StdResult<Vec<u8>, String> {
         let path = self.tls_chain_path()?;
         std::fs::read(path.clone())
-            .map_err(|e| format!("Failed reading TLS chain from {}: {:?}", path, e))
+            .map_err(|e| format!("Failed reading TLS chain from {path}: {e:?}"))
     }
 
     /// Retrieve the TLS key file path to use for this connection.
@@ -188,7 +188,7 @@ pub trait ConnectionUri:
     fn tls_key(&self) -> StdResult<Vec<u8>, String> {
         let path = self.tls_key_path()?;
         std::fs::read(path.clone())
-            .map_err(|e| format!("Failed reading TLS key from {}: {:?}", path, e))
+            .map_err(|e| format!("Failed reading TLS key from {path}: {e:?}"))
     }
 }
 

--- a/watcher/src/bin/db-dump.rs
+++ b/watcher/src/bin/db-dump.rs
@@ -47,7 +47,7 @@ fn main() {
 
     println!("Last synced blocks:");
     for (url, block_index) in last_synced_blocks.iter() {
-        println!("{:width$}: {:?}", url, block_index, width = max_url_len);
+        println!("{url:max_url_len$}: {block_index:?}");
     }
     println!();
 
@@ -66,10 +66,7 @@ fn main() {
                 Ok(block_data) => block_data.signature().map(|sig| *sig.signer()),
                 Err(WatcherDBError::NotFound) => None,
                 Err(err) => {
-                    panic!(
-                        "Failed getting block {}@{}: {}",
-                        tx_src_url, cur_start_index, err
-                    );
+                    panic!("Failed getting block {tx_src_url}@{cur_start_index}: {err}");
                 }
             };
 
@@ -84,7 +81,7 @@ fn main() {
         }
         ranges.push(((cur_start_index, cur_end_index), cur_signer.take()));
 
-        println!("{}", tx_src_url);
+        println!("{tx_src_url}");
         for ((start, end), signer) in ranges.iter() {
             let report_status = display_report_status(&watcher_db, tx_src_url, signer);
 

--- a/watcher/src/block_data_store.rs
+++ b/watcher/src/block_data_store.rs
@@ -93,9 +93,9 @@ impl BlockDataStore {
 
     /// Add a single BlockData that was fetched from `src_url` into the
     /// database.
-    pub fn add_block_data<'env>(
+    pub fn add_block_data(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         block_data: &BlockData,
     ) -> Result<(), WatcherDBError> {
@@ -169,7 +169,7 @@ impl BlockDataStore {
         let first_key_bytes = block_index.to_be_bytes();
 
         let mut results = HashMap::default();
-        for (key_bytes, value_bytes) in cursor.iter_from(&first_key_bytes).filter_map(Result::ok) {
+        for (key_bytes, value_bytes) in cursor.iter_from(first_key_bytes).filter_map(Result::ok) {
             // Try and get the index and tx source url from the database key.
             // Remember that the key is the block index , followed by the source url.
             if key_bytes.len() < first_key_bytes.len() {
@@ -210,9 +210,9 @@ impl BlockDataStore {
     /// that there are no gaps (no blocks were skipped).
     /// It does not remove Block/BlockContents as those might be shared with
     /// other source URLs.
-    pub fn remove_all_for_source_url<'env>(
+    pub fn remove_all_for_source_url(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         last_synced_block_index: u64,
     ) -> Result<(), WatcherDBError> {
@@ -237,9 +237,9 @@ impl BlockDataStore {
         Ok(())
     }
 
-    fn store_block<'env>(
+    fn store_block(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         block: &Block,
     ) -> Result<Vec<u8>, WatcherDBError> {
         let hash = block.digest32::<MerlinTranscript>(b"block").to_vec();
@@ -255,9 +255,9 @@ impl BlockDataStore {
         }
     }
 
-    fn store_block_contents<'env>(
+    fn store_block_contents(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         block_contents: &BlockContents,
     ) -> Result<Vec<u8>, WatcherDBError> {
         let hash: Vec<u8> = block_contents.hash().as_ref().to_vec();

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -99,7 +99,7 @@ impl SourceConfig {
         if !url.ends_with('/') {
             url.push('/');
         }
-        Url::from_str(&url).unwrap_or_else(|err| panic!("invalid url {}: {}", url, err))
+        Url::from_str(&url).unwrap_or_else(|err| panic!("invalid url {url}: {err}"))
     }
 
     /// Get consensus client URL, if available.
@@ -111,7 +111,7 @@ impl SourceConfig {
     pub fn consensus_client_auth_token_secret(&self) -> Option<[u8; 32]> {
         self.consensus_client_auth_token_secret.as_ref().map(|s| {
             hex::FromHex::from_hex(s).unwrap_or_else(|err| {
-                panic!("failed parsing consensus client auth token secret: {}", err)
+                panic!("failed parsing consensus client auth token secret: {err}")
             })
         })
     }

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -83,27 +83,22 @@ impl NodeClient for ConsensusNodeClient {
             credentials_provider,
             logger,
         )
-        .map_err(|err| {
-            format!(
-                "Failed constructing client to connect to {}: {}",
-                node_url, err
-            )
-        })?;
+        .map_err(|err| format!("Failed constructing client to connect to {node_url}: {err}"))?;
 
         client
             .attest()
-            .map_err(|err| format!("Failed attesting {}: {}", node_url, err))
+            .map_err(|err| format!("Failed attesting {node_url}: {err}"))
     }
 
     /// Get the block signer key out of a VerificationReport
     fn get_block_signer(verification_report: &VerificationReport) -> Result<Ed25519Public, String> {
         let report_data = VerificationReportData::try_from(verification_report)
-            .map_err(|err| format!("Failed constructing VerificationReportData: {}", err))?;
+            .map_err(|err| format!("Failed constructing VerificationReportData: {err}"))?;
 
         let report_body = report_data
             .quote
             .report_body()
-            .map_err(|err| format!("Failed getting report body: {}", err))?;
+            .map_err(|err| format!("Failed getting report body: {err}"))?;
 
         let custom_data = report_body.report_data();
         let custom_data_bytes: &[u8] = custom_data.as_ref();
@@ -118,7 +113,7 @@ impl NodeClient for ConsensusNodeClient {
         let signer_bytes = &custom_data_bytes[32..];
 
         let signer_public_key = Ed25519Public::try_from(signer_bytes)
-            .map_err(|err| format!("Unable to construct key: {}", err))?;
+            .map_err(|err| format!("Unable to construct key: {err}"))?;
 
         Ok(signer_public_key)
     }
@@ -659,8 +654,7 @@ mod tests {
 
             if tries == 0 {
                 panic!(
-                    "report not synced: reports_signer2:{:?} reports_signer3:{:?}",
-                    reports_signer2, reports_signer3
+                    "report not synced: reports_signer2:{reports_signer2:?} reports_signer3:{reports_signer3:?}"
                 );
             }
             tries -= 1;

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -383,7 +383,7 @@ impl WatcherDB {
         );
 
         cursor
-            .iter_dup_of(&key_bytes)
+            .iter_dup_of(key_bytes)
             .map(|result| {
                 let (key_bytes2, value_bytes) = result?;
                 // Sanity check.
@@ -574,7 +574,7 @@ impl WatcherDB {
         let mut cursor = db_txn.open_ro_cursor(self.config)?;
 
         cursor
-            .iter_dup_of(&CONFIG_DB_KEY_TX_SOURCE_URLS)
+            .iter_dup_of(CONFIG_DB_KEY_TX_SOURCE_URLS)
             .filter_map(|r| r.ok())
             .map(|(_db_key, db_value)| bytes_to_url(db_value))
             .collect()
@@ -708,9 +708,9 @@ impl WatcherDB {
 
     /// A helper for writing a single (src_url, signer) -> VerificationReport
     /// entry in the database.
-    fn write_verification_report<'env>(
+    fn write_verification_report(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         signer: &Ed25519Public,
         verification_report: Option<&VerificationReport>,
@@ -900,9 +900,9 @@ impl WatcherDB {
     /// Note that this method is not exposed outside of this object. It is used
     /// inside `add_block_signature` to ensure all block signers get queued
     /// up automatically.
-    fn queue_verification_report_poll<'env>(
+    fn queue_verification_report_poll(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         expected_block_signer: &Ed25519Public,
     ) -> Result<(), WatcherDBError> {
@@ -970,9 +970,9 @@ impl WatcherDB {
     }
 
     /// Remove a single entry from the verification report polling queue
-    fn remove_verification_report_poll_from_queue<'env>(
+    fn remove_verification_report_poll_from_queue(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         block_signer: &Ed25519Public,
     ) -> Result<(), WatcherDBError> {
@@ -1124,7 +1124,7 @@ pub mod tests {
         let url1 = Url::parse("http://www.my_url1.com").unwrap();
         let url2 = Url::parse("http://www.my_url2.com").unwrap();
         let urls = [url1, url2];
-        let watcher_db = setup_watcher_db(&urls, logger.clone());
+        let watcher_db = setup_watcher_db(&urls, logger);
 
         let blocks = setup_blocks();
 
@@ -1202,7 +1202,7 @@ pub mod tests {
     // Config URL storage should behave as expected.
     #[test_with_logger]
     fn test_config_urls(logger: Logger) {
-        let watcher_db = setup_watcher_db(&[], logger.clone());
+        let watcher_db = setup_watcher_db(&[], logger);
 
         // Initially, the configuration is empty.
         assert!(watcher_db
@@ -1849,7 +1849,7 @@ pub mod tests {
 
         let blocks_data = setup_blocks();
 
-        let watcher_db = setup_watcher_db(&urls, logger.clone());
+        let watcher_db = setup_watcher_db(&urls, logger);
 
         // Removing a URL that has no data should work.
         watcher_db.remove_all_for_source_url(&url1).unwrap();


### PR DESCRIPTION
### Motivation
The repo is currently using  of the `nightly-2022-04-29` version of rust. This is problematic because it prevents us from using some of the latest features (e.g. #2965). This PR makes some updates  and fixes a few clippy errors such as:
- [Inline text formatting](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)


If you see any instances of changes outside of those outlined above, feel free to leave a comment and I'll double check that it should be included.

### Future Work
* Actually update rust in a separate PR and ignore the`result_large_err` lint
* Update repos that use mobilecoin.git as a submodule.
