### PR TITLE
Clarify that `diesel_cli` must be version 1 for Fog migrations to run correctly

### DIFF
--- a/fog/README.md
+++ b/fog/README.md
@@ -80,7 +80,7 @@ If you don't want to run the tests in docker, you can set up postgres locally, o
 4. Create a PostgreSQL user that matches your current login username:
     `sudo -u postgres createuser --superuser $USER`
 5. You should now be able to create a database: `createdb fog_test`
-6. Install diesel-cli: `cargo install diesel_cli --no-default-features --features postgres`
+6. Install diesel-cli: `cargo install diesel_cli --no-default-features --features postgres --version 1.4.1`
 7. To populate your newly created database with the fog tables, run this:
     `cd src/fog/sql_recovery_db && DATABASE_URL=postgres://$USER@localhost/fog_test diesel migration run`
 8. Fog services that require connecting to the database need the DATABASE_URL environment variable set:


### PR DESCRIPTION
This is a simple update to the Fog README to change the Diesel CLI install instructions to specify version 1.4.1. We expect Diesel version 1.* in our migrations, and by default `cargo install` will select a 2.* version of Diesel.

I chose not to explain that in the README and just change the install instructions, but I'd be open to being told I should explain as well. I also chose not to try to port the migrations to 2.*, as I don't really know anything about Diesel currently.

### Motivation

The current instructions have become wrong over time and will confuse new devs on the project.
