### PR TITLE
Dependabot reviewers and labels update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,8 @@ updates:
     time: "22:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 5
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
@@ -18,10 +16,8 @@ updates:
     time: "23:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
@@ -29,10 +25,8 @@ updates:
     time: "00:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
@@ -40,10 +34,8 @@ updates:
     time: "01:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
@@ -51,10 +43,8 @@ updates:
     time: "02:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -62,3 +52,5 @@ updates:
     time: "03:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
+  reviewers:
+    - "mobilecoinfoundation/coredev"


### PR DESCRIPTION
- Dependabot PRs request reviews from @mobilecoinfoundation/coredev.
- Remove explicit label selection (will be dependencies,rust).

### Motivation

Github now allows automatic assignment to particular users when a group review is requested. I've turned that on for coredev, which means we can request a review from the group, and group members will be tagged automatically.

Additionally, the blocks-v5.0.0 label isn't really proving useful, so I'd rather just remove it, which means we can revert back to dependabot picking "dependencies" and "rust" labels itself.

[Soundtrack of this PR](https://music.youtube.com/playlist?list=OLAK5uy_k2RFXIfn6MsHK3JpYKtXoOlQ_LVK_ltJo&feature=share)
