### PR TITLE
Remove cd triggers for PRs, main and master branches

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -10,19 +10,11 @@ env:
   RELEASE_3X_TAG: v3.0.0-dev
 
 on:
-  pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches:
-    - master
-    - main
     - feature/*
-    - release/*
     tags:
       - v[0-9]+*
-    paths-ignore:
-    - '**.md'
 
 # don't run more than one at a time for a branch/tag
 concurrency:
@@ -467,34 +459,10 @@ jobs:
 ###############################################################
 # Clean up deployments
 ###############################################################
-# we keep master and feature/*
-# run on pr, run on tag, run on release/*.
-# break this up because 4 or 5 part boolean logic is hard with GHA basic statements.
-# Yes this is less DRY, but way more readable and easier to follow.
-  cleanup-after-pr:
-    if: github.event_name == 'pull_request'
-    needs:
-    - test-current-bv3-release
-    - generate-metadata
-    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
-    with:
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      delete_namespace: true
-    secrets: inherit
-
+# we keep feature/*
+# run on tag
   cleanup-after-tag:
     if: github.ref_type == 'tag'
-    needs:
-    - test-current-bv3-release
-    - generate-metadata
-    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
-    with:
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      delete_namespace: true
-    secrets: inherit
-
-  cleanup-after-release-branch:
-    if: github.ref_type == 'branch' && startsWith('release/', github.ref_name)
     needs:
     - test-current-bv3-release
     - generate-metadata

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -13,11 +13,15 @@ on:
   pull_request:
     branches:
     - 'release/**'
+    paths-ignore:
+    - '**.md'
   push:
     branches:
     - 'feature/**'
     tags:
     - 'v[0-9]+*'
+    paths-ignore:
+    - '**.md'
 
 # don't run more than one at a time for a branch/tag
 concurrency:
@@ -486,7 +490,7 @@ jobs:
     secrets: inherit
 
   cleanup-after-pr-to-release-branch:
-    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/')
     needs:
     - test-current-bv3-release
     - generate-metadata

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -10,11 +10,14 @@ env:
   RELEASE_3X_TAG: v3.0.0-dev
 
 on:
+  pull_request:
+    branches:
+    - 'release/**'
   push:
     branches:
-    - feature/*
+    - 'feature/**'
     tags:
-      - v[0-9]+*
+    - 'v[0-9]+*'
 
 # don't run more than one at a time for a branch/tag
 concurrency:
@@ -456,13 +459,34 @@ jobs:
       generate_and_submit_mint_config_tx_uses_json: true
     secrets: inherit
 
+  mobilecoin-cd-complete:
+    # Dummy step for a standard GHA Check that won't change when we update the tests.
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - test-current-bv3-release
+    steps:
+      - name: CD is Complete
+        run: 'true'
+
 ###############################################################
 # Clean up deployments
 ###############################################################
 # we keep feature/*
 # run on tag
+# run on pr to release/*
   cleanup-after-tag:
     if: github.ref_type == 'tag'
+    needs:
+    - test-current-bv3-release
+    - generate-metadata
+    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
+    with:
+      namespace: ${{ needs.generate-metadata.outputs.namespace }}
+      delete_namespace: true
+    secrets: inherit
+
+  cleanup-after-pr-to-release-branch:
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
     needs:
     - test-current-bv3-release
     - generate-metadata

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -35,7 +35,7 @@ done
 # leads to build errors in enclave workspaces, so check it here.
 cargo clippy --all --all-features --all-targets
 
-cargo install cargo-sort
+cargo +stable install cargo-sort
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -31,11 +31,11 @@ while [ "$1" != "" ]; do
   shift
 done
 
+cargo install --version 1.0.9 --locked cargo-sort
+
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
 cargo clippy --all --all-features --all-targets
-
-cargo +stable install cargo-sort
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null


### PR DESCRIPTION
### Motivation

We're finding there's a lot of pain in the dynamic environments at the moment.  We don't want to loose the production like deployment testing, but we're going to roll back the CD requirement for new work going towards master branch.

- Limit trigger to PRs with 'release/*' as the base ref
- remove push trigger on main, master, and release/* branch
- change clean up tasks CD to match new triggers.
- Add mobilecoin-cd-complete dummy job that is just successful if the rest of the workflow is successful.  This way we have a "standard" job with a static name we can use for branch protection checks.