### PR TITLE
v4.0 to v4.1 roll up - Remove cd triggers for PRs, main and master branches (#3029)

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -11,16 +11,15 @@ env:
 
 on:
   pull_request:
+    branches:
+    - 'release/**'
     paths-ignore:
     - '**.md'
   push:
     branches:
-    - master
-    - main
-    - feature/*
-    - release/*
+    - 'feature/**'
     tags:
-      - v[0-9]+*
+    - 'v[0-9]+*'
     paths-ignore:
     - '**.md'
 
@@ -464,24 +463,21 @@ jobs:
       generate_and_submit_mint_config_tx_uses_json: true
     secrets: inherit
 
+  mobilecoin-cd-complete:
+    # Dummy step for a standard GHA Check that won't change when we update the tests.
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - test-current-bv3-release
+    steps:
+      - name: CD is Complete
+        run: 'true'
+
 ###############################################################
 # Clean up deployments
 ###############################################################
-# we keep master and feature/*
-# run on pr, run on tag, run on release/*.
-# break this up because 4 or 5 part boolean logic is hard with GHA basic statements.
-# Yes this is less DRY, but way more readable and easier to follow.
-  cleanup-after-pr:
-    if: github.event_name == 'pull_request'
-    needs:
-    - test-current-bv3-release
-    - generate-metadata
-    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
-    with:
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      delete_namespace: true
-    secrets: inherit
-
+# we keep feature/*
+# run on tag
+# run on pr to release/*
   cleanup-after-tag:
     if: github.ref_type == 'tag'
     needs:
@@ -493,8 +489,8 @@ jobs:
       delete_namespace: true
     secrets: inherit
 
-  cleanup-after-release-branch:
-    if: github.ref_type == 'branch' && startsWith('release/', github.ref_name)
+  cleanup-after-pr-to-release-branch:
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/')
     needs:
     - test-current-bv3-release
     - generate-metadata

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -31,11 +31,11 @@ while [ "$1" != "" ]; do
   shift
 done
 
+cargo install --version 1.0.9 --locked cargo-sort
+
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
 cargo clippy --all --all-features --all-targets
-
-cargo install cargo-sort
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null


### PR DESCRIPTION
Roll up PR ([#3029]) to v4.1

* fix: remove cd triggers for PRs, main, master branches
* fix: lint script to use version and locked cargo-sort install
