### PR TITLE
always include the masked amount version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [4.1.0]
+
+### Changed
+
+- mobilecoind-json now always includes the MaskedAmount version in its responses ([#3036])
+
 ## [4.0.1]
 
 ### Added

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -501,7 +501,7 @@ impl From<&mc_api::external::TxOut_oneof_masked_amount> for JsonMaskedAmount {
                 commitment: hex::encode(src.get_commitment().get_data()),
                 masked_value: JsonU64(src.get_masked_value()),
                 masked_token_id: hex::encode(src.get_masked_token_id()),
-                version: None,
+                version: Some(1),
             },
             mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(src) => Self {
                 commitment: hex::encode(src.get_commitment().get_data()),


### PR DESCRIPTION
I don't think there's a reason not to include it for v1, since this is a new field it should not break existing mobilecoind-json users, they could just ignore it.