### PR TITLE
release/v4.1 - feat(cd/testing): add ability to manually deploy a test/main network to dev

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -409,7 +409,6 @@ jobs:
     - generate-metadata
     with:
       block_version: 2
-      tokens_json_version: 2
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
       ingest_color: blue
@@ -442,7 +441,6 @@ jobs:
     - generate-metadata
     with:
       block_version: 3
-      tokens_json_version: 2
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -11,16 +11,15 @@ env:
 
 on:
   pull_request:
+    branches:
+    - 'release/**'
     paths-ignore:
     - '**.md'
   push:
     branches:
-    - master
-    - main
-    - feature/*
-    - release/*
+    - 'feature/**'
     tags:
-      - v[0-9]+*
+    - 'v[0-9]+*'
     paths-ignore:
     - '**.md'
 
@@ -464,24 +463,21 @@ jobs:
       generate_and_submit_mint_config_tx_uses_json: true
     secrets: inherit
 
+  mobilecoin-cd-complete:
+    # Dummy step for a standard GHA Check that won't change when we update the tests.
+    runs-on: [self-hosted, Linux, small]
+    needs:
+    - test-current-bv3-release
+    steps:
+      - name: CD is Complete
+        run: 'true'
+
 ###############################################################
 # Clean up deployments
 ###############################################################
-# we keep master and feature/*
-# run on pr, run on tag, run on release/*.
-# break this up because 4 or 5 part boolean logic is hard with GHA basic statements.
-# Yes this is less DRY, but way more readable and easier to follow.
-  cleanup-after-pr:
-    if: github.event_name == 'pull_request'
-    needs:
-    - test-current-bv3-release
-    - generate-metadata
-    uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
-    with:
-      namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      delete_namespace: true
-    secrets: inherit
-
+# we keep feature/*
+# run on tag
+# run on pr to release/*
   cleanup-after-tag:
     if: github.ref_type == 'tag'
     needs:
@@ -493,8 +489,8 @@ jobs:
       delete_namespace: true
     secrets: inherit
 
-  cleanup-after-release-branch:
-    if: github.ref_type == 'branch' && startsWith('release/', github.ref_name)
+  cleanup-after-pr-to-release-branch:
+    if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/')
     needs:
     - test-current-bv3-release
     - generate-metadata

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -26,7 +26,7 @@ on:
         description: "Bootstrap Blockchain from selected version"
         type: choice
         required: true
-        default: v3.0.0-dev
+        default: none
         options:
         - none
         - v1.1.3-dev

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -17,6 +17,20 @@ on:
         description: "Chart Version"
         type: string
         required: true
+      block_version:
+        description: "Consensus block_version"
+        type: string
+        required: true
+        default: '3'
+      bootstrap_version:
+        description: "Bootstrap Blockchain from selected version"
+        type: choice
+        required: true
+        default: v3.0.0-dev
+        options:
+        - none
+        - v1.1.3-dev
+        - v3.0.0-dev
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice
@@ -25,15 +39,6 @@ on:
         options:
         - blue
         - green
-      block_version:
-        description: "Consensus block_version"
-        type: string
-        required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -62,11 +67,38 @@ jobs:
       run: |
         .internal-ci/util/print_details.sh
 
+  bootstrap-v1-1-3-bv0:
+    needs:
+    - list-values
+    if: inputs.bootstrap_version == 'v1.1.3-dev'
+    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+    with:
+      block_version: 0
+      chart_repo: ${{ inputs.chart_repo }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.bootstrap_version }}
+    secrets: inherit
+
+  bootstrap-v3-0-0-bv2:
+    needs:
+    - list-values
+    if: inputs.bootstrap_version == 'v3.0.0-dev'
+    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+    with:
+      block_version: 2
+      chart_repo: ${{ inputs.chart_repo }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.bootstrap_version }}
+    secrets: inherit
+
   deploy:
+    if: '! failure()'
+    needs:
+    - bootstrap-v1-1-3-bv0
+    - bootstrap-v3-0-0-bv2
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       docker_image_org: ${{ inputs.docker_image_org }}
       ingest_color: ${{ inputs.ingest_color }}

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -21,12 +21,7 @@ on:
         description: "Block Version"
         type: string
         required: true
-        default: '2'
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
+        default: '3'
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -41,5 +36,4 @@ jobs:
       version: ${{ inputs.version }}
       chart_repo: ${{ inputs.chart_repo }}
       block_version: "${{ inputs.block_version }}"
-      tokens_json_version: "${{ inputs.tokens_json_version }}"
     secrets: inherit

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -33,11 +33,6 @@ on:
         description: "block_version"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
     secrets:
       DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -58,7 +53,6 @@ jobs:
     uses: ./.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
     with:
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.version }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -20,11 +20,6 @@ on:
         description: "Target Namespace"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       version:
         description: "Chart Version"
         type: string
@@ -100,13 +95,37 @@ on:
         description: "Rancher access token"
         required: true
       DEV_TOKENS_CONFIG_V1_JSON:
-        description: "signed tokens config json"
+        description: "dev signed tokens config json"
         required: true
       DEV_TOKENS_CONFIG_V2_JSON:
-        description: "signed tokens config json"
+        description: "dev signed tokens config json"
         required: true
       IP_INFO_TOKEN:
         description: "ipinfo.io token for authenticated access"
+        required: true
+      MAIN_IAS_KEY:
+        description: "MainNet IAS"
+        required: true
+      MAIN_IAS_SPID:
+        description: "MainNet IAS"
+        required: true
+      MAIN_TOKENS_CONFIG_V1_JSON:
+        description: "MainNet signed tokens config json"
+        required: true
+      MAIN_TOKENS_CONFIG_V2_JSON:
+        description: "MainNet signed tokens config json"
+        required: true
+      TEST_IAS_KEY:
+        description: "TestNet IAS"
+        required: true
+      TEST_IAS_SPID:
+        description: "TestNet IAS"
+        required: true
+      TEST_TOKENS_CONFIG_V1_JSON:
+        description: "TestNet signed tokens config json"
+        required: true
+      TEST_TOKENS_CONFIG_V2_JSON:
+        description: "TestNet signed tokens config json"
         required: true
 
 jobs:
@@ -117,6 +136,7 @@ jobs:
       MINTING_BASE_PATH: .tmp/minting
       SEEDS_BASE_PATH: .tmp/seeds
       VALUES_BASE_PATH: .tmp/values
+      TOKENS_PATH: .tmp/tokens.signed.json
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -188,34 +208,42 @@ jobs:
         src: ${{ env.MINTING_BASE_PATH }}
 
     - name: Write tokens.signed.json
+      env:
+        DEV_TOKENS_CONFIG_V1_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}
+        DEV_TOKENS_CONFIG_V2_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}
+        MAIN_TOKENS_CONFIG_V1_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V1_JSON }}
+        MAIN_TOKENS_CONFIG_V2_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V2_JSON }}
+        TEST_TOKENS_CONFIG_V1_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V1_JSON }}
+        TEST_TOKENS_CONFIG_V2_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V2_JSON }}
       run: |
-        echo "Tokens json version: ${{ inputs.tokens_json_version }}"
+        # Create base path
         mkdir -p "${BASE_PATH}"
-        case "${{ inputs.tokens_json_version }}" in
-          1)
-            echo '${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}' > "${BASE_PATH}/tokens.signed.json"
-            ;;
-          2)
-            echo '${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}' > "${BASE_PATH}/tokens.signed.json"
-            ;;
-          *)
-            echo "Unknown tokens.json version ${{ inputs.tokens_json_version }}"
-            exit 1
-            ;;
-          esac
 
+        # Set dev/main/test tokens file based on semver tag.
+        .internal-ci/util/set_tokens_config_version.sh ${{ inputs.version }} > "${TOKENS_PATH}"
+
+    # We're only deploying to the dev cluster here.
+    # We want to still point at dev values for buckets and certs.
+    # We need "production" IAS creds to start up test/main enclaves.
     - name: Generate environment values file
       env:
-        IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-        IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+        DEV_IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+        DEV_IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+        MAIN_IAS_KEY: ${{ secrets.MAIN_IAS_KEY }}
+        MAIN_IAS_SPID: ${{ secrets.MAIN_IAS_SPID }}
+        TEST_IAS_KEY: ${{ secrets.TEST_IAS_KEY }}
+        TEST_IAS_SPID: ${{ secrets.TEST_IAS_SPID }}
         LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
         LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
         FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
         FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
         IP_INFO_TOKEN: ${{ secrets.IP_INFO_TOKEN }}
       run: |
+        # Create values base path
         mkdir -p "${VALUES_BASE_PATH}"
-        .internal-ci/util/generate_dev_values.sh > "${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml"
+
+        # Generate values for standard dev cluster deployment.
+        .internal-ci/util/generate_dev_values.sh ${{ inputs.version }} > "${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml"
 
     - name: Deploy environment setup
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -20,11 +20,6 @@ on:
         description: "Target Namespace"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       version:
         description: "release version"
         type: string
@@ -46,7 +41,6 @@ jobs:
     with:
       namespace: ${{ inputs.namespace }}
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.internal-ci/util/.shared_functions
+++ b/.internal-ci/util/.shared_functions
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+
+shopt -s extglob
+
+# 1: semver tag
+# returns: network tier dev|test|main
+get_network_tier()
+{
+    case "${1}" in
+        v+([0-9])\.+([0-9])\.+([0-9])-test )
+            echo "Found Test version ${1}" >&2
+            echo "test"
+        ;;
+        v+([0-9])\.+([0-9])\.+([0-9]) )
+            echo "Found Main version ${1}" >&2
+            echo "main"
+        ;;
+        * )
+            echo "Found Development version ${1}" >&2
+            echo "dev"
+        ;;
+    esac
+}
+
+# 1: semver tag
+# returns: major version
+get_major_version()
+{
+    # Trim off version from - "dev" metadata
+    version=${1%%-*}
+    echo "DEBUG: version: $version" >&2
+    # Trim off the "patch"
+    v_major_minor=${version%.*}
+    echo "DEBUG: v_major_minor $v_major_minor" >&2
+    # Trim off the minor
+    v_major=${v_major_minor%.*}
+    echo "DEBUG: v_major $v_major" >&2
+    # Trim off the v
+    major=${v_major#v}
+
+    echo "${major}"
+}
+

--- a/.internal-ci/util/generate_dev_values.sh
+++ b/.internal-ci/util/generate_dev_values.sh
@@ -4,7 +4,12 @@
 # Generates message signer keys and populates other variables.
 
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# shellcheck source=.shared_functions
+source "${location}/.shared_functions"
+
 BASE_PATH=${BASE_PATH:-.tmp}
+TOKENS_PATH=${TOKENS_PATH:-"${BASE_PATH}/tokens.signed.json"}
 
 # generate msg signer keys
 declare -a signer_keys_pub
@@ -21,10 +26,32 @@ done
 
 # Get token config or set empty for older configs.
 tokens_signed_json="{}"
-if [[ -f "${BASE_PATH}/tokens.signed.json" ]]
+if [[ -f "${TOKENS_PATH}" ]]
 then
-  tokens_signed_json=$(cat "${BASE_PATH}/tokens.signed.json")
+  tokens_signed_json=$(cat "${TOKENS_PATH}")
 fi
+
+echo "Get config for network based semver tag" >&2
+network=$(get_network_tier "${1}")
+case "${network}" in
+  test)
+    IAS_KEY=${TEST_IAS_KEY}
+    IAS_SPID=${TEST_IAS_SPID}
+  ;;
+  main)
+    IAS_KEY=${MAIN_IAS_KEY}
+    IAS_SPID=${MAIN_IAS_SPID}
+  ;;
+  dev)
+    IAS_KEY=${DEV_IAS_KEY}
+    IAS_SPID=${DEV_IAS_SPID}
+  ;;
+  *)
+    echo "ERROR: Unknown network ${network}"
+    exit 1;
+  ;;
+esac
+
 
 cat << EOF
 global:

--- a/.internal-ci/util/set_tokens_config_version.sh
+++ b/.internal-ci/util/set_tokens_config_version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+
+# Select the correct tokens file to use based on release version.
+
+set -eu
+
+location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# shellcheck source=.shared_functions
+source "${location}/.shared_functions"
+
+network=$(get_network_tier "${1}")
+major=$(get_major_version "${1}")
+
+echo "Found network ${network}" >&2
+echo "Found major version ${major}" >&2
+
+# 0 - dev use V2
+# 1|2|3 - use V1 - note 1 doesn't consume
+# 4 or greater use v2
+if [[ ${major} -eq 0 ]]
+then
+    version="V2"
+elif [[ ${major} -ge 1 ]] && [[ ${major} -le 3 ]]
+then
+    version="V1"
+elif [[ ${major} -ge 4 ]]
+then
+    version="V2"
+else
+    echo "Major version is invalid? ${1} ${major}" >&2
+    exit 1
+fi
+
+# ^^ upper case network
+token_json="${network^^}_TOKENS_CONFIG_${version}_JSON"
+echo "Using ${token_json}" >&2
+# ! use value as the variable name
+echo "${!token_json}"

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -31,11 +31,11 @@ while [ "$1" != "" ]; do
   shift
 done
 
+cargo install --version 1.0.9 --locked cargo-sort
+
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
 cargo clippy --all --all-features --all-targets
-
-cargo install cargo-sort
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null


### PR DESCRIPTION
### Motivation

Its currently a fiddly process to deploy a main/test signed artifacts to the dev cluster for smoke testing. This improves the process from 1h+ manual effort to 10m of automated "push-button" deployment.

- scripts to detect and set correct signed tokens.json based on version and network tier.
- add option to bootstrap a dispatch deploy from backup.
- update dispatch deploy defaults for v4 release.
- remove need to specify a tokens version.
- add secrets (really configs because the values are not secrets) for testnet/mainnet tokens.json
- add secrets for test/main ias 

This will be promoted to release/v4.1 -> master.