### PR TITLE
Roll-up v4.1 changes  to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,8 @@ updates:
     time: "22:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 5
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
@@ -18,10 +16,8 @@ updates:
     time: "23:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
@@ -29,10 +25,8 @@ updates:
     time: "00:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
@@ -40,10 +34,8 @@ updates:
     time: "01:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
@@ -51,10 +43,8 @@ updates:
     time: "02:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
+  reviewers:
+    - "mobilecoinfoundation/coredev"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -62,3 +52,5 @@ updates:
     time: "03:00"
     timezone: "America/Los_Angeles"
   open-pull-requests-limit: 2
+  reviewers:
+    - "mobilecoinfoundation/coredev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
   open-pull-requests-limit: 5
   reviewers:
     - "mobilecoinfoundation/coredev"
+  labels:
+    - "blocks-v5.0.0"
+    - "dependencies"
+    - "rust"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
@@ -18,6 +22,10 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
+  labels:
+    - "blocks-v5.0.0"
+    - "dependencies"
+    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
@@ -27,6 +35,10 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
+  labels:
+    - "blocks-v5.0.0"
+    - "dependencies"
+    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
@@ -36,6 +48,10 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
+  labels:
+    - "blocks-v5.0.0"
+    - "dependencies"
+    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
@@ -45,6 +61,10 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
+  labels:
+    - "blocks-v5.0.0"
+    - "dependencies"
+    - "rust"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,6 @@ updates:
   open-pull-requests-limit: 5
   reviewers:
     - "mobilecoinfoundation/coredev"
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
 - package-ecosystem: cargo
   directory: "/consensus/enclave/trusted/"
   schedule:
@@ -22,10 +18,6 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/ingest/enclave/trusted/"
   schedule:
@@ -35,10 +27,6 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/ledger/enclave/trusted/"
   schedule:
@@ -48,10 +36,6 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
 - package-ecosystem: cargo
   directory: "/fog/view/enclave/trusted/"
   schedule:
@@ -61,10 +45,6 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
-  labels:
-    - "blocks-v5.0.0"
-    - "dependencies"
-    - "rust"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -409,7 +409,6 @@ jobs:
     - generate-metadata
     with:
       block_version: 2
-      tokens_json_version: 2
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
       ingest_color: blue
@@ -442,7 +441,6 @@ jobs:
     - generate-metadata
     with:
       block_version: 3
-      tokens_json_version: 2
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -17,6 +17,20 @@ on:
         description: "Chart Version"
         type: string
         required: true
+      block_version:
+        description: "Consensus block_version"
+        type: string
+        required: true
+        default: '3'
+      bootstrap_version:
+        description: "Bootstrap Blockchain from selected version"
+        type: choice
+        required: true
+        default: none
+        options:
+        - none
+        - v1.1.3-dev
+        - v3.0.0-dev
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice
@@ -25,15 +39,6 @@ on:
         options:
         - blue
         - green
-      block_version:
-        description: "Consensus block_version"
-        type: string
-        required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -62,11 +67,38 @@ jobs:
       run: |
         .internal-ci/util/print_details.sh
 
+  bootstrap-v1-1-3-bv0:
+    needs:
+    - list-values
+    if: inputs.bootstrap_version == 'v1.1.3-dev'
+    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+    with:
+      block_version: 0
+      chart_repo: ${{ inputs.chart_repo }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.bootstrap_version }}
+    secrets: inherit
+
+  bootstrap-v3-0-0-bv2:
+    needs:
+    - list-values
+    if: inputs.bootstrap_version == 'v3.0.0-dev'
+    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+    with:
+      block_version: 2
+      chart_repo: ${{ inputs.chart_repo }}
+      namespace: ${{ inputs.namespace }}
+      version: ${{ inputs.bootstrap_version }}
+    secrets: inherit
+
   deploy:
+    if: '! failure()'
+    needs:
+    - bootstrap-v1-1-3-bv0
+    - bootstrap-v3-0-0-bv2
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       docker_image_org: ${{ inputs.docker_image_org }}
       ingest_color: ${{ inputs.ingest_color }}

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -21,12 +21,7 @@ on:
         description: "Block Version"
         type: string
         required: true
-        default: '2'
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
+        default: '3'
       chart_repo:
         description: "Chart Repo URL"
         type: string
@@ -41,5 +36,4 @@ jobs:
       version: ${{ inputs.version }}
       chart_repo: ${{ inputs.chart_repo }}
       block_version: "${{ inputs.block_version }}"
-      tokens_json_version: "${{ inputs.tokens_json_version }}"
     secrets: inherit

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -33,11 +33,6 @@ on:
         description: "block_version"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
     secrets:
       DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -58,7 +53,6 @@ jobs:
     uses: ./.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
     with:
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.version }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -20,11 +20,6 @@ on:
         description: "Target Namespace"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       version:
         description: "Chart Version"
         type: string
@@ -100,13 +95,37 @@ on:
         description: "Rancher access token"
         required: true
       DEV_TOKENS_CONFIG_V1_JSON:
-        description: "signed tokens config json"
+        description: "dev signed tokens config json"
         required: true
       DEV_TOKENS_CONFIG_V2_JSON:
-        description: "signed tokens config json"
+        description: "dev signed tokens config json"
         required: true
       IP_INFO_TOKEN:
         description: "ipinfo.io token for authenticated access"
+        required: true
+      MAIN_IAS_KEY:
+        description: "MainNet IAS"
+        required: true
+      MAIN_IAS_SPID:
+        description: "MainNet IAS"
+        required: true
+      MAIN_TOKENS_CONFIG_V1_JSON:
+        description: "MainNet signed tokens config json"
+        required: true
+      MAIN_TOKENS_CONFIG_V2_JSON:
+        description: "MainNet signed tokens config json"
+        required: true
+      TEST_IAS_KEY:
+        description: "TestNet IAS"
+        required: true
+      TEST_IAS_SPID:
+        description: "TestNet IAS"
+        required: true
+      TEST_TOKENS_CONFIG_V1_JSON:
+        description: "TestNet signed tokens config json"
+        required: true
+      TEST_TOKENS_CONFIG_V2_JSON:
+        description: "TestNet signed tokens config json"
         required: true
 
 jobs:
@@ -117,6 +136,7 @@ jobs:
       MINTING_BASE_PATH: .tmp/minting
       SEEDS_BASE_PATH: .tmp/seeds
       VALUES_BASE_PATH: .tmp/values
+      TOKENS_PATH: .tmp/tokens.signed.json
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -188,34 +208,42 @@ jobs:
         src: ${{ env.MINTING_BASE_PATH }}
 
     - name: Write tokens.signed.json
+      env:
+        DEV_TOKENS_CONFIG_V1_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}
+        DEV_TOKENS_CONFIG_V2_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}
+        MAIN_TOKENS_CONFIG_V1_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V1_JSON }}
+        MAIN_TOKENS_CONFIG_V2_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V2_JSON }}
+        TEST_TOKENS_CONFIG_V1_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V1_JSON }}
+        TEST_TOKENS_CONFIG_V2_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V2_JSON }}
       run: |
-        echo "Tokens json version: ${{ inputs.tokens_json_version }}"
+        # Create base path
         mkdir -p "${BASE_PATH}"
-        case "${{ inputs.tokens_json_version }}" in
-          1)
-            echo '${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}' > "${BASE_PATH}/tokens.signed.json"
-            ;;
-          2)
-            echo '${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}' > "${BASE_PATH}/tokens.signed.json"
-            ;;
-          *)
-            echo "Unknown tokens.json version ${{ inputs.tokens_json_version }}"
-            exit 1
-            ;;
-          esac
 
+        # Set dev/main/test tokens file based on semver tag.
+        .internal-ci/util/set_tokens_config_version.sh ${{ inputs.version }} > "${TOKENS_PATH}"
+
+    # We're only deploying to the dev cluster here.
+    # We want to still point at dev values for buckets and certs.
+    # We need "production" IAS creds to start up test/main enclaves.
     - name: Generate environment values file
       env:
-        IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
-        IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+        DEV_IAS_KEY: ${{ secrets.DEV_IAS_KEY }}
+        DEV_IAS_SPID: ${{ secrets.DEV_IAS_SPID }}
+        MAIN_IAS_KEY: ${{ secrets.MAIN_IAS_KEY }}
+        MAIN_IAS_SPID: ${{ secrets.MAIN_IAS_SPID }}
+        TEST_IAS_KEY: ${{ secrets.TEST_IAS_KEY }}
+        TEST_IAS_SPID: ${{ secrets.TEST_IAS_SPID }}
         LEDGER_AWS_ACCESS_KEY_ID: ${{ secrets.DEV_LEDGER_AWS_ACCESS_KEY_ID }}
         LEDGER_AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_LEDGER_AWS_SECRET_ACCESS_KEY }}
         FOG_REPORT_SIGNING_CERT: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT }}
         FOG_REPORT_SIGNING_CERT_KEY: ${{ secrets.DEV_FOG_REPORT_SIGNING_CERT_KEY }}
         IP_INFO_TOKEN: ${{ secrets.IP_INFO_TOKEN }}
       run: |
+        # Create values base path
         mkdir -p "${VALUES_BASE_PATH}"
-        .internal-ci/util/generate_dev_values.sh > "${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml"
+
+        # Generate values for standard dev cluster deployment.
+        .internal-ci/util/generate_dev_values.sh ${{ inputs.version }} > "${VALUES_BASE_PATH}/mc-core-dev-env-values.yaml"
 
     - name: Deploy environment setup
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -20,11 +20,6 @@ on:
         description: "Target Namespace"
         type: string
         required: true
-      tokens_json_version:
-        description: "The version of the tokens.json file we will generate"
-        type: string
-        default: '1'
-        required: false
       version:
         description: "release version"
         type: string
@@ -46,7 +41,6 @@ jobs:
     with:
       namespace: ${{ inputs.namespace }}
       block_version: ${{ inputs.block_version }}
-      tokens_json_version: ${{ inputs.tokens_json_version }}
       chart_repo: ${{ inputs.chart_repo }}
       version: ${{ inputs.version }}
     secrets: inherit

--- a/.internal-ci/helm/consensus-node-config/values.yaml
+++ b/.internal-ci/helm/consensus-node-config/values.yaml
@@ -63,5 +63,5 @@ global:
   ### Enable haproxy IP blocklist for ingress
   # pattern is the object in the configmap shared between infra-haproxy-blocklist and haproxy kubernetes-ingress
   blocklist:
-    enabled: false
+    enabled: "false"
     pattern: patterns/blocked-countries

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- if .Values.node.client.attest.rateLimits.enabled }}
     {{- toYaml .Values.node.client.attest.rateLimits.annotations | nindent 4 }}
     {{- end }}
-    {{- if (include "consensusNode.blocklist.enabled" .) }}
+    {{- if eq (include "consensusNode.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "consensusNode.blocklist.pattern" . }}
     {{- end }}
     {{- toYaml .Values.node.client.ingress.annotations | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "consensusNode.blocklist.enabled" .) }}
+    {{- if eq (include "consensusNode.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "consensusNode.blocklist.pattern" . }}
     {{- end }}
     {{- toYaml .Values.node.client.ingress.annotations | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "consensusNode.blocklist.enabled" .) }}
+    {{- if eq (include "consensusNode.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "consensusNode.blocklist.pattern" . }}
     {{- end }}
     {{- toYaml .Values.node.peer.ingress.annotations | nindent 4 }}

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -30,7 +30,7 @@ global:
     #     { json }
 
   blocklist:
-    enabled: false
+    enabled: "false"
     pattern: patterns/blocked-countries
 
 ### Enable to launch child chart to create node required configMaps and secrets.

--- a/.internal-ci/helm/fog-services-config/values.yaml
+++ b/.internal-ci/helm/fog-services-config/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ''
 # Shared by all charts in the dependency tree
 global:
   blocklist:
-    enabled: false
+    enabled: "false"
     pattern: patterns/blocked-countries
 
 fogRecoveryDatabaseReader:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" .) }}
+    {{- if eq (include "fogServices.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" . }}
     {{- end }}
     {{ toYaml (tpl .Values.fogLedger.ingress.grpc.annotations . | fromYaml) | nindent 4 }}

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" .) }}
+    {{- if eq (include "fogServices.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" . }}
     {{- end }}
     {{ toYaml (tpl .Values.fogLedger.ingress.http.annotations . | fromYaml) | nindent 4 }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- if $.Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ $.Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" $) }}
+    {{- if eq (include "fogServices.blocklist.enabled" $) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" $ }}
     {{- end }}
     {{- toYaml $.Values.fogReport.ingress.grpc.annotations | nindent 4 }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- if $.Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ $.Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" $) }}
+    {{- if eq (include "fogServices.blocklist.enabled" $) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" $ }}
     {{- end }}
     {{- toYaml $.Values.fogReport.ingress.http.annotations | nindent 4 }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" .) }}
+    {{- if eq (include "fogServices.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" . }}
     {{- end }}
     {{ toYaml (tpl .Values.fogView.ingress.grpc.annotations . | fromYaml) | nindent 4 }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if .Values.global.certManagerClusterIssuer }}
     cert-manager.io/cluster-issuer: {{ .Values.global.certManagerClusterIssuer }}
     {{- end }}
-    {{- if (include "fogServices.blocklist.enabled" .) }}
+    {{- if eq (include "fogServices.blocklist.enabled" .) "true" }}
     haproxy.org/blacklist: {{ include "fogServices.blocklist.pattern" . }}
     {{- end }}
     {{ toYaml (tpl .Values.fogView.ingress.http.annotations . | fromYaml) | nindent 4 }}

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -24,7 +24,7 @@ image:
 global:
   certManagerClusterIssuer: letsencrypt-production-http
   blocklist:
-    enabled: false
+    enabled: "false"
     pattern: patterns/blocked-countries
 
 ### Fog Report Service

--- a/.internal-ci/util/.shared_functions
+++ b/.internal-ci/util/.shared_functions
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+
+shopt -s extglob
+
+# 1: semver tag
+# returns: network tier dev|test|main
+get_network_tier()
+{
+    case "${1}" in
+        v+([0-9])\.+([0-9])\.+([0-9])-test )
+            echo "Found Test version ${1}" >&2
+            echo "test"
+        ;;
+        v+([0-9])\.+([0-9])\.+([0-9]) )
+            echo "Found Main version ${1}" >&2
+            echo "main"
+        ;;
+        * )
+            echo "Found Development version ${1}" >&2
+            echo "dev"
+        ;;
+    esac
+}
+
+# 1: semver tag
+# returns: major version
+get_major_version()
+{
+    # Trim off version from - "dev" metadata
+    version=${1%%-*}
+    echo "DEBUG: version: $version" >&2
+    # Trim off the "patch"
+    v_major_minor=${version%.*}
+    echo "DEBUG: v_major_minor $v_major_minor" >&2
+    # Trim off the minor
+    v_major=${v_major_minor%.*}
+    echo "DEBUG: v_major $v_major" >&2
+    # Trim off the v
+    major=${v_major#v}
+
+    echo "${major}"
+}
+

--- a/.internal-ci/util/generate_dev_values.sh
+++ b/.internal-ci/util/generate_dev_values.sh
@@ -4,7 +4,12 @@
 # Generates message signer keys and populates other variables.
 
 location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# shellcheck source=.shared_functions
+source "${location}/.shared_functions"
+
 BASE_PATH=${BASE_PATH:-.tmp}
+TOKENS_PATH=${TOKENS_PATH:-"${BASE_PATH}/tokens.signed.json"}
 
 # generate msg signer keys
 declare -a signer_keys_pub
@@ -21,10 +26,32 @@ done
 
 # Get token config or set empty for older configs.
 tokens_signed_json="{}"
-if [[ -f "${BASE_PATH}/tokens.signed.json" ]]
+if [[ -f "${TOKENS_PATH}" ]]
 then
-  tokens_signed_json=$(cat "${BASE_PATH}/tokens.signed.json")
+  tokens_signed_json=$(cat "${TOKENS_PATH}")
 fi
+
+echo "Get config for network based semver tag" >&2
+network=$(get_network_tier "${1}")
+case "${network}" in
+  test)
+    IAS_KEY=${TEST_IAS_KEY}
+    IAS_SPID=${TEST_IAS_SPID}
+  ;;
+  main)
+    IAS_KEY=${MAIN_IAS_KEY}
+    IAS_SPID=${MAIN_IAS_SPID}
+  ;;
+  dev)
+    IAS_KEY=${DEV_IAS_KEY}
+    IAS_SPID=${DEV_IAS_SPID}
+  ;;
+  *)
+    echo "ERROR: Unknown network ${network}"
+    exit 1;
+  ;;
+esac
+
 
 cat << EOF
 global:

--- a/.internal-ci/util/set_tokens_config_version.sh
+++ b/.internal-ci/util/set_tokens_config_version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+
+# Select the correct tokens file to use based on release version.
+
+set -eu
+
+location=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# shellcheck source=.shared_functions
+source "${location}/.shared_functions"
+
+network=$(get_network_tier "${1}")
+major=$(get_major_version "${1}")
+
+echo "Found network ${network}" >&2
+echo "Found major version ${major}" >&2
+
+# 0 - dev use V2
+# 1|2|3 - use V1 - note 1 doesn't consume
+# 4 or greater use v2
+if [[ ${major} -eq 0 ]]
+then
+    version="V2"
+elif [[ ${major} -ge 1 ]] && [[ ${major} -le 3 ]]
+then
+    version="V1"
+elif [[ ${major} -ge 4 ]]
+then
+    version="V2"
+else
+    echo "Major version is invalid? ${1} ${major}" >&2
+    exit 1
+fi
+
+# ^^ upper case network
+token_json="${network^^}_TOKENS_CONFIG_${version}_JSON"
+echo "Using ${token_json}" >&2
+# ! use value as the variable name
+echo "${!token_json}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [4.1.0]
+
+### Changed
+
+- mobilecoind-json now always includes the MaskedAmount version in its responses ([#3036])
+
+## [4.0.2]
+
+### Fixed
+
+- fix(charts): fix blocklist activation logic ([#3048])
+
 ## [4.0.1]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2312,14 +2312,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2420,7 +2420,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "bincode",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2562,7 +2562,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "cargo-emit",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-common",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "chrono",
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -3089,13 +3089,14 @@ version = "2.0.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
+ "prost",
  "serde",
  "zeroize",
 ]
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "digest 0.10.5",
@@ -3115,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "digest 0.10.5",
@@ -3131,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -3160,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3174,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3183,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3191,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -3200,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3208,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -3217,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -3253,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3267,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3281,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3302,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3311,7 +3312,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3341,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3368,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "clap 4.0.32",
@@ -3380,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3391,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3402,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3434,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "crossbeam-channel",
@@ -3468,7 +3469,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3492,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "assert_cmd",
  "clap 4.0.32",
@@ -3531,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3566,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3583,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3591,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3624,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3637,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3649,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "dirs",
@@ -3707,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3732,7 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3748,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3770,7 +3771,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3799,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3817,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3825,7 +3826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3848,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3861,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -3916,7 +3917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -3933,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -3961,14 +3962,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -3979,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -3997,7 +3998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4005,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4044,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4060,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4079,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4088,7 +4089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -4112,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4129,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4144,7 +4145,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4181,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -4191,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4204,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4212,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "clap 4.0.32",
@@ -4264,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4285,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4296,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4311,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "clap 4.0.32",
@@ -4345,7 +4346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "clap 4.0.32",
@@ -4357,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4391,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "digest 0.10.5",
@@ -4425,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4445,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4453,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4473,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4508,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4526,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4534,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4556,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4569,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -4588,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4611,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4662,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4691,7 +4692,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "dirs",
@@ -4714,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-api",
@@ -4725,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "lmdb-rkv",
@@ -4738,7 +4739,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4772,7 +4773,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "clap 4.0.32",
@@ -4842,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4861,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "async-channel",
  "clap 4.0.32",
@@ -4893,7 +4894,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -4970,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5003,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "grpcio",
  "hex",
@@ -5027,7 +5028,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5037,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5045,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5054,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -5062,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "hex_fmt",
@@ -5071,21 +5072,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5096,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5112,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5122,18 +5123,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5144,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5156,7 +5157,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5166,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5175,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5190,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5212,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5245,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "assert_matches",
@@ -5293,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5308,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5345,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5356,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "hex",
@@ -5365,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.1",
@@ -5381,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5389,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5397,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5408,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5419,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-util-build-info",
@@ -5427,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -5440,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -5451,18 +5452,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-account-keys",
@@ -5481,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -5515,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -5526,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-common",
@@ -5537,11 +5538,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -5570,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5580,7 +5581,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5589,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5597,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5610,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "hex",
  "itertools",
@@ -5619,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5630,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "mc-crypto-keys",
@@ -5643,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "prost",
  "protobuf",
@@ -5655,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5666,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "itertools",
@@ -5679,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5687,7 +5688,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5696,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-uri"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -5714,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -5722,14 +5723,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "getrandom 0.2.8",
  "mc-account-keys",
@@ -5744,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -5788,7 +5789,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "serde",
@@ -6161,9 +6162,9 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7513,9 +7513,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6045,9 +6045,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,9 +137,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.7"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
+checksum = "9834fcc22e0874394a010230586367d4a3e9f11b560f469262678547e1d2575e"
 dependencies = [
  "bstr",
  "doc-comment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6779,21 +6779,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7536,9 +7536,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -7552,9 +7552,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "thiserror",
@@ -3239,7 +3239,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_hc 0.3.1",
  "schnorrkel-og",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "sha2 0.10.6",
@@ -7153,7 +7153,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
@@ -7342,9 +7342,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -93,7 +93,7 @@ impl fmt::Display for PublicAddress {
             .iter()
             .chain(self.view_public_key().to_bytes().iter())
         {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         if !self.fog_report_url.is_empty() {
             write!(f, ":'{}'", self.fog_report_url)?;

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -84,7 +84,7 @@ fn info(state: &rocket::State<State>) -> Result<Json<JsonInfoResponse>, String> 
     let info = state
         .admin_api_client
         .get_info(&Empty::new())
-        .map_err(|err| format!("Failed getting info: {}", err))?;
+        .map_err(|err| format!("Failed getting info: {err}"))?;
 
     Ok(Json(JsonInfoResponse::try_from(&info)?))
 }
@@ -105,7 +105,7 @@ fn set_rust_log(
     let _resp = state
         .admin_api_client
         .set_rust_log(&req)
-        .map_err(|err| format!("failed setting rust_log: {}", err))?;
+        .map_err(|err| format!("failed setting rust_log: {err}"))?;
 
     Ok(Redirect::to("/"))
 }
@@ -115,7 +115,7 @@ fn metrics(state: &rocket::State<State>) -> Result<String, String> {
     let resp = state
         .admin_api_client
         .get_prometheus_metrics(&Empty::new())
-        .map_err(|err| format!("failed getting metrics: {}", err))?;
+        .map_err(|err| format!("failed getting metrics: {err}"))?;
     Ok(resp.metrics)
 }
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -36,6 +36,7 @@ mod reduced_tx_out;
 mod ring_mlsag;
 mod ristretto_private;
 mod signature_rct_bulletproofs;
+mod signed_contingent_input;
 mod signing_data;
 mod tx;
 mod tx_hash;
@@ -64,7 +65,7 @@ use std::path::PathBuf;
 /// Helper method for getting the suggested path/filename for a given block
 /// index.
 pub fn block_num_to_s3block_path(block_index: BlockIndex) -> PathBuf {
-    let filename = format!("{:016x}.pb", block_index);
+    let filename = format!("{block_index:016x}.pb");
     let mut path = PathBuf::new();
     for i in 0..7 {
         path.push(&filename[i * 2..i * 2 + 2]);
@@ -81,7 +82,7 @@ pub fn merged_block_num_to_s3block_path(
     bucket_size: u64,
     first_block_index: BlockIndex,
 ) -> PathBuf {
-    let base_dir = format!("merged-{}", bucket_size);
+    let base_dir = format!("merged-{bucket_size}");
     let mut path = PathBuf::new();
     path.push(base_dir);
     path.push(block_num_to_s3block_path(first_block_index));

--- a/api/src/convert/signed_contingent_input.rs
+++ b/api/src/convert/signed_contingent_input.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! Convert to/from external::SignedContingentInput.
+
+use crate::{external, ConversionError};
+use mc_transaction_core::{ring_signature::RingMLSAG, tx::TxIn};
+use mc_transaction_extra::{SignedContingentInput, UnmaskedAmount};
+
+/// Convert mc_transaction_extra::SignedContingentInput -->
+/// external::SignedContingentInput.
+impl From<&SignedContingentInput> for external::SignedContingentInput {
+    fn from(src: &SignedContingentInput) -> Self {
+        let mut sci = external::SignedContingentInput::new();
+        sci.set_block_version(src.block_version);
+        sci.set_tx_in(external::TxIn::from(&src.tx_in));
+        sci.set_mlsag(external::RingMLSAG::from(&src.mlsag));
+        sci.set_pseudo_output_amount(external::UnmaskedAmount::from(&src.pseudo_output_amount));
+        sci.set_required_output_amounts(
+            src.required_output_amounts
+                .iter()
+                .map(external::UnmaskedAmount::from)
+                .collect(),
+        );
+        sci.set_tx_out_global_indices(src.tx_out_global_indices.clone());
+
+        sci
+    }
+}
+
+/// Convert external::SignedContingentInput -->
+/// mc_transaction_extra::SignedContingentInput.
+impl TryFrom<&external::SignedContingentInput> for SignedContingentInput {
+    type Error = ConversionError;
+
+    fn try_from(src: &external::SignedContingentInput) -> Result<Self, Self::Error> {
+        let block_version = src.get_block_version();
+        let tx_in = TxIn::try_from(src.get_tx_in())?;
+        let mlsag = RingMLSAG::try_from(src.get_mlsag())?;
+        let pseudo_output_amount = UnmaskedAmount::try_from(src.get_pseudo_output_amount())?;
+        let required_output_amounts = src
+            .get_required_output_amounts()
+            .iter()
+            .map(UnmaskedAmount::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let tx_out_global_indices = src.get_tx_out_global_indices().to_vec();
+
+        Ok(SignedContingentInput {
+            block_version,
+            tx_in,
+            mlsag,
+            pseudo_output_amount,
+            required_output_amounts,
+            tx_out_global_indices,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mc_account_keys::AccountKey;
+    use mc_crypto_ring_signature_signer::NoKeysRingSigner;
+    use mc_fog_report_validation_test_utils::MockFogResolver;
+    use mc_transaction_builder::{
+        test_utils::get_input_credentials, EmptyMemoBuilder, ReservedSubaddresses,
+        SignedContingentInputBuilder,
+    };
+    use mc_transaction_core::{
+        constants::MILLIMOB_TO_PICOMOB, tokens::Mob, Amount, BlockVersion, Token, TokenId,
+    };
+    use protobuf::Message;
+    use rand::{rngs::StdRng, SeedableRng};
+
+    #[test]
+    /// SignedContingentInput --> external::SignedContingentInput -->
+    /// SignedContingentInput should be the identity function
+    fn test_convert_signed_contingent_input() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let charlie = AccountKey::random(&mut rng);
+
+        let token2 = TokenId::from(2);
+
+        let fpr = MockFogResolver::default();
+
+        // Charlie makes a signed contingent input, offering 1000 token2's for 1 MOB
+        let input_credentials = get_input_credentials(
+            BlockVersion::MAX,
+            Amount::new(1000, token2),
+            &charlie,
+            &fpr,
+            &mut rng,
+        );
+        let proofs = input_credentials.membership_proofs.clone();
+        let mut sci_builder = SignedContingentInputBuilder::new(
+            BlockVersion::MAX,
+            input_credentials,
+            fpr.clone(),
+            EmptyMemoBuilder::default(),
+        )
+        .unwrap();
+
+        // Originator requests an output worth 1MOB destined to themselves
+        sci_builder
+            .add_partial_fill_output(
+                Amount::new(1000 * MILLIMOB_TO_PICOMOB, Mob::ID),
+                &charlie.default_subaddress(),
+                &mut rng,
+            )
+            .unwrap();
+
+        // Change amount matches the input value
+        sci_builder
+            .add_partial_fill_change_output(
+                Amount::new(1000, token2),
+                &ReservedSubaddresses::from(&charlie),
+                &mut rng,
+            )
+            .unwrap();
+        let mut sci = sci_builder.build(&NoKeysRingSigner {}, &mut rng).unwrap();
+
+        sci.tx_in.proofs = proofs;
+        sci.tx_out_global_indices = vec![1, 2, 3, 4];
+
+        // decode(encode(sci)) should be the identity function.
+        {
+            let bytes = mc_util_serial::encode(&sci);
+            let recovered_sci = mc_util_serial::decode(&bytes).unwrap();
+            assert_eq!(sci, recovered_sci);
+        }
+
+        // Converting mc_transaction_extra::SignedContingentInput ->
+        // external::SignedContingentInput ->
+        // mc_transaction_extra::SignedContingentInput should be the identity
+        // function.
+        {
+            let external_sci = external::SignedContingentInput::from(&sci);
+            let recovered_sci = SignedContingentInput::try_from(&external_sci).unwrap();
+            assert_eq!(sci, recovered_sci);
+        }
+
+        // Encoding with prost, decoding with protobuf should be the identity function.
+        {
+            let bytes = mc_util_serial::encode(&sci);
+            let recovered_sci = external::SignedContingentInput::parse_from_bytes(&bytes).unwrap();
+            assert_eq!(recovered_sci, external::SignedContingentInput::from(&sci));
+        }
+
+        // Encoding with protobuf, decoding with prost should be the identity function.
+        {
+            let external_sci = external::SignedContingentInput::from(&sci);
+            let bytes = external_sci.write_to_bytes().unwrap();
+            let recovered_sci = mc_util_serial::decode(&bytes).unwrap();
+            assert_eq!(sci, recovered_sci);
+        }
+    }
+}

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 license = "MIT/Apache-2.0"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/core/src/ias/json.rs
+++ b/attest/core/src/ias/json.rs
@@ -162,6 +162,6 @@ impl From<JsonObject> for JsonValue {
 pub(crate) fn parse(src: &str) -> (usize, Option<JsonValue>) {
     let data: Vec<char> = src.chars().collect();
     let mut idx = 0;
-    let retval = rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&*data, &mut idx);
+    let retval = rjson::parse::<JsonValue, JsonArray, JsonObject, JsonValue>(&data, &mut idx);
     (idx, retval)
 }

--- a/attest/core/src/nonce.rs
+++ b/attest/core/src/nonce.rs
@@ -232,7 +232,7 @@ mod test {
             [2, 154, 47, 57, 69, 168, 246, 187, 31, 181, 177, 26, 84, 40, 58, 64],
             ias_nonce.0
         );
-        let decoded = hex::decode(&s).unwrap();
+        let decoded = hex::decode(s).unwrap();
         assert_eq!(decoded, ias_nonce.0);
     }
 }

--- a/attest/core/src/quote.rs
+++ b/attest/core/src/quote.rs
@@ -77,7 +77,7 @@ impl Display for QuoteSignType {
             QuoteSignType::Unlinkable => "Unlinkable",
             QuoteSignType::Linkable => "Linkable",
         };
-        write!(formatter, "{}", text)
+        write!(formatter, "{text}")
     }
 }
 

--- a/attest/core/src/types/epid_group_id.rs
+++ b/attest/core/src/types/epid_group_id.rs
@@ -59,7 +59,7 @@ impl Hash for EpidGroupId {
 
 impl Ord for EpidGroupId {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.0[..]).cmp(&other.0[..])
+        self.0[..].cmp(&other.0[..])
     }
 }
 
@@ -134,6 +134,6 @@ mod test {
     fn test_display() {
         let gid: sgx_epid_group_id_t = [0x2eu8, 0x0b, 0, 0];
         let epid_gid = EpidGroupId::from(gid);
-        assert_eq!("00000b2e", format!("{}", epid_gid));
+        assert_eq!("00000b2e", format!("{epid_gid}"));
     }
 }

--- a/attest/core/src/types/measurement.rs
+++ b/attest/core/src/types/measurement.rs
@@ -96,8 +96,8 @@ impl PartialEq<MrSigner> for Measurement {
 impl Display for Measurement {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            Measurement::MrEnclave(e) => write!(f, "MRENCLAVE: {}", e),
-            Measurement::MrSigner(s) => write!(f, "MRSIGNER: {}", s),
+            Measurement::MrEnclave(e) => write!(f, "MRENCLAVE: {e}"),
+            Measurement::MrSigner(s) => write!(f, "MRSIGNER: {s}"),
         }
     }
 }

--- a/attest/core/src/types/report_body.rs
+++ b/attest/core/src/types/report_body.rs
@@ -223,7 +223,7 @@ impl Ord for ReportBody {
     /// Attributes, Misc Select, ConfigId, ConfigSVN, CPU SVN, and
     /// ReportData, in that order
     fn cmp(&self, other: &Self) -> Ordering {
-        match (&self.0.isv_family_id[..]).cmp(&other.0.isv_family_id[..]) {
+        match self.0.isv_family_id[..].cmp(&other.0.isv_family_id[..]) {
             Ordering::Equal => match self.0.isv_prod_id.cmp(&other.0.isv_prod_id) {
                 Ordering::Equal => match self.0.isv_ext_prod_id.cmp(&other.0.isv_ext_prod_id) {
                     Ordering::Equal => match self.0.isv_svn.cmp(&other.0.isv_svn) {

--- a/attest/core/src/types/update_info.rs
+++ b/attest/core/src/types/update_info.rs
@@ -30,8 +30,7 @@ impl Debug for UpdateInfo {
         let psw_update = self.0.pswUpdate;
         write!(
             f,
-            "UpdateInfo {{ ucodeUpdate: i32({}), csmeFwUpdate: i32({}), pswUpdate: i32({}) }}",
-            ucode_update, csme_fw_update, psw_update,
+            "UpdateInfo {{ ucodeUpdate: i32({ucode_update}), csmeFwUpdate: i32({csme_fw_update}), pswUpdate: i32({psw_update}) }}",
         )
     }
 }
@@ -43,8 +42,7 @@ impl Display for UpdateInfo {
         let psw_update = self.0.pswUpdate;
         write!(
             f,
-            "Microcode {}, Management Engine Firmware {}, Platform Services {}",
-            ucode_update, csme_fw_update, psw_update
+            "Microcode {ucode_update}, Management Engine Firmware {csme_fw_update}, Platform Services {psw_update}"
         )
     }
 }

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -104,15 +104,14 @@ fn purge_expired_cert(path: &Path) {
             // regenerated.
             if utc_now + Duration::hours(24) > not_after {
                 remove_file(path)
-                    .unwrap_or_else(|e| panic!("failed deleting expired cert {:?}: {:?}", path, e));
+                    .unwrap_or_else(|e| panic!("failed deleting expired cert {path:?}: {e:?}"));
             }
         }
         Err(_) => {
             // Failed getting expiration date from certificate, delete it so it gets
             // regenerated.
-            remove_file(path).unwrap_or_else(|e| {
-                panic!("failed deleting non-parseable cert {:?}: {:?}", path, e)
-            });
+            remove_file(path)
+                .unwrap_or_else(|e| panic!("failed deleting non-parseable cert {path:?}: {e:?}"));
         }
     }
 }
@@ -275,7 +274,7 @@ fn main() {
             .write_pem_string(&mut csprng)
             .expect("Could not create PEM string of certificate");
 
-        write(chain_path, &(root_cert_pem + &signer_cert_pem)).expect("Unable to write cert chain");
+        write(chain_path, root_cert_pem + &signer_cert_pem).expect("Unable to write cert chain");
     }
 
     let env = Environment::default();

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/blockchain/validators/src/metadata/key_range/config.rs
+++ b/blockchain/validators/src/metadata/key_range/config.rs
@@ -122,7 +122,7 @@ fn parse_pem_or_hex(
 
     let base_path = base_path.into().or_else(|| std::env::current_dir().ok());
     let path = if let Some(base) = base_path {
-        base.join(&value)
+        base.join(value)
     } else {
         value.into()
     };

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/common/src/logger/loggers/mod.rs
+++ b/common/src/logger/loggers/mod.rs
@@ -187,7 +187,7 @@ pub fn create_root_logger() -> Logger {
             if !key_val_str.is_empty() {
                 let key_val = key_val_str.split('=').collect::<Vec<&str>>();
                 if key_val.len() != 2 {
-                    panic!("invalid MC_LOG_EXTRA key/val: {}", key_val_str)
+                    panic!("invalid MC_LOG_EXTRA key/val: {key_val_str}")
                 }
 
                 let k = key_val[0].to_string();

--- a/common/src/logger/loggers/sentry_logger.rs
+++ b/common/src/logger/loggers/sentry_logger.rs
@@ -76,7 +76,7 @@ pub struct KeyValueList(pub Vec<(Key, String)>);
 
 impl Serializer for KeyValueList {
     fn emit_arguments(&mut self, key: Key, val: &std::fmt::Arguments) -> slog::Result {
-        self.0.push((key, format!("{}", val)));
+        self.0.push((key, format!("{val}")));
         Ok(())
     }
 }

--- a/common/src/logger/mod.rs
+++ b/common/src/logger/mod.rs
@@ -98,7 +98,7 @@ cfg_if::cfg_if! {
                     + (self.start.elapsed().subsec_nanos() as f64 / 1_000_000.0);
 
                 let time = match time_in_ms as u64 {
-                    0..=3000 => format!("{}ms", time_in_ms),
+                    0..=3000 => format!("{time_in_ms}ms"),
                     3001..=60000 => format!("{:.2}s", time_in_ms / 1000.0),
                     _ => format!("{:.2}m", time_in_ms / 1000.0 / 60.0),
                 };
@@ -119,7 +119,7 @@ cfg_if::cfg_if! {
             fn basic_trace_time() {
                 let logger = create_test_logger("basic_trace_time".to_string());
 
-                slog_scope::scope(&logger.clone(), || {
+                slog_scope::scope(&logger, || {
                     trace_time!(global_logger(), "test global");
 
                     {

--- a/common/src/panic_handler.rs
+++ b/common/src/panic_handler.rs
@@ -16,18 +16,15 @@ pub fn setup_panic_handler() {
 }
 
 fn handle_panic(panic_info: &PanicInfo<'_>) {
-    let details = format!("{}", panic_info);
+    let details = format!("{panic_info}");
     let backtrace = format!("{:#?}", Backtrace::new());
     let thread_name = thread::current().name().unwrap_or("?").to_string();
     let process_name = env::args().next().unwrap_or_else(|| "?".to_string());
 
     // First, print the crash details.
-    println!(
-        "OH NO, WE CRASHED :( thread {} on {}",
-        thread_name, process_name
-    );
-    println!("Details: {}", details);
-    println!("{}", backtrace);
+    println!("OH NO, WE CRASHED :( thread {thread_name} on {process_name}");
+    println!("Details: {details}");
+    println!("{backtrace}");
 
     // Also attempt to log using the logger.
     logger::global_log::crit!(

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/src/credentials.rs
+++ b/connection/src/credentials.rs
@@ -63,7 +63,7 @@ impl HardcodedCredentialsProvider {
 
 impl<URI: ConnectionUri> From<&URI> for HardcodedCredentialsProvider {
     fn from(src: &URI) -> Self {
-        Self::new(&src.username(), &src.password())
+        Self::new(src.username(), src.password())
     }
 }
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -104,7 +104,7 @@ impl<L: Ledger + Sync> BlockchainConnection for MockBlockchainConnection<L> {
         real_range
             .map(|block_index| {
                 self.ledger
-                    .get_block(block_index as u64)
+                    .get_block(block_index)
                     .or(Err(ConnectionError::NotFound))
             })
             .collect::<Result<Vec<Block>, ConnectionError>>()
@@ -164,7 +164,7 @@ mod tests {
             // Get blocks 25,26,27. These are entirely out of range, so should return an
             // error.
             if let Ok(blocks) = mock_peer.fetch_blocks(25..28) {
-                println!("Blocks: {:?}", blocks);
+                println!("Blocks: {blocks:?}");
                 panic!();
             }
         }

--- a/connection/test-utils/src/lib.rs
+++ b/connection/test-utils/src/lib.rs
@@ -10,8 +10,7 @@ mod user_tx;
 
 pub fn test_client_uri(node_id: u32) -> ConsensusClientUri {
     ConsensusClientUri::from_str(&format!(
-        "mc://node{}.test.com?responder-id=loadbalancer.foo.com:4882",
-        node_id
+        "mc://node{node_id}.test.com?responder-id=loadbalancer.foo.com:4882"
     ))
     .expect("Could not construct client uri from string")
 }

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "consensus_enclave_edl"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -44,7 +44,7 @@ mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
 
 mbedtls = { version = "0.8.1", default-features = false, features = ["no_std_deps"] }
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { version = "1.17", default-features = false, features = ["alloc", "race"] }
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 rand_core = { version = "0.6", default-features = false }
 subtle = { version = "2.4", default-features = false, features = ["i128"] }

--- a/consensus/enclave/impl/build.rs
+++ b/consensus/enclave/impl/build.rs
@@ -47,13 +47,13 @@ fn main() {
     // Check for env var and override
     fee_spend_public_key[..].copy_from_slice(
         &hex::decode(
-            &var("FEE_SPEND_PUBLIC_KEY").unwrap_or_else(|_| default_fee_spend_pub.to_string()),
+            var("FEE_SPEND_PUBLIC_KEY").unwrap_or_else(|_| default_fee_spend_pub.to_string()),
         )
         .expect("Failed parsing public spend key."),
     );
     fee_view_public_key[..].copy_from_slice(
         &hex::decode(
-            &var("FEE_VIEW_PUBLIC_KEY").unwrap_or_else(|_| default_fee_view_pub.to_string()),
+            var("FEE_VIEW_PUBLIC_KEY").unwrap_or_else(|_| default_fee_view_pub.to_string()),
         )
         .expect("Failed parsing public view key."),
     );
@@ -76,7 +76,7 @@ fn main() {
     };
 
     let parsed_pem =
-        pem::parse(&pem_bytes).expect("Failed parsing minting trust root public key PEM file");
+        pem::parse(pem_bytes).expect("Failed parsing minting trust root public key PEM file");
     let minting_trust_root_public_key = Ed25519Public::try_from_der(&parsed_pem.contents[..])
         .expect("Failed parsing minting trust root public key DER");
     let minting_trust_root_public_key_bytes = minting_trust_root_public_key.to_bytes();
@@ -85,16 +85,13 @@ fn main() {
         "// Copyright (c) 2018-2022 The MobileCoin Foundation\n\n// Auto-generated file\n\n"
             .to_string();
     constants.push_str(&format!(
-        "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {:?};\n\n",
-        fee_spend_public_key
+        "pub const FEE_SPEND_PUBLIC_KEY: [u8; 32] = {fee_spend_public_key:?};\n\n"
     ));
     constants.push_str(&format!(
-        "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {:?};\n",
-        fee_view_public_key
+        "pub const FEE_VIEW_PUBLIC_KEY: [u8; 32] = {fee_view_public_key:?};\n"
     ));
     constants.push_str(&format!(
-        "pub const MINTING_TRUST_ROOT_PUBLIC_KEY: [u8; 32] = {:?};\n",
-        minting_trust_root_public_key_bytes
+        "pub const MINTING_TRUST_ROOT_PUBLIC_KEY: [u8; 32] = {minting_trust_root_public_key_bytes:?};\n"
     ));
 
     // Output directory for generated constants.

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -726,14 +726,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "bitflags",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "digest",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1278,11 +1278,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1313,29 +1313,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1364,14 +1364,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1379,11 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -1465,14 +1465,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "prost",
  "serde",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
 ]
@@ -1568,9 +1568,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -19,7 +19,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for the business logic / implementation state
     static ref ENCLAVE: SgxConsensusEnclave = SgxConsensusEnclave::new(mc_sgx_slog::default_logger());

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/mint-client/src/bin/main.rs
+++ b/consensus/mint-client/src/bin/main.rs
@@ -54,7 +54,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_config_tx_opt(&(&tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -141,7 +141,7 @@ fn main() {
                     common_headers_call_option(&chain_id),
                 )
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -183,7 +183,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_tx_opt(&(&tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -227,7 +227,7 @@ fn main() {
         }
 
         Commands::HashTxFile { tx_file } => {
-            println!("{}", hex::encode(&tx_file.hash_tx_prefix()));
+            println!("{}", hex::encode(tx_file.hash_tx_prefix()));
         }
 
         Commands::HashMintTx { params } => {
@@ -279,7 +279,7 @@ fn main() {
             let resp = client_api
                 .propose_mint_tx_opt(&(&merged_tx).into(), common_headers_call_option(&chain_id))
                 .expect("propose tx");
-            println!("response: {:?}", resp);
+            println!("response: {resp:?}");
 
             // Relying on the success result code being 0, we terminate ourselves in a way
             // that allows whoever started this binary to easily determine if submitting the
@@ -340,7 +340,7 @@ fn main() {
                     .map(|signer| {
                         Ed25519Pair::from(Ed25519Private::from(signer))
                             .try_sign(message.as_ref())
-                            .map_err(|e| format!("Failed to sign: {}", e))
+                            .map_err(|e| format!("Failed to sign: {e}"))
                     })
                     .collect::<Result<Vec<_>, _>>()
                     .expect("failed signing"),
@@ -378,7 +378,7 @@ fn main() {
             match pubkey.verify(&hash, &signature) {
                 Ok(()) => println!("signature Ok"),
                 Err(e) => {
-                    println!("{:?}", e);
+                    println!("{e:?}");
                     exit(1)
                 }
             }

--- a/consensus/mint-client/src/config.rs
+++ b/consensus/mint-client/src/config.rs
@@ -64,7 +64,7 @@ impl MintConfigTxPrefixParams {
         fallback_tombstone_block: impl Fn() -> u64,
     ) -> Result<MintConfigTxPrefix, String> {
         let mut mint_config_tx_prefix = MintConfigTxPrefix::try_from(&self.mint_config_tx_file)
-            .map_err(|err| format!("Failed to parse mint config tx file: {}", err))?;
+            .map_err(|err| format!("Failed to parse mint config tx file: {err}"))?;
 
         // Override tombstone block if provided.
         if let Some(tombstone) = self.tombstone {
@@ -138,7 +138,7 @@ impl MintConfigTxParams {
             .map(|signer| {
                 Ed25519Pair::from(Ed25519Private::from(signer))
                     .try_sign(message.as_ref())
-                    .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {}", e))
+                    .map_err(|e| format!("Failed to sign MintConfigTxPrefix: {e}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         signatures.extend(self.signatures);
@@ -183,8 +183,7 @@ impl MintTxPrefixParams {
         let mut tombstone_block = self.tombstone.unwrap_or_else(fallback_tombstone_block);
         let e_fog_hint = self.recipient.fog_report_url().map(|fog_url| -> Result<_, String> {
             let fog_bits = fog_bits.ok_or_else(|| format!(
-                "This recipient has a fog url, but a CSS to validate fog public keys was not supplied: '{}'",
-                fog_url,
+                "This recipient has a fog url, but a CSS to validate fog public keys was not supplied: '{fog_url}'",
             ))?;
             let (e_fog_hint, pubkey_expiry) = fog_bits.get_e_fog_hint(&self.recipient)?;
             tombstone_block = tombstone_block.min(pubkey_expiry);
@@ -243,7 +242,7 @@ impl MintTxParams {
             .map(|signer| {
                 Ed25519Pair::from(Ed25519Private::from(signer))
                     .try_sign(message.as_ref())
-                    .map_err(|e| format!("Failed to sign MintTxPrefix: {}", e))
+                    .map_err(|e| format!("Failed to sign MintTxPrefix: {e}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
         signatures.extend(self.signatures);
@@ -496,25 +495,25 @@ pub struct Config {
 // trait for use with clap
 pub fn load_mint_private_key_from_pem(filename: &str) -> Result<MintPrivateKey, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
 
-    let parsed_pem = pem::parse(&bytes)
-        .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
+    let parsed_pem =
+        pem::parse(bytes).map_err(|err| format!("Failed parsing PEM file '{filename}': {err}"))?;
 
     let key = Ed25519Private::try_from_der(&parsed_pem.contents[..])
-        .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing DER from PEM file '{filename}': {err}"))?;
     Ok(MintPrivateKey(key))
 }
 
 pub fn load_key_from_pem<K: DistinguishedEncoding>(filename: &str) -> Result<K, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
 
-    let parsed_pem = pem::parse(&bytes)
-        .map_err(|err| format!("Failed parsing PEM file '{}': {}", filename, err))?;
+    let parsed_pem =
+        pem::parse(bytes).map_err(|err| format!("Failed parsing PEM file '{filename}': {err}"))?;
 
     let key = K::try_from_der(&parsed_pem.contents[..])
-        .map_err(|err| format!("Failed parsing DER from PEM file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing DER from PEM file '{filename}': {err}"))?;
     Ok(key)
 }
 
@@ -523,44 +522,37 @@ pub fn load_or_parse_ed25519_signature(
 ) -> Result<Ed25519Signature, String> {
     // Check if the signature provided is a filename.
     let bytes = if Path::new(filename_or_hex_signature).exists() {
-        let bytes = fs::read(filename_or_hex_signature).map_err(|err| {
-            format!(
-                "Failed reading file '{}': {}",
-                filename_or_hex_signature, err
-            )
-        })?;
+        let bytes = fs::read(filename_or_hex_signature)
+            .map_err(|err| format!("Failed reading file '{filename_or_hex_signature}': {err}"))?;
 
-        let parsed_pem = pem::parse(&bytes).map_err(|err| {
-            format!(
-                "Failed parsing PEM file '{}': {}",
-                filename_or_hex_signature, err
-            )
+        let parsed_pem = pem::parse(bytes).map_err(|err| {
+            format!("Failed parsing PEM file '{filename_or_hex_signature}': {err}")
         })?;
 
         parsed_pem.contents
     } else if filename_or_hex_signature.len() == Ed25519Signature::BYTE_SIZE * 2 {
         // *2 due to hex encoding
         hex::decode(filename_or_hex_signature)
-            .map_err(|err| format!("Failed decoding hex signature: {}", err))?
+            .map_err(|err| format!("Failed decoding hex signature: {err}"))?
     } else {
         return Err("Signature must either be a PEM file or a hex-encoded string".to_string());
     };
 
     Ed25519Signature::try_from(&bytes[..])
-        .map_err(|err| format!("Failed parsing Ed25519 signature: {}", err))
+        .map_err(|err| format!("Failed parsing Ed25519 signature: {err}"))
 }
 
 fn parse_public_address(b58: &str) -> Result<PublicAddress, String> {
     let printable_wrapper = PrintableWrapper::b58_decode(b58.into())
-        .map_err(|err| format!("failed parsing b58 address '{}': {}", b58, err))?;
+        .map_err(|err| format!("failed parsing b58 address '{b58}': {err}"))?;
 
     if printable_wrapper.has_public_address() {
         let public_address = PublicAddress::try_from(printable_wrapper.get_public_address())
-            .map_err(|err| format!("failed converting b58 public address '{}': {}", b58, err))?;
+            .map_err(|err| format!("failed converting b58 public address '{b58}': {err}"))?;
 
         Ok(public_address)
     } else {
-        Err(format!("b58 address '{}' is not a public address", b58))
+        Err(format!("b58 address '{b58}' is not a public address"))
     }
 }
 
@@ -582,10 +574,9 @@ fn get_or_generate_nonce(nonce: Option<[u8; NONCE_LENGTH]>) -> Vec<u8> {
 }
 
 fn load_tx_file_from_path(path: &str) -> Result<TxFile, String> {
-    TxFile::from_json_file(path).map_err(|e| format!("failed loading file {:?}: {}", path, e))
+    TxFile::from_json_file(path).map_err(|e| format!("failed loading file {path:?}: {e}"))
 }
 
 fn load_mint_config_tx_file_from_path(path: &str) -> Result<MintConfigTxFile, String> {
-    MintConfigTxFile::from_json_file(path)
-        .map_err(|e| format!("failed loading file {:?}: {}", path, e))
+    MintConfigTxFile::from_json_file(path).map_err(|e| format!("failed loading file {path:?}: {e}"))
 }

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -61,7 +61,7 @@ impl FogContext {
         public_address: &PublicAddress,
     ) -> Result<FullyValidatedFogPubkey, String> {
         let fog_uri = FogUri::from_str(public_address.fog_report_url().ok_or("Missing fog url")?)
-            .map_err(|err| format!("Invalid fog uri: {}", err))?;
+            .map_err(|err| format!("Invalid fog uri: {err}"))?;
 
         let conn = GrpcFogReportConnection::new(
             self.chain_id.clone(),
@@ -71,14 +71,14 @@ impl FogContext {
 
         let responses = conn
             .fetch_fog_reports([fog_uri].into_iter())
-            .map_err(|err| format!("Error fetching fog reports: {}", err))?;
+            .map_err(|err| format!("Error fetching fog reports: {err}"))?;
 
         let verifier = get_fog_ingest_verifier(self.css_signature.clone());
         let resolver = FogResolver::new(responses, &verifier)
-            .map_err(|err| format!("Error building FogResolver: {}", err))?;
+            .map_err(|err| format!("Error building FogResolver: {err}"))?;
         resolver
             .get_fog_pubkey(public_address)
-            .map_err(|err| format!("Could not validate fog pubkey: {}", err))
+            .map_err(|err| format!("Could not validate fog pubkey: {err}"))
     }
 }
 

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -17,14 +17,14 @@ const PEM_TAG_PUBLIC_KEY: &str = "PUBLIC KEY";
 
 pub fn print_mint_config_tx(tx: &MintConfigTx, indent: usize) {
     let indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfigTx:", indent_str);
+    println!("{indent_str}MintConfigTx:");
     print_mint_config_tx_prefix(&tx.prefix, indent + 1);
     print_multi_sig(&tx.signature, indent + 1);
 }
 
 pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfigTxPrefix:", indent_str);
+    println!("{indent_str}MintConfigTxPrefix:");
 
     indent_str.push_str(INDENT_STR);
     println!(
@@ -45,7 +45,7 @@ pub fn print_mint_config_tx_prefix(prefix: &MintConfigTxPrefix, indent: usize) {
 
 pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintConfig:", indent_str);
+    println!("{indent_str}MintConfig:");
 
     indent_str.push_str(INDENT_STR);
     println!("{}Token id: {}", indent_str, mint_config.token_id);
@@ -55,7 +55,7 @@ pub fn print_mint_config(mint_config: &MintConfig, indent: usize) {
 
 pub fn print_mint_tx(tx: &MintTx, indent: usize) {
     let indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintTx:", indent_str);
+    println!("{indent_str}MintTx:");
     print_mint_tx_prefix(&tx.prefix, indent + 1);
     print_multi_sig(&tx.signature, indent + 1);
 }
@@ -67,7 +67,7 @@ pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
     let b58_recipient = wrapper.b58_encode().expect("failed encoding b58 address");
 
     let mut indent_str = INDENT_STR.repeat(indent);
-    println!("{}MintTxPrefix:", indent_str);
+    println!("{indent_str}MintTxPrefix:");
     indent_str.push_str(INDENT_STR);
     println!("{}Token id: {}", indent_str, prefix.token_id);
     println!("{}Mint amount: {}", indent_str, prefix.amount);
@@ -76,7 +76,7 @@ pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
         "{}Spend public key: {}",
         indent_str, prefix.spend_public_key
     );
-    println!("{}Recipient B58 address: {}", indent_str, b58_recipient);
+    println!("{indent_str}Recipient B58 address: {b58_recipient}");
     println!("{}Nonce: {}", indent_str, hex::encode(&prefix.nonce));
     println!("{}Tombstone block: {}", indent_str, prefix.tombstone_block);
 }
@@ -118,6 +118,6 @@ pub fn print_pem(obj: &impl DistinguishedEncoding, tag: &str, indent: usize) {
         contents: obj.to_der(),
     });
     for line in pem_str.lines() {
-        println!("{}{}", indent_str, line);
+        println!("{indent_str}{line}");
     }
 }

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Stellar Consensus Protocol"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/scp/play/src/main.rs
+++ b/consensus/scp/play/src/main.rs
@@ -43,10 +43,10 @@ pub struct Config {
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet, String> {
     let quorum_set: QuorumSet = serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+        .map_err(|err| format!("Error parsing quorum set {src}: {err:?}"))?;
 
     if !quorum_set.is_valid() {
-        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+        return Err(format!("Invalid quorum set: {quorum_set:?}"));
     }
 
     Ok(quorum_set)
@@ -54,7 +54,7 @@ fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet, String> {
 
 fn parse_node_id_from_uri(src: &str) -> Result<NodeID, String> {
     let uri = PeerUri::from_str(src)
-        .map_err(|err| format!("Could not get URI from param {}: {:?}", src, err))?;
+        .map_err(|err| format!("Could not get URI from param {src}: {err:?}"))?;
     Ok(NodeID::from(&uri))
 }
 

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -305,7 +305,7 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
 
         let validate_nominate = |payload: &NominatePayload<V>| -> Result<(), String> {
             if payload.X.intersection(&payload.Y).next().is_some() {
-                Err(format!("X intersects Y, msg: {}", self))
+                Err(format!("X intersects Y, msg: {self}"))
             } else {
                 Ok(())
             }
@@ -314,21 +314,21 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
         let validate_prepare = |payload: &PreparePayload<V>| -> Result<(), String> {
             if let Some(P) = &payload.P {
                 if payload.B < *P {
-                    return Err(format!("B < P, msg: {}", self));
+                    return Err(format!("B < P, msg: {self}"));
                 }
 
                 if let Some(PP) = &payload.PP {
                     if *PP >= *P {
-                        return Err(format!("PP >= P, msg: {}", self));
+                        return Err(format!("PP >= P, msg: {self}"));
                     }
                 }
             }
 
             if payload.CN > payload.HN {
-                return Err(format!("CN > HN, msg: {}", self));
+                return Err(format!("CN > HN, msg: {self}"));
             }
             if payload.HN > payload.B.N {
-                return Err(format!("HN > BN, msg: {}", self));
+                return Err(format!("HN > BN, msg: {self}"));
             }
 
             Ok(())
@@ -350,7 +350,7 @@ impl<V: Value, ID: GenericNodeId + DeserializeOwned> Msg<V, ID> {
 
             Commit(ref payload) => {
                 if payload.CN > payload.HN {
-                    return Err(format!("CN > HN, msg: {}", self));
+                    return Err(format!("CN > HN, msg: {self}"));
                 }
             }
 
@@ -607,7 +607,7 @@ impl<V: Value, ID: GenericNodeId> fmt::Display for Msg<V, ID> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let format_opt_ballot = |b: &Option<Ballot<V>>| match b {
             None => "<>".to_string(),
-            Some(b) => format!("{}", b),
+            Some(b) => format!("{b}"),
         };
 
         // Returns "<set.len, hash(set)>".
@@ -759,7 +759,7 @@ mod msg_tests {
                 QuorumSet::empty(),
                 1,
                 Prepare(PreparePayload {
-                    B: ballot.clone(),
+                    B: ballot,
                     P: Some(prepared.clone()),
                     PP: Some(prepared_prime.clone()),
                     CN: 0, /* c_counter -> if h_counter > 0, and ballot is confirmed prepared,

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -467,7 +467,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_from_self.clone(), msg_from_self.clone()]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -502,7 +502,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_future_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -537,7 +537,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_old_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 0),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -587,7 +587,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_current_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 1), // Should return a message.
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -638,7 +638,7 @@ mod tests {
 
         match node.handle_messages(vec![msg_for_recent_slot]) {
             Ok(outgoing_msgs) => assert_eq!(outgoing_msgs.len(), 1), // Should return a message.
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -747,7 +747,7 @@ mod tests {
             Arc::new(trivial_validity_fn),
             Arc::new(trivial_combine_fn),
             slot_index,
-            logger.clone(),
+            logger,
         );
 
         // Client(s) submits some values to node 2.

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -753,7 +753,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 
         // Invariants: p' is less-than-and-incompatible-with p.
         if let (Some(p), Some(pp)) = (&self.P, &self.PP) {
-            assert!(pp < p, "p: {:?}, pp: {:?}", p, pp);
+            assert!(pp < p, "p: {p:?}, pp: {pp:?}");
             assert_ne!(p.X, pp.X);
         }
 
@@ -2626,7 +2626,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // When the timer fires, we should advance to a new ballot with all 4 values.
         {
@@ -2758,7 +2758,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // When the timer fires, we should advance to a new ballot with all 4 values.
         // The prepared value should not change.
@@ -2869,7 +2869,7 @@ mod ballot_protocol_tests {
         }
 
         // Force ballot timeout timer to fire.
-        slot.next_ballot_at = Some(Instant::now() - Duration::from_secs(1));
+        slot.next_ballot_at = Some(Instant::now().checked_sub(Duration::from_secs(1)).unwrap());
 
         // The next higher ballot should **not** include the latest confirmed nominated
         // values.

--- a/consensus/scp/tests/mock_network/cyclic_topology.rs
+++ b/consensus/scp/tests/mock_network/cyclic_topology.rs
@@ -29,12 +29,12 @@ pub fn directed_cycle(num_nodes: usize) -> mock_network::NetworkConfig {
             .collect::<Vec<NodeID>>();
 
         nodes.push(mock_network::NodeConfig::new(
-            format!("c{}", node_index),
+            format!("c{node_index}"),
             test_utils::test_node_id(node_index as u32),
             peers_vector.iter().cloned().collect::<HashSet<NodeID>>(),
             QuorumSet::new_with_node_ids(1, vec![next_node_id]),
         ));
     }
 
-    mock_network::NetworkConfig::new(format!("cyclic{}", num_nodes), nodes)
+    mock_network::NetworkConfig::new(format!("cyclic{num_nodes}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/mesh_topology.rs
+++ b/consensus/scp/tests/mock_network/mesh_topology.rs
@@ -26,12 +26,12 @@ pub fn dense_mesh(
             .collect::<Vec<NodeID>>();
 
         nodes.push(mock_network::NodeConfig::new(
-            format!("m{}", node_index),
+            format!("m{node_index}"),
             test_utils::test_node_id(node_index as u32),
             peers_vector.iter().cloned().collect::<HashSet<NodeID>>(),
             QuorumSet::new_with_node_ids(k as u32, peers_vector),
         ));
     }
 
-    mock_network::NetworkConfig::new(format!("m{}k{}", n, k), nodes)
+    mock_network::NetworkConfig::new(format!("m{n}k{k}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/metamesh_topology.rs
+++ b/consensus/scp/tests/mock_network/metamesh_topology.rs
@@ -87,7 +87,7 @@ pub fn metamesh(
                 .collect::<HashSet<NodeID>>();
 
             nodes.push(mock_network::NodeConfig::new(
-                format!("mm{}-{}", org_index, server_index),
+                format!("mm{org_index}-{server_index}"),
                 node_id,
                 peers,
                 QuorumSet::new_with_inner_sets(k_n as u32, inner_quorum_sets),
@@ -95,5 +95,5 @@ pub fn metamesh(
         }
     }
 
-    mock_network::NetworkConfig::new(format!("{}k{}-{}k{}", n, k_n, m, k_m), nodes)
+    mock_network::NetworkConfig::new(format!("{n}k{k_n}-{m}k{k_m}"), nodes)
 }

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -449,7 +449,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_value failed: {:?}", err);
+                    panic!("send_value failed: {err:?}");
                 }
             },
         }
@@ -462,7 +462,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_msg failed: {:?}", err);
+                    panic!("send_msg failed: {err:?}");
                 }
             },
         }
@@ -474,7 +474,7 @@ impl SCPNode {
             Err(err) => match err {
                 crossbeam_channel::TrySendError::Disconnected(_) => {}
                 _ => {
-                    panic!("send_stop failed: {:?}", err);
+                    panic!("send_stop failed: {err:?}");
                 }
             },
         }

--- a/consensus/scp/tests/test_cyclic_networks.rs
+++ b/consensus/scp/tests/test_cyclic_networks.rs
@@ -15,7 +15,7 @@ fn cyclic_test_helper(num_nodes: usize, logger: Logger) {
     test_options.values_to_submit = 10000;
 
     let network_config = mock_network::cyclic_topology::directed_cycle(num_nodes);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -20,7 +20,7 @@ fn mesh_test_helper(
     let mut test_options = mock_network::TestOptions::new();
     test_options.values_to_submit = 10000;
     let network_config = mock_network::mesh_topology::dense_mesh(n, k);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]

--- a/consensus/scp/tests/test_metamesh_networks.rs
+++ b/consensus/scp/tests/test_metamesh_networks.rs
@@ -28,29 +28,29 @@ fn metamesh_test_helper(
     test_options.scp_timebase = Duration::from_millis(100);
 
     let network_config = mock_network::metamesh_topology::metamesh(n, k_n, m, k_m);
-    mock_network::build_and_test(&network_config, &test_options, logger.clone());
+    mock_network::build_and_test(&network_config, &test_options, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_3k1(logger: Logger) {
-    metamesh_test_helper(3, 2, 3, 1, logger.clone());
+    metamesh_test_helper(3, 2, 3, 1, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_3k2(logger: Logger) {
-    metamesh_test_helper(3, 2, 3, 2, logger.clone());
+    metamesh_test_helper(3, 2, 3, 2, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_4k3(logger: Logger) {
-    metamesh_test_helper(3, 2, 4, 3, logger.clone());
+    metamesh_test_helper(3, 2, 4, 3, logger);
 }
 
 #[test_with_logger]
 #[serial]
 fn metamesh_3k2_5k4(logger: Logger) {
-    metamesh_test_helper(3, 2, 5, 4, logger.clone());
+    metamesh_test_helper(3, 2, 5, 4, logger);
 }

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2018"
 readme = "../README.md"

--- a/consensus/scp/types/src/test_utils.rs
+++ b/consensus/scp/types/src/test_utils.rs
@@ -26,7 +26,7 @@ pub fn test_node_id_and_signer(node_id: u32) -> (NodeID, Ed25519Pair) {
     let signer_keypair = Ed25519Pair::from_random(&mut seeded_rng);
     (
         NodeID {
-            responder_id: ResponderId::from_str(&format!("node{}.test.com:8443", node_id)).unwrap(),
+            responder_id: ResponderId::from_str(&format!("node{node_id}.test.com:8443")).unwrap(),
             public_key: signer_keypair.public_key(),
         },
         signer_keypair,

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -54,7 +54,7 @@ lazy_static = "1.4"
 once_cell = "1.16"
 protobuf = "2.27.1"
 rand = "0.8"
-rayon = "1.5"
+rayon = "1.6"
 retry = "2.0"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -25,6 +25,6 @@ hex = "0.4"
 pem = "1.1"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1.0"
-serde_with = "2.0"
+serde_with = "2.2"
 toml = "0.5"
 

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -154,7 +154,7 @@ impl Config {
     pub fn tokens(&self) -> TokensConfig {
         if let Some(tokens_path) = &self.tokens_path {
             TokensConfig::load_from_path(tokens_path).unwrap_or_else(|_| {
-                panic!("failed loading tokens configuration from {:?}", tokens_path)
+                panic!("failed loading tokens configuration from {tokens_path:?}")
             })
         } else {
             TokensConfig::default()
@@ -169,10 +169,10 @@ impl Config {
 fn keypair_from_base64(private_key: &str) -> Result<Arc<Ed25519Pair>, String> {
     let privkey_bytes = BASE64_ENGINE
         .decode(private_key)
-        .map_err(|err| format!("Could not decode private key from base64 {:?}", err))?;
+        .map_err(|err| format!("Could not decode private key from base64 {err:?}"))?;
 
     let secret_key = Ed25519Private::try_from_der(privkey_bytes.as_slice())
-        .map_err(|err| format!("Could not get Ed25519Private from der {:?}", err))?;
+        .map_err(|err| format!("Could not get Ed25519Private from der {err:?}"))?;
     Ok(Arc::new(Ed25519Pair::from(secret_key)))
 }
 

--- a/consensus/service/config/src/network.rs
+++ b/consensus/service/config/src/network.rs
@@ -89,11 +89,10 @@ impl NetworkConfig {
             .cloned()
             .map(|uri| {
                 (
-                    uri.responder_id().unwrap_or_else(|e| {
-                        panic!("unable to get responder_id for {}: {:?}", uri, e)
-                    }),
+                    uri.responder_id()
+                        .unwrap_or_else(|e| panic!("unable to get responder_id for {uri}: {e:?}")),
                     uri.node_id()
-                        .unwrap_or_else(|e| panic!("unable to get node_id for {}: {:?}", uri, e)),
+                        .unwrap_or_else(|e| panic!("unable to get node_id for {uri}: {e:?}")),
                 )
             })
             .collect();
@@ -102,12 +101,12 @@ impl NetworkConfig {
             for uri in known_peers.iter() {
                 let responder_id = uri
                     .responder_id()
-                    .unwrap_or_else(|e| panic!("unable to get responder_id for {}: {:?}", uri, e));
+                    .unwrap_or_else(|e| panic!("unable to get responder_id for {uri}: {e:?}"));
                 let node_id = uri
                     .node_id()
-                    .unwrap_or_else(|e| panic!("unable to get node_id for {}: {:?}", uri, e));
+                    .unwrap_or_else(|e| panic!("unable to get node_id for {uri}: {e:?}"));
                 if peer_map.get(&responder_id).unwrap_or(&node_id) != &node_id {
-                    panic!("node id mismatch for {}", responder_id);
+                    panic!("node id mismatch for {responder_id}");
                 } else {
                     peer_map.insert(responder_id, node_id);
                 }
@@ -137,7 +136,7 @@ impl NetworkConfig {
                         peer_map
                             .get(responder_id)
                             .unwrap_or_else(|| {
-                                panic!("Unknown responder_id {} in quorum set", responder_id)
+                                panic!("Unknown responder_id {responder_id} in quorum set")
                             })
                             .clone(),
                     ),

--- a/consensus/service/config/src/signer_identity.rs
+++ b/consensus/service/config/src/signer_identity.rs
@@ -23,9 +23,9 @@ impl FromStr for PemEd25519Public {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let pem = pem::parse(s).map_err(|e| format!("Failed to parse PEM {:?}: {}", s, e))?;
+        let pem = pem::parse(s).map_err(|e| format!("Failed to parse PEM {s:?}: {e}"))?;
         let public_key = Ed25519Public::try_from_der(&pem.contents)
-            .map_err(|e| format!("Failed to parse public key {:?}: {}", s, e))?;
+            .map_err(|e| format!("Failed to parse public key {s:?}: {e}"))?;
         Ok(PemEd25519Public(public_key))
     }
 }

--- a/consensus/service/src/api/attested_api_service.rs
+++ b/consensus/service/src/api/attested_api_service.rs
@@ -161,7 +161,7 @@ mod peer_tests {
             .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
             .expect("Could not create anonymous bind");
         server.start();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = AttestedApiClient::new(ch);
         (client, server)
     }
@@ -188,13 +188,13 @@ mod peer_tests {
 
         match client.auth(&AuthMessage::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }
@@ -227,7 +227,7 @@ mod client_tests {
             .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
             .expect("Could not create anonymous bind");
         server.start();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = AttestedApiClient::new(ch);
         (client, server)
     }
@@ -254,13 +254,13 @@ mod client_tests {
 
         match client.auth(&AuthMessage::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -96,7 +96,7 @@ impl<L: Ledger + Clone> BlockchainApiService<L> {
         // Get "persistence type" blocks.
         let mut blocks: Vec<mc_blockchain_types::Block> = Vec::new();
         for block_index in start_index..end_index {
-            match self.ledger.get_block(block_index as u64) {
+            match self.ledger.get_block(block_index) {
                 Ok(block) => blocks.push(block),
                 Err(mc_ledger_db::Error::NotFound) => {
                     // This is okay - it means we have reached the last block in the ledger in the
@@ -207,7 +207,7 @@ mod tests {
             .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
             .expect("Could not create anonymous bind");
         server.start();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = BlockchainApiClient::new(ch);
         (client, server)
     }
@@ -268,13 +268,13 @@ mod tests {
 
         match client.get_last_block_info(&Empty::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }
@@ -422,13 +422,13 @@ mod tests {
 
         match client.get_blocks(&BlocksRequest::default()) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         }
     }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -87,7 +87,7 @@ impl ClientApiService {
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {
             if let TxManagerError::TransactionValidation(cause) = &err {
-                counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", cause));
+                counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{cause:?}"));
             }
             err
         })?;
@@ -116,7 +116,7 @@ impl ClientApiService {
     ) -> Result<ProposeMintConfigTxResponse, ConsensusGrpcError> {
         counters::PROPOSE_MINT_CONFIG_TX_INITIATED.inc();
         let mint_config_tx = MintConfigTx::try_from(&grpc_tx)
-            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{err:?}")))?;
         let response = ProposeMintConfigTxResponse::new();
 
         // Validate the transaction.
@@ -142,7 +142,7 @@ impl ClientApiService {
     ) -> Result<ProposeMintTxResponse, ConsensusGrpcError> {
         counters::PROPOSE_MINT_TX_INITIATED.inc();
         let mint_tx = MintTx::try_from(&grpc_tx)
-            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusGrpcError::InvalidArgument(format!("{err:?}")))?;
         let response = ProposeMintTxResponse::new();
 
         // Validate the transaction.
@@ -396,14 +396,14 @@ mod client_api_tests {
             .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
             .expect("Could not create anonymous bind");
         server.start();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = ConsensusClientApiClient::new(ch);
         (client, server)
     }
 
     /// Get a dummy config object
     fn get_config() -> Config {
-        Config::try_parse_from(&[
+        Config::try_parse_from([
             "foo",
             "--chain-id=local",
             "--peer-responder-id=localhost:8081",
@@ -505,7 +505,7 @@ mod client_api_tests {
                 assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -576,7 +576,7 @@ mod client_api_tests {
                 assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -627,7 +627,7 @@ mod client_api_tests {
             Ok(_) => {
                 panic!("Got success, but failure was expected");
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -705,7 +705,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -765,7 +765,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -833,7 +833,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -875,12 +875,12 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -930,12 +930,12 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         // This is a global variable. It affects other unit tests, so must be reset :(
@@ -979,13 +979,13 @@ mod client_api_tests {
         let message = Message::default();
         match client.client_tx_propose(&message) {
             Ok(response) => {
-                panic!("Unexpected response {:?}", response);
+                panic!("Unexpected response {response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
             Err(err) => {
-                panic!("Unexpected error {:?}", err);
+                panic!("Unexpected error {err:?}");
             }
         };
     }
@@ -1046,7 +1046,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert_eq!(
@@ -1115,7 +1115,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1160,12 +1160,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1218,12 +1218,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1275,12 +1275,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_config_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1347,7 +1347,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert_eq!(
@@ -1421,7 +1421,7 @@ mod client_api_tests {
                 );
                 assert_eq!(propose_tx_response.get_block_count(), num_blocks);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1471,12 +1471,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1534,12 +1534,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAVAILABLE);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());
@@ -1596,12 +1596,12 @@ mod client_api_tests {
         let (client, _server) = get_client_server(instance);
         match client.propose_mint_tx(&(&tx).into()) {
             Ok(propose_tx_response) => {
-                panic!("Unexpected response {:?}", propose_tx_response);
+                panic!("Unexpected response {propose_tx_response:?}");
             }
             Err(GrpcError::RpcFailure(rpc_status)) => {
                 assert_eq!(rpc_status.code(), RpcStatusCode::UNAUTHENTICATED);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         assert!(submitted_values.lock().unwrap().is_empty());

--- a/consensus/service/src/api/grpc_error.rs
+++ b/consensus/service/src/api/grpc_error.rs
@@ -85,7 +85,7 @@ impl From<TxManagerError> for ConsensusGrpcError {
             TxManagerError::Enclave(err) => Self::from(err),
             TxManagerError::TransactionValidation(err) => Self::from(err),
             TxManagerError::LedgerDb(err) => Self::from(err),
-            _ => Self::Other(format!("tx manager error: {}", src)),
+            _ => Self::Other(format!("tx manager error: {src}")),
         }
     }
 }
@@ -110,7 +110,7 @@ impl From<ConsensusGrpcError> for RpcStatus {
         match src {
             ConsensusGrpcError::RpcStatus(rpc_status) => rpc_status,
             ConsensusGrpcError::Ledger(err) => {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Ledger error: {}", err))
+                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Ledger error: {err}"))
             }
             ConsensusGrpcError::OverCapacity => RpcStatus::with_message(
                 RpcStatusCode::UNAVAILABLE,
@@ -132,12 +132,10 @@ impl From<ConsensusGrpcError> for RpcStatus {
                 global_log::error!("Attempting to convert a ConsensusGrpcError::TransactionValidation into RpcStatus, this should not happen! Error is: {}", err);
                 RpcStatus::with_message(
                     RpcStatusCode::INTERNAL,
-                    format!("Unexpected transaction validation error: {}", err),
+                    format!("Unexpected transaction validation error: {err}"),
                 )
             }
-            _ => {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Internal error: {}", src))
-            }
+            _ => RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("Internal error: {src}")),
         }
     }
 }

--- a/consensus/service/src/api/peer_api_service.rs
+++ b/consensus/service/src/api/peer_api_service.rs
@@ -162,9 +162,9 @@ impl PeerApiService {
                         logger,
                         "Error validating transaction {tx_hash}: {err}",
                         tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
+                        err = format!("{err:?}")
                     );
-                    counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{:?}", err));
+                    counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{err:?}"));
                 }
 
                 Err(err) => {
@@ -172,7 +172,7 @@ impl PeerApiService {
                         logger,
                         "tx_propose failed for {tx_hash}: {err}",
                         tx_hash = tx_hash.to_string(),
-                        err = format!("{:?}", err)
+                        err = format!("{err:?}")
                     );
                 }
             };
@@ -462,7 +462,7 @@ mod tests {
             .add_listening_port("127.0.0.1:0", ServerCredentials::insecure())
             .expect("Could not create anonymous bind");
         server.start();
-        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{port}"));
         let client = ConsensusPeerApiClient::new(ch);
         (client, server)
     }
@@ -531,7 +531,7 @@ mod tests {
                     ConsensusMsgResult::UnknownPeer
                 );
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -602,7 +602,7 @@ mod tests {
             Ok(consensus_msg_response) => {
                 assert_eq!(consensus_msg_response.get_result(), ConsensusMsgResult::Ok);
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
 
         // TODO: Should pass the message to incoming_consensus_msgs_sender
@@ -640,12 +640,12 @@ mod tests {
         message.set_payload(vec![240, 159, 146, 150]); // UTF-8 "sparkle heart".
 
         match client.send_consensus_msg(&message) {
-            Ok(response) => panic!("Unexpected response: {:?}", response),
+            Ok(response) => panic!("Unexpected response: {response:?}"),
             Err(RpcFailure(_rpc_status)) => {
                 // This is expected.
                 // TODO: check status code.
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 
@@ -717,12 +717,12 @@ mod tests {
         message.set_payload(mc_util_serial::serialize(&payload).unwrap());
 
         match client.send_consensus_msg(&message) {
-            Ok(response) => panic!("Unexpected response: {:?}", response),
+            Ok(response) => panic!("Unexpected response: {response:?}"),
             Err(RpcFailure(_rpc_status)) => {
                 // This is expected.
                 // TODO: check status code.
             }
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 

--- a/consensus/service/src/background_work_queue.rs
+++ b/consensus/service/src/background_work_queue.rs
@@ -94,7 +94,7 @@ impl<T: Send + 'static> BackgroundWorkQueue<T> {
         if let Some(join_handle) = self.join_handle.take() {
             return join_handle
                 .join()
-                .map_err(|e| BackgroundWorkQueueError::JoinFailed(format!("{:?}", e)))?;
+                .map_err(|e| BackgroundWorkQueueError::JoinFailed(format!("{e:?}")))?;
         }
 
         Ok(())

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -236,7 +236,7 @@ impl ByzantineLedger {
                 peer_manager,
                 tx_manager,
                 mint_tx_manager,
-                broadcaster.clone(),
+                broadcaster,
                 task_receiver,
                 is_behind.clone(),
                 highest_peer_block.clone(),
@@ -481,7 +481,7 @@ mod tests {
             msg_signer_key,
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, byzantine_ledger is not behind.
@@ -574,7 +574,7 @@ mod tests {
             local_signer_key.clone(),
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, there should be no messages to the network.
@@ -708,8 +708,7 @@ mod tests {
                 .msgs;
             assert!(
                 msgs.contains(&expected_msg),
-                "Nominate msg not found. msgs={:#?}",
-                msgs,
+                "Nominate msg not found. msgs={msgs:#?}",
             );
         }
 
@@ -956,7 +955,7 @@ mod tests {
             local_signer_key.clone(),
             Vec::new(),
             None,
-            logger.clone(),
+            logger,
         );
 
         // Initially, there should be no messages to the network.
@@ -1046,8 +1045,7 @@ mod tests {
                 .msgs;
             assert!(
                 msgs.contains(&expected_msg),
-                "Nominate msg not found. msgs={:#?}",
-                msgs,
+                "Nominate msg not found. msgs={msgs:#?}",
             );
         }
 

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -841,13 +841,13 @@ impl<
         let well_formed_encrypted_txs_with_proofs = self
             .tx_manager
             .tx_hashes_to_well_formed_encrypted_txs_and_proofs(&tx_hashes)
-            .unwrap_or_else(|e| panic!("failed resolving tx_hashes {:?}: {:?}", tx_hashes, e));
+            .unwrap_or_else(|e| panic!("failed resolving tx_hashes {tx_hashes:?}: {e:?}"));
 
         // Bundle mint_txs with the matching configuration that allows the minting.
         let mint_txs_with_config = self
             .mint_tx_manager
             .mint_txs_with_config(&mint_txs)
-            .unwrap_or_else(|e| panic!("failed resolving mint txs {:?}: {:?}", mint_txs, e));
+            .unwrap_or_else(|e| panic!("failed resolving mint txs {mint_txs:?}: {e:?}"));
 
         // Get the root membership element, which is needed for validating the
         // membership proofs (and also storing in the block for bookkeeping
@@ -881,10 +881,7 @@ impl<
 
     fn get_block_metadata(&self, block_id: &BlockID) -> BlockMetadata {
         let verification_report = self.enclave.get_ias_report().unwrap_or_else(|err| {
-            panic!(
-                "Failed to fetch verification report after forming block {:?}: {}",
-                block_id, err
-            )
+            panic!("Failed to fetch verification report after forming block {block_id:?}: {err}")
         });
         let contents = BlockMetadataContents::new(
             block_id.clone(),
@@ -894,12 +891,7 @@ impl<
         );
 
         BlockMetadata::from_contents_and_keypair(contents, &self.msg_signer_key).unwrap_or_else(
-            |err| {
-                panic!(
-                    "Failed to sign block metadata for block {:?}: {}",
-                    block_id, err
-                )
-            },
+            |err| panic!("Failed to sign block metadata for block {block_id:?}: {err}"),
         )
     }
 }
@@ -1170,7 +1162,7 @@ mod tests {
                 attempt_sync_at: now,
                 num_sync_attempts: 0,
             },
-            logger.clone(),
+            logger,
         );
     }
 

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -297,8 +297,7 @@ impl<
 
         self.consensus_msgs_from_network.stop().map_err(|e| {
             ConsensusServiceError::BackgroundWorkQueueStop(format!(
-                "consensus_msgs_from_network: {:?}",
-                e
+                "consensus_msgs_from_network: {e:?}"
             ))
         })?;
 
@@ -656,7 +655,7 @@ impl<
                             // If a value was submitted to `scp_client_value_sender` that means it
                             // should've found it's way into the cache. Suddenly not having it there
                             // indicates something is broken, so for the time being we will panic.
-                            panic!("tx hash {} expected to be in cache but wasn't", tx_hash);
+                            panic!("tx hash {tx_hash} expected to be in cache but wasn't");
                         }
                     }
                 }

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -220,7 +220,7 @@ pub mod well_formed_tests {
                 assert_eq!(current_block_index, num_blocks - 1);
                 assert_eq!(highest_index_proofs.len(), 3)
             }
-            Err(e) => panic!("Unexpected error {}", e),
+            Err(e) => panic!("Unexpected error {e}"),
         }
     }
 

--- a/consensus/tool/src/main.rs
+++ b/consensus/tool/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
                         }
                     }
                     Err(err) => {
-                        eprintln!("{}: get_last_block_info(): {}", uri, err);
+                        eprintln!("{uri}: get_last_block_info(): {err}");
                         needs_retry = true;
                     }
                 };
@@ -147,7 +147,7 @@ fn main() {
                             }
                         }
                         Err(err) => {
-                            eprintln!("{}: get_last_block_info(): {}", uri, err);
+                            eprintln!("{uri}: get_last_block_info(): {err}");
                             was_updated = true;
                         }
                     };
@@ -164,7 +164,7 @@ fn main() {
                 std::thread::sleep(Duration::from_secs(period));
             };
             // Print the stopping point on STDOUT so that scripts can capture this easily
-            print!("{}", last_block_index)
+            print!("{last_block_index}")
         }
     }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,7 +40,7 @@ mc-util-test-vector = { path = "../util/test-vector" }
 mc-util-test-with-data = { path = "../util/test-with-data" }
 
 serde = { version = "1.0.152", features = [ "derive" ] }
-serde_json = { version = "1.0.85" }
+serde_json = { version = "1.0.91" }
 
 [[example]]
 name = "slip10"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,3 @@ pub mod consts;
 pub mod subaddress;
 
 pub mod slip10;
-
-#[cfg(feature = "protos")]
-pub mod protos;

--- a/core/src/protos.rs
+++ b/core/src/protos.rs
@@ -1,8 +1,0 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
-
-//! Generated rust objects from api/protos
-
-#![allow(missing_docs)]
-#![allow(non_snake_case)]
-
-include!(concat!(env!("OUT_DIR"), "/external.rs"));

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -8,10 +8,12 @@ readme = "README.md"
 
 [features]
 serde = ["dep:serde"]
+prost = ["dep:prost", "mc-crypto-keys/prost"]
 
 [dependencies]
 # External dependencies
 curve25519-dalek = { version = "4.0.0-pre.2", default-features = false }
+prost = { version = "0.11", optional = true, default-features = false }
 serde = { version = "1.0.152", optional = true, default-features = false, features = [ "derive" ] }
 zeroize = { version = "1.5", default-features = false }
 

--- a/core/types/src/account.rs
+++ b/core/types/src/account.rs
@@ -60,6 +60,54 @@ impl Account {
     }
 }
 
+/// MobileCoin view only account object.
+///
+/// Derived from an [Account] object, used where spend key custody is external
+/// (offline or via hardware).
+#[derive(Zeroize)]
+pub struct ViewAccount {
+    /// Root view private key
+    view_private: RootViewPrivate,
+
+    /// Root spend public key
+    spend_public: RootSpendPublic,
+}
+
+impl ViewAccount {
+    /// Create an view-only account from existing private keys
+    pub fn new(view_private: RootViewPrivate, spend_public: RootSpendPublic) -> Self {
+        Self {
+            view_private,
+            spend_public,
+        }
+    }
+
+    /// Fetch account view public key
+    pub fn view_public_key(&self) -> RootViewPublic {
+        RootViewPublic::from(&self.view_private)
+    }
+
+    /// Fetch account spend public key
+    pub fn spend_public_key(&self) -> &RootSpendPublic {
+        &self.spend_public
+    }
+
+    /// Fetch account view private key
+    pub fn view_private_key(&self) -> &RootViewPrivate {
+        &self.view_private
+    }
+}
+
+/// Create a [ViewAccount] from a root [Account] object
+impl From<&Account> for ViewAccount {
+    fn from(a: &Account) -> Self {
+        Self {
+            view_private: a.view_private_key().clone(),
+            spend_public: a.spend_public_key(),
+        }
+    }
+}
+
 /// MobileCoin spend subaddress object.
 ///
 /// Contains view and spend private keys.
@@ -102,6 +150,7 @@ impl SpendSubaddress {
 pub struct ViewSubaddress {
     /// sub-address view private key
     pub view_private: SubaddressViewPrivate,
+
     /// sub-address spend private key
     pub spend_public: SubaddressSpendPublic,
 }

--- a/core/types/src/keys.rs
+++ b/core/types/src/keys.rs
@@ -10,7 +10,7 @@ use core::{
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
 use zeroize::Zeroize;
 
-use mc_crypto_keys::{KeyError, RistrettoPrivate, RistrettoPublic};
+use mc_crypto_keys::{KeyError, ReprBytes, RistrettoPrivate, RistrettoPublic};
 
 use crate::markers::*;
 
@@ -36,12 +36,20 @@ pub type RootViewPublic = Key<Root, View, RistrettoPublic>;
 /// Root spend public key
 pub type RootSpendPublic = Key<Root, Spend, RistrettoPublic>;
 
+/// TxOut public key
+pub type TxOutPublic = Key<TxOut, Public, RistrettoPublic>;
+/// TxOut target public key
+pub type TxOutTargetPublic = Key<TxOut, Target, RistrettoPublic>;
+
 /// Generic key object, see type aliases for use
 #[derive(Clone, Debug, Zeroize)]
 pub struct Key<ADDR, KIND, KEY: Default + Zeroize> {
+    /// Key data
     key: KEY,
+    /// Address (root, sub, etc.) marker
     #[zeroize(skip)]
     _addr: PhantomData<ADDR>,
+    /// Kind (view, spend, etc.) marker
     #[zeroize(skip)]
     _kind: PhantomData<KIND>,
 }
@@ -68,6 +76,29 @@ impl<ADDR, KIND, KEY: Default + Zeroize> Default for Key<ADDR, KIND, KEY> {
             _addr: PhantomData,
             _kind: PhantomData,
         }
+    }
+}
+
+/// Expose [`ReprBytes`] for internal `KEY` types implementing this
+impl<ADDR, KIND, KEY> ReprBytes for Key<ADDR, KIND, KEY>
+where
+    KEY: ReprBytes + Default + Zeroize,
+{
+    type Size = <KEY as ReprBytes>::Size;
+
+    type Error = <KEY as ReprBytes>::Error;
+
+    fn from_bytes(src: &mc_crypto_keys::GenericArray<u8, Self::Size>) -> Result<Self, Self::Error> {
+        let key = <KEY as ReprBytes>::from_bytes(src)?;
+        Ok(Key {
+            key,
+            _addr: PhantomData,
+            _kind: PhantomData,
+        })
+    }
+
+    fn to_bytes(&self) -> mc_crypto_keys::GenericArray<u8, Self::Size> {
+        <KEY as ReprBytes>::to_bytes(&self.key)
     }
 }
 
@@ -117,10 +148,20 @@ impl<ADDR, KIND> TryFrom<&[u8; 32]> for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// Access underlying [`RistrettoPoint`] for public keys using [`AsRef`]
-impl<ADDR, KIND> AsRef<RistrettoPoint> for Key<ADDR, KIND, RistrettoPublic> {
-    fn as_ref(&self) -> &RistrettoPoint {
-        self.key.as_ref()
+/// Attempt to create a public key from a compressed point, wrapping
+/// [`RistrettoPublic::try_from`]
+impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPublic> {
+    type Error = KeyError;
+
+    fn try_from(p: [u8; 32]) -> Result<Self, Self::Error> {
+        Self::try_from(&p)
+    }
+}
+
+/// Access underlying [`RistrettoPoint`] for public key containers
+impl<ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPublic>> for RistrettoPoint {
+    fn from(k: &Key<ADDR, KIND, RistrettoPublic>) -> Self {
+        *k.key.as_ref()
     }
 }
 
@@ -145,34 +186,34 @@ impl<ADDR, KIND> PartialEq<Key<ADDR, KIND, RistrettoPublic>> for RistrettoPublic
     }
 }
 
-/// [`core::fmt::Display`] for public key objects
+/// [core::fmt::Display] for public key objects
 impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02x}", d)?;
+            write!(f, "{d:02x}")?;
         }
         Ok(())
     }
 }
 
-/// [`core::fmt::LowerHex`] for public key objects
+/// [core::fmt::LowerHex] for public key objects
 impl<ADDR, KIND> core::fmt::LowerHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02x}", d)?;
+            write!(f, "{d:02x}")?;
         }
         Ok(())
     }
 }
 
-/// [`core::fmt::UpperHex`] for public key objects
+/// [core::fmt::UpperHex] for public key objects
 impl<ADDR, KIND> core::fmt::UpperHex for Key<ADDR, KIND, RistrettoPublic> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let data = self.key.to_bytes();
         for d in data {
-            write!(f, "{:02X}", d)?;
+            write!(f, "{d:02X}")?;
         }
         Ok(())
     }
@@ -210,7 +251,7 @@ impl<ADDR, KIND> From<Key<ADDR, KIND, RistrettoPrivate>> for Key<ADDR, KIND, Ris
 }
 
 /// Attempt to create a private key from a compressed point, wrapping
-/// [`RistrettoPrivate::try_from`]
+/// [RistrettoPrivate::try_from]
 impl<ADDR, KIND> TryFrom<&[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
     type Error = KeyError;
 
@@ -224,14 +265,24 @@ impl<ADDR, KIND> TryFrom<&[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// Access underlying [`Scalar`] for private keys using [`AsRef`]
-impl<ADDR, KIND> AsRef<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
-    fn as_ref(&self) -> &Scalar {
-        self.key.as_ref()
+/// Attempt to create a private key from a compressed point, wrapping
+/// [RistrettoPrivate::try_from]
+impl<ADDR, KIND> TryFrom<[u8; 32]> for Key<ADDR, KIND, RistrettoPrivate> {
+    type Error = KeyError;
+
+    fn try_from(p: [u8; 32]) -> Result<Self, Self::Error> {
+        Self::try_from(&p)
     }
 }
 
-/// Create private keys from raw [`Scalar`]
+/// Access underlying [Scalar] for private key objects
+impl<ADDR, KIND> From<&Key<ADDR, KIND, RistrettoPrivate>> for Scalar {
+    fn from(k: &Key<ADDR, KIND, RistrettoPrivate>) -> Self {
+        *k.key.as_ref()
+    }
+}
+
+/// Create a private key from raw [Scalar]
 impl<ADDR, KIND> From<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
     fn from(s: Scalar) -> Self {
         Self {
@@ -242,35 +293,35 @@ impl<ADDR, KIND> From<Scalar> for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// [`PartialEq`] via public key conversion for Private key objects
+/// [PartialEq] via public key conversion for Private key objects
 impl<ADDR, KIND> PartialEq for Key<ADDR, KIND, RistrettoPrivate> {
     fn eq(&self, other: &Self) -> bool {
         RistrettoPublic::from(&self.key) == RistrettoPublic::from(&other.key)
     }
 }
 
-/// PartialEq for backwards compatibility with private key objects
+/// [PartialEq] for backwards compatibility with private key objects
 impl<ADDR, KIND> PartialEq<RistrettoPrivate> for Key<ADDR, KIND, RistrettoPrivate> {
     fn eq(&self, other: &RistrettoPrivate) -> bool {
         RistrettoPublic::from(&self.key) == RistrettoPublic::from(other)
     }
 }
 
-/// PartialEq for backwards compatibility with private key objects
+/// [PartialEq] for backwards compatibility with private key objects
 impl<ADDR, KIND> PartialEq<Key<ADDR, KIND, RistrettoPrivate>> for RistrettoPrivate {
     fn eq(&self, other: &Key<ADDR, KIND, RistrettoPrivate>) -> bool {
         RistrettoPublic::from(self) == RistrettoPublic::from(&other.key)
     }
 }
 
-/// [`core::fmt::Display`] for private key objects
+/// [core::fmt::Display] for private key objects
 impl<ADDR, KIND> Display for Key<ADDR, KIND, RistrettoPrivate> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "pub({})", RistrettoPublic::from(&self.key))
     }
 }
 
-/// [`serde::Serialize`] implementation for private key types
+/// [serde::Serialize] implementation for private key types
 #[cfg(feature = "serde")]
 impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPrivate> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -278,7 +329,7 @@ impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPrivate> {
     }
 }
 
-/// [`serde::Serialize`] implementation for public key types
+/// [serde::Serialize] implementation for public key types
 #[cfg(feature = "serde")]
 impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPublic> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -286,7 +337,7 @@ impl<ADDR, KIND> serde::ser::Serialize for Key<ADDR, KIND, RistrettoPublic> {
     }
 }
 
-/// [`serde::Deserialize`] implementation for all key types
+/// [serde::Deserialize] implementation for all key types
 #[cfg(feature = "serde")]
 impl<'de, ADDR, KIND, KEY> serde::de::Deserialize<'de> for Key<ADDR, KIND, KEY>
 where
@@ -311,7 +362,7 @@ where
 #[cfg(feature = "serde")]
 struct KeyVisitor<KEY>(PhantomData<KEY>);
 
-/// Visitor implementation for [`Key`] types supporting `TryFrom<&[u8]>`
+/// Visitor implementation for [Key] types supporting `TryFrom<&[u8]>`
 #[cfg(feature = "serde")]
 impl<'de, KEY> serde::de::Visitor<'de> for KeyVisitor<KEY>
 where
@@ -332,5 +383,45 @@ where
             Ok(v) => Ok(v),
             Err(e) => Err(E::custom(e)),
         }
+    }
+}
+
+/// [Key] implementation of [prost::Message] when its inner `KEY` type
+/// implements [prost::Message].
+#[cfg(feature = "prost")]
+impl<ADDR, KIND, KEY> prost::Message for Key<ADDR, KIND, KEY>
+where
+    ADDR: Send + Sync + Debug,
+    KIND: Send + Sync + Debug,
+    KEY: prost::Message + Zeroize + Default + Debug,
+{
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: prost::bytes::BufMut,
+        Self: Sized,
+    {
+        <KEY as prost::Message>::encode_raw(&self.key, buf)
+    }
+
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: prost::encoding::WireType,
+        buf: &mut B,
+        ctx: prost::encoding::DecodeContext,
+    ) -> Result<(), prost::DecodeError>
+    where
+        B: prost::bytes::Buf,
+        Self: Sized,
+    {
+        <KEY as prost::Message>::merge_field(&mut self.key, tag, wire_type, buf, ctx)
+    }
+
+    fn encoded_len(&self) -> usize {
+        <KEY as prost::Message>::encoded_len(&self.key)
+    }
+
+    fn clear(&mut self) {
+        <KEY as prost::Message>::clear(&mut self.key)
     }
 }

--- a/core/types/src/markers.rs
+++ b/core/types/src/markers.rs
@@ -17,3 +17,15 @@ pub struct View;
 /// Spend key marker type
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct Spend;
+
+/// TxOut key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct TxOut;
+
+/// Transaction public key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Public;
+
+/// Transaction target key marker type
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct Target;

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mc-crypto-dalek"
 description = "MobileCoin Dalek Crypto Configurator Package"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/derive/src/lib.rs
+++ b/crypto/digestible/derive/src/lib.rs
@@ -621,7 +621,7 @@ fn try_digestible_enum_transparent(
             };
 
             if ith_type == jth_type {
-                panic!("The types of the {}'th and {}'th variants of {} appear to be the same. When using digestible(transparent), this is highly suspect", j, i, ident);
+                panic!("The types of the {j}'th and {i}'th variants of {ident} appear to be the same. When using digestible(transparent), this is highly suspect");
             }
         }
     }

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/src/lib.rs
+++ b/crypto/digestible/src/lib.rs
@@ -246,7 +246,7 @@ impl Digestible for u16 {
         transcript: &mut DT,
     ) {
         // Note: encoding of the size of the uint is implicit in merlin's framing
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -257,7 +257,7 @@ impl Digestible for u32 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -268,7 +268,7 @@ impl Digestible for u64 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"uint", &self.to_le_bytes())
+        transcript.append_primitive(context, b"uint", self.to_le_bytes())
     }
 }
 
@@ -279,7 +279,7 @@ impl Digestible for i8 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -290,7 +290,7 @@ impl Digestible for i16 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -301,7 +301,7 @@ impl Digestible for i32 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 
@@ -312,7 +312,7 @@ impl Digestible for i64 {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"int", &self.to_le_bytes())
+        transcript.append_primitive(context, b"int", self.to_le_bytes())
     }
 }
 

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/test-utils/src/inspect_ast.rs
+++ b/crypto/digestible/test-utils/src/inspect_ast.rs
@@ -521,8 +521,8 @@ impl From<&ASTNode> for serde_json::Value {
 impl From<&ASTPrimitive> for serde_json::Value {
     fn from(src: &ASTPrimitive) -> Self {
         json!({
-            utf8(&src.context): "primitive",
-            "type_name": utf8(&src.type_name),
+            utf8(src.context): "primitive",
+            "type_name": utf8(src.type_name),
             "data": pretty_bytes(&src.data)
         })
     }
@@ -531,7 +531,7 @@ impl From<&ASTPrimitive> for serde_json::Value {
 impl From<&ASTNone> for serde_json::Value {
     fn from(src: &ASTNone) -> Self {
         json!({
-            utf8(&src.context): "",
+            utf8(src.context): "",
         })
     }
 }
@@ -539,7 +539,7 @@ impl From<&ASTNone> for serde_json::Value {
 impl From<&ASTSequence> for serde_json::Value {
     fn from(src: &ASTSequence) -> Self {
         let mut result = json!({
-            utf8(&src.context): "sequence",
+            utf8(src.context): "sequence",
             "len": src.len,
         });
         result.as_object_mut().unwrap().insert(
@@ -553,7 +553,7 @@ impl From<&ASTSequence> for serde_json::Value {
 impl From<&ASTAggregate> for serde_json::Value {
     fn from(src: &ASTAggregate) -> Self {
         let mut result = json!({
-            utf8(&src.context): "aggregate",
+            utf8(src.context): "aggregate",
             "name": utf8(&src.name),
         });
         result.as_object_mut().unwrap().insert(
@@ -572,7 +572,7 @@ impl From<&ASTVariant> for serde_json::Value {
             serde_json::Value::String("**incomplete**".to_string())
         };
         json!({
-            utf8(&src.context): "variant",
+            utf8(src.context): "variant",
             "name": utf8(&src.name),
             "which": src.which,
             "value": value_json,

--- a/crypto/digestible/test-utils/src/lib.rs
+++ b/crypto/digestible/test-utils/src/lib.rs
@@ -19,9 +19,9 @@ pub fn digestible_test_case<D: Digestible>(
     let mut transcript = MockMerlin::new();
     obj.append_to_transcript(context.as_bytes(), &mut transcript);
     if &transcript.append_bytes_calls[..] != expected_append_bytes {
+        let append_bytes_calls = transcript.append_bytes_calls;
         panic!(
-            "Digestible test case failed: context = {}\nExpected:\n{:?}\nFound:\n{:?}",
-            context, expected_append_bytes, transcript.append_bytes_calls
+            "Digestible test case failed: context = {context}\nExpected:\n{expected_append_bytes:?}\nFound:\n{append_bytes_calls:?}",
         );
     }
 }
@@ -34,8 +34,7 @@ pub fn digestible_test_case_ast<D: Digestible>(
     let ast = calculate_digest_ast(context.as_bytes(), obj);
     if ast != expected_ast {
         panic!(
-            "Digestible AST test case failed: context = {}\nExpected:\n{}\nFound:\n{}",
-            context, expected_ast, ast
+            "Digestible AST test case failed: context = {context}\nExpected:\n{expected_ast}\nFound:\n{ast}",
         );
     }
 }

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -447,7 +447,7 @@ impl Digestible for Ed25519Signature {
         context: &'static [u8],
         transcript: &mut DT,
     ) {
-        transcript.append_primitive(context, b"ed25519-sig", &self);
+        transcript.append_primitive(context, b"ed25519-sig", self);
     }
 }
 
@@ -610,15 +610,15 @@ mod ed25519_tests {
     fn openssl_version() {
         run_and_log("openssl", &["version"]);
 
-        let output = Command::new("openssl").args(&["version"]).output().unwrap();
+        let output = Command::new("openssl").args(["version"]).output().unwrap();
         let output_string = String::from_utf8(output.stdout).unwrap();
         let mut iter = output_string.split(' ');
         iter.next();
         let ver_string = iter.next().unwrap();
-        eprintln!("version: {}", ver_string);
+        eprintln!("version: {ver_string}");
         let ver = Version::parse(ver_string).unwrap();
         let ver_req = VersionReq::parse(">= 1.1").unwrap();
-        assert!(ver_req.matches(&ver), "Version of openssl should be {}, install a better one and put it in path (or run in docker)", ver_req);
+        assert!(ver_req.matches(&ver), "Version of openssl should be {ver_req}, install a better one and put it in path (or run in docker)");
     }
 
     // This test is only run in nightly, because it has a dependency on host version

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -115,7 +115,7 @@ pub struct Fingerprint<D: digest::OutputSizeUser>(
 /// Debug impl for fingerprint objects
 impl<D: digest::OutputSizeUser> core::fmt::Debug for Fingerprint<D> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Fingerprint({})", self)
+        write!(f, "Fingerprint({self})")
     }
 }
 
@@ -142,7 +142,7 @@ impl<T: PublicKey + DistinguishedEncoding> Fingerprintable for T {
         let der = self.to_der_slice(&mut buff);
 
         // Get the hash of the DER bytes
-        let hash = D::digest(&der);
+        let hash = D::digest(der);
 
         // Return fingerprint
         Fingerprint(hash)

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -262,8 +262,7 @@ impl Debug for X25519Public {
 
         write!(
             f,
-            "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
-            b64_str
+            "-----BEGIN PUBLIC KEY-----\n{b64_str}\n-----END PUBLIC KEY-----\n",
         )
     }
 }

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin multi-signature implementations"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/crypto/ring-signature/src/amount/commitment.rs
+++ b/crypto/ring-signature/src/amount/commitment.rs
@@ -53,7 +53,7 @@ impl fmt::Debug for Commitment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Commitment(")?;
         for i in self.to_bytes() {
-            write!(f, "{:02x}", i)?;
+            write!(f, "{i:02x}")?;
         }
         write!(f, ")")
     }

--- a/crypto/ring-signature/src/lib.rs
+++ b/crypto/ring-signature/src/lib.rs
@@ -29,6 +29,9 @@ pub use ring_signature::{
 #[cfg(feature = "alloc")]
 pub use ring_signature::RingMLSAG;
 
+#[cfg(feature = "internals")]
+pub use ring_signature::{MlsagSignCtx, MlsagSignParams, MlsagVerify, Ring};
+
 /// Get the shared secret for a transaction output.
 ///
 /// # Arguments

--- a/crypto/ring-signature/src/onetime_keys.rs
+++ b/crypto/ring-signature/src/onetime_keys.rs
@@ -75,7 +75,7 @@ use crate::domain_separators::HASH_TO_SCALAR_DOMAIN_TAG;
 use curve25519_dalek::{
     constants::RISTRETTO_BASEPOINT_POINT, ristretto::RistrettoPoint, scalar::Scalar,
 };
-use mc_account_keys_types::RingCtAddress;
+use mc_core_types::account::RingCtAddress;
 use mc_crypto_hashes::{Blake2b512, Digest};
 use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 
@@ -84,7 +84,7 @@ const G: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
 /// Hashes a curve point to a Scalar.
 fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_SCALAR_DOMAIN_TAG);
+    hasher.update(HASH_TO_SCALAR_DOMAIN_TAG);
     hasher.update(point.compress().as_bytes());
     Scalar::from_hash(hasher)
 }
@@ -103,11 +103,13 @@ pub fn create_tx_out_target_key(
     // `Hs( r * C)`
     let Hs: Scalar = {
         let r = tx_private_key.as_ref();
-        let C = recipient.view_public_key().as_ref();
+        let view_public = recipient.view_public_key();
+        let C: &RistrettoPoint = &RistrettoPoint::from(&view_public);
         hash_to_scalar(r * C)
     };
 
-    let D = recipient.spend_public_key().as_ref();
+    let spend_public = recipient.spend_public_key();
+    let D: &RistrettoPoint = &RistrettoPoint::from(&spend_public);
     RistrettoPublic::from(Hs * G + D)
 }
 
@@ -138,8 +140,8 @@ pub fn create_tx_out_public_key(
 ///
 /// # Arguments
 /// * `view_private_key` - The recipient's view private key `a`.
-/// * `tx_out_target_key` - The output's target_key.
-/// * `tx_out_public_key` - The output's public_key.
+/// * `tx_out_target_key` - The output's tx_target_key.
+/// * `tx_out_public_key` - The output's tx_public_key `R`.
 pub fn recover_public_subaddress_spend_key(
     view_private_key: &RistrettoPrivate,
     tx_out_target_key: &RistrettoPublic,

--- a/crypto/ring-signature/src/ring_signature/mlsag.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag.rs
@@ -1,52 +1,45 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-extern crate alloc;
+use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 
-use alloc::{vec, vec::Vec};
-use curve25519_dalek::ristretto::RistrettoPoint;
-use mc_crypto_digestible::Digestible;
-use mc_crypto_hashes::{Blake2b512, Digest};
-use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
-use prost::Message;
+use alloc::vec::Vec;
 use rand_core::CryptoRngCore;
+use zeroize::Zeroize;
+
+use mc_crypto_digestible::Digestible;
+
+#[cfg(feature = "prost")]
+use prost::Message;
+
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use zeroize::{Zeroize, Zeroizing};
 
 use crate::{
-    domain_separators::RING_MLSAG_CHALLENGE_DOMAIN_TAG,
     ring_signature::{
-        hash_to_point, CurveScalar, Error, KeyImage, PedersenGens, Scalar, B_BLINDING,
+        mlsag_sign::MlsagSignParams, mlsag_verify::MlsagVerify, CurveScalar, Error, KeyImage,
+        PedersenGens, Scalar,
     },
-    Commitment, CompressedCommitment,
+    Commitment, CompressedCommitment, ReducedTxOut,
 };
-
-/// A reduced representation of a TxOut, appropriate for making MLSAG
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-pub struct ReducedTxOut {
-    /// The tx_out.public_key field
-    pub public_key: CompressedRistrettoPublic,
-    /// The tx_out.target_key field
-    pub target_key: CompressedRistrettoPublic,
-    /// The tx_out.masked_amount.commitment field
-    pub commitment: CompressedCommitment,
-}
 
 /// MLSAG for a ring of public keys and amount commitments.
 /// Note: Serialize and Deserialize appear to be cruft left over from
 /// sdk_json_interface.
-#[derive(Clone, Digestible, PartialEq, Eq, Serialize, Deserialize, Message, Zeroize)]
+#[derive(Clone, Digestible, PartialEq, Eq, Zeroize)]
+#[cfg_attr(feature = "prost", derive(Message))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RingMLSAG {
     /// The initial challenge `c[0]`.
-    #[prost(message, required, tag = "1")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "1"))]
     pub c_zero: CurveScalar,
 
     /// Responses `r_{0,0}, r_{0,1}, ... , r_{ring_size-1,0},
     /// r_{ring_size-1,1}`.
-    #[prost(message, repeated, tag = "2")]
+    #[cfg_attr(feature = "prost", prost(message, repeated, tag = "2"))]
     pub responses: Vec<CurveScalar>,
 
     /// Key image "spent" by this signature.
-    #[prost(message, required, tag = "3")]
+    #[cfg_attr(feature = "prost", prost(message, required, tag = "3"))]
     pub key_image: KeyImage,
 }
 
@@ -112,6 +105,7 @@ impl RingMLSAG {
     // * `check_value_is_preserved` - If true, check that the value of inputs equals
     //   value of outputs.
     // * `rng` - Randomness.
+    #[allow(unreachable_code, unused_variables)]
     fn sign_with_balance_check(
         message: &[u8],
         ring: &[ReducedTxOut],
@@ -122,116 +116,46 @@ impl RingMLSAG {
         output_blinding: &Scalar,
         generator: &PedersenGens,
         check_value_is_preserved: bool,
-        // Note: this `mut rng` can just be `rng` if this is merged upstream:
-        // https://github.com/dalek-cryptography/curve25519-dalek/pull/394
-        mut rng: &mut dyn CryptoRngCore,
+        rng: &mut dyn CryptoRngCore,
     ) -> Result<Self, Error> {
         let ring_size = ring.len();
 
-        if real_index >= ring_size {
-            return Err(Error::IndexOutOfBounds);
-        }
-
-        let G = B_BLINDING;
-        debug_assert!(
-            generator.B_blinding == G,
-            "basepoint for blindings mismatch"
+        // Setup buffers
+        let (mut responses, mut decompressed_ring) = (
+            alloc::vec![CurveScalar::from(Scalar::zero()); 2 * ring_size],
+            alloc::vec![(RistrettoPublic::default(), Commitment::default()); ring_size],
         );
 
-        let key_image = KeyImage::from(onetime_private_key);
-
-        // The uncompressed key_image.
-        let I: RistrettoPoint = key_image.point.decompress().ok_or(Error::InvalidKeyImage)?;
-
-        // Uncompressed output commitment.
-        // This ensures that each address and commitment encodes a valid Ristretto
-        // point.
-        let output_commitment = Commitment::new(value, *output_blinding, generator);
-
-        // Ring must decompress.
-        let decompressed_ring = decompress_ring(ring)?;
-
-        // Challenges `c_0, ... c_{ring_size - 1}`.
-        let mut c: Vec<Scalar> = vec![Scalar::zero(); ring_size];
-
-        // Responses `r_{0,0}, r_{0,1}, ... , r_{ring_size-1,0}, r_{ring_size-1,1}`.
-        let mut r: Vec<Scalar> = vec![Scalar::zero(); 2 * ring_size];
-        for i in 0..ring_size {
-            if i == real_index {
-                continue;
-            }
-            r[2 * i] = Scalar::random(&mut rng);
-            r[2 * i + 1] = Scalar::random(&mut rng);
+        // Pre-decompress ring
+        for (i, r) in ring.iter().enumerate() {
+            decompressed_ring[i] = r.try_into()?;
         }
 
-        let alpha_0 = Zeroizing::new(Scalar::random(&mut rng));
-        let alpha_1 = Zeroizing::new(Scalar::random(&mut rng));
+        // Setup and call signer
+        let opts = MlsagSignParams {
+            ring_size,
+            message,
+            real_index,
+            onetime_private_key,
+            value,
+            blinding,
+            output_blinding,
+            generator,
+            check_value_is_preserved,
+        };
+        let (key_image, c_zero) = opts.sign(&decompressed_ring[..], rng, &mut responses)?;
 
-        for n in 0..ring_size {
-            // Iterate around the ring, starting at real_index.
-            let i = (real_index + n) % ring_size;
-            let (P_i, input_commitment) = &decompressed_ring[i];
-
-            let (L0, R0, L1) = if i == real_index {
-                // c_{i+1} = Hn( m | key_image | alpha_0 * G | alpha_0 * Hp(P_i) | alpha_1 * G )
-                //         = Hn( m | key_image |      L0     |         R0        |      L1     )
-                //
-                // where P_i is the i^th onetime public key.
-                // There is no R1 term because no key image is needed for the commitment to
-                // zero.
-
-                let L0 = *alpha_0 * G;
-                let R0 = *alpha_0 * hash_to_point(P_i);
-                let L1 = *alpha_1 * G;
-                (L0, R0, L1)
-            } else {
-                // c_{i+1} = Hn( m | key_image | r_{i,0} * G + c_i * P_i | r_{i,0} * Hp(P_i) +
-                // c_i * I | r_{i,1} * G + c_i * Z_i )         = Hn( m |
-                // key_image |           L0            |               R0            |
-                // L1          )
-                //
-                // where:
-                // * P_i is the i^th onetime public key.
-                // * I is the key image of the real input's private key,
-                // * Z_i is the i^th "commitment to zero" = output_commitment -
-                //   input_commitment.
-                //
-                // There is no R1 term because no key image is needed for the commitment to
-                // zero.
-
-                let L0 = r[2 * i] * G + c[i] * P_i.as_ref();
-                let R0 = r[2 * i] * hash_to_point(P_i) + c[i] * I;
-                let L1 =
-                    r[2 * i + 1] * G + c[i] * (output_commitment.point - input_commitment.point);
-                (L0, R0, L1)
-            };
-
-            c[(i + 1) % ring_size] = challenge(message, &key_image, &L0, &R0, &L1);
-        }
-
-        // "Close the loop" by computing responses for the real index.
-
-        let s: Scalar = *onetime_private_key.as_ref();
-        r[2 * real_index] = *alpha_0 - c[real_index] * s;
-
-        let z: Scalar = output_blinding - blinding;
-        r[2 * real_index + 1] = *alpha_1 - c[real_index] * z;
-
-        if check_value_is_preserved {
-            let (_, input_commitment) = decompressed_ring[real_index];
-            let difference: RistrettoPoint = output_commitment.point - input_commitment.point;
-            if difference != (z * G) {
-                return Err(Error::ValueNotConserved);
-            }
-        }
-
-        let responses: Vec<CurveScalar> = r.into_iter().map(CurveScalar::from).collect();
-
-        Ok(RingMLSAG {
-            c_zero: CurveScalar::from(c[0]),
+        // Build MLSAG output
+        let res = RingMLSAG {
+            c_zero,
             responses,
             key_image,
-        })
+        };
+
+        // Zeroize buffers
+        decompressed_ring.iter_mut().for_each(|(p, _c)| p.zeroize());
+
+        Ok(res)
     }
 
     /// Verify MLSAG signature.
@@ -247,124 +171,50 @@ impl RingMLSAG {
         output_commitment: &CompressedCommitment,
     ) -> Result<(), Error> {
         let ring_size = ring.len();
-        // `responses` must contain `2 * ring_size` elements.
-        if self.responses.len() != 2 * ring_size {
-            return Err(Error::LengthMismatch(2 * ring_size, self.responses.len()));
+
+        // Setup buffers for recomputed_c and decompressed rings
+        let (mut recomputed_c, mut decompressed_ring) = (
+            alloc::vec![Scalar::zero(); ring_size],
+            alloc::vec![(RistrettoPublic::default(), Commitment::default()); ring_size],
+        );
+
+        // Pre-decompress ring
+        for (i, r) in ring.iter().enumerate() {
+            decompressed_ring[i] = r.try_into()?;
         }
 
-        let G = B_BLINDING;
+        // Setup and execute verification
+        let opts = MlsagVerify {
+            key_image: &self.key_image,
+            c_zero: &self.c_zero,
+            responses: &self.responses,
+            message,
+            ring: &decompressed_ring[..],
+            output_commitment,
+        };
 
-        // The key image must decompress.
-        // This ensures that the key image encodes a valid Ristretto point.
-        let I: RistrettoPoint = self
-            .key_image
-            .point
-            .decompress()
-            .ok_or(Error::InvalidKeyImage)?;
+        // Execute verification
+        let res = opts.verify(&mut recomputed_c);
 
-        let r: Vec<Scalar> = self
-            .responses
-            .iter()
-            .map(|response| response.scalar)
-            .collect();
+        // Zeroize buffers
+        recomputed_c.iter_mut().for_each(|v| v.zeroize());
+        decompressed_ring.iter_mut().for_each(|(p, _c)| p.zeroize());
 
-        // Output commitment must decompress.
-        let output_commitment: Commitment = Commitment::try_from(output_commitment)?;
-
-        // Ring must decompress.
-        // This ensures that each address and commitment encodes a valid Ristretto
-        // point.
-        let decompressed_ring = decompress_ring(ring)?;
-
-        // Scalars must be canonical.
-        if !self.c_zero.scalar.is_canonical() {
-            return Err(Error::InvalidCurveScalar);
-        }
-
-        // Scalars must be canonical.
-        for response in &self.responses {
-            if !response.scalar.is_canonical() {
-                return Err(Error::InvalidCurveScalar);
-            }
-        }
-
-        // Recompute challenges.
-        let mut recomputed_c = vec![Scalar::zero(); ring.len()];
-
-        for (i, (P_i, input_commitment)) in decompressed_ring.iter().enumerate() {
-            let c_i = if i == 0 {
-                // Initialize loop using the signature's c_0 term.
-                self.c_zero.scalar
-            } else {
-                recomputed_c[i]
-            };
-
-            // c_{i+1} = Hn( m | key_image |  r_{i,0} * G + c_i * P_i | r_{i,0} * Hp(P_i) +
-            // c_i * I | r_{i,1} * G + c_i * Z_i )         = Hn( m | key_image |
-            // L0            |               R0            |           L1            )
-            //
-            // where:
-            // * P_i is the i^th onetime public key.
-            // * I is the key image of the real input's private key,
-            // * Z_i is the i^th "commitment to zero" = output_commitment - i^th
-            //   input_commitment.
-
-            let L0 = r[2 * i] * G + c_i * P_i.as_ref();
-            let R0 = r[2 * i] * hash_to_point(P_i) + c_i * I;
-            let L1 = r[2 * i + 1] * G + c_i * (output_commitment.point - input_commitment.point);
-
-            recomputed_c[(i + 1) % ring_size] = challenge(message, &self.key_image, &L0, &R0, &L1);
-        }
-
-        if self.c_zero.scalar == recomputed_c[0] {
-            Ok(())
-        } else {
-            Err(Error::InvalidSignature)
-        }
+        res
     }
-}
-
-// Compute the "challenge" H( message | key_image | L0 | R0 | L1 ).
-fn challenge(
-    message: &[u8],
-    key_image: &KeyImage,
-    L0: &RistrettoPoint,
-    R0: &RistrettoPoint,
-    L1: &RistrettoPoint,
-) -> Scalar {
-    let mut hasher = Blake2b512::new();
-    hasher.update(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
-    hasher.update(message);
-    hasher.update(key_image);
-    hasher.update(L0.compress().as_bytes());
-    hasher.update(R0.compress().as_bytes());
-    hasher.update(L1.compress().as_bytes());
-    Scalar::from_hash(hasher)
-}
-
-fn decompress_ring(ring: &[ReducedTxOut]) -> Result<Vec<(RistrettoPublic, Commitment)>, Error> {
-    // Ring must decompress.
-    let mut decompressed_ring: Vec<(RistrettoPublic, Commitment)> = Vec::new();
-    for tx_out in ring {
-        let ristretto_public =
-            RistrettoPublic::try_from(&tx_out.target_key).map_err(|_e| Error::InvalidCurvePoint)?;
-        let commitment = Commitment::try_from(&tx_out.commitment)?;
-        decompressed_ring.push((ristretto_public, commitment));
-    }
-    Ok(decompressed_ring)
 }
 
 #[cfg(test)]
 mod mlsag_tests {
     use super::*;
     use crate::generators;
-    use alloc::vec::Vec;
     use curve25519_dalek::ristretto::CompressedRistretto;
     use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPrivate, RistrettoPublic};
     use mc_util_from_random::FromRandom;
-    use mc_util_test_helper::{CryptoRng, RngCore, RngType, SeedableRng};
+    use mc_util_test_helper::{RngCore, RngType, SeedableRng};
     use proptest::prelude::*;
 
+    use alloc::vec::Vec;
     #[derive(Clone)]
     struct RingMLSAGParameters {
         message: [u8; 32],
@@ -378,7 +228,7 @@ mod mlsag_tests {
     }
 
     impl RingMLSAGParameters {
-        fn random<RNG: RngCore + CryptoRng>(
+        fn random<RNG: CryptoRngCore>(
             num_mixins: usize,
             pseudo_output_blinding: Scalar,
             rng: &mut RNG,
@@ -397,7 +247,7 @@ mod mlsag_tests {
                     let blinding = Scalar::random(rng);
                     CompressedCommitment::new(value, blinding, &generator)
                 };
-                ring.push(ReducedTxOut {
+                let _ = ring.push(ReducedTxOut {
                     public_key,
                     target_key,
                     commitment,
@@ -420,7 +270,7 @@ mod mlsag_tests {
             };
 
             let real_index = rng.next_u64() as usize % (num_mixins + 1);
-            ring.insert(real_index, reduced_tx_out);
+            let _ = ring.insert(real_index, reduced_tx_out);
             assert_eq!(ring.len(), num_mixins + 1);
 
             Self {
@@ -435,7 +285,7 @@ mod mlsag_tests {
             }
         }
 
-        fn sign<RNG: RngCore + CryptoRng>(&self, rng: &mut RNG) -> Result<RingMLSAG, Error> {
+        fn sign<RNG: CryptoRngCore>(&self, rng: &mut RNG) -> Result<RingMLSAG, Error> {
             RingMLSAG::sign(
                 &self.message,
                 &self.ring,
@@ -449,7 +299,7 @@ mod mlsag_tests {
             )
         }
 
-        fn sign_without_balance_check<RNG: RngCore + CryptoRng>(
+        fn sign_without_balance_check<RNG: CryptoRngCore>(
             &self,
             rng: &mut RNG,
         ) -> Result<RingMLSAG, Error> {
@@ -822,7 +672,7 @@ mod mlsag_tests {
             // Modify the signature to have too many responses.
             {
                 let mut invalid_signature = signature;
-                invalid_signature.responses.push(CurveScalar::from_random(&mut rng));
+                let _ = invalid_signature.responses.push(CurveScalar::from_random(&mut rng));
 
                 let result =
                     invalid_signature.verify(&params.message, &params.ring, &output_commitment);
@@ -835,6 +685,7 @@ mod mlsag_tests {
         }
 
         #[test]
+        #[cfg(feature = "prost")]
         // decode(encode(&signature)) should be the identity function.
         fn test_encode_decode(
             num_mixins in 1..17usize,

--- a/crypto/ring-signature/src/ring_signature/mlsag_sign.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag_sign.rs
@@ -1,0 +1,343 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! RingMLSAG signing internals
+
+use core::fmt::Debug;
+
+use curve25519_dalek::ristretto::RistrettoPoint;
+use rand_core::CryptoRngCore;
+use zeroize::Zeroize;
+
+use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
+
+use crate::{
+    ring_signature::{
+        challenge, hash_to_point, CurveScalar, Error, KeyImage, PedersenGens, Ring, Scalar,
+        B_BLINDING,
+    },
+    Commitment,
+};
+
+/// MLSAG Signing object, provides context for generating ring signatures
+#[derive(Debug)]
+pub struct MlsagSignParams<'a> {
+    /// Size of ring to be signed
+    pub ring_size: usize,
+    /// Message to be signed.
+    pub message: &'a [u8],
+    /// The index in the ring of the real input.
+    pub real_index: usize,
+    /// The real input's private key.
+    pub onetime_private_key: &'a RistrettoPrivate,
+    /// Value of the real input.
+    pub value: u64,
+    /// Blinding of the real input.
+    pub blinding: &'a Scalar,
+    /// The output amount's blinding factor.
+    pub output_blinding: &'a Scalar,
+    /// The pedersen generator to use for this commitment and signature
+    pub generator: &'a PedersenGens,
+    /// If true, check that the value of inputs equals
+    pub check_value_is_preserved: bool,
+}
+
+impl<'a> MlsagSignParams<'a> {
+    /// Sign a ring of input addresses and amount commitments using a modified
+    /// MLSAG
+    ///
+    /// Returns the signed key_image and c_zero scalar
+    pub fn sign(
+        &self,
+        ring: impl Ring,
+        // Note: this `mut rng` can just be `rng` if this is merged upstream:
+        // https://github.com/dalek-cryptography/curve25519-dalek/pull/394
+        rng: impl CryptoRngCore,
+        responses: &mut [CurveScalar],
+    ) -> Result<(KeyImage, CurveScalar), Error> {
+        let ring_size = ring.size();
+
+        if self.real_index >= ring_size {
+            return Err(Error::IndexOutOfBounds);
+        }
+
+        // Check buffer lengths are correct
+
+        // `responses` must contain `2 * ring_size` elements.
+        if responses.len() != 2 * ring_size {
+            return Err(Error::LengthMismatch(2 * ring_size, responses.len()));
+        }
+
+        // Ring must decompress.
+        ring.check()?;
+
+        // Setup signing context
+        let mut sign_ctx = MlsagSignCtx::init(self, rng, responses)?;
+
+        // Iterate around the ring, starting at real_index.
+        // NOTE: THIS REORDERING IS CRITICAL FOR PIECEWISE COMPUTATION
+        for n in 0..ring_size {
+            let i = (self.real_index + n) % ring_size;
+            let tx_out = &ring.index(i)?;
+
+            sign_ctx.update(self, i, tx_out)?;
+        }
+
+        // "Close the loop" by computing responses for the real index.
+        let (key_image, c_zero) = sign_ctx.finalise(self)?;
+
+        Ok((key_image, c_zero))
+    }
+}
+
+/// MLSAG signing context, supports incremental computation for ring signing.
+///
+/// WARNING: MISUSE OF THIS API MAY GENERATE INVALID RINGS,
+/// SEE [`MlsagSign`] FOR A PREFERRED HIGHER LEVEL ABSTRACTION
+#[derive(Debug, Zeroize)]
+pub struct MlsagSignCtx<R: AsMut<[CurveScalar]>> {
+    alpha_0: Scalar,
+    alpha_1: Scalar,
+    G: RistrettoPoint,
+    I: RistrettoPoint,
+
+    /// Cache real input for balance checking
+    #[zeroize(skip)]
+    real_input: Option<(RistrettoPublic, Commitment)>,
+
+    /// Number of rings computed
+    ring_count: usize,
+
+    responses: R,
+
+    real_challenge: Option<Scalar>,
+    last_challenge: Option<Scalar>,
+    zeroth_challenge: Option<Scalar>,
+
+    #[zeroize(skip)]
+    key_image: KeyImage,
+
+    #[zeroize(skip)]
+    output_commitment: Commitment,
+
+    complete: bool,
+}
+
+#[allow(dead_code)]
+impl<R: AsRef<[CurveScalar]> + AsMut<[CurveScalar]>> MlsagSignCtx<R> {
+    /// Initialise signing state, including `challenges` and `responses` working
+    /// buffers
+    pub fn init<'a>(
+        params: &'a MlsagSignParams<'a>,
+        mut rng: impl CryptoRngCore,
+        mut responses: R,
+    ) -> Result<Self, Error> {
+        let G = B_BLINDING;
+        debug_assert!(
+            params.generator.B_blinding == G,
+            "basepoint for blindings mismatch"
+        );
+
+        let r = responses.as_mut();
+
+        // Check buffer lengths are correct for ring size
+        if r.len() != params.ring_size * 2 {
+            return Err(Error::LengthMismatch(params.ring_size * 2, r.len()));
+        }
+
+        // Generate KeyImage from generated transaction private key
+        let key_image = KeyImage::from(params.onetime_private_key);
+
+        // The uncompressed key_image.
+        let I = key_image.point.decompress().ok_or(Error::InvalidKeyImage)?;
+
+        // Uncompressed output commitment.
+        // This ensures that each address and commitment encodes a valid Ristretto
+        // point.
+        let output_commitment =
+            Commitment::new(params.value, *params.output_blinding, params.generator);
+
+        // Responses `r_{0,0}, r_{0,1}, ... , r_{ring_size-1,0}, r_{ring_size-1,1}`.
+        r.iter_mut()
+            .for_each(|v| *v = CurveScalar::from(Scalar::zero()));
+
+        for i in 0..params.ring_size {
+            if i == params.real_index {
+                continue;
+            }
+            r[2 * i].scalar = Scalar::random(&mut rng);
+            r[2 * i + 1].scalar = Scalar::random(&mut rng);
+        }
+
+        Ok(Self {
+            G,
+            I,
+            key_image,
+            output_commitment,
+            alpha_0: Scalar::random(&mut rng),
+            alpha_1: Scalar::random(&mut rng),
+            ring_count: 0,
+            real_input: None,
+            real_challenge: None,
+            last_challenge: None,
+            zeroth_challenge: None,
+            responses,
+            complete: false,
+        })
+    }
+
+    /// Update signing context with provided tx_out.
+    ///
+    /// NOTE THIS _MUST_ FOLLOW A CALL TO INIT AND TRAVERSE THE RING STARTING
+    /// WITH THE REAL TXOUT
+    pub fn update<'a>(
+        &mut self,
+        params: &MlsagSignParams<'a>,
+        i: usize,
+        tx_out: &(RistrettoPublic, Commitment),
+    ) -> Result<(), Error> {
+        let MlsagSignParams {
+            real_index,
+            message,
+            ring_size,
+            ..
+        } = params;
+
+        let responses = self.responses.as_mut();
+
+        // Check tx_out index matches current state
+        if i != (real_index + self.ring_count) % ring_size {
+            return Err(Error::UnexpectedTxout);
+        }
+
+        let (P_i, input_commitment) = tx_out;
+
+        let (L0, R0, L1) = if i == *real_index {
+            // c_{i+1} = Hn( m | key_image | alpha_0 * G | alpha_0 * Hp(P_i) | alpha_1 * G )
+            //         = Hn( m | key_image |      L0     |         R0        |      L1     )
+            //
+            // where P_i is the i^th onetime public key.
+            // There is no R1 term because no key image is needed for the commitment to
+            // zero.
+
+            let L0 = self.alpha_0 * self.G;
+            let R0 = self.alpha_0 * hash_to_point(P_i);
+            let L1 = self.alpha_1 * self.G;
+            (L0, R0, L1)
+        } else {
+            let last_challenge = match self.last_challenge {
+                Some(c) => c,
+                // TODO: replace with a better error
+                None => return Err(Error::IndexOutOfBounds),
+            };
+
+            // c_{i+1} = Hn( m | key_image | r_{i,0} * G + c_i * P_i | r_{i,0} * Hp(P_i) +
+            // c_i * I | r_{i,1} * G + c_i * Z_i )         = Hn( m |
+            // key_image |           L0            |               R0            |
+            // L1          )
+            //
+            // where:
+            // * P_i is the i^th onetime public key.
+            // * I is the key image of the real input's private key,
+            // * Z_i is the i^th "commitment to zero" = output_commitment -
+            //   input_commitment.
+            //
+            // There is no R1 term because no key image is needed for the commitment to
+            // zero.
+
+            let L0 = responses[2 * i].scalar * self.G + last_challenge * P_i.as_ref();
+            let R0 = responses[2 * i].scalar * hash_to_point(P_i) + last_challenge * self.I;
+            let L1 = responses[2 * i + 1].scalar * self.G
+                + last_challenge * (self.output_commitment.point - input_commitment.point);
+            (L0, R0, L1)
+        };
+
+        // Generate the challenge for the _next_ ring entry
+        let c = challenge(message, &self.key_image, &L0, &R0, &L1);
+
+        // Cache the real input for balance checking
+        if i == *real_index {
+            self.real_input = Some(*tx_out);
+        }
+
+        // This logic is a little strange because we're generating the (i+1)th
+        // challenge, which can't be cached at step i because this might not yet be
+        // generated...
+
+        // If the next entry is the real entry, store the challenge for balance checking
+        if (i + 1) % ring_size == *real_index {
+            // Cache real challenge
+            self.real_challenge = Some(c);
+        }
+
+        // If the next entry is the zeroth entry, store c_zero
+        if (i + 1) % ring_size == 0 {
+            self.zeroth_challenge = Some(c);
+        }
+
+        // Store the generated challenge for the next iteration
+        self.last_challenge = Some(c);
+
+        self.ring_count += 1;
+
+        Ok(())
+    }
+
+    /// Finalise MLSAG signing operation
+    pub fn finalise<'a>(
+        &mut self,
+        params: &'a MlsagSignParams<'a>,
+    ) -> Result<(KeyImage, CurveScalar), Error> {
+        let MlsagSignParams {
+            ring_size,
+            real_index,
+            ..
+        } = params;
+
+        let responses = self.responses.as_mut();
+
+        // Check ring size matches added entries
+        if *ring_size != self.ring_count {
+            return Err(Error::IndexOutOfBounds);
+        }
+
+        // Check we have zeroth and real challenges
+        let (_c_real, _c_zero) = match (self.real_challenge, self.zeroth_challenge) {
+            (Some(r), Some(z)) => (r, z),
+            _ => return Err(Error::InvalidState),
+        };
+
+        // "Close the loop" by computing responses for the real index.
+
+        let s: Scalar = *params.onetime_private_key.as_ref();
+        responses[2 * real_index].scalar = self.alpha_0 - _c_real * s;
+
+        let z: Scalar = *params.output_blinding - *params.blinding;
+        responses[2 * real_index + 1].scalar = self.alpha_1 - _c_real * z;
+
+        if params.check_value_is_preserved {
+            let (_, input_commitment) = match self.real_input {
+                Some(v) => v,
+                None => return Err(Error::IndexOutOfBounds),
+            };
+
+            let difference: RistrettoPoint = self.output_commitment.point - input_commitment.point;
+            if difference != (z * self.G) {
+                return Err(Error::ValueNotConserved);
+            }
+        }
+
+        self.complete = true;
+
+        Ok((self.key_image, CurveScalar::from(_c_zero)))
+    }
+
+    /// Fetch responses from a -completed- signer context
+    ///
+    /// Returns a slice of responses or None if incomplete
+    pub fn responses(&self) -> Option<&[CurveScalar]> {
+        match self.complete {
+            true => Some(self.responses.as_ref()),
+            false => None,
+        }
+    }
+}

--- a/crypto/ring-signature/src/ring_signature/mlsag_verify.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag_verify.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! RingMLSAG verification internals
+
+use curve25519_dalek::ristretto::RistrettoPoint;
+
+use crate::{
+    ring_signature::{
+        challenge, hash_to_point, CurveScalar, Error, KeyImage, Ring, Scalar, B_BLINDING,
+    },
+    Commitment, CompressedCommitment,
+};
+
+/// MLSAG Verification object
+pub struct MlsagVerify<'a, R: Ring> {
+    /// Key image to be verified
+    pub key_image: &'a KeyImage,
+    /// Zero-th challenge scalar
+    pub c_zero: &'a CurveScalar,
+    /// Signed message.
+    pub message: &'a [u8],
+    /// A ring of input onetime addresses and amount commitments.
+    pub ring: R,
+    /// Responses from the signed ring
+    pub responses: &'a [CurveScalar],
+    /// Output amount commitment
+    pub output_commitment: &'a CompressedCommitment,
+}
+
+impl<'a, R: Ring> MlsagVerify<'a, R> {
+    /// mlsag verification logic, buffer based for no_std compatibility
+    pub fn verify(&self, recomputed_c: &mut [Scalar]) -> Result<(), Error> {
+        let ring_size = self.ring.size();
+
+        // `responses` must contain `2 * ring_size` elements.
+        if self.responses.len() != 2 * ring_size {
+            return Err(Error::LengthMismatch(2 * ring_size, self.responses.len()));
+        }
+        // `recomputed_c` buffer must contain `ring_size` elements.
+        if recomputed_c.len() != ring_size {
+            return Err(Error::LengthMismatch(ring_size, recomputed_c.len()));
+        }
+
+        let G = B_BLINDING;
+
+        // The key image must decompress.
+        // This ensures that the key image encodes a valid Ristretto point.
+        let I: RistrettoPoint = self
+            .key_image
+            .point
+            .decompress()
+            .ok_or(Error::InvalidKeyImage)?;
+
+        // Output commitment must decompress.
+        let output_commitment: Commitment = Commitment::try_from(self.output_commitment)?;
+
+        // Ring must decompress.
+        // This ensures that each address and commitment encodes a valid Ristretto
+        // point.
+        self.ring.check()?;
+
+        // Scalars must be canonical.
+        if !self.c_zero.scalar.is_canonical() {
+            return Err(Error::InvalidCurveScalar);
+        }
+
+        // Scalars must be canonical.
+        for response in self.responses {
+            if !response.scalar.is_canonical() {
+                return Err(Error::InvalidCurveScalar);
+            }
+        }
+
+        // Recompute challenges.
+        recomputed_c.iter_mut().for_each(|v| *v = Scalar::zero());
+
+        for i in 0..ring_size {
+            let (P_i, input_commitment) = &self.ring.index(i)?;
+
+            let c_i = if i == 0 {
+                // Initialize loop using the signature's c_0 term.
+                self.c_zero.scalar
+            } else {
+                recomputed_c[i]
+            };
+
+            // c_{i+1} = Hn( m | key_image |  r_{i,0} * G + c_i * P_i | r_{i,0} * Hp(P_i) +
+            // c_i * I | r_{i,1} * G + c_i * Z_i )         = Hn( m | key_image |
+            // L0            |               R0            |           L1            )
+            //
+            // where:
+            // * P_i is the i^th onetime public key.
+            // * I is the key image of the real input's private key,
+            // * Z_i is the i^th "commitment to zero" = output_commitment - i^th
+            //   input_commitment.
+
+            let L0 = self.responses[2 * i].scalar * G + c_i * P_i.as_ref();
+            let R0 = self.responses[2 * i].scalar * hash_to_point(P_i) + c_i * I;
+            let L1 = self.responses[2 * i + 1].scalar * G
+                + c_i * (output_commitment.point - input_commitment.point);
+
+            recomputed_c[(i + 1) % ring_size] =
+                challenge(self.message, self.key_image, &L0, &R0, &L1);
+        }
+
+        let res = match self.c_zero.scalar == recomputed_c[0] {
+            true => Ok(()),
+            false => Err(Error::InvalidSignature),
+        };
+
+        // Clear challenge buffer
+        recomputed_c.iter_mut().for_each(|v| *v = Scalar::zero());
+
+        res
+    }
+}

--- a/crypto/ring-signature/src/ring_signature/mod.rs
+++ b/crypto/ring-signature/src/ring_signature/mod.rs
@@ -4,27 +4,45 @@
 
 #![allow(non_snake_case)]
 
-pub use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+pub use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek::{
+    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
+    ristretto::RistrettoPoint,
+};
+
+#[cfg(feature = "alloc")]
+use curve25519_dalek::traits::MultiscalarMul;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 mod curve_scalar;
 mod error;
 mod key_image;
+mod mlsag_sign;
+mod mlsag_verify;
+
+#[cfg(feature = "alloc")]
 mod mlsag;
 
-pub use self::{
-    curve_scalar::CurveScalar,
-    error::Error,
-    key_image::KeyImage,
-    mlsag::{ReducedTxOut, RingMLSAG},
+#[cfg(feature = "alloc")]
+pub use self::mlsag::RingMLSAG;
+
+pub use self::{curve_scalar::CurveScalar, error::Error, key_image::KeyImage};
+
+use crate::{
+    domain_separators::{HASH_TO_POINT_DOMAIN_TAG, RING_MLSAG_CHALLENGE_DOMAIN_TAG},
+    Commitment, CompressedCommitment,
 };
 
-use crate::domain_separators::HASH_TO_POINT_DOMAIN_TAG;
-use curve25519_dalek::{
-    constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT},
-    traits::MultiscalarMul,
+#[cfg(feature = "internals")]
+pub use self::{
+    mlsag_sign::{MlsagSignCtx, MlsagSignParams},
+    mlsag_verify::MlsagVerify,
 };
+
 use mc_crypto_hashes::{Blake2b512, Digest};
-use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
 
 /// The base point for blinding factors used with all amount commitments
 pub const B_BLINDING: RistrettoPoint = RISTRETTO_BASEPOINT_POINT;
@@ -45,7 +63,13 @@ impl PedersenGens {
     /// Creates a Pedersen commitment using the value scalar and a blinding
     /// factor.
     pub fn commit(&self, value: Scalar, blinding: Scalar) -> RistrettoPoint {
-        RistrettoPoint::multiscalar_mul(&[value, blinding], &[self.B, self.B_blinding])
+        // Use optimised Straus' method if alloc is available
+        #[cfg(feature = "alloc")]
+        return RistrettoPoint::multiscalar_mul(&[value, blinding], &[self.B, self.B_blinding]);
+
+        // Otherwise fallback to naive method
+        #[cfg(not(feature = "alloc"))]
+        return value * self.B + blinding * self.B_blinding;
     }
 }
 
@@ -59,7 +83,7 @@ impl PedersenGens {
 /// For amounts, H varies based on the token id.
 pub fn generators(token_id: u64) -> PedersenGens {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(HASH_TO_POINT_DOMAIN_TAG);
 
     // This step xors the token id bytes on top of the "base point" bytes
     // used prior to the introduction of token ids.
@@ -91,9 +115,120 @@ pub fn generators(token_id: u64) -> PedersenGens {
 /// Applies a hash function and returns a RistrettoPoint.
 pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
     let mut hasher = Blake2b512::new();
-    hasher.update(&HASH_TO_POINT_DOMAIN_TAG);
-    hasher.update(&ristretto_public.to_bytes());
+    hasher.update(HASH_TO_POINT_DOMAIN_TAG);
+    hasher.update(ristretto_public.to_bytes());
     RistrettoPoint::from_hash(hasher)
+}
+
+// Compute the ring "challenge" H( message | key_image | L0 | R0 | L1 ).
+pub(crate) fn challenge(
+    message: &[u8],
+    key_image: &KeyImage,
+    L0: &RistrettoPoint,
+    R0: &RistrettoPoint,
+    L1: &RistrettoPoint,
+) -> Scalar {
+    let mut hasher = Blake2b512::new();
+    hasher.update(&RING_MLSAG_CHALLENGE_DOMAIN_TAG);
+    hasher.update(message);
+    hasher.update(key_image);
+    hasher.update(L0.compress().as_bytes());
+    hasher.update(R0.compress().as_bytes());
+    hasher.update(L1.compress().as_bytes());
+    Scalar::from_hash(hasher)
+}
+
+/// A reduced representation of a TxOut, appropriate for making MLSAG
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ReducedTxOut {
+    /// The tx_out.public_key field
+    pub public_key: CompressedRistrettoPublic,
+    /// The tx_out.target_key field
+    pub target_key: CompressedRistrettoPublic,
+    /// The tx_out.masked_amount.commitment field
+    pub commitment: CompressedCommitment,
+}
+
+/// Expand a [`ReducedTxOut`] to `(RistrettoPublic, Commitment)` for MLSAG use
+impl TryFrom<&ReducedTxOut> for (RistrettoPublic, Commitment) {
+    type Error = Error;
+
+    fn try_from(r: &ReducedTxOut) -> Result<(RistrettoPublic, Commitment), Self::Error> {
+        let ristretto_public =
+            RistrettoPublic::try_from(&r.target_key).map_err(|_e| Error::InvalidCurvePoint)?;
+        let commitment = Commitment::try_from(&r.commitment)?;
+
+        Ok((ristretto_public, commitment))
+    }
+}
+
+/// [`Ring`] trait allows implementations to be generic over rings for
+/// performance (pre-decompressed) or space (decompress-on-access)
+pub trait Ring {
+    /// Return size of ring
+    ///
+    /// (a-la `slice::len`, except we don't have a trait for this)
+    fn size(&self) -> usize;
+
+    /// Access a decompressed ring element by index
+    ///
+    /// (a-la `core::ops::Index`, defined here to avoid orphan rules)
+    fn index(&self, index: usize) -> Result<(RistrettoPublic, Commitment), Error>;
+
+    /// Ensure ring decompresses (no-op for pre-decompressed rings)
+    fn check(&self) -> Result<(), Error>;
+}
+
+/// [`Ring`] implementation for pre-decompressed slices
+impl Ring for &[(RistrettoPublic, Commitment)] {
+    /// Fetch ring size
+    fn size(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    /// Access a pre-decompressed ring element by index
+    fn index(&self, index: usize) -> Result<(RistrettoPublic, Commitment), Error> {
+        match self.as_ref().get(index) {
+            Some(v) => Ok(*v),
+            None => Err(Error::IndexOutOfBounds),
+        }
+    }
+
+    /// Pre-decompressed ring always decompresses...
+    fn check(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// [`Ring`] implementation for reduced slices
+impl Ring for &[ReducedTxOut] {
+    /// Fetch ring size
+    fn size(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    /// Decompress and access a ring element by index
+    fn index(&self, index: usize) -> Result<(RistrettoPublic, Commitment), Error> {
+        let tx_out = match self.as_ref().get(index) {
+            Some(v) => v,
+            None => return Err(Error::IndexOutOfBounds),
+        };
+
+        let decompressed: (RistrettoPublic, Commitment) = tx_out.try_into()?;
+
+        Ok(decompressed)
+    }
+
+    /// Decompress each entry to check ring
+    fn check(&self) -> Result<(), Error> {
+        // Ring must decompress.
+        for i in 0..self.size() {
+            let _tx_out = self.index(i)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verification of X509 certificate chains"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -34,7 +34,7 @@ crossbeam-channel = "0.5"
 grpcio = "0.12.0"
 lazy_static = "1.4"
 rand = "0.8"
-rayon = "1.5"
+rayon = "1.6"
 retry = "2.0"
 tempfile = "3.3"
 

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -287,7 +287,7 @@ fn main() {
         let fog_resolver = build_fog_resolver(&fog_uri, &env2, &logger);
 
         thread::Builder::new()
-            .name(format!("worker{}", i))
+            .name(format!("worker{i}"))
             .spawn(move || {
                 worker_thread_entry(
                     spendable_txouts_receiver2,
@@ -413,8 +413,7 @@ fn select_spendable_tx_outs(
                     .get_value(&shared_secret)
                     .unwrap_or_else(|err| {
                         panic!(
-                        "TX ownership is not as expected: tx #{} not owned by account_index {}: {}",
-                        index, account_index, err
+                        "TX ownership is not as expected: tx #{index} not owned by account_index {account_index}: {err}"
                     )
                     });
 

--- a/fog/distribution/tests/bootstrap.rs
+++ b/fog/distribution/tests/bootstrap.rs
@@ -15,11 +15,11 @@ use tempfile::TempDir;
 fn test_find_spendable_tx_outs() {
     let me = PathBuf::from(args().next().unwrap());
     let bin = me.parent().unwrap().parent().unwrap();
-    println!("bin = {:?}", bin);
+    println!("bin = {bin:?}");
 
     let dir = TempDir::new().unwrap();
     set_current_dir(dir.path()).unwrap();
-    println!("dir = {:?}", dir);
+    println!("dir = {dir:?}");
 
     assert!(Command::new(bin.join("sample-keys"))
         .args([

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -26,7 +26,7 @@ mc-util-from-random = { path = "../../../util/from-random" }
 mc-watcher = { path = "../../../watcher" }
 
 # third party
-assert_cmd = "2.0.7"
+assert_cmd = "2.0.8"
 predicates = "2"
 rand = "0.8"
 tempdir = "0.3"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/src/config.rs
+++ b/fog/ingest/client/src/config.rs
@@ -28,7 +28,7 @@ pub struct IngestConfig {
 fn parse_ristretto_hex(src: &str) -> Result<CompressedRistrettoPublic, String> {
     let mut key_bytes = [0u8; 32];
     hex::decode_to_slice(src.as_bytes(), &mut key_bytes[..])
-        .map_err(|err| format!("Hex decode error: {:?}", err))?;
+        .map_err(|err| format!("Hex decode error: {err:?}"))?;
     Ok(CompressedRistrettoPublic::from(&key_bytes))
 }
 

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/impl/tests/tx_processing.rs
+++ b/fog/ingest/enclave/impl/tests/tx_processing.rs
@@ -287,8 +287,7 @@ fn test_ingest_enclave_malformed_txos(logger: Logger) {
                 assert_eq!(some_rows.len(), 3);
                 assert_eq!(
                     some_rows[0].search_key, bob_search_key,
-                    "unexpected search key for {}'th tx for Bob",
-                    index3
+                    "unexpected search key for {index3}'th tx for Bob"
                 );
                 assert_ne!(some_rows[1].search_key, bob_search_key);
                 assert_ne!(some_rows[2].search_key, bob_search_key);
@@ -512,51 +511,39 @@ fn test_ingest_enclave_overflow(logger: Logger) {
 
             assert!(
                 alice_found || bob_found,
-                "Could not match {}'th tx row to Alice's or Bob's RNG's",
-                idx
+                "Could not match {idx}'th tx row to Alice's or Bob's RNG's"
             );
             assert!(
                 !alice_found || !bob_found,
-                "Matched {}'th tx row to BOTH Alice and to Bob",
-                idx
+                "Matched {idx}'th tx row to BOTH Alice and to Bob"
             );
 
             match alice_fog_credential.decrypt_tx_out_result(tx_row.payload.clone()) {
                 Ok(tx_out_record) => {
                     assert_eq!(
                         tx_out_record.tx_out_global_index, idx as u64,
-                        "{:?} {:?} alice:{} bob:{}",
-                        tx_out_record, tx_row, alice_found, bob_found,
+                        "{tx_out_record:?} {tx_row:?} alice:{alice_found} bob:{bob_found}",
                     );
                     let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,
-                        "{:?} {:?}",
-                        tx_out_record,
-                        tx_row,
+                        "{tx_out_record:?} {tx_row:?}",
                     );
-                    assert_eq!(
-                        tx_out_record.block_index, 1,
-                        "{:?} {:?}",
-                        tx_out_record, tx_row
-                    );
+                    assert_eq!(tx_out_record.block_index, 1, "{tx_out_record:?} {tx_row:?}");
                     assert!(
                         alice_found,
-                        "Alice wasn't supposed to be able to decrypt {}'th tx row. bob_found = {}: {:?} {:?}",
-                        idx, bob_found, tx_out_record, tx_row,
+                        "Alice wasn't supposed to be able to decrypt {idx}'th tx row. bob_found = {bob_found}: {tx_out_record:?} {tx_row:?}",
                     );
                 }
                 Err(err @ TxOutRecoveryError::MacCheckFailed) => {
                     assert!(
                         !alice_found,
-                        "Alice was supposed to be able to decrypt {}'th tx row: {}",
-                        idx, err
+                        "Alice was supposed to be able to decrypt {idx}'th tx row: {err}"
                     );
                 }
                 Err(err) => {
-                    panic!("Alice got an unexpected error when attempting to decrypt {}'th tx row: {}. alice_found = {}",
-                        idx, err, alice_found
+                    panic!("Alice got an unexpected error when attempting to decrypt {idx}'th tx row: {err}. alice_found = {alice_found}"
                     );
                 }
             };
@@ -565,38 +552,28 @@ fn test_ingest_enclave_overflow(logger: Logger) {
                 Ok(tx_out_record) => {
                     assert_eq!(
                         tx_out_record.tx_out_global_index, idx as u64,
-                        "{:?} {:?} alice:{} bob:{}",
-                        tx_out_record, tx_row, alice_found, bob_found,
+                        "{tx_out_record:?} {tx_row:?} alice:{alice_found} bob:{bob_found}",
                     );
                     let expected_fog_tx_out = FogTxOut::try_from(&all_tx_outs[idx]).unwrap();
                     assert_eq!(
                         tx_out_record.get_fog_tx_out().unwrap(),
                         expected_fog_tx_out,
-                        "{:?} {:?}",
-                        tx_out_record,
-                        tx_row,
+                        "{tx_out_record:?} {tx_row:?}",
                     );
-                    assert_eq!(
-                        tx_out_record.block_index, 1,
-                        "{:?} {:?}",
-                        tx_out_record, tx_row
-                    );
+                    assert_eq!(tx_out_record.block_index, 1, "{tx_out_record:?} {tx_row:?}");
                     assert!(
                         bob_found,
-                        "Bob wasn't supposed to be able to decrypt {}'th tx row. alice_found = {}: {:?} {:?}",
-                        idx, alice_found, tx_out_record, tx_row,
+                        "Bob wasn't supposed to be able to decrypt {idx}'th tx row. alice_found = {alice_found}: {tx_out_record:?} {tx_row:?}",
                     );
                 }
                 Err(err @ TxOutRecoveryError::MacCheckFailed) => {
                     assert!(
                         !bob_found,
-                        "Bob was supposed to be able to decrypt {}'th tx row: {}",
-                        idx, err
+                        "Bob was supposed to be able to decrypt {idx}'th tx row: {err}"
                     );
                 }
                 Err(err) => {
-                    panic!("Bob got an unexpected error when attempting to decrypt {}'th tx row: {}. bob_found = {}",
-                        idx, err, bob_found
+                    panic!("Bob got an unexpected error when attempting to decrypt {idx}'th tx row: {err}. bob_found = {bob_found}"
                     );
                 }
             };

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ingest Enclave - Measurement"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -740,14 +740,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "bitflags",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "digest",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1263,14 +1263,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1377,11 +1377,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1412,36 +1412,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1470,14 +1470,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1485,11 +1485,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1571,14 +1571,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "prost",
  "serde",
@@ -1597,14 +1597,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1682,9 +1682,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/trusted/src/lib.rs
+++ b/fog/ingest/enclave/trusted/src/lib.rs
@@ -21,7 +21,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for the business logic / implementation state
     static ref ENCLAVE: SgxIngestEnclave<OcallORAMStorageCreator> = SgxIngestEnclave::new(default_logger());

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -59,10 +59,7 @@ fn main() {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-ingest cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-ingest cannot connect to database '{database_url}': {err:?}")
     });
 
     let ledger_db = LedgerDB::open(&config.ledger_db).expect("Could not read ledger DB");

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn ingest_server_config_example() {
         let config = IngestConfig::try_parse_from(
-         &["/usr/bin/fog_ingest_server",
+         ["/usr/bin/fog_ingest_server",
       "--ledger-db", "/fog-data/ledger",
       "--watcher-db", "/fog-data/watcher",
      "--ias-spid", "00000000000000000000000000000000", "--ias-api-key", "00000000000000000000000000000000",

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -153,7 +153,7 @@ where
         ) {
             Ok(enclave) => enclave,
             Err(NewEnclaveError::Create(err)) => {
-                panic!("Could not create new enclave: {}", err);
+                panic!("Could not create new enclave: {err}");
             }
             Err(NewEnclaveError::Init(err)) => {
                 log::error!(
@@ -1107,10 +1107,10 @@ where
                     // wrong set to false.
                     Err(err @ PeerBackupError::FailedRemoteKeyBackup(_))
                     | Err(err @ PeerBackupError::FailedRemoteSetPeers(_)) => {
-                        panic!("Should not have attempted remote modification during confirm backup. Logic Error: {}", err);
+                        panic!("Should not have attempted remote modification during confirm backup. Logic Error: {err}");
                     }
                     Err(err @ PeerBackupError::CreatingNewIngressKey) => {
-                        panic!("Should not have attempted creating new ingress key during confirm backup. Logic Error. {}", err);
+                        panic!("Should not have attempted creating new ingress key during confirm backup. Logic Error. {err}");
                     }
                     //Nonretriable errors that can occur normally during confirm backup.
                     Err(err @ PeerBackupError::AnotherActivePeer(_))

--- a/fog/ingest/server/src/controller_state.rs
+++ b/fog/ingest/server/src/controller_state.rs
@@ -148,8 +148,7 @@ impl IngestControllerState {
     pub fn increment_next_block_index(&mut self) {
         assert!(
             !self.is_idle(),
-            "next_block_index should not be incremented if we are idle: {}",
-            self
+            "next_block_index should not be incremented if we are idle: {self}"
         );
         // Perform the increment
         self.next_block_index += 1;
@@ -295,7 +294,7 @@ impl Display for IngestControllerState {
             self.mode, self.next_block_index, self.pubkey_expiry_window
         )?;
         if let Some(iid) = self.ingest_invocation_id {
-            write!(f, "ingest_invocation_id: {}, ", iid)?;
+            write!(f, "ingest_invocation_id: {iid}, ")?;
         }
         write!(f, "peers: {} }}", SeqDisplay(self.peers.iter()))
     }

--- a/fog/ingest/server/src/state_file.rs
+++ b/fog/ingest/server/src/state_file.rs
@@ -50,7 +50,7 @@ impl StateFile {
         let proto_data = state_data.write_to_bytes().map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed serializing state data: {}", e),
+                format!("failed serializing state data: {e}"),
             )
         })?;
         let mut file = fs::File::create(&self.file_path)?;
@@ -62,7 +62,7 @@ impl StateFile {
     /// fails, in order to prevent a crash loop.
     pub fn move_to_bak(&self) -> Result<()> {
         let bak = self.file_path.with_extension("bak");
-        std::fs::rename(&self.file_path, &bak)?;
+        std::fs::rename(&self.file_path, bak)?;
         Ok(())
     }
 }

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/src/lib.rs
+++ b/fog/ingest/server/test-utils/src/lib.rs
@@ -36,7 +36,7 @@ const OMAP_CAPACITY: u64 = 4096;
 fn make_uris(base_port: u16, idx: u8) -> (FogIngestUri, IngestPeerUri) {
     let port = base_port + 5 * (idx as u16 + 1);
     let client_listen_uri =
-        FogIngestUri::from_str(&format!("insecure-fog-ingest://0.0.0.0:{}/", port)).unwrap();
+        FogIngestUri::from_str(&format!("insecure-fog-ingest://0.0.0.0:{port}/")).unwrap();
     let peer_listen_uri =
         IngestPeerUri::from_str(&format!("insecure-igp://0.0.0.0:{}/", port + 1)).unwrap();
 
@@ -72,9 +72,7 @@ impl TestIngestNode {
             }
             assert!(
                 start.elapsed() <= timeout,
-                "Timed out waiting for ingest node to process blocks; ingested {} blocks, target is {}",
-                ingest_height,
-                height,
+                "Timed out waiting for ingest node to process blocks; ingested {ingest_height} blocks, target is {height}",
             );
             sleep(Duration::from_millis(100));
         }
@@ -193,7 +191,7 @@ impl IngestServerTestHelper {
         let state_file_path = TempDir::new("ingest_state")
             .expect("Could not make tempdir for ingest state")
             .into_path()
-            .join(format!("mc-fog-ingest-state-{}", idx));
+            .join(format!("mc-fog-ingest-state-{idx}"));
         self.make_node_with_state(idx, peer_idxs, state_file_path)
     }
 
@@ -313,9 +311,7 @@ impl IngestServerTestHelper {
             }
             assert!(
                 start.elapsed() <= *timeout,
-                "Timed out waiting for active node to process data; recovery_db has {} blocks, target is {}",
-                recovery_db_count,
-                target,
+                "Timed out waiting for active node to process data; recovery_db has {recovery_db_count} blocks, target is {target}",
             );
             sleep(Duration::from_millis(100));
         }

--- a/fog/ingest/server/tests/key_sharing_on_activate.rs
+++ b/fog/ingest/server/tests/key_sharing_on_activate.rs
@@ -8,7 +8,7 @@ const BASE_PORT: u16 = 3997;
 
 #[test_with_logger]
 fn test_key_sharing_on_activate(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
 
     let nodes = helper.make_nodes(5);
@@ -32,8 +32,7 @@ fn test_key_sharing_on_activate(logger: Logger) {
     nodes.iter().skip(1).enumerate().for_each(|(i, node)| {
         assert!(
             node.activate().is_err(),
-            "node{} should not be able to activate",
-            i
+            "node{i} should not be able to activate"
         )
     });
 

--- a/fog/ingest/server/tests/peer_key_sharing.rs
+++ b/fog/ingest/server/tests/peer_key_sharing.rs
@@ -150,8 +150,7 @@ fn test_ingest_pool_integration(db_test_context: Arc<SqlRecoveryDbTestContext>, 
             let result = primary_ingest_client.new_keys();
             assert!(
                 result.is_err(),
-                "new_keys should return an error code when the server is active: {:?}",
-                result
+                "new_keys should return an error code when the server is active: {result:?}"
             );
             let final_primary_key = primary_ingest_client
                 .get_status()

--- a/fog/ingest/server/tests/sealed_key.rs
+++ b/fog/ingest/server/tests/sealed_key.rs
@@ -7,7 +7,7 @@ const BASE_PORT: u16 = 3457;
 
 #[test_with_logger]
 fn test_ingest_sealed_key_recovery(logger: Logger) {
-    let helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let helper = IngestServerTestHelper::new(BASE_PORT, logger);
 
     let node = helper.make_node(1, 1..=1);
     let original_key = node.get_ingress_key();

--- a/fog/ingest/server/tests/three_node_cluster.rs
+++ b/fog/ingest/server/tests/three_node_cluster.rs
@@ -18,7 +18,7 @@ const BASE_PORT: u16 = 4997;
 // to idle because the key is retired in the DB.
 #[test_with_logger]
 fn three_node_cluster_activation_retiry(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
 
     // Do three repetitions of the whole thing
@@ -103,7 +103,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node0, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node0, should have got KeyAlreadyRetired: {err}");
             }
         };
 
@@ -115,7 +115,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node1, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node1, should have got KeyAlreadyRetired: {err}");
             }
         };
 
@@ -127,7 +127,7 @@ fn three_node_cluster_activation_retiry(logger: Logger) {
                 assert_eq!(key, original_key);
             }
             Err(err) => {
-                panic!("Unexpected error when trying to activate node2, should have got KeyAlreadyRetired: {}", err);
+                panic!("Unexpected error when trying to activate node2, should have got KeyAlreadyRetired: {err}");
             }
         };
 

--- a/fog/ingest/server/tests/tx_recovery.rs
+++ b/fog/ingest/server/tests/tx_recovery.rs
@@ -111,7 +111,7 @@ fn test_ingest_polling_integration(base_port: u16, mut rng: RngType, logger: Log
 // Function for generating the random number of txs to put in a block
 fn gen_num_tx_for_block(rng: &mut impl RngCore) -> usize {
     loop {
-        let n = (rng.next_u64() % NUM_TX_PER_BLOCK as u64) as usize;
+        let n = (rng.next_u64() % NUM_TX_PER_BLOCK) as usize;
         if n != 0 {
             break n;
         }

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = """

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = '''

--- a/fog/ledger/enclave/impl/src/key_image_store.rs
+++ b/fog/ledger/enclave/impl/src/key_image_store.rs
@@ -182,8 +182,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> KeyImageStore<OS
                 oram_result_code == OMAP_FOUND
                     || oram_result_code == OMAP_NOT_FOUND
                     || oram_result_code == OMAP_INVALID_KEY,
-                "oram_result_code had an unexpected value: {}",
-                oram_result_code
+                "oram_result_code had an unexpected value: {oram_result_code}"
             );
         }
 

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Ledger Enclave - Measurement"

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -107,7 +107,7 @@ impl LedgerSgxEnclave {
 
         sgx_enclave
             .enclave_init(self_id, desired_capacity)
-            .unwrap_or_else(|e| panic!("enclave_init({}) failed: {:?}", self_id, e));
+            .unwrap_or_else(|e| panic!("enclave_init({self_id}) failed: {e:?}"));
 
         sgx_enclave
     }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -744,14 +744,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "bitflags",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "digest",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if",
  "rand",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1227,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1325,11 +1325,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1360,36 +1360,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1418,14 +1418,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1433,11 +1433,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1519,14 +1519,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "prost",
  "serde",
@@ -1545,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1630,9 +1630,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cexpr"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1685,9 +1685,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.2"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1695,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -21,7 +21,7 @@ use mc_util_serial::{deserialize, serialize};
 
 lazy_static! {
     /// Storage for ECALL results whose given outbuf was not large enough
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 
     /// Storage for business logic / implementation state of ledger enclave
     static ref ENCLAVE: SgxLedgerEnclave<OcallORAMStorageCreator> = SgxLedgerEnclave::new(default_logger());

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/server/src/bin/main.rs
+++ b/fog/ledger/server/src/bin/main.rs
@@ -68,7 +68,7 @@ fn main() {
     let config2 = config.clone();
     let get_config_json = Arc::new(move || {
         serde_json::to_string(&config2)
-            .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{:?}", err)))
+            .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{err:?}")))
     });
     let _admin_server = config.admin_listen_uri.as_ref().map(|admin_listen_uri| {
         AdminServer::start(

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -302,7 +302,7 @@ mod test {
             mock_ledger.clone(),
             enclave,
             authenticator,
-            logger.clone(),
+            logger,
         );
 
         let request = OutputContext {
@@ -361,7 +361,7 @@ mod test {
             mock_ledger,
             enclave,
             authenticator,
-            logger.clone(),
+            logger,
         );
 
         let request = OutputContext {

--- a/fog/ledger/server/src/server.rs
+++ b/fog/ledger/server/src/server.rs
@@ -129,7 +129,7 @@ impl<E: LedgerEnclaveProxy, R: RaClient + Send + Sync + 'static> LedgerServer<E,
             config.chain_id.clone(),
             ledger,
             watcher,
-            client_authenticator.clone(),
+            client_authenticator,
             logger.clone(),
         );
 

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -247,14 +247,13 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
                         assert_eq!(status.message(), expected);
                     }
                     _ => {
-                        panic!("unexpected grpcio error: {}", err);
+                        panic!("unexpected grpcio error: {err}");
                     }
                 }
             } else {
                 panic!("Expected an error when chain-id is wrong");
             }
         }
-
         // grpcio detaches all its threads and does not join them :(
         // we opened a PR here: https://github.com/tikv/grpc-rs/pull/455
         // in the meantime we can just sleep after grpcio env and all related
@@ -588,12 +587,8 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
             .expect("Failed starting ledger server");
 
         // Make unattested ledger client
-        let client = FogUntrustedLedgerGrpcClient::new(
-            client_uri,
-            GRPC_RETRY_CONFIG,
-            grpc_env,
-            logger.clone(),
-        );
+        let client =
+            FogUntrustedLedgerGrpcClient::new(client_uri, GRPC_RETRY_CONFIG, grpc_env, logger);
 
         // Try to get a block
         let queries = [0..1];
@@ -750,12 +745,8 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
             .expect("Failed starting ledger server");
 
         // Make unattested ledger client
-        let client = FogUntrustedLedgerGrpcClient::new(
-            client_uri,
-            GRPC_RETRY_CONFIG,
-            grpc_env,
-            logger.clone(),
-        );
+        let client =
+            FogUntrustedLedgerGrpcClient::new(client_uri, GRPC_RETRY_CONFIG, grpc_env, logger);
 
         // Get a tx_out that is actually in the ledger
         let real_tx_out0 = { ledger.get_tx_out_by_index(0).unwrap() };
@@ -830,7 +821,7 @@ fn add_block_to_ledger(
                 src_url,
                 block_index,
                 signature.clone(),
-                format!("00/{}", block_index),
+                format!("00/{block_index}"),
             )
             .expect("Could not add block signature");
     }

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/src/bin/ingest.rs
+++ b/fog/load_testing/src/bin/ingest.rs
@@ -129,11 +129,11 @@ impl AutoKillChild {
     pub fn assert_not_stopped(&mut self) {
         match self.0.try_wait() {
             Ok(Some(stat)) => {
-                panic!("child stopped unexpectedly: status: {}", stat)
+                panic!("child stopped unexpectedly: status: {stat}")
             }
             Ok(None) => {}
             Err(err) => {
-                panic!("error getting child status: {}", err)
+                panic!("error getting child status: {err}")
             }
         }
     }
@@ -145,7 +145,7 @@ impl Drop for AutoKillChild {
             // Invalid input means the process is already dead, and we don't have to kill
             // it. Anything else means that killing it failed somehow
             if err.kind() != std::io::ErrorKind::InvalidInput {
-                panic!("Could not send SIGKILL to child: {}", err)
+                panic!("Could not send SIGKILL to child: {err}")
             }
         }
 
@@ -174,12 +174,11 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         let ingest_client_port = base_port + 4;
         let ingest_peer_port = base_port + 5;
         let client_listen_uri = FogIngestUri::from_str(&format!(
-            "insecure-fog-ingest://127.0.0.1:{}",
-            ingest_client_port
+            "insecure-fog-ingest://127.0.0.1:{ingest_client_port}"
         ))
         .unwrap();
         let peer_listen_uri =
-            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{}", ingest_peer_port))
+            IngestPeerUri::from_str(&format!("insecure-igp://127.0.0.1:{ingest_peer_port}"))
                 .unwrap();
         let local_node_id = peer_listen_uri.responder_id().unwrap();
 
@@ -230,17 +229,17 @@ fn load_test(ingest_server_binary: &Path, test_params: TestParams, logger: Logge
         // Maybe we should take ias-spid from env also
         let mut command = std::process::Command::new(ingest_server_binary.to_str().unwrap());
         command
-            .args(&["--ledger-db", ledger_db_path.path().to_str().unwrap()])
-            .args(&["--watcher-db", watcher_db_path.path().to_str().unwrap()])
-            .args(&["--client-listen-uri", &client_listen_uri.to_string()])
-            .args(&["--peer-listen-uri", &peer_listen_uri.to_string()])
-            .args(&["--ias-spid", &"0".repeat(32)])
-            .args(&["--ias-api-key", &"0".repeat(32)])
-            .args(&["--local-node-id", &local_node_id.to_string()])
-            .args(&["--peers", &peer_listen_uri.to_string()])
-            .args(&["--state-file", state_file_path.to_str().unwrap()])
-            .args(&["--admin-listen-uri", &admin_listen_uri.to_string()])
-            .args(&["--user-capacity", &test_params.user_capacity.to_string()]);
+            .args(["--ledger-db", ledger_db_path.path().to_str().unwrap()])
+            .args(["--watcher-db", watcher_db_path.path().to_str().unwrap()])
+            .args(["--client-listen-uri", client_listen_uri.as_ref()])
+            .args(["--peer-listen-uri", peer_listen_uri.as_ref()])
+            .args(["--ias-spid", &"0".repeat(32)])
+            .args(["--ias-api-key", &"0".repeat(32)])
+            .args(["--local-node-id", &local_node_id.to_string()])
+            .args(["--peers", peer_listen_uri.as_ref()])
+            .args(["--state-file", state_file_path.to_str().unwrap()])
+            .args(["--admin-listen-uri", admin_listen_uri.as_ref()])
+            .args(["--user-capacity", &test_params.user_capacity.to_string()]);
 
         log::info!(logger, "Spawning ingest server: {:?}", command);
 
@@ -446,6 +445,6 @@ fn main() {
     // XXX: Write results to a results file or something?
     println!("Load testing results\n================");
     for result in results.iter() {
-        println!("{}", result);
+        println!("{result}");
     }
 }

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/src/lib.rs
+++ b/fog/ocall_oram_storage/trusted/src/lib.rs
@@ -344,8 +344,7 @@ where
             let (last_idx, last_hash) = last_hash.expect("should not be empty at this point");
             assert!(
                 bool::from(self.trusted_merkle_roots[last_idx as usize].ct_eq(&last_hash)),
-                "authentication failed, trusted merkle root mismatch at {}",
-                last_idx
+                "authentication failed, trusted merkle root mismatch at {last_idx}"
             );
         }
     }
@@ -695,11 +694,9 @@ mod helpers {
 
         for (x, idx) in idx.iter().enumerate() {
             let byte_index = (idx * DataSize::U64) as usize;
-            (&mut data[x])
-                .copy_from_slice(&allocation.data[byte_index..byte_index + DataSize::USIZE]);
+            data[x].copy_from_slice(&allocation.data[byte_index..byte_index + DataSize::USIZE]);
             let byte_index = (idx * MetaSize::U64) as usize;
-            (&mut meta[x])
-                .copy_from_slice(&allocation.meta[byte_index..byte_index + MetaSize::USIZE]);
+            meta[x].copy_from_slice(&allocation.meta[byte_index..byte_index + MetaSize::USIZE]);
         }
     }
 

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/src/lib.rs
+++ b/fog/ocall_oram_storage/untrusted/src/lib.rs
@@ -92,13 +92,11 @@ impl UntrustedAllocation {
         global_log::info!("Untrusted is allocating oram storage: count = {}, data_size = {}, meta_size = {}, mem = {} KB. Total mem allocated this way = {} KB", count, data_item_size, meta_item_size, mem_kb, total_mem_kb);
         assert!(
             data_item_size % 8 == 0,
-            "data item size is not good: {}",
-            data_item_size
+            "data item size is not good: {data_item_size}"
         );
         assert!(
             meta_item_size % 8 == 0,
-            "meta item size is not good: {}",
-            meta_item_size
+            "meta item size is not good: {meta_item_size}"
         );
 
         let data_pointer = unsafe {
@@ -181,7 +179,7 @@ pub unsafe extern "C" fn allocate_oram_storage(
 /// id must be a valid id previously returned by allocate_oram_storage
 #[no_mangle]
 pub unsafe extern "C" fn release_oram_storage(id: u64) {
-    let ptr: *mut UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *mut UntrustedAllocation = id as *mut UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when releasing storage"
@@ -219,7 +217,7 @@ pub unsafe extern "C" fn checkout_oram_storage(
 ) {
     #[cfg(debug_assertions)]
     debug_checks::check_id(id);
-    let ptr: *const UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *const UntrustedAllocation = id as *const UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when checking out storage"
@@ -291,7 +289,7 @@ pub unsafe extern "C" fn checkin_oram_storage(
 ) {
     #[cfg(debug_assertions)]
     debug_checks::check_id(id);
-    let ptr: *const UntrustedAllocation = core::mem::transmute(id);
+    let ptr: *const UntrustedAllocation = id as *const UntrustedAllocation;
     assert!(
         !(*ptr).critical_section_flag.swap(true, Ordering::SeqCst),
         "Could not enter critical section when checking in storage"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/src/bin/main.rs
+++ b/fog/overseer/server/src/bin/main.rs
@@ -29,10 +29,7 @@ async fn main() -> Result<(), rocket::Error> {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-overseer cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-overseer cannot connect to database '{database_url}': {err:?}")
     });
 
     let mut overseer_service =

--- a/fog/overseer/server/src/config.rs
+++ b/fog/overseer/server/src/config.rs
@@ -40,7 +40,7 @@ mod tests {
     use mc_fog_uri::ConnectionUri;
     #[test]
     fn ingest_server_config_example() {
-        let config = OverseerConfig::try_parse_from(&[
+        let config = OverseerConfig::try_parse_from([
             "/usr/bin/fog_overseer_server",
             "--overseer-listen-host",
             "www.mycoolhost.com",

--- a/fog/overseer/server/src/service.rs
+++ b/fog/overseer/server/src/service.rs
@@ -141,7 +141,7 @@ where
         encoder.encode(&metric_families, &mut buffer).unwrap();
 
         String::from_utf8(buffer)
-            .map_err(|err| format!("Get prometheus metrics from_utf8 failed: {}", err))
+            .map_err(|err| format!("Get prometheus metrics from_utf8 failed: {err}"))
     }
 
     /// Try and fetch summaries from all ingest clients.
@@ -161,16 +161,14 @@ where
                         );
                         IngestSummary::try_from(&proto_ingest_summary).map_err(|err| {
                             format!(
-                                "Could not parse ingest summary for node with URI '{}': {}",
-                                uri, err
+                                "Could not parse ingest summary for node with URI '{uri}': {err}"
                             )
                         })
                     }
 
                     Err(err) => {
                         let error_message = format!(
-                            "Unable to retrieve ingest summary for node with URI '{}': {}",
-                            uri, err
+                            "Unable to retrieve ingest summary for node with URI '{uri}': {err}"
                         );
                         log::trace!(self.logger, "{}", error_message);
                         Err(error_message)

--- a/fog/overseer/server/src/worker.rs
+++ b/fog/overseer/server/src/worker.rs
@@ -234,7 +234,7 @@ where
                             })
                             .collect();
                     let error_message =
-                        format!("Active ingress keys: {:?}", active_node_ingress_pubkeys);
+                        format!("Active ingress keys: {active_node_ingress_pubkeys:?}");
                     let error = OverseerError::MultipleActiveNodes(error_message);
                     log::error!(self.logger, "{}", error);
                 }
@@ -276,10 +276,8 @@ where
                     }
 
                     Err(err) => {
-                        let error_message = format!(
-                            "Unable to retrieve ingest summary for node ({}): {}",
-                            uri, err
-                        );
+                        let error_message =
+                            format!("Unable to retrieve ingest summary for node ({uri}): {err}");
                         log::trace!(logger, "{}", error_message);
                         unresponsive_node_urls.insert(uri.clone());
                         Err(OverseerError::UnresponsiveNodeError(error_message))
@@ -338,7 +336,7 @@ where
             }
             _ => {
                 self.is_enabled.store(false, Ordering::SeqCst);
-                let error_message = format!("This is unexpected and requires manual intervention. As such, we've disabled overseer. Take the appropriate action and then re-enable overseer by calling the /enable endpoint. Inactive oustanding keys: {:?}", inactive_outstanding_keys);
+                let error_message = format!("This is unexpected and requires manual intervention. As such, we've disabled overseer. Take the appropriate action and then re-enable overseer by calling the /enable endpoint. Inactive oustanding keys: {inactive_outstanding_keys:?}");
                 Err(OverseerError::MultipleInactiveOutstandingKeys(
                     error_message,
                 ))
@@ -468,7 +466,7 @@ where
                 }
                 Err(err) => {
                     let number_of_remaining_tries = Self::NUMBER_OF_TRIES - current_try as usize;
-                    let error_message = format!("The following key was not successfully reported as lost: {}. Will try {} more times. Underlying error: {}", inactive_outstanding_key, number_of_remaining_tries, err);
+                    let error_message = format!("The following key was not successfully reported as lost: {inactive_outstanding_key}. Will try {number_of_remaining_tries} more times. Underlying error: {err}");
                     OperationResult::Retry(OverseerError::ReportLostKey(error_message))
                 }
             },

--- a/fog/overseer/server/tests/get_ingest_summaries.rs
+++ b/fog/overseer/server/tests/get_ingest_summaries.rs
@@ -13,7 +13,7 @@ const BASE_PORT: u16 = 8850;
 // cluster has one active node.
 #[test_with_logger]
 fn one_active_node_produces_ingest_summaries(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -35,7 +35,6 @@ fn one_active_node_produces_ingest_summaries(logger: Logger) {
     assert_eq!(
         active_pattern.captures_len(),
         1,
-        "JSON body should have exactly 1 ACTIVE: {}",
-        body
+        "JSON body should have exactly 1 ACTIVE: {body}"
     );
 }

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_does_not_have_key.rs
@@ -19,7 +19,7 @@ const BASE_PORT: u16 = 8550;
 fn inactive_oustanding_key_idle_node_does_not_have_key_idle_node_is_activated_and_original_key_is_reported_lost(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let mut nodes = VecDeque::from(helper.make_nodes(3));
 

--- a/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
+++ b/fog/overseer/server/tests/inactive_outstanding_key_idle_has_key.rs
@@ -19,7 +19,7 @@ const BASE_PORT: u16 = 8600;
 fn inactive_oustanding_key_idle_node_has_original_key_node_is_activated_and_key_is_not_reported_lost_or_retired(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let mut nodes = VecDeque::from(helper.make_nodes(3));
 

--- a/fog/overseer/server/tests/one_active_node.rs
+++ b/fog/overseer/server/tests/one_active_node.rs
@@ -14,7 +14,7 @@ const BASE_PORT: u16 = 8650;
 // Fog Overseer shouldn't take any action.
 #[test_with_logger]
 fn one_active_node_cluster_state_does_not_change(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 

--- a/fog/overseer/server/tests/prometheus_produces_metrics.rs
+++ b/fog/overseer/server/tests/prometheus_produces_metrics.rs
@@ -17,7 +17,7 @@ const BASE_PORT: u16 = 8700;
 // original active key as lost.
 #[test_with_logger]
 fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -35,35 +35,30 @@ fn one_active_node_idle_nodes_different_keys_produces_prometheus_metrics(logger:
     let correct_active_node_count = Regex::new(r#"active_node_count"} 1"#).unwrap();
     assert!(
         correct_active_node_count.is_match(&body),
-        "Body does not have expected active_node_count: {}",
-        body
+        "Body does not have expected active_node_count: {body}"
     );
 
     let correct_egress_key_count = Regex::new(r#"egress_key_count"} 3"#).unwrap();
     assert!(
         correct_egress_key_count.is_match(&body),
-        "Body does not have expected egress_key_count: {}",
-        body
+        "Body does not have expected egress_key_count: {body}"
     );
 
     let correct_idle_node_count = Regex::new(r#"idle_node_count"} 2"#).unwrap();
     assert!(
         correct_idle_node_count.is_match(&body),
-        "Body does not have expected idle_node_count: {}",
-        body
+        "Body does not have expected idle_node_count: {body}"
     );
 
     let correct_ingress_key_count = Regex::new(r#"ingress_key_count"} 1"#).unwrap();
     assert!(
         correct_ingress_key_count.is_match(&body),
-        "Body does not have expected ingress_key_count: {}",
-        body
+        "Body does not have expected ingress_key_count: {body}"
     );
 
     let correct_unresponsive_node_count_name = Regex::new(r#"unresponsive_node_count"#).unwrap();
     assert!(
         !correct_unresponsive_node_count_name.is_match(&body),
-        "Body should not have unresponsive_node_count: {}",
-        body
+        "Body should not have unresponsive_node_count: {body}"
     );
 }

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_different_keys.rs
@@ -18,7 +18,7 @@ const BASE_PORT: u16 = 8750;
 fn active_key_is_retired_not_outstanding_idle_nodes_have_different_keys_new_key_is_set_node_activated(
     logger: Logger,
 ) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 

--- a/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
+++ b/fog/overseer/server/tests/retired_key_not_outstanding_idles_have_same_key.rs
@@ -17,7 +17,7 @@ const BASE_PORT: u16 = 8800;
 // activate it.
 #[test_with_logger]
 fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: Logger) {
-    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger.clone());
+    let mut helper = IngestServerTestHelper::new(BASE_PORT, logger);
     helper.add_origin_block();
     let nodes = helper.make_nodes(3);
 
@@ -60,7 +60,7 @@ fn active_key_is_retired_not_outstanding_new_key_is_set_node_activated(logger: L
         .zip(new_ingress_keys.iter())
         .enumerate()
         .for_each(|(index, (original, new))| {
-            assert_ne!(original, new, "node{} ingress key did not change", index)
+            assert_ne!(original, new, "node{index} ingress key did not change")
         });
 
     // Ensure that the old active key is retired.

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/report/api/tests/fog_types.rs
+++ b/fog/report/api/tests/fog_types.rs
@@ -41,9 +41,9 @@ where
 
 fn prost_verification_report(name: &str) -> ProstVerificationReport {
     ProstVerificationReport {
-        sig: format!("{} sig", name).into_bytes().into(),
+        sig: format!("{name} sig").into_bytes().into(),
         chain: Default::default(),
-        http_body: format!("{} body", name),
+        http_body: format!("{name} body"),
     }
 }
 
@@ -70,7 +70,7 @@ fn prost_test_cases() -> Vec<ProstReport> {
 
 fn protobuf_verification_signature(name: &str) -> ProtobufVerificationSignature {
     let mut sig = ProtobufVerificationSignature::new();
-    sig.set_contents(format!("{} sig", name).into_bytes());
+    sig.set_contents(format!("{name} sig").into_bytes());
     sig
 }
 
@@ -78,7 +78,7 @@ fn protobuf_verification_report(name: &str) -> ProtobufVerificationReport {
     let mut report = ProtobufVerificationReport::new();
     report.set_sig(protobuf_verification_signature(name));
     report.set_chain(RepeatedField::from_vec(make_chain()));
-    report.set_http_body(format!("{} body", name));
+    report.set_http_body(format!("{name} body"));
     report
 }
 
@@ -112,7 +112,7 @@ fn round_trip_prost_report() {
 #[test]
 fn round_trip_protobuf_report() {
     for case in protobuf_test_cases() {
-        eprintln!("report = {:?}", case);
+        eprintln!("report = {case:?}");
         round_trip_protobuf::<ProtobufReport, ProstReport>(case);
     }
 }

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/cli/src/main.rs
+++ b/fog/report/cli/src/main.rs
@@ -116,12 +116,12 @@ fn get_fog_response_with_retries(
             Err(Error::NoReports(_)) => {
                 std::thread::sleep(Duration::from_millis(500));
                 if Instant::now() > deadline {
-                    eprintln!("No reports after {:?} time retrying", retry_duration);
+                    eprintln!("No reports after {retry_duration:?} time retrying");
                     exit(1)
                 }
             }
             Err(err) => {
-                eprintln!("Could not get fog response ({}): {}", fog_uri, err);
+                eprintln!("Could not get fog response ({fog_uri}): {err}");
                 exit(1);
             }
         }
@@ -284,11 +284,8 @@ fn main() {
     // if show-expiry is selected, we show key and expiry, formatted as json
     // else just print the hex bytes of key
     if config.show_expiry {
-        print!(
-            "{{ \"pubkey\": \"{}\", \"pubkey_expiry\": {} }}",
-            hex_str, pubkey_expiry
-        );
+        print!("{{ \"pubkey\": \"{hex_str}\", \"pubkey_expiry\": {pubkey_expiry} }}");
     } else {
-        print!("{}", hex_str);
+        print!("{hex_str}");
     }
 }

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/server/src/bin/main.rs
+++ b/fog/report/server/src/bin/main.rs
@@ -26,10 +26,7 @@ fn main() {
         logger.clone(),
     )
     .unwrap_or_else(|err| {
-        panic!(
-            "fog-report cannot connect to database '{}': {:?}",
-            database_url, err
-        )
+        panic!("fog-report cannot connect to database '{database_url}': {err:?}")
     });
 
     let mut server = Server::new(

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -353,7 +353,7 @@ impl CachedTxData {
 
         let tx_values: Vec<u64> = available.iter().map(|txo| txo.amount.value).collect();
 
-        let selected = input_selection_heuristic(&tx_values, amount.value, max_inputs)?;
+        let selected = input_selection_heuristic(tx_values, amount.value, max_inputs)?;
 
         Ok(selected
             .into_iter()
@@ -855,7 +855,7 @@ impl CachedTxData {
             self.rng_set.get_rngs().len()
         ));
         for owned_tx_out in self.owned_tx_outs.values() {
-            lines.push(format!("{:?}\n", owned_tx_out));
+            lines.push(format!("{owned_tx_out:?}\n"));
         }
         lines.join("\n")
     }

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -276,8 +276,7 @@ impl Client {
                                     }
                                     MALFORMED_REQUEST => {
                                         panic!(
-                                            "Server reported our request {:?} was malformed",
-                                            public_key
+                                            "Server reported our request {public_key:?} was malformed"
                                         );
                                     }
                                     DATABASE_ERROR => {
@@ -294,7 +293,7 @@ impl Client {
                                         }
                                     }
                                     other => {
-                                        panic!("Server returned an unknown status code: {}", other);
+                                        panic!("Server returned an unknown status code: {other}");
                                     }
                                 };
                             }
@@ -370,7 +369,7 @@ impl Client {
         let fee_map = self.get_fee_map(true)?;
 
         // Make fog resolver
-        let fog_uris = (&[&self.account_key.change_subaddress(), target_address])
+        let fog_uris = [&self.account_key.change_subaddress(), target_address]
             .iter()
             .filter_map(|addr| addr.fog_report_url())
             .map(FogUri::from_str)
@@ -423,8 +422,8 @@ impl Client {
         assert_eq!(inputs.len(), 1);
         assert_eq!(rings.len(), 1);
 
-        let (input, input_proof) = (&inputs[0]).clone();
-        let ring = (&rings[0]).clone();
+        let (input, input_proof) = inputs[0].clone();
+        let ring = rings[0].clone();
 
         // Check amount found, calculate change
         let input_amount = input.amount;
@@ -556,8 +555,7 @@ impl Client {
             match result.status() {
                 Err(err) => {
                     return Err(Error::FogMerkleProof(format!(
-                        "Server failed to compute a merkle proof: {}",
-                        err
+                        "Server failed to compute a merkle proof: {err}"
                     )))
                 }
                 Ok(None) => {
@@ -788,8 +786,7 @@ impl Client {
                 }
                 match result.status() {
                     Err(err) => Err(Error::FogMerkleProof(format!(
-                        "Server failed to compute a merkle proof: {}",
-                        err
+                        "Server failed to compute a merkle proof: {err}"
                     ))),
                     Ok(None) => Err(Error::FogMerkleProof(
                         "Server did not find one of the outputs we need".to_string(),
@@ -881,10 +878,9 @@ impl Client {
                     panic!("unhandled: Server returned indices in an unexpected order");
                 }
                 match result.status() {
-                    Err(err) => panic!(
-                        "unhandled: Server failed to computer a merkle proof: {}",
-                        err
-                    ),
+                    Err(err) => {
+                        panic!("unhandled: Server failed to computer a merkle proof: {err}")
+                    }
                     Ok(None) => panic!("unhandled: Server did not find one of the outputs we need"),
                     Ok(Some(res)) => res,
                 }

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog authority signatures"

--- a/fog/sig/authority/src/ristretto.rs
+++ b/fog/sig/authority/src/ristretto.rs
@@ -25,7 +25,7 @@ impl Verifier for RistrettoPublic {
 
     fn verify_authority(&self, spki_bytes: &[u8], sig: &Self::Sig) -> Result<(), String> {
         self.verify_schnorrkel(super::context(), spki_bytes, sig)
-            .map_err(|e| format!("{:#}", e))
+            .map_err(|e| format!("{e:#}"))
     }
 }
 

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Create and verify fog report signatures"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -251,8 +251,7 @@ impl SqlRecoveryDb {
             }))
         } else {
             Err(Error::IngressKeysSchemaViolation(format!(
-                "Found multiple entries for key: {:?}",
-                key
+                "Found multiple entries for key: {key:?}"
             )))
         }
     }
@@ -347,8 +346,7 @@ impl SqlRecoveryDb {
                     Ok(accepted_start_block_count)
                 } else {
                     Err(Error::IngressKeyUnsuccessfulInsert(format!(
-                        "Unable to insert ingress key: {:?}",
-                        key
+                        "Unable to insert ingress key: {key:?}"
                     )))
                 }
             })
@@ -662,8 +660,7 @@ impl SqlRecoveryDb {
                 }
             } else {
                 return Err(Error::IngressKeysSchemaViolation(format!(
-                    "Found multiple entries for key: {:?}",
-                    lost_ingress_key
+                    "Found multiple entries for key: {lost_ingress_key:?}"
                 )));
             };
 
@@ -1100,8 +1097,7 @@ impl SqlRecoveryDb {
                 Ok(Some(cumulative_txo_count as u64))
             } else {
                 Err(Error::IngestedBlockSchemaViolation(format!(
-                    "Found multiple cumulative_txo_count values for block {}: {:?}",
-                    block_index, data
+                    "Found multiple cumulative_txo_count values for block {block_index}: {data:?}"
                 )))
             }
         }
@@ -2581,9 +2577,9 @@ mod tests {
             .collect();
 
         VerificationReport {
-            sig: format!("{} sig", name).into_bytes().into(),
+            sig: format!("{name} sig").into_bytes().into(),
             chain,
-            http_body: format!("{} body", name),
+            http_body: format!("{name} body"),
         }
     }
 
@@ -3664,7 +3660,7 @@ mod tests {
 
     #[test_with_logger]
     fn get_expired_invocations_multiple_expired(logger: Logger) {
-        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger.clone());
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
 
         let mut rng = thread_rng();
@@ -3699,7 +3695,7 @@ mod tests {
 
     #[test_with_logger]
     fn get_expired_invocations_mixed(logger: Logger) {
-        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger.clone());
+        let db_test_context = test_utils::SqlRecoveryDbTestContext::new(logger);
         let db = db_test_context.get_db_instance();
 
         let mut rng = thread_rng();

--- a/fog/sql_recovery_db/src/test_utils.rs
+++ b/fog/sql_recovery_db/src/test_utils.rs
@@ -42,17 +42,17 @@ impl SqlRecoveryDbTestContext {
 
         // First, connect to postgres db to be able to create our test
         // database.
-        let postgres_url = format!("{}/postgres", base_url);
+        let postgres_url = format!("{base_url}/postgres");
         log::info!(&logger, "Connecting to root PG DB {}", postgres_url);
         let conn = SqlRecoveryDbTestContext::establish_connection(&postgres_url);
         // Create a new database for the test
-        let query = diesel::sql_query(format!("CREATE DATABASE {};", db_name).as_str());
+        let query = diesel::sql_query(format!("CREATE DATABASE {db_name};").as_str());
         let _ = query
             .execute(&conn)
-            .unwrap_or_else(|err| panic!("Could not create database {}: {:?}", db_name, err));
+            .unwrap_or_else(|err| panic!("Could not create database {db_name}: {err:?}"));
 
         // Now we can connect to the database and run the migrations
-        let db_url = format!("{}/{}", base_url, db_name);
+        let db_url = format!("{base_url}/{db_name}");
         log::info!(&logger, "Connecting to newly created PG DB '{}'", db_url);
 
         let conn = SqlRecoveryDbTestContext::establish_connection(&db_url);
@@ -90,7 +90,7 @@ impl SqlRecoveryDbTestContext {
     pub fn new_conn(&self) -> PgConnection {
         let db_url = self.db_url();
         PgConnection::establish(&db_url)
-            .unwrap_or_else(|err| panic!("Cannot connect to database {}: {}", db_url, err))
+            .unwrap_or_else(|err| panic!("Cannot connect to database {db_url}: {err}"))
     }
 
     fn establish_connection(url: &str) -> PgConnection {
@@ -100,7 +100,7 @@ impl SqlRecoveryDbTestContext {
                 .take(TOTAL_RETRY_COUNT),
             || PgConnection::establish(url),
         )
-        .unwrap_or_else(|err| panic!("Cannot connect to PG database '{}: {}'", url, err))
+        .unwrap_or_else(|err| panic!("Cannot connect to PG database '{url}: {err}'"))
     }
 }
 

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -56,9 +56,8 @@ fn main() {
         };
 
         let get_config_json = Arc::new(move || {
-            serde_json::to_string(&json_data).map_err(|err| {
-                RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{:?}", err))
-            })
+            serde_json::to_string(&json_data)
+                .map_err(|err| RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("{err:?}")))
         });
         AdminServer::start(
             None,
@@ -108,7 +107,7 @@ fn main() {
                 "Transactions could not clear in {:?} seconds",
                 config.consensus_wait
             ),
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 }

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -950,7 +950,7 @@ impl TestClient {
     /// * token_id: The token id to use
     /// * num_transactions: The number of transactions to run
     pub fn run_test(&self, num_transactions: usize) -> Result<(), TestClientError> {
-        let client_count = self.account_keys.len() as usize;
+        let client_count = self.account_keys.len();
         assert!(client_count > 1);
         log::info!(self.logger, "Creating {} clients", client_count);
         let clients = self.build_clients(client_count);
@@ -1062,7 +1062,7 @@ impl TestClient {
     /// but it should be equal in most cases where the period is sufficiently
     /// larger than the expected transfer duration.
     pub fn run_continuously(&self, period: Duration) {
-        let client_count = self.account_keys.len() as usize;
+        let client_count = self.account_keys.len();
         assert!(client_count > 1);
         log::debug!(self.logger, "Creating {} clients", client_count);
         let clients = self.build_clients(client_count);
@@ -1432,7 +1432,7 @@ impl core::fmt::Display for TxInfo {
             )?;
         }
         if let Some(appeared) = &guard.tx_appeared {
-            write!(f, "Appeared in block index {}, ", appeared)?;
+            write!(f, "Appeared in block index {appeared}, ")?;
         }
         if let Some(tx) = &guard.tx {
             write!(

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test_infra/src/bin/add_test_block.rs
+++ b/fog/test_infra/src/bin/add_test_block.rs
@@ -111,7 +111,7 @@ fn main() {
     let watcher = mc_watcher::watcher_db::WatcherDB::open_rw(
         &config.watcher,
         &[tx_source_url.clone()],
-        logger.clone(),
+        logger,
     )
     .expect("Could not create watcher_db");
 

--- a/fog/test_infra/src/db_tests.rs
+++ b/fog/test_infra/src/db_tests.rs
@@ -82,8 +82,7 @@ pub fn recovery_db_smoke_tests_new_apis<DB: RecoveryDb>(
                 .count();
             assert_eq!(
                 num_rng_events, SEEDS_PER_ROUND,
-                "unexpected number of rng events: found {} expected {}",
-                num_rng_events, SEEDS_PER_ROUND
+                "unexpected number of rng events: found {num_rng_events} expected {SEEDS_PER_ROUND}"
             );
 
             assert_rng_record_rows_were_recovered(
@@ -134,8 +133,7 @@ pub fn recovery_db_smoke_tests_new_apis<DB: RecoveryDb>(
             assert_eq!(user_events.len(), 0);
             assert_eq!(
                 next_start_from_user_event_id, start_from_user_event_id,
-                "expected next_start_from_user_event_id not to be different: found {} expected {}",
-                next_start_from_user_event_id, start_from_user_event_id
+                "expected next_start_from_user_event_id not to be different: found {next_start_from_user_event_id} expected {start_from_user_event_id}"
             );
         }
     }

--- a/fog/test_infra/src/lib.rs
+++ b/fog/test_infra/src/lib.rs
@@ -127,7 +127,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
                     src_url,
                     block_index,
                     block_signature,
-                    format!("00/{}", block_index),
+                    format!("00/{block_index}"),
                 )
                 .expect("Could not add block signature");
         }
@@ -182,10 +182,7 @@ pub fn test_block<T: RngCore + CryptoRng, C: FogViewConnection>(
         return global_txo_count + num_new_txos;
     }
 
-    panic!(
-        "polling failed to yield expected result {:?}, obtained {:?}",
-        expected_result, result
-    );
+    panic!("polling failed to yield expected result {expected_result:?}, obtained {result:?}");
 }
 
 /// Throw all the user phones in the pool and see if they can recover them via

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -107,7 +107,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         key.clone_from_slice(search_key);
         value[0] = (ValueSize::USIZE - 1 - ciphertext.len()) as u8;
         let data_end = ValueSize::USIZE - value[0] as usize;
-        (&mut value[1..data_end]).clone_from_slice(ciphertext);
+        value[1..data_end].clone_from_slice(ciphertext);
         self.last_ciphertext_size_byte = value[0];
 
         // Note: Passing true means we allow overwrite, which seems fine since
@@ -177,8 +177,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
                 oram_result_code == OMAP_FOUND
                     || oram_result_code == OMAP_NOT_FOUND
                     || oram_result_code == OMAP_INVALID_KEY,
-                "oram_result_code had an unexpected value: {}",
-                oram_result_code
+                "oram_result_code had an unexpected value: {oram_result_code}"
             );
         }
 

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Fog View Enclave - Application Code"

--- a/fog/view/enclave/tests/basic.rs
+++ b/fog/view/enclave/tests/basic.rs
@@ -17,7 +17,7 @@ fn get_enclave(logger: Logger) -> SgxViewEnclave {
         get_enclave_path(mc_fog_view_enclave::ENCLAVE_FILE),
         ResponderId::from_str("abc:123").unwrap(),
         VIEW_OMAP_CAPACITY,
-        logger.clone(),
+        logger,
     )
 }
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -750,14 +750,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "bitflags",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "digest",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1188,14 +1188,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1387,11 +1387,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1431,36 +1431,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1489,14 +1489,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1504,11 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "prost",
  "serde",
@@ -1616,14 +1616,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "displaydoc",
  "serde",
@@ -1701,9 +1701,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "packed_simd_2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defdcfef86dcc44ad208f71d9ff4ce28df6537a4e0d6b0e8e845cb8ca10059a6"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if 1.0.0",
  "libm",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Fog user-facing server's enclave entry point."

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -19,7 +19,7 @@ use mc_sgx_types::{c_void, sgx_is_outside_enclave, sgx_status_t};
 use mc_util_serial::{deserialize, serialize};
 
 lazy_static::lazy_static! {
-    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(&ecall_dispatcher);
+    static ref RETRY_BUFFER: RetryBuffer = RetryBuffer::new(ecall_dispatcher);
 }
 
 /// The entry point implementation for test_enclave_api

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -138,7 +138,7 @@ fn build_fog_view_conn(
     log::debug!(logger, "Fog view attestation verifier: {:?}", verifier);
 
     let client_uri = FogViewUri::from_str(uri)
-        .unwrap_or_else(|e| panic!("Could not parse client uri: {}: {:?}", uri, e));
+        .unwrap_or_else(|e| panic!("Could not parse client uri: {uri}: {e:?}"));
 
     // TODO: Supply chain-id to the load-test binary?
     FogViewGrpcClient::new(

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -24,12 +24,7 @@ fn main() {
         config.postgres_config.clone(),
         logger.clone(),
     )
-    .unwrap_or_else(|err| {
-        panic!(
-            "fog-view cannot connect to database '{}': {:?}",
-            database_url, err
-        )
-    });
+    .unwrap_or_else(|err| panic!("fog-view cannot connect to database '{database_url}': {err:?}"));
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
         env!("CARGO_PKG_NAME"),

--- a/fog/view/server/src/block_tracker.rs
+++ b/fog/view/server/src/block_tracker.rs
@@ -177,8 +177,8 @@ impl BlockTracker {
     /// Get the highest block count we have encountered.
     pub fn highest_known_block_count(&self) -> u64 {
         self.processed_block_per_ingress_key
-            .iter()
-            .map(|(_key, block_index)| *block_index + 1)
+            .values()
+            .map(|block_index| *block_index + 1)
             .max()
             .unwrap_or(0)
     }
@@ -195,7 +195,7 @@ mod tests {
 
     #[test_with_logger]
     fn next_blocks_empty(logger: Logger) {
-        let block_tracker = BlockTracker::new(logger.clone());
+        let block_tracker = BlockTracker::new(logger);
         assert_eq!(block_tracker.next_blocks(&[]).len(), 0);
     }
 
@@ -232,8 +232,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -314,8 +313,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -364,8 +362,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -434,8 +431,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Repeated call should result in the same expected result.
@@ -509,7 +505,7 @@ mod tests {
     // highest_fully_processed_block_count behaves as expected
     #[test_with_logger]
     fn highest_fully_processed_block_count_all_empty(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         assert_eq!(
             block_tracker.highest_fully_processed_block_count(&[]),
@@ -520,7 +516,7 @@ mod tests {
     // Check with a key that hasn't yet processed anything.
     #[test_with_logger]
     fn highest_fully_processed_block_missing_blocks_nothing_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -543,7 +539,7 @@ mod tests {
     // are processed when the start block is 0.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
@@ -578,7 +574,7 @@ mod tests {
     // when the start block is greater than zero
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
@@ -614,7 +610,7 @@ mod tests {
     // then the key is reported lost
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed3(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec = IngressPublicKeyRecord {
@@ -661,7 +657,7 @@ mod tests {
     // When the slow one is marked lost, that unblocks progress.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -728,8 +724,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -741,8 +736,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -760,7 +754,7 @@ mod tests {
     // key is loaded
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs_some_lost2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -830,8 +824,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -843,8 +836,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -876,7 +868,7 @@ mod tests {
     /// key, makes progress
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_followed_by_gap(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -899,8 +891,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -911,8 +902,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -949,8 +939,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             // Make the block "exist" and "load" it
@@ -962,8 +951,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }
@@ -975,7 +963,7 @@ mod tests {
     /// when everything works.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -998,8 +986,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1010,8 +997,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1027,8 +1013,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1039,8 +1024,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1066,8 +1050,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1080,8 +1063,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1095,8 +1077,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec2.last_scanned_block = Some(index);
@@ -1107,8 +1088,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }
@@ -1123,7 +1103,7 @@ mod tests {
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active_both_lost(
         logger: Logger,
     ) {
-        let mut block_tracker = BlockTracker::new(logger.clone());
+        let mut block_tracker = BlockTracker::new(logger);
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
@@ -1146,8 +1126,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1158,8 +1137,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1175,8 +1153,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1187,8 +1164,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1214,8 +1190,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec1.last_scanned_block = Some(index);
@@ -1228,8 +1203,7 @@ mod tests {
             assert_eq!(
                 block_tracker.highest_fully_processed_block_count(&[rec1.clone(), rec2.clone()]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
 
@@ -1273,8 +1247,7 @@ mod tests {
             assert_eq!(
                 block_tracker.next_blocks(&[rec1.clone(), rec2.clone(), rec3.clone()]),
                 expected_state,
-                "i = {}",
-                i
+                "i = {i}"
             );
 
             rec3.last_scanned_block = Some(index);
@@ -1289,8 +1262,7 @@ mod tests {
                     rec3.clone()
                 ]),
                 expected,
-                "i = {}",
-                i
+                "i = {i}"
             );
         }
     }

--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -750,9 +750,9 @@ mod tests {
             .collect();
 
         VerificationReport {
-            sig: format!("{} sig", name).into_bytes().into(),
+            sig: format!("{name} sig").into_bytes().into(),
             chain,
-            http_body: format!("{} body", name),
+            http_body: format!("{name} body"),
         }
     }
 }

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -69,7 +69,7 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewService<E, DB> {
                 .map_err(|err| {
                     RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("AAD deserialization error: {}", err),
+                        format!("AAD deserialization error: {err}"),
                     )
                 })?;
 
@@ -171,7 +171,7 @@ impl<E: ViewEnclaveProxy, DB: RecoveryDb + Send + Sync> FogViewApi for FogViewSe
                         sink,
                         Err(rpc_permissions_error(
                             "client_auth",
-                            format!("Permission denied: {}", client_error),
+                            format!("Permission denied: {client_error}"),
                             logger,
                         )),
                         logger,

--- a/fog/view/server/tests/smoke_tests.rs
+++ b/fog/view/server/tests/smoke_tests.rs
@@ -56,7 +56,7 @@ fn get_test_environment(
     let db = db_test_context.get_db_instance();
 
     let port = portpicker::pick_unused_port().expect("pick_unused_port");
-    let uri = FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{}", port)).unwrap();
+    let uri = FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{port}")).unwrap();
 
     let server = {
         let config = ViewConfig {
@@ -277,8 +277,7 @@ fn test_view_integration(view_omap_capacity: u64, logger: Logger) {
         let server_num_blocks = server.highest_processed_block_count();
         if server_num_blocks > db_num_blocks {
             panic!(
-                "Server num blocks should never be larger than db num blocks: {} > {}",
-                server_num_blocks, db_num_blocks
+                "Server num blocks should never be larger than db num blocks: {server_num_blocks} > {db_num_blocks}"
             );
         }
         if server_num_blocks == db_num_blocks {

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/src/bin/main.rs
+++ b/go-grpc-gateway/testing/src/bin/main.rs
@@ -13,11 +13,7 @@ fn main() {
 
     let config = Config::parse();
 
-    let mut server = Server::new(
-        &config.client_listen_uri,
-        config.chain_id.clone(),
-        logger.clone(),
-    );
+    let mut server = Server::new(&config.client_listen_uri, config.chain_id.clone(), logger);
     server.start();
 
     loop {

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/db/src/ledger_db.rs
+++ b/ledger/db/src/ledger_db.rs
@@ -2158,12 +2158,12 @@ mod ledger_db_test {
         let n_blocks = 43;
         let expected_blocks = populate_db(&mut ledger_db, n_blocks, 1);
 
-        for block_index in 0..n_blocks {
+        for (block_index, _) in expected_blocks.iter().enumerate().take(n_blocks) {
             let block = ledger_db
                 .get_block(block_index as u64)
-                .unwrap_or_else(|_| panic!("Could not get block {:?}", block_index));
+                .unwrap_or_else(|_| panic!("Could not get block {block_index:?}"));
 
-            assert_eq!(&block, expected_blocks[block_index as usize].block());
+            assert_eq!(&block, expected_blocks[block_index].block());
         }
     }
 
@@ -2175,12 +2175,12 @@ mod ledger_db_test {
         let n_blocks = 43;
         let expected_blocks = populate_db(&mut ledger_db, n_blocks, 1);
 
-        for block_index in 0..n_blocks {
+        for (block_index, _) in expected_blocks.iter().enumerate().take(n_blocks) {
             let block_contents = ledger_db
                 .get_block_contents(block_index as u64)
-                .unwrap_or_else(|_| panic!("Could not get block contents {:?}", block_index));
+                .unwrap_or_else(|_| panic!("Could not get block contents {block_index:?}"));
 
-            let expected_block_contents = expected_blocks[block_index as usize].contents();
+            let expected_block_contents = expected_blocks[block_index].contents();
             assert_eq!(&block_contents, expected_block_contents);
         }
     }
@@ -2200,7 +2200,7 @@ mod ledger_db_test {
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 
@@ -2242,7 +2242,7 @@ mod ledger_db_test {
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 

--- a/ledger/db/src/mint_tx_store.rs
+++ b/ledger/db/src/mint_tx_store.rs
@@ -651,7 +651,7 @@ mod tests {
                 ]
                 .contains(&mint_limit));
             }
-            Err(err) => panic!("Unexpected error {}", err),
+            Err(err) => panic!("Unexpected error {err}"),
         }
     }
 

--- a/ledger/db/src/test_utils/mock_ledger.rs
+++ b/ledger/db/src/test_utils/mock_ledger.rs
@@ -68,8 +68,7 @@ impl MockLedger {
         for ki in &contents.key_images {
             assert!(
                 inner.key_images.insert(*ki, block.index).is_none(),
-                "duplicate key image: {:?}",
-                ki
+                "duplicate key image: {ki:?}"
             );
         }
 

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -326,7 +326,7 @@ pub fn initialize_ledger(
         let block_data =
             add_txos_and_key_images_to_ledger(ledger, block_version, outputs, key_images, rng)
                 .unwrap_or_else(|err| {
-                    panic!("failed to append block with index {}: {}", block_index, err)
+                    panic!("failed to append block with index {block_index}: {err}")
                 });
 
         to_spend = Some(block_data.contents().outputs[0].clone());
@@ -335,7 +335,7 @@ pub fn initialize_ledger(
     }
 
     // Verify that db now contains n transactions.
-    assert_eq!(ledger.num_blocks().unwrap(), n_blocks as u64);
+    assert_eq!(ledger.num_blocks().unwrap(), { n_blocks });
 
     results
 }

--- a/ledger/db/src/tx_out_store.rs
+++ b/ledger/db/src/tx_out_store.rs
@@ -379,7 +379,7 @@ pub fn containing_ranges(index: u64, num_leaves: u64) -> Result<Vec<(u64, u64)>,
 
     if let Some(num_leaves_full_tree) = num_leaves.checked_next_power_of_two() {
         // The depth of a full binary tree large enough to contain num_leaves.
-        let depth: u32 = 64 - (num_leaves_full_tree as u64).leading_zeros() - 1;
+        let depth: u32 = 64 - num_leaves_full_tree.leading_zeros() - 1;
         let ranges: Vec<(u64, u64)> = (0..=depth).map(|d| containing_range(index, d)).collect();
         Ok(ranges)
     } else {
@@ -886,11 +886,11 @@ pub mod tx_out_store_tests {
         // unrecognized hash.
         let unrecognized_hash: Hash = [0u8; 32];
         match tx_out_store.get_tx_out_index_by_hash(&unrecognized_hash, &ro_transaction) {
-            Ok(index) => panic!("Returned index {:?} for unrecognized hash.", index),
+            Ok(index) => panic!("Returned index {index:?} for unrecognized hash."),
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected Error {:?}", e),
+            Err(e) => panic!("Unexpected Error {e:?}"),
         }
     }
 
@@ -932,11 +932,11 @@ pub mod tx_out_store_tests {
         let unrecognized_public_key = CompressedRistrettoPublic::from(&[0; 32]);
         match tx_out_store.get_tx_out_index_by_public_key(&unrecognized_public_key, &ro_transaction)
         {
-            Ok(index) => panic!("Returned index {:?} for unrecognized public key.", index),
+            Ok(index) => panic!("Returned index {index:?} for unrecognized public key."),
             Err(Error::NotFound) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected Error {:?}", e),
+            Err(e) => panic!("Unexpected Error {e:?}"),
         }
     }
 
@@ -980,7 +980,7 @@ pub mod tx_out_store_tests {
                 Err(Error::NotFound) => {
                     // This is expected.
                 }
-                Err(e) => panic!("Unexpected Error {:?}", e),
+                Err(e) => panic!("Unexpected Error {e:?}"),
             }
         }
         ro_transaction.commit().unwrap();
@@ -1091,7 +1091,7 @@ pub mod tx_out_store_tests {
     #[test]
     fn test_containing_ranges() {
         let ranges: Vec<(u64, u64)> = containing_ranges(5, 13).unwrap();
-        println!("{:?}", ranges);
+        println!("{ranges:?}");
 
         assert_eq!(5, ranges.len());
 
@@ -1102,7 +1102,7 @@ pub mod tx_out_store_tests {
         assert!(ranges.contains(&(0, 15)));
 
         // Ranges must be in order from smallest to largest.
-        assert_eq!((5, 5), *ranges.get(0).unwrap());
+        assert_eq!((5, 5), *ranges.first().unwrap());
         assert_eq!((4, 5), *ranges.get(1).unwrap());
         assert_eq!((4, 7), *ranges.get(2).unwrap());
         assert_eq!((0, 7), *ranges.get(3).unwrap());
@@ -1303,7 +1303,7 @@ pub mod tx_out_store_tests {
 
             let ranges: Vec<Range> = proof.elements.iter().map(|e| e.range).collect();
 
-            println!("{:?}", ranges);
+            println!("{ranges:?}");
             assert_eq!(ranges[0], Range::new(5, 5).unwrap());
             assert_eq!(ranges[1], Range::new(4, 4).unwrap());
             assert_eq!(ranges[2], Range::new(6, 7).unwrap());
@@ -1343,7 +1343,7 @@ pub mod tx_out_store_tests {
             Err(Error::TxOutIndexOutOfBounds(43)) => {
                 // This is expected.
             }
-            Err(e) => panic!("Unexpected error {:?}", e),
+            Err(e) => panic!("Unexpected error {e:?}"),
         }
     }
 }

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/distribution/src/main.rs
+++ b/ledger/distribution/src/main.rs
@@ -240,7 +240,7 @@ impl BlockHandler for LocalBlockWriter {
         let dir = dest.as_path().parent().expect("failed getting parent");
 
         fs::create_dir_all(dir)
-            .unwrap_or_else(|e| panic!("failed creating directory {:?}: {:?}", dir, e));
+            .unwrap_or_else(|e| panic!("failed creating directory {dir:?}: {e:?}"));
         fs::write(&dest, bytes).unwrap_or_else(|err| {
             panic!(
                 "failed writing block #{} to {:?}: {}",
@@ -281,11 +281,10 @@ impl BlockHandler for LocalBlockWriter {
         let dir = dest.as_path().parent().expect("failed getting parent");
 
         fs::create_dir_all(dir)
-            .unwrap_or_else(|e| panic!("failed creating directory {:?}: {:?}", dir, e));
+            .unwrap_or_else(|e| panic!("failed creating directory {dir:?}: {e:?}"));
         fs::write(&dest, bytes).unwrap_or_else(|err| {
             panic!(
-                "failed writing merged block #{}-{} to {:?}: {}",
-                first_block_index, last_block_index, dest, err,
+                "failed writing merged block #{first_block_index}-{last_block_index} to {dest:?}: {err}",
             )
         });
     }
@@ -336,10 +335,10 @@ fn main() {
             // See if the state file exists and read it if it does.
             if state_file_path.as_path().exists() {
                 let file_data = fs::read_to_string(&state_file_path).unwrap_or_else(|e| {
-                    panic!("Failed reading state file {:?}: {:?}", state_file_path, e)
+                    panic!("Failed reading state file {state_file_path:?}: {e:?}")
                 });
                 let state_data: StateData = serde_json::from_str(&file_data).unwrap_or_else(|e| {
-                    panic!("Failed parsing state file {:?}: {:?}", state_file_path, e)
+                    panic!("Failed parsing state file {state_file_path:?}: {e:?}")
                 });
                 state_data.next_block
             } else {
@@ -355,9 +354,8 @@ fn main() {
         }
 
         Destination::Local { path } => {
-            fs::create_dir_all(&path).unwrap_or_else(|_| {
-                panic!("Failed creating local destination directory {:?}", path)
-            });
+            fs::create_dir_all(&path)
+                .unwrap_or_else(|_| panic!("Failed creating local destination directory {path:?}"));
             Box::new(LocalBlockWriter::new(path, logger.clone()))
         }
     };
@@ -410,9 +408,9 @@ fn main() {
                     // the ledger due to block_index <= next_block_num (which we
                     // successfully fetched or otherwise this code wouldn't be
                     // running).
-                    let block_data = ledger_db.get_block_data(block_index).unwrap_or_else(|err| {
-                        panic!("failed getting block #{}: {}", block_index, err)
-                    });
+                    let block_data = ledger_db
+                        .get_block_data(block_index)
+                        .unwrap_or_else(|err| panic!("failed getting block #{block_index}: {err}"));
                     blocks_data.push(block_data);
                 }
 

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
                 // Append new data to the ledger
                 local_ledger
                     .append_block_data(&block_data)
-                    .unwrap_or_else(|_| panic!("Could not append block {:?}", block_index))
+                    .unwrap_or_else(|_| panic!("Could not append block {block_index:?}"))
             }
             Err(err) => {
                 log::info!(

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/migration/src/lib.rs
+++ b/ledger/migration/src/lib.rs
@@ -135,7 +135,7 @@ pub fn migrate(ledger_db_path: impl AsRef<Path>, logger: &Logger) {
             }
             // Don't know how to migrate.
             Err(err) => {
-                panic!("Error while migrating: {:?}", err);
+                panic!("Error while migrating: {err:?}");
             }
         };
     }

--- a/ledger/migration/src/main.rs
+++ b/ledger/migration/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let config = Config::parse();
 
-    migrate(&config.ledger_db, &logger);
+    migrate(config.ledger_db, &logger);
 
     // Give logger a moment to flush.
     sleep(Duration::from_secs(1));

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/ledger/sync/src/network_state/polling_network_state.rs
+++ b/ledger/sync/src/network_state/polling_network_state.rs
@@ -85,11 +85,11 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
             let thread_logger = self.logger.clone();
             let thread_results_and_condvar = results_and_condvar.clone();
             thread::Builder::new()
-                .name(format!("Poll:{}", responder_id))
+                .name(format!("Poll:{responder_id}"))
                 .spawn(move || {
                     log::debug!(thread_logger, "Getting last block from {}", conn);
 
-                    let &(ref lock, ref condvar) = &*thread_results_and_condvar;
+                    let (lock, condvar) = &*thread_results_and_condvar;
 
                     let block_info_result = conn.fetch_block_info(Self::get_retry_iterator());
 
@@ -121,7 +121,7 @@ impl<BC: BlockchainConnection + 'static> PollingNetworkState<BC> {
         }
 
         // Wait until we get all results.
-        let &(ref lock, ref condvar) = &*results_and_condvar;
+        let (lock, condvar) = &*results_and_condvar;
         let num_peers = self.manager.len();
         let results = condvar //.wait(lock.lock().unwrap()).unwrap();
             .wait_while(lock.lock().unwrap(), |ref mut results| {

--- a/ledger/sync/src/reqwest_transactions_fetcher.rs
+++ b/ledger/sync/src/reqwest_transactions_fetcher.rs
@@ -190,7 +190,7 @@ impl ReqwestTransactionsFetcher {
         let obj = M::parse_from_bytes(&bytes).map_err(|err| {
             ReqwestTransactionsFetcherError::InvalidBlockReceived(
                 url.to_string(),
-                format!("protobuf parse failed: {:?}", err),
+                format!("protobuf parse failed: {err:?}"),
             )
         })?;
 

--- a/ledger/sync/src/test_app/main.rs
+++ b/ledger/sync/src/test_app/main.rs
@@ -74,7 +74,7 @@ fn main() {
 
     std::fs::copy(
         "../../target/sample_data/ledger/data.mdb",
-        format!("{}/data.mdb", ledger_path_str),
+        format!("{ledger_path_str}/data.mdb"),
     )
     .expect("failed copying ledger");
 
@@ -107,7 +107,7 @@ fn main() {
         .into_iter()
         .map(|node_id| {
             let node_uri =
-                ClientUri::from_str(&format!("mc://node{}.{}.mobilecoin.com/", node_id, NETWORK))
+                ClientUri::from_str(&format!("mc://node{node_id}.{NETWORK}.mobilecoin.com/"))
                     .expect("failed parsing URI");
 
             ThickClient::new(

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/mobilecoind-dev-faucet/src/bin/main.rs
+++ b/mobilecoind-dev-faucet/src/bin/main.rs
@@ -4,6 +4,7 @@
 
 #![deny(missing_docs)]
 #![feature(proc_macro_hygiene, decl_macro)]
+#![allow(clippy::let_unit_value)]
 
 use clap::Parser;
 use mc_common::logger::{create_app_logger, log, o};

--- a/mobilecoind-dev-faucet/src/data_types.rs
+++ b/mobilecoind-dev-faucet/src/data_types.rs
@@ -116,10 +116,10 @@ impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
     fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
-            tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
-            tx_out_hash: hex::encode(&src.get_tx_out_hash()),
+            tx_public_key: hex::encode(src.get_tx_public_key().get_data()),
+            tx_out_hash: hex::encode(src.get_tx_out_hash()),
             tombstone: src.get_tombstone(),
-            confirmation_number: hex::encode(&src.get_confirmation_number()),
+            confirmation_number: hex::encode(src.get_confirmation_number()),
         }
     }
 }
@@ -146,11 +146,11 @@ pub struct JsonPublicAddress {
 impl From<&PublicAddress> for JsonPublicAddress {
     fn from(src: &PublicAddress) -> Self {
         Self {
-            view_public_key: hex::encode(&src.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&src.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(src.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(src.get_spend_public_key().get_data()),
             fog_report_url: src.get_fog_report_url().into(),
             fog_report_id: src.get_fog_report_id().into(),
-            fog_authority_sig: hex::encode(&src.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(src.get_fog_authority_sig()),
         }
     }
 }
@@ -240,7 +240,7 @@ impl TryFrom<&JsonSlamRequest> for SlamParams {
                 .iter()
                 .map(|uri| FromStr::from_str(uri.as_str()))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|err| format!("Invalid uri: {}", err))?;
+                .map_err(|err| format!("Invalid uri: {err}"))?;
         }
         Ok(result)
     }

--- a/mobilecoind-dev-faucet/src/lib.rs
+++ b/mobilecoind-dev-faucet/src/lib.rs
@@ -196,7 +196,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .add_monitor(&req)
-                .map_err(|err| format!("Failed adding a monitor: {}", err))?;
+                .map_err(|err| format!("Failed adding a monitor: {err}"))?;
 
             resp.monitor_id
         };
@@ -208,7 +208,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .get_public_address(&req)
-                .map_err(|err| format!("Failed getting public address: {}", err))?;
+                .map_err(|err| format!("Failed getting public address: {err}"))?;
 
             resp.b58_code
         };
@@ -224,7 +224,7 @@ impl State {
 
             let resp = mobilecoind_api_client
                 .get_network_status(&Default::default())
-                .map_err(|err| format!("Failed getting network status: {}", err))?;
+                .map_err(|err| format!("Failed getting network status: {err}"))?;
 
             for (k, v) in resp.get_last_block_info().minimum_fees.iter() {
                 result.insert(k.into(), *v);
@@ -248,7 +248,7 @@ impl State {
         req: &JsonFaucetRequest,
     ) -> Result<api::SubmitTxResponse, String> {
         let printable_wrapper = PrintableWrapper::b58_decode(req.b58_address.clone())
-            .map_err(|err| format!("Could not decode b58 address: {}", err))?;
+            .map_err(|err| format!("Could not decode b58 address: {err}"))?;
 
         let public_address = if printable_wrapper.has_public_address() {
             printable_wrapper.get_public_address()
@@ -279,9 +279,9 @@ impl State {
         let resp = self
             .mobilecoind_api_client
             .generate_tx_from_tx_out_list_async(&req)
-            .map_err(|err| format!("Failed to build Tx: {}", err))?
+            .map_err(|err| format!("Failed to build Tx: {err}"))?
             .await
-            .map_err(|err| format!("Build Tx ended in error: {}", err))?;
+            .map_err(|err| format!("Build Tx ended in error: {err}"))?;
 
         // Submit the tx proposal
         let mut req = api::SubmitTxRequest::new();
@@ -290,9 +290,9 @@ impl State {
         let resp = self
             .mobilecoind_api_client
             .submit_tx_async(&req)
-            .map_err(|err| format!("Failed to submit Tx: {}", err))?
+            .map_err(|err| format!("Failed to submit Tx: {err}"))?
             .await
-            .map_err(|err| format!("Submit Tx ended in error: {}", err))?;
+            .map_err(|err| format!("Submit Tx ended in error: {err}"))?;
 
         // Tell the worker that this utxo was submitted, so that it can track and
         // recycle the utxo if this payment fails
@@ -318,18 +318,10 @@ impl State {
             let resp = self
                 .mobilecoind_api_client
                 .get_balance_async(&req)
-                .map_err(|err| {
-                    format!(
-                        "Failed to check balance for token id '{}': {}",
-                        token_id, err
-                    )
-                })?
+                .map_err(|err| format!("Failed to check balance for token id '{token_id}': {err}"))?
                 .await
                 .map_err(|err| {
-                    format!(
-                        "Balance check request for token id '{}' ended in error: {}",
-                        token_id, err
-                    )
+                    format!("Balance check request for token id '{token_id}' ended in error: {err}")
                 })?;
             balances.insert(*token_id, resp.balance);
         }

--- a/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
+++ b/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
@@ -86,7 +86,7 @@ impl PreparedUtxo {
                 ))
             })
             .collect::<Result<Vec<_>, ConversionError>>()
-            .map_err(|err| format!("Conversion error: {}", err))?
+            .map_err(|err| format!("Conversion error: {err}"))?
             .into_iter()
             .unzip();
 
@@ -110,9 +110,9 @@ impl PreparedUtxo {
 
         let proofs_resp = mobilecoind_api_client
             .get_membership_proofs_async(&req)
-            .map_err(|err| format!("Failed to request membership proofs: {}", err))?
+            .map_err(|err| format!("Failed to request membership proofs: {err}"))?
             .await
-            .map_err(|err| format!("Request membership proofs ended in error: {}", err))?;
+            .map_err(|err| format!("Request membership proofs ended in error: {err}"))?;
 
         // Get mixins for this utxo
         let mut req = api::GetMixinsRequest::new();
@@ -122,9 +122,9 @@ impl PreparedUtxo {
 
         let mixins_resp = mobilecoind_api_client
             .get_mixins_async(&req)
-            .map_err(|err| format!("Failed to request mixins: {}", err))?
+            .map_err(|err| format!("Failed to request mixins: {err}"))?
             .await
-            .map_err(|err| format!("Request mixins ended in error: {}", err))?;
+            .map_err(|err| format!("Request mixins ended in error: {err}"))?;
 
         Ok((proofs_resp, mixins_resp))
     }
@@ -141,10 +141,7 @@ impl PreparedUtxo {
         // Get block version to target
         let block_version = network_state.get_last_block_info().network_block_version;
         let block_version = BlockVersion::try_from(block_version).map_err(|err| {
-            format!(
-                "Got invalid block version {} from network ({})",
-                block_version, err
-            )
+            format!("Got invalid block version {block_version} from network ({err})")
         })?;
 
         // Get minimum fee for this token id
@@ -154,7 +151,7 @@ impl PreparedUtxo {
             .get_last_block_info()
             .minimum_fees
             .get(&token_id)
-            .ok_or_else(|| format!("Missing fee for token id: {}", token_id))?;
+            .ok_or_else(|| format!("Missing fee for token id: {token_id}"))?;
         let token_id = TokenId::from(token_id);
         let fee_amount = Amount::new(fee_value, token_id);
 
@@ -165,7 +162,7 @@ impl PreparedUtxo {
             let report_verifier = Verifier::default();
 
             FogResolver::new(responses, &report_verifier)
-                .map_err(|err| format!("Fog resolver: {}", err))?
+                .map_err(|err| format!("Fog resolver: {err}"))?
         };
 
         // Create tx_builder.
@@ -175,7 +172,7 @@ impl PreparedUtxo {
             fog_resolver,
             EmptyMemoBuilder::default(),
         )
-        .map_err(|err| format!("Transaction builder new: {}", err))?;
+        .map_err(|err| format!("Transaction builder new: {err}"))?;
 
         tx_builder.set_tombstone_block(tombstone_block);
         tx_builder.add_input(self.get_input_credentials(account_key)?);
@@ -185,11 +182,11 @@ impl PreparedUtxo {
                 recipient,
                 &mut rng,
             )
-            .map_err(|err| format!("Add output: {}", err))?;
+            .map_err(|err| format!("Add output: {err}"))?;
 
         tx_builder
             .build(&LocalRingSigner::from(account_key), &mut rng)
-            .map_err(|err| format!("Build Tx: {}", err))
+            .map_err(|err| format!("Build Tx: {err}"))
     }
 
     fn get_input_credentials(&self, account_key: &AccountKey) -> Result<InputCredentials, String> {
@@ -202,6 +199,6 @@ impl PreparedUtxo {
             onetime_key_derive_data,
             *account_key.view_private_key(),
         )
-        .map_err(|err| format!("InputCredentials: {}", err))
+        .map_err(|err| format!("InputCredentials: {err}"))
     }
 }

--- a/mobilecoind-dev-faucet/src/slam/tx_submitter.rs
+++ b/mobilecoind-dev-faucet/src/slam/tx_submitter.rs
@@ -28,7 +28,7 @@ impl TxSubmitter {
             return Err("No consensus uris".to_owned());
         }
         let conns = Self::get_connections(&uris, env, logger)
-            .map_err(|err| format!("consensus connection: {}", err))?;
+            .map_err(|err| format!("consensus connection: {err}"))?;
         Ok(Self { conns })
     }
 

--- a/mobilecoind-dev-faucet/src/worker.rs
+++ b/mobilecoind-dev-faucet/src/worker.rs
@@ -235,7 +235,7 @@ impl Worker {
         for (token_id, value) in target_amounts.iter() {
             let minimum_fee_value = minimum_fees
                 .get(token_id)
-                .unwrap_or_else(|| panic!("Missing minimum fee for {}", token_id));
+                .unwrap_or_else(|| panic!("Missing minimum fee for {token_id}"));
             let (state, receiver) = WorkerTokenState::new(*token_id, *minimum_fee_value, *value);
             worker_token_states.push(state);
             receivers.insert(*token_id, receiver);
@@ -564,7 +564,7 @@ impl WorkerTokenState {
             let key_image: KeyImage = utxo
                 .get_key_image()
                 .try_into()
-                .map_err(|err| format!("invalid key image: {}", err))?;
+                .map_err(|err| format!("invalid key image: {err}"))?;
             if let Entry::Vacant(e) = self.known_utxos.entry(key_image) {
                 // We found a utxo not in the cache, let's queue and add to cache
                 log::trace!(
@@ -823,14 +823,14 @@ impl WorkerTokenState {
 
             let mut resp = client
                 .generate_tx(&req)
-                .map_err(|err| format!("Failed to generate rebalancing tx: {}", err))?;
+                .map_err(|err| format!("Failed to generate rebalancing tx: {err}"))?;
 
             // Submit the Tx
             let mut req = api::SubmitTxRequest::new();
             req.set_tx_proposal(resp.take_tx_proposal());
             let submit_tx_response = client
                 .submit_tx(&req)
-                .map_err(|err| format!("Failed to submit rebalancing tx: {}", err))?;
+                .map_err(|err| format!("Failed to submit rebalancing tx: {err}"))?;
 
             // This lets us keep tabs on when this split payment has resolved, so that we
             // can avoid sending another payment until it does

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind-json/src/bin/main.rs
+++ b/mobilecoind-json/src/bin/main.rs
@@ -52,12 +52,12 @@ fn set_password(
     let mut req = api::SetDbPasswordRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
-            .map_err(|err| format!("Failed decoding password hex: {}", err))?,
+            .map_err(|err| format!("Failed decoding password hex: {err}"))?,
     );
     let _resp = state
         .mobilecoind_api_client
         .set_db_password(&req)
-        .map_err(|err| format!("Failed setting password: {}", err))?;
+        .map_err(|err| format!("Failed setting password: {err}"))?;
     Ok(Json(JsonPasswordResponse { success: true }))
 }
 
@@ -70,12 +70,12 @@ fn unlock_db(
     let mut req = api::UnlockDbRequest::new();
     req.set_password(
         hex::decode(password.password.clone())
-            .map_err(|err| format!("Failed decoding password hex: {}", err))?,
+            .map_err(|err| format!("Failed decoding password hex: {err}"))?,
     );
     let _resp = state
         .mobilecoind_api_client
         .unlock_db(&req)
-        .map_err(|err| format!("Failed unlocking database: {}", err))?;
+        .map_err(|err| format!("Failed unlocking database: {err}"))?;
     Ok(Json(JsonUnlockDbResponse { success: true }))
 }
 
@@ -85,7 +85,7 @@ fn version(state: &rocket::State<State>) -> Result<Json<JsonMobilecoindVersionRe
     let resp = state
         .mobilecoind_api_client
         .get_version(&api::Empty::new())
-        .map_err(|err| format!("Failed getting version: {}", err))?;
+        .map_err(|err| format!("Failed getting version: {err}"))?;
     Ok(Json(JsonMobilecoindVersionResponse::from(&resp)))
 }
 
@@ -95,7 +95,7 @@ fn entropy(state: &rocket::State<State>) -> Result<Json<JsonRootEntropyResponse>
     let resp = state
         .mobilecoind_api_client
         .generate_root_entropy(&api::Empty::new())
-        .map_err(|err| format!("Failed getting entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting entropy: {err}"))?;
     Ok(Json(JsonRootEntropyResponse::from(&resp)))
 }
 
@@ -105,7 +105,7 @@ fn account_key_from_root_entropy(
     root_entropy: String,
 ) -> Result<Json<JsonAccountKeyResponse>, String> {
     let entropy =
-        hex::decode(root_entropy).map_err(|err| format!("Failed to decode hex key: {}", err))?;
+        hex::decode(root_entropy).map_err(|err| format!("Failed to decode hex key: {err}"))?;
 
     let mut req = api::GetAccountKeyFromRootEntropyRequest::new();
     req.set_root_entropy(entropy.to_vec());
@@ -113,7 +113,7 @@ fn account_key_from_root_entropy(
     let resp = state
         .mobilecoind_api_client
         .get_account_key_from_root_entropy(&req)
-        .map_err(|err| format!("Failed getting account key for root entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting account key for root entropy: {err}"))?;
 
     Ok(Json(JsonAccountKeyResponse::from(&resp)))
 }
@@ -124,7 +124,7 @@ fn mnemonic(state: &rocket::State<State>) -> Result<Json<JsonMnemonicResponse>, 
     let resp = state
         .mobilecoind_api_client
         .generate_mnemonic(&api::Empty::new())
-        .map_err(|err| format!("Failed getting entropy: {}", err))?;
+        .map_err(|err| format!("Failed getting entropy: {err}"))?;
     Ok(Json(JsonMnemonicResponse::from(&resp)))
 }
 
@@ -139,7 +139,7 @@ fn account_key_from_mnemonic(
     let resp = state
         .mobilecoind_api_client
         .get_account_key_from_mnemonic(&req)
-        .map_err(|err| format!("Failed getting account key for mnemonic: {}", err))?;
+        .map_err(|err| format!("Failed getting account key for mnemonic: {err}"))?;
 
     Ok(Json(JsonAccountKeyResponse::from(&resp)))
 }
@@ -155,12 +155,12 @@ fn add_monitor(
     let mut view_private_key = RistrettoPrivate::new();
     view_private_key.set_data(
         hex::decode(&monitor.account_key.view_private_key)
-            .map_err(|err| format!("Failed to decode hex key: {}", err))?,
+            .map_err(|err| format!("Failed to decode hex key: {err}"))?,
     );
     let mut spend_private_key = RistrettoPrivate::new();
     spend_private_key.set_data(
         hex::decode(&monitor.account_key.spend_private_key)
-            .map_err(|err| format!("Failed to decode hex key: {}", err))?,
+            .map_err(|err| format!("Failed to decode hex key: {err}"))?,
     );
     account_key.set_view_private_key(view_private_key);
     account_key.set_spend_private_key(spend_private_key);
@@ -174,7 +174,7 @@ fn add_monitor(
     let monitor_response = state
         .mobilecoind_api_client
         .add_monitor(&req)
-        .map_err(|err| format!("Failed adding monitor: {}", err))?;
+        .map_err(|err| format!("Failed adding monitor: {err}"))?;
 
     Ok(Json(JsonMonitorResponse::from(&monitor_response)))
 }
@@ -183,7 +183,7 @@ fn add_monitor(
 #[delete("/monitors/<monitor_hex>")]
 fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(), String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::RemoveMonitorRequest::new();
     req.set_monitor_id(monitor_id);
@@ -191,7 +191,7 @@ fn remove_monitor(state: &rocket::State<State>, monitor_hex: String) -> Result<(
     let _resp = state
         .mobilecoind_api_client
         .remove_monitor(&req)
-        .map_err(|err| format!("Failed removing monitor: {}", err))?;
+        .map_err(|err| format!("Failed removing monitor: {err}"))?;
 
     Ok(())
 }
@@ -202,7 +202,7 @@ fn monitors(state: &rocket::State<State>) -> Result<Json<JsonMonitorListResponse
     let resp = state
         .mobilecoind_api_client
         .get_monitor_list(&api::Empty::new())
-        .map_err(|err| format!("Failed getting monitor list: {}", err))?;
+        .map_err(|err| format!("Failed getting monitor list: {err}"))?;
     Ok(Json(JsonMonitorListResponse::from(&resp)))
 }
 
@@ -213,7 +213,7 @@ fn monitor_status(
     monitor_hex: String,
 ) -> Result<Json<JsonMonitorStatusResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetMonitorStatusRequest::new();
     req.set_monitor_id(monitor_id);
@@ -221,7 +221,7 @@ fn monitor_status(
     let resp = state
         .mobilecoind_api_client
         .get_monitor_status(&req)
-        .map_err(|err| format!("Failed getting monitor status: {}", err))?;
+        .map_err(|err| format!("Failed getting monitor status: {err}"))?;
 
     Ok(Json(JsonMonitorStatusResponse::from(&resp)))
 }
@@ -234,7 +234,7 @@ fn balance(
     subaddress_index: u64,
 ) -> Result<Json<JsonBalanceResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetBalanceRequest::new();
     req.set_monitor_id(monitor_id);
@@ -243,7 +243,7 @@ fn balance(
     let resp = state
         .mobilecoind_api_client
         .get_balance(&req)
-        .map_err(|err| format!("Failed getting balance: {}", err))?;
+        .map_err(|err| format!("Failed getting balance: {err}"))?;
 
     Ok(Json(JsonBalanceResponse::from(&resp)))
 }
@@ -255,7 +255,7 @@ fn utxos(
     subaddress_index: u64,
 ) -> Result<Json<JsonUtxosResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetUnspentTxOutListRequest::new();
     req.set_monitor_id(monitor_id);
@@ -264,7 +264,7 @@ fn utxos(
     let resp = state
         .mobilecoind_api_client
         .get_unspent_tx_out_list(&req)
-        .map_err(|err| format!("Failed getting utxos: {}", err))?;
+        .map_err(|err| format!("Failed getting utxos: {err}"))?;
 
     Ok(Json(JsonUtxosResponse::from(&resp)))
 }
@@ -277,7 +277,7 @@ fn public_address(
     subaddress_index: u64,
 ) -> Result<Json<JsonPublicAddressResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     // Get our public address.
     let mut req = api::GetPublicAddressRequest::new();
@@ -287,7 +287,7 @@ fn public_address(
     let resp = state
         .mobilecoind_api_client
         .get_public_address(&req)
-        .map_err(|err| format!("Failed getting public address: {}", err))?;
+        .map_err(|err| format!("Failed getting public address: {err}"))?;
 
     Ok(Json(JsonPublicAddressResponse::from(&resp)))
 }
@@ -299,7 +299,7 @@ fn create_request_code(
     request: Json<JsonCreateRequestCodeRequest>,
 ) -> Result<Json<JsonCreateRequestCodeResponse>, String> {
     let receiver = api::external::PublicAddress::try_from(&request.receiver)
-        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+        .map_err(|err| format!("Failed to parse receiver's public address: {err}"))?;
 
     // Generate b58 code
     let mut req = api::CreateRequestCodeRequest::new();
@@ -314,7 +314,7 @@ fn create_request_code(
     let resp = state
         .mobilecoind_api_client
         .create_request_code(&req)
-        .map_err(|err| format!("Failed creating request code: {}", err))?;
+        .map_err(|err| format!("Failed creating request code: {err}"))?;
 
     Ok(Json(JsonCreateRequestCodeResponse::from(&resp)))
 }
@@ -330,7 +330,7 @@ fn parse_request_code(
     let resp = state
         .mobilecoind_api_client
         .parse_request_code(&req)
-        .map_err(|err| format!("Failed parsing request code: {}", err))?;
+        .map_err(|err| format!("Failed parsing request code: {err}"))?;
 
     // The response contains the public keys encoded in the read request, as well as
     // a memo and requested value. This can be used as-is in the transfer call
@@ -345,7 +345,7 @@ fn create_address_code(
     request: Json<JsonCreateAddressCodeRequest>,
 ) -> Result<Json<JsonCreateAddressCodeResponse>, String> {
     let receiver = api::external::PublicAddress::try_from(&request.receiver)
-        .map_err(|err| format!("Failed to parse receiver's public address: {}", err))?;
+        .map_err(|err| format!("Failed to parse receiver's public address: {err}"))?;
 
     // Generate b58 code
     let mut req = api::CreateAddressCodeRequest::new();
@@ -354,7 +354,7 @@ fn create_address_code(
     let resp = state
         .mobilecoind_api_client
         .create_address_code(&req)
-        .map_err(|err| format!("Failed creating address code: {}", err))?;
+        .map_err(|err| format!("Failed creating address code: {err}"))?;
 
     Ok(Json(JsonCreateAddressCodeResponse::from(&resp)))
 }
@@ -370,7 +370,7 @@ fn parse_address_code(
     let resp = state
         .mobilecoind_api_client
         .parse_address_code(&req)
-        .map_err(|err| format!("Failed parding address code: {}", err))?;
+        .map_err(|err| format!("Failed parding address code: {err}"))?;
 
     // The response contains the public keys encoded in the read request
     Ok(Json(JsonParseAddressCodeResponse::from(&resp)))
@@ -390,7 +390,7 @@ fn build_and_submit(
     transfer: Json<JsonSendPaymentRequest>,
 ) -> Result<Json<JsonSendPaymentResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let public_address = PublicAddress::try_from(&transfer.request_data.receiver)?;
 
@@ -420,7 +420,7 @@ fn build_and_submit(
     let resp = state
         .mobilecoind_api_client
         .send_payment(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSendPaymentResponse::from(&resp)))
@@ -440,7 +440,7 @@ fn pay_address_code(
     transfer: Json<JsonPayAddressCodeRequest>,
 ) -> Result<Json<JsonSendPaymentResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     // Get amount.
     let amount = u64::from(transfer.value);
@@ -467,7 +467,7 @@ fn pay_address_code(
     let resp = state
         .mobilecoind_api_client
         .pay_address_code(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSendPaymentResponse::from(&resp)))
@@ -488,7 +488,7 @@ fn generate_request_code_transaction(
     request: Json<JsonCreateTxProposalRequest>,
 ) -> Result<Json<JsonCreateTxProposalResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let public_address = PublicAddress::try_from(&request.transfer.receiver)?;
 
@@ -502,7 +502,7 @@ fn generate_request_code_transaction(
         .iter()
         .map(|input| {
             api::UnspentTxOut::try_from(input)
-                .map_err(|err| format!("Failed to convert input: {}", err))
+                .map_err(|err| format!("Failed to convert input: {err}"))
         })
         .collect::<Result<_, String>>()?;
 
@@ -516,7 +516,7 @@ fn generate_request_code_transaction(
     let resp = state
         .mobilecoind_api_client
         .generate_tx(&req)
-        .map_err(|err| format!("Failed to generate tx: {}", err))?;
+        .map_err(|err| format!("Failed to generate tx: {err}"))?;
 
     Ok(Json(JsonCreateTxProposalResponse::from(&resp)))
 }
@@ -531,13 +531,13 @@ fn submit_tx(
     let mut req = api::SubmitTxRequest::new();
     req.set_tx_proposal(
         api::TxProposal::try_from(&proposal.tx_proposal)
-            .map_err(|err| format!("Failed to convert tx proposal: {}", err))?,
+            .map_err(|err| format!("Failed to convert tx proposal: {err}"))?,
     );
 
     let resp = state
         .mobilecoind_api_client
         .submit_tx(&req)
-        .map_err(|err| format!("Failed to send payment: {}", err))?;
+        .map_err(|err| format!("Failed to send payment: {err}"))?;
 
     // The receipt from the payment request can be used by the status check below
     Ok(Json(JsonSubmitTxResponse::from(&resp)))
@@ -553,9 +553,9 @@ fn check_transfer_status(
         .mobilecoind_api_client
         .get_tx_status_as_sender(
             &api::SubmitTxResponse::try_from(&submit_response.0)
-                .map_err(|err| format!("Could not convert JsonSubmitTxResponse: {}", err))?,
+                .map_err(|err| format!("Could not convert JsonSubmitTxResponse: {err}"))?,
         )
-        .map_err(|err| format!("Failed getting status: {}", err))?;
+        .map_err(|err| format!("Failed getting status: {err}"))?;
 
     Ok(Json(JsonStatusResponse::from(&resp)))
 }
@@ -578,17 +578,17 @@ fn check_receiver_transfer_status(
     receipt: Json<JsonReceiverTxReceipt>,
 ) -> Result<Json<JsonStatusResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut receiver_receipt = api::ReceiverTxReceipt::new();
     let mut tx_public_key = CompressedRistretto::new();
-    tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{}", err))?);
+    tx_public_key.set_data(hex::decode(&receipt.tx_public_key).map_err(|err| format!("{err}"))?);
     receiver_receipt.set_tx_public_key(tx_public_key);
     receiver_receipt
-        .set_tx_out_hash(hex::decode(&receipt.tx_out_hash).map_err(|err| format!("{}", err))?);
+        .set_tx_out_hash(hex::decode(&receipt.tx_out_hash).map_err(|err| format!("{err}"))?);
     receiver_receipt.set_tombstone(receipt.tombstone);
     receiver_receipt.set_confirmation_number(
-        hex::decode(&receipt.confirmation_number).map_err(|err| format!("{}", err))?,
+        hex::decode(&receipt.confirmation_number).map_err(|err| format!("{err}"))?,
     );
 
     let mut req = api::GetTxStatusAsReceiverRequest::new();
@@ -598,7 +598,7 @@ fn check_receiver_transfer_status(
     let resp = state
         .mobilecoind_api_client
         .get_tx_status_as_receiver(&req)
-        .map_err(|err| format!("Failed getting status: {}", err))?;
+        .map_err(|err| format!("Failed getting status: {err}"))?;
 
     Ok(Json(JsonStatusResponse::from(&resp)))
 }
@@ -609,7 +609,7 @@ fn ledger_info(state: &rocket::State<State>) -> Result<Json<JsonLedgerInfoRespon
     let resp = state
         .mobilecoind_api_client
         .get_ledger_info(&api::Empty::new())
-        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+        .map_err(|err| format!("Failed getting ledger info: {err}"))?;
 
     Ok(Json(JsonLedgerInfoResponse::from(&resp)))
 }
@@ -626,7 +626,7 @@ fn block_info(
     let resp = state
         .mobilecoind_api_client
         .get_block_info(&req)
-        .map_err(|err| format!("Failed getting ledger info: {}", err))?;
+        .map_err(|err| format!("Failed getting ledger info: {err}"))?;
 
     Ok(Json(JsonBlockInfoResponse::from(&resp)))
 }
@@ -643,7 +643,7 @@ fn block_details(
     let resp = state
         .mobilecoind_api_client
         .get_block(&req)
-        .map_err(|err| format!("Failed getting block details: {}", err))?;
+        .map_err(|err| format!("Failed getting block details: {err}"))?;
 
     Ok(Json(JsonBlockDetailsResponse::from(&resp)))
 }
@@ -655,7 +655,7 @@ fn processed_block(
     block_num: u64,
 ) -> Result<Json<JsonProcessedBlockResponse>, String> {
     let monitor_id =
-        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {}", err))?;
+        hex::decode(monitor_hex).map_err(|err| format!("Failed to decode monitor hex: {err}"))?;
 
     let mut req = api::GetProcessedBlockRequest::new();
     req.set_monitor_id(monitor_id);
@@ -664,7 +664,7 @@ fn processed_block(
     let resp = state
         .mobilecoind_api_client
         .get_processed_block(&req)
-        .map_err(|err| format!("Failed getting processed block: {}", err))?;
+        .map_err(|err| format!("Failed getting processed block: {err}"))?;
 
     Ok(Json(JsonProcessedBlockResponse::from(&resp)))
 }
@@ -676,7 +676,7 @@ fn tx_out_get_block_index_by_public_key(
     public_key_hex: String,
 ) -> Result<Json<JsonBlockIndexByTxPubKeyResponse>, String> {
     let tx_out_public_key = hex::decode(public_key_hex)
-        .map_err(|err| format!("Failed to decode hex public key: {}", err))?;
+        .map_err(|err| format!("Failed to decode hex public key: {err}"))?;
 
     let mut tx_out_public_key_proto = CompressedRistretto::new();
     tx_out_public_key_proto.set_data(tx_out_public_key);
@@ -687,7 +687,7 @@ fn tx_out_get_block_index_by_public_key(
     let resp = state
         .mobilecoind_api_client
         .get_block_index_by_tx_pub_key(&req)
-        .map_err(|err| format!("Failed getting block index: {}", err))?;
+        .map_err(|err| format!("Failed getting block index: {err}"))?;
 
     Ok(Json(JsonBlockIndexByTxPubKeyResponse::from(&resp)))
 }
@@ -712,7 +712,7 @@ fn get_proof_of_membership(
     let get_membership_proofs_response = state
         .mobilecoind_api_client
         .get_membership_proofs(&get_membership_proofs_request)
-        .map_err(|err| format!("Failed getting membership proofs: {}", err))?;
+        .map_err(|err| format!("Failed getting membership proofs: {err}"))?;
 
     // Return JSON response
     let (outputs, membership_proofs): (Vec<JsonTxOut>, Vec<JsonTxOutMembershipProof>) =
@@ -755,7 +755,7 @@ fn get_mixins(
     let get_mixins_response = state
         .mobilecoind_api_client
         .get_mixins(&get_mixins_request)
-        .map_err(|err| format!("Failed getting mixins: {}", err))?;
+        .map_err(|err| format!("Failed getting mixins: {err}"))?;
 
     let (mixins, membership_proofs): (Vec<JsonTxOut>, Vec<JsonTxOutMembershipProof>) =
         get_mixins_response

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -67,9 +67,9 @@ pub struct JsonAccountKeyResponse {
 impl From<&api::GetAccountKeyResponse> for JsonAccountKeyResponse {
     fn from(src: &api::GetAccountKeyResponse) -> Self {
         Self {
-            view_private_key: hex::encode(&src.get_account_key().get_view_private_key().get_data()),
+            view_private_key: hex::encode(src.get_account_key().get_view_private_key().get_data()),
             spend_private_key: hex::encode(
-                &src.get_account_key().get_spend_private_key().get_data(),
+                src.get_account_key().get_spend_private_key().get_data(),
             ),
         }
     }
@@ -160,11 +160,11 @@ impl From<&api::UnspentTxOut> for JsonUnspentTxOut {
         Self {
             tx_out: src.get_tx_out().into(),
             subaddress_index: src.get_subaddress_index(),
-            key_image: hex::encode(&src.get_key_image().get_data()),
+            key_image: hex::encode(src.get_key_image().get_data()),
             value: JsonU64(src.value),
             attempted_spend_height: src.get_attempted_spend_height(),
             attempted_spend_tombstone: src.get_attempted_spend_tombstone(),
-            monitor_id: hex::encode(&src.get_monitor_id()),
+            monitor_id: hex::encode(src.get_monitor_id()),
         }
     }
 }
@@ -177,14 +177,14 @@ impl TryFrom<&JsonUnspentTxOut> for api::UnspentTxOut {
         let mut key_image = KeyImage::new();
         key_image.set_data(
             hex::decode(&src.key_image)
-                .map_err(|err| format!("Failed to decode key image hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode key image hex: {err}"))?,
         );
 
         // Reconstruct the public address as a protobuf
         let mut utxo = api::UnspentTxOut::new();
         utxo.set_tx_out(
             mc_api::external::TxOut::try_from(&src.tx_out)
-                .map_err(|err| format!("Failed to get TxOut: {}", err))?,
+                .map_err(|err| format!("Failed to get TxOut: {err}"))?,
         );
         utxo.set_subaddress_index(src.subaddress_index);
         utxo.set_key_image(key_image);
@@ -193,7 +193,7 @@ impl TryFrom<&JsonUnspentTxOut> for api::UnspentTxOut {
         utxo.set_attempted_spend_tombstone(src.attempted_spend_tombstone);
         utxo.set_monitor_id(
             hex::decode(&src.monitor_id)
-                .map_err(|err| format!("Failed to decode monitor id hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode monitor id hex: {err}"))?,
         );
 
         Ok(utxo)
@@ -258,11 +258,11 @@ pub struct JsonPublicAddress {
 impl From<&PublicAddress> for JsonPublicAddress {
     fn from(src: &PublicAddress) -> Self {
         Self {
-            view_public_key: hex::encode(&src.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&src.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(src.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(src.get_spend_public_key().get_data()),
             fog_report_url: String::from(src.get_fog_report_url()),
             fog_report_id: String::from(src.get_fog_report_id()),
-            fog_authority_sig: hex::encode(&src.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(src.get_fog_authority_sig()),
         }
     }
 }
@@ -292,11 +292,11 @@ impl From<&api::GetPublicAddressResponse> for JsonPublicAddressResponse {
     fn from(src: &api::GetPublicAddressResponse) -> Self {
         let public_address = src.get_public_address();
         Self {
-            view_public_key: hex::encode(&public_address.get_view_public_key().get_data()),
-            spend_public_key: hex::encode(&public_address.get_spend_public_key().get_data()),
+            view_public_key: hex::encode(public_address.get_view_public_key().get_data()),
+            spend_public_key: hex::encode(public_address.get_spend_public_key().get_data()),
             fog_report_url: String::from(public_address.get_fog_report_url()),
             fog_report_id: String::from(public_address.get_fog_report_id()),
-            fog_authority_sig: hex::encode(&public_address.get_fog_authority_sig()),
+            fog_authority_sig: hex::encode(public_address.get_fog_authority_sig()),
             b58_address_code: src.get_b58_code().to_string(),
         }
     }
@@ -311,12 +311,12 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
         let mut view_public_key = CompressedRistretto::new();
         view_public_key.set_data(
             hex::decode(&src.view_public_key)
-                .map_err(|err| format!("Failed to decode view key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode view key hex: {err}"))?,
         );
         let mut spend_public_key = CompressedRistretto::new();
         spend_public_key.set_data(
             hex::decode(&src.spend_public_key)
-                .map_err(|err| format!("Failed to decode spend key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode spend key hex: {err}"))?,
         );
 
         // Reconstruct the public address as a protobuf
@@ -327,7 +327,7 @@ impl TryFrom<&JsonPublicAddress> for PublicAddress {
         public_address.set_fog_report_id(src.fog_report_id.clone());
         public_address.set_fog_authority_sig(
             hex::decode(&src.fog_authority_sig)
-                .map_err(|err| format!("Failed to decode fog authority sig hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode fog authority sig hex: {err}"))?,
         );
 
         Ok(public_address)
@@ -414,10 +414,10 @@ impl From<&api::ReceiverTxReceipt> for JsonReceiverTxReceipt {
     fn from(src: &api::ReceiverTxReceipt) -> Self {
         Self {
             recipient: JsonPublicAddress::from(src.get_recipient()),
-            tx_public_key: hex::encode(&src.get_tx_public_key().get_data()),
-            tx_out_hash: hex::encode(&src.get_tx_out_hash()),
+            tx_public_key: hex::encode(src.get_tx_public_key().get_data()),
+            tx_out_hash: hex::encode(src.get_tx_out_hash()),
             tombstone: src.get_tombstone(),
-            confirmation_number: hex::encode(&src.get_confirmation_number()),
+            confirmation_number: hex::encode(src.get_confirmation_number()),
         }
     }
 }
@@ -479,7 +479,7 @@ impl TryFrom<&JsonOutlay> for api::Outlay {
         outlay.set_value(src.value.into());
         outlay.set_receiver(
             PublicAddress::try_from(&src.receiver)
-                .map_err(|err| format!("Could not convert receiver: {}", err))?,
+                .map_err(|err| format!("Could not convert receiver: {err}"))?,
         );
 
         Ok(outlay)
@@ -501,7 +501,7 @@ impl From<&mc_api::external::TxOut_oneof_masked_amount> for JsonMaskedAmount {
                 commitment: hex::encode(src.get_commitment().get_data()),
                 masked_value: JsonU64(src.get_masked_value()),
                 masked_token_id: hex::encode(src.get_masked_token_id()),
-                version: None,
+                version: Some(1),
             },
             mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(src) => Self {
                 commitment: hex::encode(src.get_commitment().get_data()),
@@ -523,14 +523,14 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
         let mut commitment = CompressedRistretto::new();
         commitment.set_data(
             hex::decode(&src.commitment)
-                .map_err(|err| format!("Failed to decode commitment hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode commitment hex: {err}"))?,
         );
         let mut masked_amount = MaskedAmount::new();
         masked_amount.set_commitment(commitment);
         masked_amount.set_masked_value(src.masked_value.into());
         masked_amount.set_masked_token_id(
             hex::decode(&src.masked_token_id)
-                .map_err(|err| format!("Failed to decode masked token id hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode masked token id hex: {err}"))?,
         );
 
         match src.version {
@@ -540,7 +540,7 @@ impl TryFrom<&JsonMaskedAmount> for mc_api::external::TxOut_oneof_masked_amount 
             Some(2) => {
                 Ok(mc_api::external::TxOut_oneof_masked_amount::masked_amount_v2(masked_amount))
             }
-            Some(other) => Err(format!("Unknown masked amount version: {}", other)),
+            Some(other) => Err(format!("Unknown masked amount version: {other}")),
         }
     }
 }
@@ -574,22 +574,22 @@ impl TryFrom<&JsonTxOut> for mc_api::external::TxOut {
         let mut target_key = CompressedRistretto::new();
         target_key.set_data(
             hex::decode(&src.target_key)
-                .map_err(|err| format!("Failed to decode target key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode target key hex: {err}"))?,
         );
         let mut public_key = CompressedRistretto::new();
         public_key.set_data(
             hex::decode(&src.public_key)
-                .map_err(|err| format!("Failed to decode public key hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode public key hex: {err}"))?,
         );
         let mut e_fog_hint = EncryptedFogHint::new();
         e_fog_hint.set_data(
             hex::decode(&src.e_fog_hint)
-                .map_err(|err| format!("Failed to decode e_fog_hint hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode e_fog_hint hex: {err}"))?,
         );
         let mut e_memo = EncryptedMemo::new();
         e_memo.set_data(
             hex::decode(&src.e_memo)
-                .map_err(|err| format!("Failed to decode e_memo hex: {}", err))?,
+                .map_err(|err| format!("Failed to decode e_memo hex: {err}"))?,
         );
 
         let mut txo = mc_api::external::TxOut::new();
@@ -667,7 +667,7 @@ impl TryFrom<&JsonTxOutMembershipProof> for TxOutMembershipProof {
             let mut hash = TxOutMembershipHash::new();
             hash.set_data(
                 hex::decode(&element.hash)
-                    .map_err(|err| format!("Could not decode elem hash: {}", err))?,
+                    .map_err(|err| format!("Could not decode elem hash: {err}"))?,
             );
 
             let mut elem = TxOutMembershipElement::new();
@@ -747,7 +747,7 @@ impl TryFrom<&JsonInputRules> for InputRules {
                 .iter()
                 .map(|out| {
                     mc_api::external::TxOut::try_from(out)
-                        .map_err(|err| format!("Could not get TxOut: {}", err))
+                        .map_err(|err| format!("Could not get TxOut: {err}"))
                 })
                 .collect::<Result<_, String>>()?,
         );
@@ -784,14 +784,14 @@ impl TryFrom<&JsonTxIn> for TxIn {
         let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
         for output in &src.ring {
             let p_output = mc_api::external::TxOut::try_from(output)
-                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+                .map_err(|err| format!("Could not get TxOut: {err}"))?;
             outputs.push(p_output);
         }
 
         let mut proofs: Vec<TxOutMembershipProof> = Vec::new();
         for proof in &src.proofs {
             let p_proof = TxOutMembershipProof::try_from(proof)
-                .map_err(|err| format!("Could not get proof: {}", err))?;
+                .map_err(|err| format!("Could not get proof: {err}"))?;
             proofs.push(p_proof);
         }
 
@@ -838,14 +838,14 @@ impl TryFrom<&JsonTxPrefix> for TxPrefix {
         let mut inputs: Vec<TxIn> = Vec::new();
         for input in &src.inputs {
             let p_input =
-                TxIn::try_from(input).map_err(|err| format!("Could not get TxIn: {}", err))?;
+                TxIn::try_from(input).map_err(|err| format!("Could not get TxIn: {err}"))?;
             inputs.push(p_input);
         }
 
         let mut outputs: Vec<mc_api::external::TxOut> = Vec::new();
         for output in &src.outputs {
             let p_output = mc_api::external::TxOut::try_from(output)
-                .map_err(|err| format!("Could not get TxOut: {}", err))?;
+                .map_err(|err| format!("Could not get TxOut: {err}"))?;
             outputs.push(p_output);
         }
 
@@ -920,15 +920,14 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             let mut c_zero = mc_api::external::CurveScalar::new();
             c_zero.set_data(
                 hex::decode(&sig.c_zero)
-                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    .map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
 
             let mut responses: Vec<mc_api::external::CurveScalar> = Vec::new();
             for resp in &sig.responses {
                 let mut response = mc_api::external::CurveScalar::new();
                 response.set_data(
-                    hex::decode(resp)
-                        .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    hex::decode(resp).map_err(|err| format!("Could not decode from hex: {err}"))?,
                 );
                 responses.push(response);
             }
@@ -936,7 +935,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             let mut key_image = KeyImage::new();
             key_image.set_data(
                 hex::decode(&sig.key_image)
-                    .map_err(|err| format!("Could not decode from hex: {}", err))?,
+                    .map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
 
             let mut ring_sig = RingMLSAG::new();
@@ -951,7 +950,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
         for comm in &src.pseudo_output_commitments {
             let mut compressed = CompressedRistretto::new();
             compressed.set_data(
-                hex::decode(&comm).map_err(|err| format!("Could not decode from hex: {}", err))?,
+                hex::decode(comm).map_err(|err| format!("Could not decode from hex: {err}"))?,
             );
             commitments.push(compressed);
         }
@@ -971,10 +970,7 @@ impl TryFrom<&JsonSignatureRctBulletproofs> for SignatureRctBulletproofs {
             .iter()
             .map(|hex_str| {
                 hex::decode(hex_str).map_err(|err| {
-                    format!(
-                        "Could not decode range proof from hex '{}': {}",
-                        hex_str, err
-                    )
+                    format!("Could not decode range proof from hex '{hex_str}': {err}")
                 })
             })
             .collect::<Result<_, _>>()?;
@@ -1012,11 +1008,11 @@ impl TryFrom<&JsonTx> for Tx {
 
         tx.set_prefix(
             TxPrefix::try_from(&src.prefix)
-                .map_err(|err| format!("Could not convert TxPrefix: {}", err))?,
+                .map_err(|err| format!("Could not convert TxPrefix: {err}"))?,
         );
         tx.set_signature(
             SignatureRctBulletproofs::try_from(&src.signature)
-                .map_err(|err| format!("Could not convert signature: {}", err))?,
+                .map_err(|err| format!("Could not convert signature: {err}"))?,
         );
 
         Ok(tx)
@@ -1063,14 +1059,14 @@ impl TryFrom<&JsonTxProposal> for api::TxProposal {
         let mut inputs: Vec<api::UnspentTxOut> = Vec::new();
         for input in src.input_list.iter() {
             let utxo = api::UnspentTxOut::try_from(input)
-                .map_err(|err| format!("Failed to convert input: {}", err))?;
+                .map_err(|err| format!("Failed to convert input: {err}"))?;
             inputs.push(utxo);
         }
 
         let mut outlays: Vec<api::Outlay> = Vec::new();
         for outlay in src.outlay_list.iter() {
             let out = api::Outlay::try_from(outlay)
-                .map_err(|err| format!("Failed to convert outlay: {}", err))?;
+                .map_err(|err| format!("Failed to convert outlay: {err}"))?;
             outlays.push(out);
         }
 
@@ -1079,7 +1075,7 @@ impl TryFrom<&JsonTxProposal> for api::TxProposal {
         proposal.set_input_list(RepeatedField::from_vec(inputs));
         proposal.set_outlay_list(RepeatedField::from_vec(outlays));
         proposal
-            .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {}", err))?);
+            .set_tx(Tx::try_from(&src.tx).map_err(|err| format!("Could not convert tx: {err}"))?);
         proposal.set_fee(src.fee);
         proposal.set_outlay_index_to_tx_out_index(
             src.outlay_index_to_tx_out_index
@@ -1149,11 +1145,8 @@ impl TryFrom<&JsonSubmitTxResponse> for api::SubmitTxResponse {
             .key_images
             .iter()
             .map(|k| {
-                hex::decode(&k).map(KeyImage::from).map_err(|err| {
-                    format!(
-                        "Failed to decode hex for sender_tx_receipt.key_images: {}",
-                        err
-                    )
+                hex::decode(k).map(KeyImage::from).map_err(|err| {
+                    format!("Failed to decode hex for sender_tx_receipt.key_images: {err}")
                 })
             })
             .collect::<Result<Vec<KeyImage>, String>>()?;
@@ -1166,22 +1159,22 @@ impl TryFrom<&JsonSubmitTxResponse> for api::SubmitTxResponse {
             let mut receiver_receipt = api::ReceiverTxReceipt::new();
             receiver_receipt.set_recipient(
                 PublicAddress::try_from(&r.recipient)
-                    .map_err(|err| format!("Failed to convert recipient: {}", err))?,
+                    .map_err(|err| format!("Failed to convert recipient: {err}"))?,
             );
             let mut pubkey = mc_api::external::CompressedRistretto::new();
             pubkey.set_data(
                 hex::decode(&r.tx_public_key)
-                    .map_err(|err| format!("Failed to decode hex for tx_public_key: {}", err))?,
+                    .map_err(|err| format!("Failed to decode hex for tx_public_key: {err}"))?,
             );
             receiver_receipt.set_tx_public_key(pubkey);
             receiver_receipt.set_tx_out_hash(
                 hex::decode(&r.tx_out_hash)
-                    .map_err(|err| format!("Failed to decode hex for tx_out_hash: {}", err))?,
+                    .map_err(|err| format!("Failed to decode hex for tx_out_hash: {err}"))?,
             );
             receiver_receipt.set_tombstone(r.tombstone);
             receiver_receipt.set_confirmation_number(
                 hex::decode(&r.confirmation_number).map_err(|err| {
-                    format!("Failed to decode hex for confirmation_number: {}", err)
+                    format!("Failed to decode hex for confirmation_number: {err}")
                 })?,
             );
             receiver_receipts.push(receiver_receipt);
@@ -1291,12 +1284,12 @@ impl From<&api::GetBlockResponse> for JsonBlockDetailsResponse {
         let block = src.get_block();
 
         Self {
-            block_id: hex::encode(&block.get_id().get_data()),
+            block_id: hex::encode(block.get_id().get_data()),
             version: block.get_version(),
-            parent_id: hex::encode(&block.get_parent_id().get_data()),
+            parent_id: hex::encode(block.get_parent_id().get_data()),
             index: JsonU64(block.get_index()),
             cumulative_txo_count: JsonU64(block.get_cumulative_txo_count()),
-            contents_hash: hex::encode(&block.get_contents_hash().get_data()),
+            contents_hash: hex::encode(block.get_contents_hash().get_data()),
             key_images: src
                 .get_key_images()
                 .iter()
@@ -1326,10 +1319,10 @@ impl From<&api::ProcessedTxOut> for JsonProcessedTxOut {
         };
 
         Self {
-            monitor_id: hex::encode(&src.get_monitor_id()),
+            monitor_id: hex::encode(src.get_monitor_id()),
             subaddress_index: src.subaddress_index,
-            public_key: hex::encode(&src.get_public_key().get_data()),
-            key_image: hex::encode(&src.get_key_image().get_data()),
+            public_key: hex::encode(src.get_public_key().get_data()),
+            key_image: hex::encode(src.get_key_image().get_data()),
             value: JsonU64(src.value),
             direction: direction_str.to_owned(),
         }

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -63,7 +63,7 @@ num_cpus = "1.14"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 protobuf = "2.27.1"
 rand = "0.8"
-rayon = "1.5"
+rayon = "1.6"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls", "gzip"] }
 retry = "2.0"
 serde_json = "1.0"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/mobilecoind/src/bin/main.rs
+++ b/mobilecoind/src/bin/main.rs
@@ -218,7 +218,7 @@ fn create_or_open_ledger_db(
                     .unwrap_or_else(|_| panic!("Failed creating directory {:?}", config.ledger_db));
             }
 
-            let src = format!("{}/data.mdb", ledger_db_bootstrap);
+            let src = format!("{ledger_db_bootstrap}/data.mdb");
             std::fs::copy(src.clone(), &ledger_db_file).unwrap_or_else(|_| {
                 panic!(
                     "Failed copying ledger from {} into directory {}",

--- a/mobilecoind/src/config.rs
+++ b/mobilecoind/src/config.rs
@@ -102,10 +102,10 @@ pub struct Config {
 
 fn parse_quorum_set_from_json(src: &str) -> Result<QuorumSet<ResponderId>, String> {
     let quorum_set: QuorumSet<ResponderId> = serde_json::from_str(src)
-        .map_err(|err| format!("Error parsing quorum set {}: {:?}", src, err))?;
+        .map_err(|err| format!("Error parsing quorum set {src}: {err:?}"))?;
 
     if !quorum_set.is_valid() {
-        return Err(format!("Invalid quorum set: {:?}", quorum_set));
+        return Err(format!("Invalid quorum set: {quorum_set:?}"));
     }
 
     Ok(quorum_set)
@@ -211,9 +211,9 @@ impl Config {
             } else if let Some(verifier) = verifier.as_ref() {
                 let report_responses = conn
                     .fetch_fog_reports(fog_uris.iter().cloned())
-                    .map_err(|err| format!("Failed fetching fog reports: {}", err))?;
+                    .map_err(|err| format!("Failed fetching fog reports: {err}"))?;
                 Ok(FogResolver::new(report_responses, verifier)
-                    .map_err(|err| format!("Invalid fog url: {}", err))?)
+                    .map_err(|err| format!("Invalid fog url: {err}"))?)
             } else {
                 Err(
                     "Some recipients have fog, but no fog ingest report verifier was configured"
@@ -310,7 +310,7 @@ impl PeersConfig {
             .iter()
             .map(|peer| {
                 peer.responder_id().unwrap_or_else(|err| {
-                    panic!("Could not get responder_id from peer URI {}: {}", peer, err)
+                    panic!("Could not get responder_id from peer URI {peer}: {err}")
                 })
             })
             .collect()

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -526,7 +526,7 @@ mod test {
 
         // Set up a db with 3 random recipients and 10 blocks.
         let (_ledger_db, mobilecoind_db) =
-            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger.clone(), &mut rng);
+            get_test_databases(BlockVersion::ZERO, 3, &[], 10, logger, &mut rng);
 
         // A test accouunt.
         let account_key = AccountKey::random(&mut rng);
@@ -558,7 +558,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::MonitorIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with overlapping subaddresses should fail.
@@ -574,7 +574,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::SubaddressSPKIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with overlapping subaddresses and a different
@@ -591,7 +591,7 @@ mod test {
         match mobilecoind_db.add_monitor(&data) {
             Ok(_) => panic!("unexpected success!"),
             Err(Error::SubaddressSPKIdExists) => {}
-            Err(err) => panic!("unexpected error {:?}", err),
+            Err(err) => panic!("unexpected error {err:?}"),
         };
 
         // Inserting a monitor with non overlapping subaddresses should succeed.

--- a/mobilecoind/src/db_crypto.rs
+++ b/mobilecoind/src/db_crypto.rs
@@ -175,9 +175,9 @@ impl DbCryptoProvider {
     /// Change the password that will be used for all future
     /// encryption/decryption operations. This should only be called after
     /// all existing data has been re-encrypted to the new password!
-    pub fn change_password<'env>(
+    pub fn change_password(
         &self,
-        mut db_txn: RwTransaction<'env>,
+        mut db_txn: RwTransaction<'_>,
         password: &[u8],
     ) -> Result<(), DbCryptoError> {
         let mut state = self.state.lock().expect("muted poisoned");
@@ -303,8 +303,8 @@ impl DbCryptoProvider {
         // Hash the password hash with Blake2b to get 64 bytes, first 32 for aeskey,
         // second 32 for nonce
         let mut hasher = Blake2b512::new();
-        hasher.update(&MOBILECOIND_DB_KEY_DOMAIN_TAG);
-        hasher.update(&password);
+        hasher.update(MOBILECOIND_DB_KEY_DOMAIN_TAG);
+        hasher.update(password);
         let result = hasher.finalize();
 
         let (key, remainder) = Split::<u8, <Aes256Gcm as KeySizeUser>::KeySize>::split(result);

--- a/mobilecoind/src/monitor_store.rs
+++ b/mobilecoind/src/monitor_store.rs
@@ -186,9 +186,9 @@ impl MonitorStore {
     }
 
     /// Add a new monitor.
-    pub fn add<'env>(
+    pub fn add(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         data: &MonitorData,
     ) -> Result<MonitorId, Error> {
         let monitor_id = MonitorId::from(data);
@@ -213,9 +213,9 @@ impl MonitorStore {
     }
 
     /// Delete data for a given monitor.
-    pub fn remove<'env>(
+    pub fn remove(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
     ) -> Result<(), Error> {
         db_txn.del(self.monitor_id_to_monitor_data, monitor_id, None)?;
@@ -279,9 +279,9 @@ impl MonitorStore {
     }
 
     /// Set the MonitorData for an existing monitor
-    pub fn set_data<'env>(
+    pub fn set_data(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         data: &MonitorData,
     ) -> Result<(), Error> {
@@ -308,9 +308,9 @@ impl MonitorStore {
     /// This will fail if the current password is not set in the crypto_provider
     /// since part of the re-encryption process relies on being able to
     /// decrypt the existing data.
-    pub fn re_encrypt<'env>(
+    pub fn re_encrypt(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         new_password: &[u8],
     ) -> Result<(), Error> {
         let mut cursor = db_txn.open_rw_cursor(self.monitor_id_to_monitor_data)?;
@@ -396,9 +396,7 @@ pKZkdp8MQU5TLFOE9qjNeVsCAwEAAQ==
         assert_eq!(
             fog_expected,
             fog_id.as_bytes().to_vec(),
-            "{}/{}",
-            FOG_HEXPECTED,
-            HEXPECTED
+            "{FOG_HEXPECTED}/{HEXPECTED}"
         );
     }
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -247,14 +247,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         opt_tombstone: u64,
         opt_memo_builder: Option<Box<dyn MemoBuilder + 'static + Send + Sync>>,
     ) -> Result<TxProposal, Error> {
-        let logger = self.logger.new(o!("sender_monitor_id" => sender_monitor_id.to_string(), "outlays" => format!("{:?}", outlays)));
+        let logger = self.logger.new(o!("sender_monitor_id" => sender_monitor_id.to_string(), "outlays" => format!("{outlays:?}")));
         log::trace!(logger, "Building pending transaction...");
 
         // All inputs must be of the correct token id.
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -501,7 +501,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -696,7 +696,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if inputs.iter().any(|utxo| utxo.token_id != *token_id) {
             return Err(Error::InvalidArgument(
                 "inputs".to_string(),
-                format!("All inputs must be of token_id {}", token_id),
+                format!("All inputs must be of token_id {token_id}"),
             ));
         }
 
@@ -898,7 +898,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let mut tx_builder =
             TransactionBuilder::new_with_box(block_version, fee_amount, fog_resolver, memo_builder)
                 .map_err(|err| {
-                    Error::TxBuild(format!("Error creating transaction builder: {}", err))
+                    Error::TxBuild(format!("Error creating transaction builder: {err}"))
                 })?;
         tx_builder.set_fee_map(fee_map);
 
@@ -996,7 +996,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 ..
             } = tx_builder
                 .add_output(amount, &outlay.receiver, rng)
-                .map_err(|err| Error::TxBuild(format!("failed adding output: {}", err)))?;
+                .map_err(|err| Error::TxBuild(format!("failed adding output: {err}")))?;
 
             tx_out_to_outlay_index.insert(tx_out, i);
             outlay_confirmation_numbers.push(confirmation);
@@ -1032,7 +1032,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
             tx_builder
                 .add_change_output(change_amount, &change_dest, rng)
-                .map_err(|err| Error::TxBuild(format!("failed adding output (change): {}", err)))?;
+                .map_err(|err| Error::TxBuild(format!("failed adding output (change): {err}")))?;
         }
 
         // Set tombstone block.
@@ -1041,7 +1041,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // Build tx.
         let tx = tx_builder
             .build(&NoKeysRingSigner {}, rng)
-            .map_err(|err| Error::TxBuild(format!("build tx failed: {}", err)))?;
+            .map_err(|err| Error::TxBuild(format!("build tx failed: {err}")))?;
 
         // Map each TxOut in the constructed transaction to its respective outlay.
         let outlay_index_to_tx_out_index = tx
@@ -1064,7 +1064,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .get(&i)
                 .expect("index not in map");
             if !found_tx_out_indices.insert(tx_out_index) {
-                panic!("duplicate index {} found in map", tx_out_index);
+                panic!("duplicate index {tx_out_index} found in map");
             }
         }
 
@@ -1089,7 +1089,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 fn extract_fog_uri(addr: &PublicAddress) -> Result<Option<FogUri>, Error> {
     if let Some(string) = addr.fog_report_url() {
         Ok(Some(FogUri::from_str(string).map_err(|err| {
-            Error::Fog(format!("Could not parse recipient Fog Url: {}", err))
+            Error::Fog(format!("Could not parse recipient Fog Url: {err}"))
         })?))
     } else {
         Ok(None)

--- a/mobilecoind/src/processed_block_store.rs
+++ b/mobilecoind/src/processed_block_store.rs
@@ -182,9 +182,9 @@ impl ProcessedBlockStore {
     }
 
     /// Remove the data associated with a given monitor id.
-    pub fn remove<'env>(
+    pub fn remove(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
     ) -> Result<(), Error> {
         let start_key = ProcessedBlockKey::new(monitor_id, 0);
@@ -205,9 +205,9 @@ impl ProcessedBlockStore {
     }
 
     /// Feed data processed from a given block.
-    pub fn block_processed<'env>(
+    pub fn block_processed(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         block_index: u64,
         discovered_utxos: &[UnspentTxOut],
@@ -292,7 +292,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().expect("failed getting num blocks");
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -858,7 +858,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if utxo.token_id != request.token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -877,7 +877,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if subaddress_id.monitor_id != sender_monitor_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list.{}", i),
+                        format!("input_list.{i}"),
                     ));
                 }
 
@@ -979,7 +979,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if utxo.token_id != *token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -1048,14 +1048,14 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map(|(i, proto_utxo)| {
                 // Proto -> Rust struct conversion.
                 let utxo = UnspentTxOut::try_from(proto_utxo).map_err(|err| {
-                    rpc_internal_error(format!("unspent_tx_out[{}].try_from", i), err, &self.logger)
+                    rpc_internal_error(format!("unspent_tx_out[{i}].try_from"), err, &self.logger)
                 })?;
 
                 // Verify token id matches.
                 if utxo.token_id != request.token_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].token_id", i),
+                        format!("input_list[{i}].token_id"),
                     ));
                 }
 
@@ -1074,7 +1074,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 if subaddress_id.monitor_id != sender_monitor_id {
                     return Err(RpcStatus::with_message(
                         RpcStatusCode::INVALID_ARGUMENT,
-                        format!("input_list[{}].monitor_id", i),
+                        format!("input_list[{i}].monitor_id"),
                     ));
                 }
 
@@ -1196,7 +1196,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .ok_or_else(|| {
                     RpcStatus::with_message(
                         RpcStatusCode::INTERNAL,
-                        format!("tx out index {} not found", tx_out_index),
+                        format!("tx out index {tx_out_index} not found"),
                     )
                 })?;
 
@@ -1815,10 +1815,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         if balance > u64::max_value().into() {
             return Err(RpcStatus::with_message(
                 RpcStatusCode::INTERNAL,
-                format!(
-                    "balance of {} won't fit in u64, fetch utxo list instead",
-                    balance
-                ),
+                format!("balance of {balance} won't fit in u64, fetch utxo list instead"),
             ));
         }
 
@@ -2213,7 +2210,7 @@ mod test {
 
         // 10 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 10, &[], &[], logger, &mut rng);
 
         let monitors_map = mobilecoind_db.get_monitor_map().unwrap();
         assert_eq!(0, monitors_map.len());
@@ -2243,7 +2240,7 @@ mod test {
             request.set_monitor_id(id.to_vec());
             client
                 .remove_monitor(&request)
-                .unwrap_or_else(|_| panic!("failed to remove monitor {}", id));
+                .unwrap_or_else(|_| panic!("failed to remove monitor {id}"));
         }
 
         // Check that no monitors remain.
@@ -2441,7 +2438,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().unwrap();
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.
@@ -2517,7 +2514,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // call get entropy
         let response = client
@@ -2534,7 +2531,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // call get entropy
         let response = client.generate_mnemonic(&api::Empty::default()).unwrap();
@@ -2555,7 +2552,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Use mnemonic to construct AccountKey.
         let mnemonic_str =
@@ -2593,7 +2590,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Use root entropy to construct AccountKey.
         let root_entropy = [123u8; 32];
@@ -2635,7 +2632,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Insert into database.
         let id = mobilecoind_db.add_monitor(&data).unwrap();
@@ -2683,7 +2680,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get ledger info.
         let response = client.get_ledger_info(&api::Empty::new()).unwrap();
@@ -2697,7 +2694,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get block info for a valid block.
         let mut request = api::GetBlockInfoRequest::new();
@@ -2720,7 +2717,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Call get block info for a valid block.
         let mut request = api::GetBlockRequest::new();
@@ -2743,7 +2740,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Insert a block with some key images in it.
         let recipient = AccountKey::random(&mut rng).default_subaddress();
@@ -2827,7 +2824,7 @@ mod test {
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
-            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
+            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() + 1);
 
             let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
@@ -2848,7 +2845,7 @@ mod test {
                 (&KeyImage::from(4)).into(),
                 (&KeyImage::from(5)).into(),
             ]));
-            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
+            sender_receipt.set_tombstone(ledger_db.num_blocks().unwrap());
 
             let mut request = api::SubmitTxResponse::new();
             request.set_sender_tx_receipt(sender_receipt);
@@ -2974,7 +2971,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // A call with an invalid hash should fail
         {
@@ -3010,7 +3007,7 @@ mod test {
 
             let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
-            receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64 + 1);
+            receipt.set_tombstone(ledger_db.num_blocks().unwrap() + 1);
 
             let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -3026,7 +3023,7 @@ mod test {
 
             let mut receipt = api::ReceiverTxReceipt::new();
             receipt.set_tx_out_hash(hash.to_vec());
-            receipt.set_tombstone(ledger_db.num_blocks().unwrap() as u64);
+            receipt.set_tombstone(ledger_db.num_blocks().unwrap());
 
             let mut request = api::GetTxStatusAsReceiverRequest::new();
             request.set_receipt(receipt);
@@ -3145,7 +3142,7 @@ mod test {
         let num_blocks = ledger_db.num_blocks().expect("failed getting num blocks");
         let account_tx_outs: Vec<TxOut> = (0..num_blocks)
             .map(|idx| {
-                let block_contents = ledger_db.get_block_contents(idx as u64).unwrap();
+                let block_contents = ledger_db.get_block_contents(idx).unwrap();
                 // We grab the 4th tx out in each block since the test ledger had 3 random
                 // recipients, followed by our known recipient.
                 // See the call to `get_testing_environment` at the beginning of the test.
@@ -3362,7 +3359,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 
@@ -3485,7 +3482,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 
@@ -4070,7 +4067,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Grab the first TxOut of each block in the database and verify its index.
         for block_index in 0..test_utils::GET_TESTING_ENVIRONMENT_NUM_BLOCKS as u64 {
@@ -4208,7 +4205,7 @@ mod test {
         let (mut ledger_db, mobilecoind_db, client, _server, _server_conn_manager) =
             get_testing_environment(
                 BLOCK_VERSION,
-                num_random_recipients as u32,
+                num_random_recipients,
                 &[sender_default_subaddress.clone()],
                 &[],
                 logger.clone(),
@@ -4262,7 +4259,7 @@ mod test {
             tx_proposal.outlays[0].value,
             // Each UTXO we have has PER_RECIPIENT_AMOUNT coins. We will be merging MAX_INPUTS of
             // those into a single output, minus the fee.
-            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS as u64) - Mob::MINIMUM_FEE,
+            (DEFAULT_PER_RECIPIENT_AMOUNT * MAX_INPUTS) - Mob::MINIMUM_FEE,
         );
 
         assert_eq!(tx_proposal.outlay_index_to_tx_out_index.len(), 1);
@@ -4889,7 +4886,7 @@ mod test {
                     "transactions_manager.build_transaction: Insufficient funds".to_owned()
                 );
             }
-            Err(err) => panic!("Unexpected error: {:?}", err),
+            Err(err) => panic!("Unexpected error: {err:?}"),
         };
 
         // Trying with a higher limit should work.
@@ -4954,8 +4951,8 @@ mod test {
         );
         let port = test_utils::get_free_port();
 
-        let uri = MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{}/", port))
-            .unwrap();
+        let uri =
+            MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{port}/")).unwrap();
 
         log::debug!(logger, "Setting up server {:?}", port);
         let (_server, server_conn_manager) = test_utils::setup_server::<MockFogPubkeyResolver>(
@@ -5262,7 +5259,7 @@ mod test {
             .get_tx_proposal()
             .get_input_list()
             .iter()
-            .map(|utxo| utxo.value as u64)
+            .map(|utxo| utxo.value)
             .sum::<u64>();
 
         let mut opt_submitted_tx: Option<Tx> = None;
@@ -5331,7 +5328,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         // Random receiver address.
         let receiver = AccountKey::random(&mut rng).default_subaddress();
@@ -5670,7 +5667,7 @@ mod test {
 
         // no known recipient, 3 random recipients and no monitors.
         let (_ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         {
             // Random receiver address.
@@ -5737,7 +5734,7 @@ mod test {
         let mut rng: StdRng = SeedableRng::from_seed([23u8; 32]);
 
         let (ledger_db, _mobilecoind_db, client, _server, _server_conn_manager) =
-            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger.clone(), &mut rng);
+            get_testing_environment(BLOCK_VERSION, 3, &[], &[], logger, &mut rng);
 
         let network_status = client.get_network_status(&api::Empty::new()).unwrap();
 
@@ -5901,7 +5898,7 @@ mod test {
                 3,
                 &[sender.default_subaddress()],
                 &[],
-                logger.clone(),
+                logger,
                 &mut rng,
             );
 

--- a/mobilecoind/src/subaddress_store.rs
+++ b/mobilecoind/src/subaddress_store.rs
@@ -110,9 +110,9 @@ impl SubaddressStore {
     }
 
     /// Insert a new subaddress spend public key into the database.
-    pub fn insert<'env>(
+    pub fn insert(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         data: &MonitorData,
         index: u64,
@@ -158,9 +158,9 @@ impl SubaddressStore {
     }
 
     /// deletes the SubaddressId stored for a subaddress spend public key
-    pub fn delete<'env>(
+    pub fn delete(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         data: &MonitorData,
         index: u64,
     ) -> Result<(), Error> {

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -101,7 +101,7 @@ impl SyncThread {
             let thread_queued_monitor_ids = queued_monitor_ids.clone();
             let thread_logger = logger.clone();
             let join_handle = thread::Builder::new()
-                .name(format!("sync_worker_{}", idx))
+                .name(format!("sync_worker_{idx}"))
                 .spawn(move || {
                     sync_thread_entry_point(
                         thread_ledger_db,

--- a/mobilecoind/src/test_utils.rs
+++ b/mobilecoind/src/test_utils.rs
@@ -228,7 +228,7 @@ pub fn get_testing_environment(
     let port = get_free_port();
 
     let uri =
-        MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{}/", port)).unwrap();
+        MobilecoindUri::from_str(&format!("insecure-mobilecoind://127.0.0.1:{port}/")).unwrap();
 
     log::debug!(logger, "Setting up server {:?}", port);
     let (server, server_conn_manager) = setup_server::<MockFogResolver>(

--- a/mobilecoind/src/utxo_store.rs
+++ b/mobilecoind/src/utxo_store.rs
@@ -133,9 +133,9 @@ impl UtxoStore {
 
     /// Append a discovered transaction to the list stored for a given
     /// subaddress.
-    pub fn append_utxo<'env>(
+    pub fn append_utxo(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         index: u64,
         utxo: &UnspentTxOut,
@@ -188,9 +188,9 @@ impl UtxoStore {
     }
 
     /// Removes all utxos associated with a given address.
-    pub fn remove_utxos<'env>(
+    pub fn remove_utxos(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         index: u64,
     ) -> Result<(), Error> {
@@ -231,9 +231,9 @@ impl UtxoStore {
     /// Removes utxos based on a list of key images.
     /// This method silently ignores key images that were not found in the
     /// database. It returns the list of utxos that were removed.
-    pub fn remove_utxos_by_key_images<'env>(
+    pub fn remove_utxos_by_key_images(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         monitor_id: &MonitorId,
         key_images: &[KeyImage],
     ) -> Result<Vec<UnspentTxOut>, Error> {
@@ -348,9 +348,9 @@ impl UtxoStore {
 
     /// Update a list of UnspentTxOuts attempted_spend_height and
     /// attempted_spend_tombstone.
-    pub fn update_attempted_spend<'env>(
+    pub fn update_attempted_spend(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         utxo_ids: &[UtxoId],
         attempted_spend_height: u64,
         attempted_spend_tombstone: u64,
@@ -393,7 +393,7 @@ impl UtxoStore {
     ) -> Result<Vec<UtxoId>, Error> {
         let mut cursor = db_txn.open_ro_cursor(self.subaddress_id_to_utxo_id)?;
         cursor
-            .iter_dup_of(&subaddress_id.to_vec())
+            .iter_dup_of(subaddress_id.to_vec())
             .map(|result| {
                 result
                     .map_err(Error::from)
@@ -586,7 +586,7 @@ mod test {
                     ) {
                         Ok(_) => panic!("unexpected success"),
                         Err(Error::DuplicateUnspentTxOut) => {}
-                        Err(err) => panic!("unexpected error {:?}", err),
+                        Err(err) => panic!("unexpected error {err:?}"),
                     }
                 }
             }

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/peers/src/consensus_msg.rs
+++ b/peers/src/consensus_msg.rs
@@ -248,7 +248,7 @@ mod tests {
         match msg.verify_signature() {
             Ok(_) => panic!("Signature verification should fail"),
             Err(ConsensusMsgError::SignatureError(_)) => {}
-            Err(e) => panic!("Sigature failed with unexpected error {:?}", e),
+            Err(e) => panic!("Sigature failed with unexpected error {e:?}"),
         }
     }
 
@@ -298,7 +298,7 @@ mod tests {
         match VerifiedConsensusMsg::try_from(msg) {
             Ok(_) => panic!("Signature verification should fail"),
             Err(ConsensusMsgError::SignatureError(_)) => {}
-            Err(e) => panic!("Sigature failed with unexpected error {:?}", e),
+            Err(e) => panic!("Sigature failed with unexpected error {e:?}"),
         }
     }
 }

--- a/peers/src/threaded_broadcaster.rs
+++ b/peers/src/threaded_broadcaster.rs
@@ -274,7 +274,7 @@ impl PeerThread {
 
         let join_handle = Some(
             thread::Builder::new()
-                .name(format!("{}", conn))
+                .name(format!("{conn}"))
                 .spawn(move || {
                     Self::thread_entrypoint(conn, retry_policy, receiver, logger);
                 })
@@ -397,7 +397,7 @@ impl PeerThread {
 
         let retry_iterator = retry_policy.get_delay_iterator().with_deadline(deadline);
 
-        match conn.send_consensus_msg(&*arc_msg, retry_iterator) {
+        match conn.send_consensus_msg(&arc_msg, retry_iterator) {
             Ok(resp) => match resp.get_result() {
                 ConsensusMsgResult::Ok => {}
                 ConsensusMsgResult::UnknownPeer => log::info!(

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -294,7 +294,7 @@ mod peer_manager_tests {
             // Get blocks 25,26,27. These are entirely out of range, so should return an
             // error.
             if let Ok(blocks) = mock_peer.fetch_blocks(25..28) {
-                println!("Blocks: {:?}", blocks);
+                println!("Blocks: {blocks:?}");
                 panic!();
             }
         }
@@ -407,11 +407,8 @@ mod threaded_broadcaster_tests {
         let peer_manager =
             ConnectionManager::new(vec![peer2.clone(), peer3.clone()], logger.clone());
 
-        let mut broadcaster = ThreadedBroadcaster::new(
-            &peer_manager,
-            &FibonacciRetryPolicy::default(),
-            logger.clone(),
-        );
+        let mut broadcaster =
+            ThreadedBroadcaster::new(&peer_manager, &FibonacciRetryPolicy::default(), logger);
 
         // Initially, nothing is broadcasted to either of our nodes.
         {
@@ -496,11 +493,8 @@ mod threaded_broadcaster_tests {
             logger.clone(),
         );
 
-        let mut broadcaster = ThreadedBroadcaster::new(
-            &peer_manager,
-            &FibonacciRetryPolicy::default(),
-            logger.clone(),
-        );
+        let mut broadcaster =
+            ThreadedBroadcaster::new(&peer_manager, &FibonacciRetryPolicy::default(), logger);
 
         // Initially, nothing is broadcasted to either of our nodes.
         {
@@ -581,7 +575,7 @@ mod threaded_broadcaster_tests {
         let mut broadcaster = ThreadedBroadcaster::new(
             &peer_manager,
             FibonacciRetryPolicy::default().initial_delay(Duration::from_millis(10)),
-            logger.clone(),
+            logger,
         );
 
         // Initially, nothing is broadcasted to either of our nodes.

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_debug_edl"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-sgx-debug"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_panic_edl"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 
 [features]

--- a/sgx/panic/src/lib.rs
+++ b/sgx/panic/src/lib.rs
@@ -11,8 +11,6 @@
 // and rethrowing them, because in Rust those APIs use the Box type.
 #![feature(lang_items)] // for eh_personality
 #![feature(thread_local)]
-// Enable "untagged unions" when we have alloc feature, used in panicking::try
-#![cfg_attr(feature = "alloc", feature(untagged_unions))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "sgx_slog_edl"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 
 [dependencies]

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "4.0.1"
+version = "4.0.2"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 
 

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/account-keys/build.rs
+++ b/test-vectors/account-keys/build.rs
@@ -131,7 +131,7 @@ fn main() {
                     .map(move |(entropy_hex, mnemonic_text)| {
                         let entropy =
                             hex::decode(*entropy_hex).expect("Could not parse entropy hex");
-                        let mnemonic = Mnemonic::from_phrase(*mnemonic_text, Language::English)
+                        let mnemonic = Mnemonic::from_phrase(mnemonic_text, Language::English)
                             .expect("Could not parse mnemonic string");
 
                         assert_eq!(mnemonic.entropy(), entropy.as_slice());

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/test-vectors/tx-out-records/build.rs
+++ b/test-vectors/tx-out-records/build.rs
@@ -85,7 +85,7 @@ fn generate_tx_out_record_data() -> TxOutRecordData {
 
     let recipient_account = AccountKey::random_with_fog(&mut rng);
     let spurious_account = AccountKey::random_with_fog(&mut rng);
-    let enclave = SgxIngestEnclave::<HeapORAMStorageCreator>::new(logger.clone());
+    let enclave = SgxIngestEnclave::<HeapORAMStorageCreator>::new(logger);
 
     let params = IngestEnclaveInitParams {
         responder_id: ResponderId::default(),

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -2845,7 +2845,7 @@ pub mod transaction_builder_tests {
             // Signing should fail if value is not conserved.
             match result {
                 Err(TxBuilderError::RingSignatureFailed(_)) => {} // Expected.
-                _ => panic!("Unexpected result {:?}", result),
+                _ => panic!("Unexpected result {result:?}"),
             }
         }
     }

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/transaction/core/src/amount/v1.rs
+++ b/transaction/core/src/amount/v1.rs
@@ -206,8 +206,8 @@ impl MaskedAmountV1 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_VALUE_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_VALUE_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     let scalar = Scalar::from_hash(hasher);
     let mut temp = [0u8; 8];
     temp.copy_from_slice(&scalar.as_bytes()[0..8]);
@@ -222,8 +222,8 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_token_id_mask(shared_secret: &RistrettoPublic) -> u64 {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_TOKEN_ID_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_TOKEN_ID_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     u64::from_le_bytes(hasher.finalize()[0..8].try_into().unwrap())
 }
 
@@ -233,8 +233,8 @@ fn get_token_id_mask(shared_secret: &RistrettoPublic) -> u64 {
 /// * `shared_secret` - The shared secret, e.g. `rB`.
 fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b512::new();
-    hasher.update(&AMOUNT_BLINDING_DOMAIN_TAG);
-    hasher.update(&shared_secret.to_bytes());
+    hasher.update(AMOUNT_BLINDING_DOMAIN_TAG);
+    hasher.update(shared_secret.to_bytes());
     Scalar::from_hash(hasher)
 }
 

--- a/transaction/core/src/amount/v2.rs
+++ b/transaction/core/src/amount/v2.rs
@@ -113,8 +113,8 @@ impl MaskedAmountV2 {
     /// Get the amount shared secret from the tx out shared secret
     pub fn compute_amount_shared_secret(tx_out_shared_secret: &RistrettoPublic) -> [u8; 32] {
         let mut hasher = Blake2b512::new();
-        hasher.update(&AMOUNT_SHARED_SECRET_DOMAIN_TAG);
-        hasher.update(&tx_out_shared_secret.to_bytes());
+        hasher.update(AMOUNT_SHARED_SECRET_DOMAIN_TAG);
+        hasher.update(tx_out_shared_secret.to_bytes());
         // Safety: Blake2b is a 512-bit (64-byte) hash.
         hasher.finalize()[0..32].try_into().unwrap()
     }

--- a/transaction/core/src/membership_proofs/mod.rs
+++ b/transaction/core/src/membership_proofs/mod.rs
@@ -32,15 +32,15 @@ lazy_static! {
 /// Merkle tree hash function for a leaf node.
 pub fn hash_leaf(tx_out: &TxOut) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_LEAF_DOMAIN_TAG);
-    hasher.update(&tx_out.hash());
+    hasher.update(TXOUT_MERKLE_LEAF_DOMAIN_TAG);
+    hasher.update(tx_out.hash());
     hasher.finalize().try_into().unwrap()
 }
 
 /// Merkle tree hash function for an internal node.
 pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_NODE_DOMAIN_TAG);
+    hasher.update(TXOUT_MERKLE_NODE_DOMAIN_TAG);
     hasher.update(left);
     hasher.update(right);
     hasher.finalize().try_into().unwrap()
@@ -49,7 +49,7 @@ pub fn hash_nodes(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
 /// Merkle tree Hash function for hashing a "nil" value.
 fn hash_nil() -> [u8; 32] {
     let mut hasher = Blake2b256::new();
-    hasher.update(&TXOUT_MERKLE_NIL_DOMAIN_TAG);
+    hasher.update(TXOUT_MERKLE_NIL_DOMAIN_TAG);
     hasher.finalize().try_into().unwrap()
 }
 

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -142,7 +142,7 @@ pub mod tests {
 
         match check_range_proofs(&proof, &commitments, &generators(0), &mut rng) {
             Ok(_) => {} // This is expected.
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
     }
 

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -1520,7 +1520,7 @@ mod rct_bulletproofs_tests {
             ) {
                 Err(Error::ValueNotConserved) => {} // Expected
                 Err(e) => {
-                    panic!("Unexpected error {}", e);
+                    panic!("Unexpected error {e}");
                 }
                 _ => panic!("Unexpected success")
             }

--- a/transaction/core/src/tx.rs
+++ b/transaction/core/src/tx.rs
@@ -98,7 +98,7 @@ impl fmt::Display for TxHash {
 
 impl fmt::Debug for TxHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Tx#{}", self)
+        write!(f, "Tx#{self}")
     }
 }
 

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -107,8 +107,7 @@ impl From<MemoError> for NewMemoError {
         match src {
             MemoError::Utf8Decoding => Self::Utf8Decoding,
             MemoError::BadLength(byte_len) => Self::BadInputs(format!(
-                "Input of length: {} exceeded max byte length",
-                byte_len
+                "Input of length: {byte_len} exceeded max byte length"
             )),
             MemoError::MaxFeeExceeded(max_fee, attempted_fee) => {
                 Self::MaxFeeExceeded(max_fee, attempted_fee)

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -38,8 +38,7 @@ pub fn validate<R: RngCore + CryptoRng>(
 ) -> TransactionValidationResult<()> {
     if BlockVersion::MAX < block_version {
         return Err(TransactionValidationError::Ledger(format!(
-            "Invalid block version: {}",
-            block_version
+            "Invalid block version: {block_version}"
         )));
     }
 

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -535,8 +535,7 @@ fn test_validate_signature_ok() {
         assert_eq!(
             validate_signature(block_version, &tx, &mut rng),
             Ok(()),
-            "failed at block version: {}",
-            block_version
+            "failed at block version: {block_version}"
         );
     }
 }
@@ -555,7 +554,7 @@ fn test_transaction_signature_err_modified_input() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -577,7 +576,7 @@ fn test_transaction_signature_err_modified_output() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -597,7 +596,7 @@ fn test_transaction_signature_err_modified_fee() {
         match validate_signature(block_version, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -617,7 +616,7 @@ fn test_transaction_signature_err_modified_token_id() {
         match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -635,7 +634,7 @@ fn test_transaction_signature_err_version_one_as_two() {
         match validate_signature(BlockVersion::TWO, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }
@@ -653,7 +652,7 @@ fn test_transaction_signature_err_version_two_as_one() {
         match validate_signature(BlockVersion::ONE, &tx, &mut rng) {
             Err(TransactionValidationError::InvalidTransactionSignature(_e)) => {} // Expected.
             Err(e) => {
-                panic!("Unexpected error {}", e);
+                panic!("Unexpected error {e}");
             }
             Ok(()) => panic!("Unexpected success"),
         }

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/extra/src/tx_out_confirmation_number.rs
+++ b/transaction/extra/src/tx_out_confirmation_number.rs
@@ -62,7 +62,7 @@ impl core::convert::From<[u8; 32]> for TxOutConfirmationNumber {
 impl core::convert::From<&RistrettoPublic> for TxOutConfirmationNumber {
     fn from(shared_secret: &RistrettoPublic) -> Self {
         let mut hasher = Blake2b256::new();
-        hasher.update(&TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
+        hasher.update(TXOUT_CONFIRMATION_NUMBER_DOMAIN_TAG);
         hasher.update(shared_secret.to_bytes());
         Self(hasher.finalize().into())
     }

--- a/transaction/extra/src/tx_summary_unblinding/report.rs
+++ b/transaction/extra/src/tx_summary_unblinding/report.rs
@@ -87,10 +87,10 @@ impl Display for TxSummaryUnblindingReport {
         let mut current_entity = None;
         for ((entity, tok), val) in self.balance_changes.iter() {
             if Some(entity) != current_entity.as_ref() {
-                writeln!(formatter, "{}:", entity)?;
+                writeln!(formatter, "{entity}:")?;
                 current_entity = Some(entity.clone());
             }
-            writeln!(formatter, "\t{}: {}", *tok, val)?;
+            writeln!(formatter, "\t{}: {val}", *tok)?;
         }
         writeln!(
             formatter,

--- a/transaction/extra/tests/verifier.rs
+++ b/transaction/extra/tests/verifier.rs
@@ -123,7 +123,7 @@ fn test_max_size_tx_payload_sizes() {
     };
 
     assert_eq!(tx.prefix.inputs.len(), MAX_INPUTS as usize);
-    assert_eq!(tx.prefix.inputs[0].proofs.len(), RING_SIZE as usize);
+    assert_eq!(tx.prefix.inputs[0].proofs.len(), { RING_SIZE });
     assert_eq!(tx.prefix.inputs[0].proofs[0].elements.len(), 32);
 
     let tx_wire = encode(&tx);
@@ -165,7 +165,7 @@ fn test_min_size_tx_payload_sizes() {
     };
 
     assert_eq!(tx.prefix.inputs.len(), 1_usize);
-    assert_eq!(tx.prefix.inputs[0].proofs.len(), RING_SIZE as usize);
+    assert_eq!(tx.prefix.inputs[0].proofs.len(), { RING_SIZE });
     assert_eq!(tx.prefix.inputs[0].proofs[0].elements.len(), 32);
 
     let tx_wire = encode(&tx);

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/b58-decoder/src/bin/main.rs
+++ b/util/b58-decoder/src/bin/main.rs
@@ -57,7 +57,7 @@ fn main() {
         }
 
         Err(err) => {
-            println!("Failed decoding b58 into a known object: {}", err);
+            println!("Failed decoding b58 into a known object: {err}");
             std::process::exit(1);
         }
     }

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -697,14 +697,14 @@ impl Builder {
         let mut command = Command::new(&self.linker);
 
         command
-            .args(&[
+            .args([
                 "-o",
                 unsigned_enclave
                     .to_str()
                     .expect("Invalid UTF-8 in unsigned enclave path"),
             ])
-            .args(&["-z", "relro", "-z", "now", "-z", "noexecstack"])
-            .args(&["--no-undefined", "-nostdlib"]);
+            .args(["-z", "relro", "-z", "now", "-z", "noexecstack"])
+            .args(["--no-undefined", "-nostdlib"]);
 
         let mut config = Config::new();
         config
@@ -736,25 +736,25 @@ impl Builder {
         }
 
         command
-            .args(&[
+            .args([
                 "--whole-archive",
-                &format!("-lsgx_trts{}", sim_postfix),
+                &format!("-lsgx_trts{sim_postfix}"),
                 "--no-whole-archive",
             ])
-            .args(&[
+            .args([
                 "--start-group",
                 "-lsgx_tstdc",
                 "-lsgx_tcxx",
                 "-lsgx_tcrypto",
-                &format!("-lsgx_tservice{}", sim_postfix),
+                &format!("-lsgx_tservice{sim_postfix}"),
                 static_archive
                     .to_str()
                     .expect("Invalid UTF-8 in enclave staticlib filename"),
                 "--end-group",
             ])
-            .args(&["-Bstatic", "-Bsymbolic", "--no-undefined"])
-            .args(&["-pie", "-eenclave_entry", "--export-dynamic"])
-            .args(&["--defsym", "__ImageBase=0"])
+            .args(["-Bstatic", "-Bsymbolic", "--no-undefined"])
+            .args(["-pie", "-eenclave_entry", "--export-dynamic"])
+            .args(["--defsym", "__ImageBase=0"])
             .arg("--gc-sections")
             .arg(format!(
                 "--version-script={}",

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -10,12 +10,12 @@ use std::{
 /// Get git revision by running `git describe` in a given directory.
 fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
     match Command::new("git")
-        .args(&["describe", "--always", "--dirty=-modified"])
+        .args(["describe", "--always", "--dirty=-modified"])
         .current_dir(current_dir)
         .output()
     {
         Err(err) => {
-            eprintln!("Couldn't run git: {}", err);
+            eprintln!("Couldn't run git: {err}");
             "??????".to_string()
         }
         Ok(proc_output) => {
@@ -40,7 +40,7 @@ fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
 /// Use the GIT_COMMIT environment variable to override this.
 fn get_root_git_commit() -> String {
     if let Ok(result) = env::var("GIT_COMMIT") {
-        eprintln!("GIT_COMMIT from env: {}", result);
+        eprintln!("GIT_COMMIT from env: {result}");
         return result;
     }
 
@@ -115,32 +115,20 @@ fn main() {
     let gen_contents = format!(
         r###"
 // This file is generated
-pub fn git_commit() -> &'static str {{ "{}" }}
-pub fn mobilecoin_git_commit() -> &'static str {{ "{}" }}
-pub fn profile() -> &'static str {{ "{}" }}
-pub fn debug() -> &'static str {{ "{}" }}
-pub fn opt_level() -> &'static str {{ "{}" }}
-pub fn debug_assertions() -> &'static str {{ "{}" }}
-pub fn target_arch() -> &'static str {{ "{}" }}
-pub fn target_os() -> &'static str {{ "{}" }}
-pub fn target_feature() -> &'static str {{ "{}" }}
-pub fn rustflags() -> &'static str {{ "{}" }}
-pub fn sgx_mode() -> &'static str {{ "{}" }}
-pub fn ias_mode() -> &'static str {{ "{}" }}
+pub fn git_commit() -> &'static str {{ "{root_git_commit}" }}
+pub fn mobilecoin_git_commit() -> &'static str {{ "{mobilecoin_git_commit}" }}
+pub fn profile() -> &'static str {{ "{profile}" }}
+pub fn debug() -> &'static str {{ "{debug}" }}
+pub fn opt_level() -> &'static str {{ "{opt_level}" }}
+pub fn debug_assertions() -> &'static str {{ "{debug_assertions}" }}
+pub fn target_arch() -> &'static str {{ "{target_arch}" }}
+pub fn target_os() -> &'static str {{ "{target_os}" }}
+pub fn target_feature() -> &'static str {{ "{target_feature}" }}
+pub fn rustflags() -> &'static str {{ "{rustflags}" }}
+pub fn sgx_mode() -> &'static str {{ "{sgx_mode}" }}
+pub fn ias_mode() -> &'static str {{ "{ias_mode}" }}
 // Note: Please update `build-info/src/lib.rs` if you add more stuff
 "###,
-        root_git_commit,
-        mobilecoin_git_commit,
-        profile,
-        debug,
-        opt_level,
-        debug_assertions,
-        target_arch,
-        target_os,
-        target_feature,
-        rustflags,
-        sgx_mode,
-        ias_mode
     );
 
     // Check the current contents and see if they are different
@@ -151,8 +139,8 @@ pub fn ias_mode() -> &'static str {{ "{}" }}
         out_file.clone().into_os_string().into_string().unwrap()
     );
     if let Ok(current_contents) = fs::read_to_string(out_file.clone()) {
-        eprintln!("current contents:\n{}", current_contents);
-        eprintln!("gen contents:\n{}", gen_contents);
+        eprintln!("current contents:\n{current_contents}");
+        eprintln!("gen contents:\n{gen_contents}");
         if current_contents == gen_contents {
             // Early return, don't cause make to rerun everything
             return;
@@ -162,5 +150,5 @@ pub fn ias_mode() -> &'static str {{ "{}" }}
     // rewrite the file
     let mut file = fs::File::create(out_file).expect("File creation");
     use std::io::Write;
-    write!(&mut file, "{}", gen_contents).expect("File I/O");
+    write!(&mut file, "{gen_contents}").expect("File I/O");
 }

--- a/util/build/info/src/bin/main.rs
+++ b/util/build/info/src/bin/main.rs
@@ -28,7 +28,7 @@ fn main() {
         } else if args[1] == "--all" {
             let mut result = String::new();
             mc_util_build_info::write_report(&mut result).unwrap();
-            print!("{}", result);
+            print!("{result}");
             return;
         }
     }

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Cargo build-script assistance, from MobileCoin."

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/build/sgx/src/edger8r.rs
+++ b/util/build/sgx/src/edger8r.rs
@@ -163,7 +163,7 @@ impl Edger8r {
         let mut command = Command::new(&self.edger8r_path);
 
         for path in &self.search_paths {
-            command.args(&[
+            command.args([
                 "--search-path",
                 path.as_os_str()
                     .to_str()
@@ -173,16 +173,16 @@ impl Edger8r {
 
         if self.output_kind == OutputKind::Trusted {
             command
-                .arg(&"--trusted")
+                .arg("--trusted")
                 .arg(&self.edl_path)
-                .arg(&"--trusted-dir");
+                .arg("--trusted-dir");
         } else {
             command
-                .arg(&"--untrusted")
+                .arg("--untrusted")
                 .arg(&self.edl_path)
-                .arg(&"--untrusted-dir");
+                .arg("--untrusted-dir");
         }
-        command.arg(&self.out_dir.to_str().expect("Invalid UTF-8 in out dir"));
+        command.arg(self.out_dir.to_str().expect("Invalid UTF-8 in out dir"));
 
         let output = command.output()?;
 
@@ -190,7 +190,7 @@ impl Edger8r {
             Ok(self)
         } else {
             Err(Error::Generate(
-                format!("{:?}", command),
+                format!("{command:?}"),
                 String::from_utf8(output.stdout)?,
                 String::from_utf8(output.stderr)?,
             ))

--- a/util/build/sgx/src/sign.rs
+++ b/util/build/sgx/src/sign.rs
@@ -66,7 +66,7 @@ impl SgxSign {
             .arg("-enclave")
             .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-key")
             .arg(private_key)
             .arg("-out")
@@ -100,7 +100,7 @@ impl SgxSign {
             .arg("-enclave")
             .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-out")
             .arg(output_datfile);
 
@@ -133,17 +133,17 @@ impl SgxSign {
         let mut cmd = Command::new(self.sgx_sign_path.clone());
         cmd.arg("catsig")
             .arg("-enclave")
-            .arg(&unsigned_enclave)
+            .arg(unsigned_enclave)
             .arg("-config")
-            .arg(&config_path)
+            .arg(config_path)
             .arg("-key")
-            .arg(&public_key_pem)
+            .arg(public_key_pem)
             .arg("-unsigned")
-            .arg(&gendata_output)
+            .arg(gendata_output)
             .arg("-sig")
-            .arg(&signature)
+            .arg(signature)
             .arg("-out")
-            .arg(&output_enclave);
+            .arg(output_enclave);
 
         if self.ignore_rel_error {
             cmd.arg("-ignore-rel-error");

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/dump-ledger/src/bin/dump_ledger.rs
+++ b/util/dump-ledger/src/bin/dump_ledger.rs
@@ -29,5 +29,5 @@ fn main() {
 
     let json = dump_ledger(&ledger_db, config.params).expect("failed to dump LedgerDB");
 
-    println!("{}", json);
+    println!("{json}");
 }

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
 name = "mc-util-ffi"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"

--- a/util/ffi/src/ffi_owned_ptr.rs
+++ b/util/ffi/src/ffi_owned_ptr.rs
@@ -55,7 +55,7 @@ impl<T: ?Sized> Drop for FfiOwnedPtr<T> {
         // misuse in unsafe Rust, in C, or a bug in the library.
         debug_assert!(!self.0.is_null());
         unsafe {
-            Box::from_raw(self.0);
+            drop(Box::from_raw(self.0));
         }
     }
 }
@@ -182,7 +182,7 @@ impl<T: ?Sized> Drop for FfiOptOwnedPtr<T> {
     fn drop(&mut self) {
         if !self.0.is_null() {
             unsafe {
-                Box::from_raw(self.0);
+                drop(Box::from_raw(self.0));
             }
         }
     }

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A trait for constructing an object from a random number generator."

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/generate-sample-ledger/tests/bootstrap.rs
+++ b/util/generate-sample-ledger/tests/bootstrap.rs
@@ -21,11 +21,11 @@ use tempfile::TempDir;
 fn test_exercise_bootstrap() {
     let me = PathBuf::from(args().next().unwrap());
     let bin = me.parent().unwrap().parent().unwrap();
-    println!("bin = {:?}", bin);
+    println!("bin = {bin:?}");
 
     let dir = TempDir::new().unwrap();
     set_current_dir(dir.path()).unwrap();
-    println!("dir = {:?}", dir);
+    println!("dir = {dir:?}");
 
     assert!(Command::new(bin.join("sample-keys"))
         .args(["--num", "5"])

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Runtime gRPC Utilities"

--- a/util/grpc/src/admin_service.rs
+++ b/util/grpc/src/admin_service.rs
@@ -75,10 +75,7 @@ impl AdminService {
 
         let mut response = GetPrometheusMetricsResponse::new();
         response.set_metrics(String::from_utf8(buffer).map_err(|err| {
-            RpcStatus::with_message(
-                RpcStatusCode::INTERNAL,
-                format!("from_utf8 failed: {}", err),
-            )
+            RpcStatus::with_message(RpcStatusCode::INTERNAL, format!("from_utf8 failed: {err}"))
         })?);
         Ok(response)
     }
@@ -94,7 +91,7 @@ impl AdminService {
         mc_util_build_info::write_report(&mut build_info_json).map_err(|err| {
             RpcStatus::with_message(
                 RpcStatusCode::INTERNAL,
-                format!("write_report failed: {}", err),
+                format!("write_report failed: {err}"),
             )
         })?;
 

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -233,7 +233,7 @@ mod test {
                 .authenticate_metadata(&metadata_builder.build())
                 .is_ok()
             {
-                panic!("Unexpected success with header {:?}", test_header_value);
+                panic!("Unexpected success with header {test_header_value:?}");
             }
         }
 
@@ -278,7 +278,7 @@ mod test {
                 .authenticate_metadata(&metadata_builder.build())
                 .is_ok()
             {
-                panic!("Unexpected success with header {:?}", test_header_value);
+                panic!("Unexpected success with header {test_header_value:?}");
             }
         }
 

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -59,7 +59,7 @@ impl<TP: TimeProvider> Authenticator for TokenAuthenticator<TP> {
         if !self.is_valid_time(timestamp)? {
             return Err(AuthenticatorError::ExpiredAuthorizationToken);
         }
-        if !self.is_valid_signature(&format!("{}:{}", username, timestamp), signature)? {
+        if !self.is_valid_signature(&format!("{username}:{timestamp}"), signature)? {
             return Err(AuthenticatorError::InvalidAuthorizationToken);
         }
         Ok(credentials.username)
@@ -154,7 +154,7 @@ impl<TP: TimeProvider> TokenBasicCredentialsGenerator<TP> {
             .since_epoch()
             .map_err(|_| TokenBasicCredentialsGeneratorError::TimeProvider)?
             .as_secs();
-        let prefix = format!("{}:{}", user_id, current_time_seconds);
+        let prefix = format!("{user_id}:{current_time_seconds}");
 
         let mut mac = Hmac::<Sha256>::new_from_slice(&self.shared_secret)
             .map_err(|_| TokenBasicCredentialsGeneratorError::InvalidHmacKey)?;

--- a/util/grpc/src/chain_id.rs
+++ b/util/grpc/src/chain_id.rs
@@ -15,7 +15,7 @@ pub fn check_request_chain_id(server_chain_id: &str, ctx: &RpcContext) -> Result
         if header == CHAIN_ID_GRPC_HEADER && server_chain_id.as_bytes() != value {
             return Err(RpcStatus::with_message(
                 RpcStatusCode::FAILED_PRECONDITION,
-                format!("{} '{}'", CHAIN_ID_MISMATCH_ERR_MSG, server_chain_id),
+                format!("{CHAIN_ID_MISMATCH_ERR_MSG} '{server_chain_id}'"),
             ));
         }
     }

--- a/util/grpc/src/server_cert_reloader.rs
+++ b/util/grpc/src/server_cert_reloader.rs
@@ -187,7 +187,7 @@ mod tests {
         let ch = ChannelBuilder::new(env)
             .override_ssl_target(ssl_target)
             .set_credentials(cred)
-            .connect(&format!("localhost:{}", port));
+            .connect(&format!("localhost:{port}"));
         HealthClient::new(ch)
     }
 
@@ -203,10 +203,10 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC server.
-        let (_server, port) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server, port) = create_test_server(&cert_file, &key_file, logger);
 
         // Connect the server whose CN is "www.server1.com" with the correct
         // certificate.
@@ -240,7 +240,7 @@ mod tests {
         // Replace server1 certificates with server2. This should trigger the reloading
         // mechanism.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {
@@ -280,10 +280,10 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC server.
-        let (_server, port) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server, port) = create_test_server(&cert_file, &key_file, logger);
 
         // Sanity that the server works.
         let client1 = create_test_client(&server1_cert, "www.server1.com", port);
@@ -323,11 +323,11 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Start the GRPC servers.
         let (_server1, port1) = create_test_server(&cert_file, &key_file, logger.clone());
-        let (_server2, port2) = create_test_server(&cert_file, &key_file, logger.clone());
+        let (_server2, port2) = create_test_server(&cert_file, &key_file, logger);
 
         // Sanity that the servers works.
         let client1 = create_test_client(&server1_cert, "www.server1.com", port1);
@@ -344,7 +344,7 @@ mod tests {
 
         // Replace server1 certificates with server2.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {
@@ -380,7 +380,7 @@ mod tests {
 
         // Write server1's cert files into the temp dir.
         std::fs::write(&cert_file, &server1_cert).unwrap();
-        std::fs::write(&key_file, &server1_key).unwrap();
+        std::fs::write(&key_file, server1_key).unwrap();
 
         // Create a listener URI.
         let port: u16 = 6544;
@@ -411,7 +411,7 @@ mod tests {
 
         // Replace server1 certificates with server2.
         std::fs::write(&cert_file, &server2_cert).unwrap();
-        std::fs::write(&key_file, &server2_key).unwrap();
+        std::fs::write(&key_file, server2_key).unwrap();
 
         // Trigger reloading.
         unsafe {

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/host-cert/src/lib.rs
+++ b/util/host-cert/src/lib.rs
@@ -39,7 +39,7 @@ const SSL_CERT_EXTENSIONS: &[&str] = &["pem", "crt"];
 /// would be used.
 fn read_cert_dir_contents(dirname: OsString) -> Result<Vec<u8>, String> {
     let entries = fs::read_dir(&dirname)
-        .map_err(|e| format!("Failed reading directory {:?}: {:?}", dirname, e))?;
+        .map_err(|e| format!("Failed reading directory {dirname:?}: {e:?}"))?;
 
     let mut retval = Vec::<u8>::with_capacity(INITIAL_BUNDLE_CAPACITY);
     let mut errors = Vec::<String>::new();
@@ -135,25 +135,22 @@ pub fn read_ca_bundle(ca_bundle: Option<PathBuf>) -> Result<Vec<u8>, String> {
                             }
 
                             Err(format!(
-                                "No certificate found in {:?} or {:?}",
-                                SSL_CERT_FILES, SSL_CERT_DIRS
+                                "No certificate found in {SSL_CERT_FILES:?} or {SSL_CERT_DIRS:?}"
                             ))
                         },
                         read_cert_dir_contents,
                     )
                 },
-                |path| {
-                    fs::read(path.clone()).map_err(|e| format!("Error reading {:?}: {:?}", path, e))
-                },
+                |path| fs::read(path.clone()).map_err(|e| format!("Error reading {path:?}: {e:?}")),
             )
         },
         |path| {
             if path.is_dir() {
                 read_cert_dir_contents(OsString::from(path))
             } else if path.is_file() {
-                fs::read(path.clone()).map_err(|e| format!("Error reading {:?}: {:?}", path, e))
+                fs::read(path.clone()).map_err(|e| format!("Error reading {path:?}: {e:?}"))
             } else {
-                Err(format!("{:?} is not a file or directory", path))
+                Err(format!("{path:?} is not a file or directory"))
             }
         },
     )

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/keyfile/src/bin/keygen_main.rs
+++ b/util/keyfile/src/bin/keygen_main.rs
@@ -42,7 +42,7 @@ fn main() {
     let mnemonic = Mnemonic::from_entropy(&entropy, Language::English)
         .expect("Could not create mnemonic from entropy");
 
-    println!("Writing to {:?}", path);
+    println!("Writing to {path:?}");
 
     keygen::write_keyfiles(
         path,

--- a/util/keyfile/src/bin/main.rs
+++ b/util/keyfile/src/bin/main.rs
@@ -14,21 +14,21 @@ use std::{
 fn print_keyfile_bytes(bytes: &[u8]) {
     let acct_key =
         if let Ok(identity) = mc_util_keyfile::read_root_entropy_keyfile_data(Cursor::new(bytes)) {
-            println!("Identity: {:?}", identity);
+            println!("Identity: {identity:?}");
             AccountKey::from(&identity)
         } else {
             mc_util_keyfile::read_keyfile_data(Cursor::new(bytes))
                 .expect("Could not parse key file as either mnemonic or legacy entropy")
         };
 
-    println!("{:?}", acct_key);
+    println!("{acct_key:?}");
 }
 
 fn main() {
     let mut n_files = 0usize;
     for path in env::args().skip(1) {
         print_keyfile_bytes(
-            &fs::read(path.clone()).unwrap_or_else(|_| panic!("Could not read file '{}'", path)),
+            &fs::read(path.clone()).unwrap_or_else(|_| panic!("Could not read file '{path}'")),
         );
         n_files += 1;
     }

--- a/util/keyfile/src/config.rs
+++ b/util/keyfile/src/config.rs
@@ -43,7 +43,7 @@ fn load_spki_from_pemfile(src: &str) -> Result<Vec<u8>, String> {
             .map_err(|e| e.to_string())?
             .contents,
     )
-    .map_err(|e| format!("{:?}", e))
+    .map_err(|e| format!("{e:?}"))
     .map(|cert| cert.subject_public_key_info().spki().to_vec())
 }
 

--- a/util/keyfile/src/error.rs
+++ b/util/keyfile/src/error.rs
@@ -39,25 +39,25 @@ impl From<AccountKeyError> for Error {
 
 impl From<ProstEncodeError> for Error {
     fn from(src: ProstEncodeError) -> Error {
-        Error::Encode(format!("{}", src))
+        Error::Encode(format!("{src}"))
     }
 }
 
 impl From<ProstDecodeError> for Error {
     fn from(src: ProstDecodeError) -> Error {
-        Error::Encode(format!("{}", src))
+        Error::Encode(format!("{src}"))
     }
 }
 
 impl From<IoError> for Error {
     fn from(src: IoError) -> Error {
-        Error::Io(format!("{}", src))
+        Error::Io(format!("{src}"))
     }
 }
 
 impl From<JsonError> for Error {
     fn from(src: JsonError) -> Error {
-        Error::Json(format!("{}", src))
+        Error::Json(format!("{src}"))
     }
 }
 

--- a/util/keyfile/src/keygen.rs
+++ b/util/keyfile/src/keygen.rs
@@ -60,7 +60,7 @@ pub fn write_keyfiles<P: AsRef<Path>>(
 
 /// Helper: Make i'th user's keyfiles' names
 fn keyfile_name(i: usize) -> String {
-    format!("account_keys_{}", i)
+    format!("account_keys_{i}")
 }
 
 /// Write the sequence of default user key files used in tests and demos

--- a/util/keyfile/src/mnemonic_acct.rs
+++ b/util/keyfile/src/mnemonic_acct.rs
@@ -52,7 +52,7 @@ impl TryFrom<UncheckedMnemonicAccount> for AccountKey {
             src.mnemonic.ok_or(Error::NoMnemonic)?.as_str(),
             Language::English,
         )
-        .map_err(|e| Error::InvalidMnemonic(format!("{}", e)))?;
+        .map_err(|e| Error::InvalidMnemonic(format!("{e}")))?;
         let slip10 = mnemonic.derive_slip10_key(src.account_index.ok_or(Error::NoAccountIndex)?);
         Ok(AccountKey::from(slip10).with_fog(
             src.fog_report_url.unwrap_or_default().as_str(),

--- a/util/keyfile/tests/b58-length.rs
+++ b/util/keyfile/tests/b58-length.rs
@@ -47,11 +47,10 @@ fn test_b58_pub_length() {
         for domain_len in 0..DOMAIN_LIMIT {
             assert!(
                 !test_b58pub_length(domain_len, 10, &mut rng),
-                "B58 address limit exceeded for domain length = {}",
-                domain_len
+                "B58 address limit exceeded for domain length = {domain_len}"
             );
         }
 
-        assert!(test_b58pub_length(DOMAIN_LIMIT, 10, &mut rng), "Domain limit is not computed correctly, we didn't exceed the limit with urls of length {}", DOMAIN_LIMIT);
+        assert!(test_b58pub_length(DOMAIN_LIMIT, 10, &mut rng), "Domain limit is not computed correctly, we didn't exceed the limit with urls of length {DOMAIN_LIMIT}");
     })
 }

--- a/util/keyfile/tests/bin-determinism.rs
+++ b/util/keyfile/tests/bin-determinism.rs
@@ -37,7 +37,7 @@ fn sample_keys_determinism() {
     let tempdir_path = tempdir.path().to_str().expect("tempdir was not UTF-8");
 
     assert!(Command::new(sample_keys_bin.clone())
-        .args(&[
+        .args([
             "--output-dir",
             tempdir_path,
             "--num",
@@ -56,7 +56,7 @@ fn sample_keys_determinism() {
     let tempdir2 = tempfile::tempdir().expect("Could not create tempdir2");
     let tempdir2_path = tempdir2.path().to_str().expect("tempdir2 was not UTF-8");
     assert!(Command::new(sample_keys_bin)
-        .args(&[
+        .args([
             "--output-dir",
             tempdir2_path,
             "--num",
@@ -73,7 +73,7 @@ fn sample_keys_determinism() {
         .success());
 
     assert!(Command::new("diff")
-        .args(&["-rq", tempdir_path, tempdir2_path])
+        .args(["-rq", tempdir_path, tempdir2_path])
         .status()
         .expect("Diff reported unexpected differences, this indicates nondeterminism")
         .success());
@@ -104,7 +104,7 @@ fn sample_keys_determinism2() {
     let tempdir_path = tempdir.path().to_str().expect("tempdir was not UTF-8");
 
     assert!(Command::new(sample_keys_bin.clone())
-        .args(&[
+        .args([
             "--output-dir",
             tempdir_path,
             "--num",
@@ -123,7 +123,7 @@ fn sample_keys_determinism2() {
     let tempdir2 = tempfile::tempdir().expect("Could not create tempdir2");
     let tempdir2_path = tempdir2.path().to_str().expect("tempdir2 was not UTF-8");
     assert!(Command::new(sample_keys_bin)
-        .args(&[
+        .args([
             "--output-dir",
             tempdir2_path,
             "--num",
@@ -140,7 +140,7 @@ fn sample_keys_determinism2() {
         .success());
     // exclude 1, any character, ., in order to exclude numbers 10 - 19
     assert!(Command::new("diff")
-        .args(&[
+        .args([
             "-rq",
             "--exclude=*1[0123456789].*",
             tempdir_path,

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/metrics/src/json_encoder.rs
+++ b/util/metrics/src/json_encoder.rs
@@ -45,11 +45,11 @@ impl Encoder for JsonEncoder {
                         // write the sum and counts
                         let h = m.get_histogram();
                         export_me.insert(
-                            flatten_metric_with_labels(&format!("{}_count", name), m),
+                            flatten_metric_with_labels(&format!("{name}_count"), m),
                             h.get_sample_count() as f64,
                         );
                         export_me.insert(
-                            flatten_metric_with_labels(&format!("{}_sum", name), m),
+                            flatten_metric_with_labels(&format!("{name}_sum"), m),
                             h.get_sample_sum(),
                         );
                     }
@@ -96,7 +96,7 @@ fn flatten_metric_with_labels(name: &str, metric: &Metric) -> String {
             .collect();
         let values = values.join(".");
         if !values.is_empty() {
-            format!("{}.{}", res, values)
+            format!("{res}.{values}")
         } else {
             res
         }

--- a/util/metrics/src/op_counters.rs
+++ b/util/metrics/src/op_counters.rs
@@ -26,38 +26,38 @@ impl OpMetrics {
         let name_str = name.into();
         OpMetrics {
             counters: IntCounterVec::new(
-                Opts::new(name_str.clone(), format!("Counters for {}", name_str)),
+                Opts::new(name_str.clone(), format!("Counters for {name_str}")),
                 &["op"],
             )
             .unwrap(),
             peer_counters: IntCounterVec::new(
                 Opts::new(
-                    format!("{}_peer_counter", name_str),
-                    format!("Counters for each remote peer of {}", name_str),
+                    format!("{name_str}_peer_counter"),
+                    format!("Counters for each remote peer of {name_str}"),
                 ),
                 &["op", "remote_responder_id"],
             )
             .unwrap(),
             gauges: IntGaugeVec::new(
                 Opts::new(
-                    format!("{}_gauge", name_str),
-                    format!("Gauges for {}", name_str),
+                    format!("{name_str}_gauge"),
+                    format!("Gauges for {name_str}"),
                 ),
                 &["op"],
             )
             .unwrap(),
             peer_gauges: IntGaugeVec::new(
                 Opts::new(
-                    format!("{}_peer_gauge", name_str),
-                    format!("Gauges for each remote peer of {}", name_str),
+                    format!("{name_str}_peer_gauge"),
+                    format!("Gauges for each remote peer of {name_str}"),
                 ),
                 &["op", "remote_responder_id"],
             )
             .unwrap(),
             histograms: HistogramVec::new(
                 HistogramOpts::new(
-                    format!("{}_duration", name_str),
-                    format!("Histogram values for {}", name_str),
+                    format!("{name_str}_duration"),
+                    format!("Histogram values for {name_str}"),
                 ),
                 &["op"],
             )

--- a/util/metrics/src/service_metrics.rs
+++ b/util/metrics/src/service_metrics.rs
@@ -90,18 +90,18 @@ impl ServiceMetrics {
 
         ServiceMetrics {
             num_req: IntCounterVec::new(
-                Opts::new(format!("{}_num_req", name_str), "Number of requests"),
+                Opts::new(format!("{name_str}_num_req"), "Number of requests"),
                 &["method"],
             )
             .unwrap(),
             num_error: IntCounterVec::new(
-                Opts::new(format!("{}_num_error", name_str), "Number of errors"),
+                Opts::new(format!("{name_str}_num_error"), "Number of errors"),
                 &["method"],
             )
             .unwrap(),
             num_status_code: IntCounterVec::new(
                 Opts::new(
-                    format!("{}_num_status_code", name_str),
+                    format!("{name_str}_num_status_code"),
                     "Number of grpc status codes",
                 ),
                 &["method", "status_code"],
@@ -110,7 +110,7 @@ impl ServiceMetrics {
             duration: HistogramVec::new(
                 //TODO: frumious: how to ensure units?
                 HistogramOpts::new(
-                    format!("{}_duration", name_str),
+                    format!("{name_str}_duration"),
                     "Duration for a request, in units of time",
                 ),
                 &["method"],
@@ -118,7 +118,7 @@ impl ServiceMetrics {
             .unwrap(),
             message_size: HistogramVec::new(
                 HistogramOpts::new(
-                    format!("{}_message_size", name_str),
+                    format!("{name_str}_message_size"),
                     "gRPC message size, in bytes (or close to)",
                 )
                 .buckets(message_size_buckets),
@@ -127,7 +127,9 @@ impl ServiceMetrics {
             .unwrap(),
         }
     }
+}
 
+impl ServiceMetrics {
     /// Register Prometheus metrics family
     pub fn new_and_registered<S: Into<String>>(name: S) -> ServiceMetrics {
         let svc = ServiceMetrics::new(name);

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/parse/src/lib.rs
+++ b/util/parse/src/lib.rs
@@ -24,9 +24,9 @@ pub fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseI
 /// as other stuff.
 pub fn load_css_file(filename: &str) -> Result<CssSignature, String> {
     let bytes =
-        fs::read(filename).map_err(|err| format!("Failed reading file '{}': {}", filename, err))?;
+        fs::read(filename).map_err(|err| format!("Failed reading file '{filename}': {err}"))?;
     let signature = CssSignature::try_from(&bytes[..])
-        .map_err(|err| format!("Failed parsing CSS file '{}': {}", filename, err))?;
+        .map_err(|err| format!("Failed parsing CSS file '{filename}': {err}"))?;
     Ok(signature)
 }
 

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -576,7 +576,7 @@ mod tests {
     fn twenty_bytes_debug_hex() {
         let value = TwentyBytes { bytes: [0xBA; 20] };
         assert_eq!(
-            format!("{:?}", value),
+            format!("{value:?}"),
             "TwentyBytes(babababababababababababababababababababa)"
         );
     }
@@ -585,7 +585,7 @@ mod tests {
     fn twenty_bytes_display_hex() {
         let value = TwentyBytes { bytes: [0xBA; 20] };
         assert_eq!(
-            format!("{}", value),
+            format!("{value}"),
             "babababababababababababababababababababa"
         );
     }

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/seeded-ed25519-key-gen/src/main.rs
+++ b/util/seeded-ed25519-key-gen/src/main.rs
@@ -30,5 +30,5 @@ fn main() {
         tag: String::from("PRIVATE KEY"),
         contents: der_bytes,
     });
-    println!("{}", pem);
+    println!("{pem}");
 }

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/serial/src/lib.rs
+++ b/util/serial/src/lib.rs
@@ -140,8 +140,7 @@ pub fn round_trip_message<SRC: Message + Eq + Default, DEST: protobuf::Message>(
 
     assert_eq!(
         *prost_val, final_val,
-        "Round-trip check failed!\nprost: {:?}\nprotobuf: {:?}",
-        prost_val, final_val
+        "Round-trip check failed!\nprost: {prost_val:?}\nprotobuf: {final_val:?}"
     );
 }
 
@@ -193,7 +192,7 @@ mod json_u64_tests {
     #[test]
     fn test_serialize_jsonu64_struct() {
         let the_struct = TestStruct {
-            nums: (&[0, 1, 2, u64::MAX]).iter().map(Into::into).collect(),
+            nums: [0, 1, 2, u64::MAX].iter().map(Into::into).collect(),
             block: JsonU64(u64::MAX - 1),
         };
         let serialized = serialize(&the_struct).unwrap();

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-helper/src/bin/generate_account_keys.rs
+++ b/util/test-helper/src/bin/generate_account_keys.rs
@@ -45,8 +45,8 @@ fn main() {
         } else {
             print!(" ");
         }
-        println!("{{\"vpk\":{:?},", vpk);
-        println!("   \"spk\":{:?}}}", spk);
+        println!("{{\"vpk\":{vpk:?},");
+        println!("   \"spk\":{spk:?}}}");
         remaining -= 1;
         i += 1;
     }

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/test-vector/src/lib.rs
+++ b/util/test-vector/src/lib.rs
@@ -15,16 +15,16 @@ pub trait TestVector: Sized {
     {
         let filename = format!("{}/{}/{}.jsonl", dir, Self::MODULE_SUBDIR, Self::FILE_NAME);
         let file = File::open(filename.clone())
-            .unwrap_or_else(|_| panic!("cannot read file '{}'", filename));
+            .unwrap_or_else(|_| panic!("cannot read file '{filename}'"));
 
         BufReader::new(file)
             .lines()
             .enumerate()
             .map(|(i, line)| {
-                let line = line
-                    .unwrap_or_else(|_| panic!("cannot read line {} of file '{}'", i, filename));
+                let line =
+                    line.unwrap_or_else(|_| panic!("cannot read line {i} of file '{filename}'"));
                 serde_json::from_str(&line)
-                    .unwrap_or_else(|_| panic!("cannot parse line {} of file '{}'", i, filename))
+                    .unwrap_or_else(|_| panic!("cannot parse line {i} of file '{filename}'"))
             })
             .collect()
     }

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/util/uri/src/lib.rs
+++ b/util/uri/src/lib.rs
@@ -335,10 +335,9 @@ mod consensus_peer_uri_tests {
 
         let mut seeded_rng: FixedRng = SeedableRng::from_seed([0u8; 32]);
         let signer_key = Ed25519Pair::from_random(&mut seeded_rng);
-        let hex_pubkey = hex::encode(&signer_key.public_key());
+        let hex_pubkey = hex::encode(signer_key.public_key());
         let uri = PeerUri::from_str(&format!(
-            "mcp://node1.test.mobilecoin.com/?consensus-msg-key={}",
-            hex_pubkey
+            "mcp://node1.test.mobilecoin.com/?consensus-msg-key={hex_pubkey}"
         ))
         .unwrap();
         assert_eq!(

--- a/util/uri/src/traits.rs
+++ b/util/uri/src/traits.rs
@@ -176,7 +176,7 @@ pub trait ConnectionUri:
     fn tls_chain(&self) -> StdResult<Vec<u8>, String> {
         let path = self.tls_chain_path()?;
         std::fs::read(path.clone())
-            .map_err(|e| format!("Failed reading TLS chain from {}: {:?}", path, e))
+            .map_err(|e| format!("Failed reading TLS chain from {path}: {e:?}"))
     }
 
     /// Retrieve the TLS key file path to use for this connection.
@@ -189,7 +189,7 @@ pub trait ConnectionUri:
     fn tls_key(&self) -> StdResult<Vec<u8>, String> {
         let path = self.tls_key_path()?;
         std::fs::read(path.clone())
-            .map_err(|e| format!("Failed reading TLS key from {}: {:?}", path, e))
+            .map_err(|e| format!("Failed reading TLS key from {path}: {e:?}"))
     }
 }
 

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A map object based on heapless Vec"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -41,7 +41,7 @@ hex = "0.4"
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
-rayon = "1.5"
+rayon = "1.6"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 toml = "0.5"
 url = "2.3"

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/watcher/src/bin/db-dump.rs
+++ b/watcher/src/bin/db-dump.rs
@@ -47,7 +47,7 @@ fn main() {
 
     println!("Last synced blocks:");
     for (url, block_index) in last_synced_blocks.iter() {
-        println!("{:width$}: {:?}", url, block_index, width = max_url_len);
+        println!("{url:max_url_len$}: {block_index:?}");
     }
     println!();
 
@@ -66,10 +66,7 @@ fn main() {
                 Ok(block_data) => block_data.signature().map(|sig| *sig.signer()),
                 Err(WatcherDBError::NotFound) => None,
                 Err(err) => {
-                    panic!(
-                        "Failed getting block {}@{}: {}",
-                        tx_src_url, cur_start_index, err
-                    );
+                    panic!("Failed getting block {tx_src_url}@{cur_start_index}: {err}");
                 }
             };
 
@@ -84,7 +81,7 @@ fn main() {
         }
         ranges.push(((cur_start_index, cur_end_index), cur_signer.take()));
 
-        println!("{}", tx_src_url);
+        println!("{tx_src_url}");
         for ((start, end), signer) in ranges.iter() {
             let report_status = display_report_status(&watcher_db, tx_src_url, signer);
 

--- a/watcher/src/block_data_store.rs
+++ b/watcher/src/block_data_store.rs
@@ -93,9 +93,9 @@ impl BlockDataStore {
 
     /// Add a single BlockData that was fetched from `src_url` into the
     /// database.
-    pub fn add_block_data<'env>(
+    pub fn add_block_data(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         block_data: &BlockData,
     ) -> Result<(), WatcherDBError> {
@@ -169,7 +169,7 @@ impl BlockDataStore {
         let first_key_bytes = block_index.to_be_bytes();
 
         let mut results = HashMap::default();
-        for (key_bytes, value_bytes) in cursor.iter_from(&first_key_bytes).filter_map(Result::ok) {
+        for (key_bytes, value_bytes) in cursor.iter_from(first_key_bytes).filter_map(Result::ok) {
             // Try and get the index and tx source url from the database key.
             // Remember that the key is the block index , followed by the source url.
             if key_bytes.len() < first_key_bytes.len() {
@@ -210,9 +210,9 @@ impl BlockDataStore {
     /// that there are no gaps (no blocks were skipped).
     /// It does not remove Block/BlockContents as those might be shared with
     /// other source URLs.
-    pub fn remove_all_for_source_url<'env>(
+    pub fn remove_all_for_source_url(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         last_synced_block_index: u64,
     ) -> Result<(), WatcherDBError> {
@@ -237,9 +237,9 @@ impl BlockDataStore {
         Ok(())
     }
 
-    fn store_block<'env>(
+    fn store_block(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         block: &Block,
     ) -> Result<Vec<u8>, WatcherDBError> {
         let hash = block.digest32::<MerlinTranscript>(b"block").to_vec();
@@ -255,9 +255,9 @@ impl BlockDataStore {
         }
     }
 
-    fn store_block_contents<'env>(
+    fn store_block_contents(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         block_contents: &BlockContents,
     ) -> Result<Vec<u8>, WatcherDBError> {
         let hash: Vec<u8> = block_contents.hash().as_ref().to_vec();

--- a/watcher/src/config.rs
+++ b/watcher/src/config.rs
@@ -99,7 +99,7 @@ impl SourceConfig {
         if !url.ends_with('/') {
             url.push('/');
         }
-        Url::from_str(&url).unwrap_or_else(|err| panic!("invalid url {}: {}", url, err))
+        Url::from_str(&url).unwrap_or_else(|err| panic!("invalid url {url}: {err}"))
     }
 
     /// Get consensus client URL, if available.
@@ -111,7 +111,7 @@ impl SourceConfig {
     pub fn consensus_client_auth_token_secret(&self) -> Option<[u8; 32]> {
         self.consensus_client_auth_token_secret.as_ref().map(|s| {
             hex::FromHex::from_hex(s).unwrap_or_else(|err| {
-                panic!("failed parsing consensus client auth token secret: {}", err)
+                panic!("failed parsing consensus client auth token secret: {err}")
             })
         })
     }

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -83,27 +83,22 @@ impl NodeClient for ConsensusNodeClient {
             credentials_provider,
             logger,
         )
-        .map_err(|err| {
-            format!(
-                "Failed constructing client to connect to {}: {}",
-                node_url, err
-            )
-        })?;
+        .map_err(|err| format!("Failed constructing client to connect to {node_url}: {err}"))?;
 
         client
             .attest()
-            .map_err(|err| format!("Failed attesting {}: {}", node_url, err))
+            .map_err(|err| format!("Failed attesting {node_url}: {err}"))
     }
 
     /// Get the block signer key out of a VerificationReport
     fn get_block_signer(verification_report: &VerificationReport) -> Result<Ed25519Public, String> {
         let report_data = VerificationReportData::try_from(verification_report)
-            .map_err(|err| format!("Failed constructing VerificationReportData: {}", err))?;
+            .map_err(|err| format!("Failed constructing VerificationReportData: {err}"))?;
 
         let report_body = report_data
             .quote
             .report_body()
-            .map_err(|err| format!("Failed getting report body: {}", err))?;
+            .map_err(|err| format!("Failed getting report body: {err}"))?;
 
         let custom_data = report_body.report_data();
         let custom_data_bytes: &[u8] = custom_data.as_ref();
@@ -118,7 +113,7 @@ impl NodeClient for ConsensusNodeClient {
         let signer_bytes = &custom_data_bytes[32..];
 
         let signer_public_key = Ed25519Public::try_from(signer_bytes)
-            .map_err(|err| format!("Unable to construct key: {}", err))?;
+            .map_err(|err| format!("Unable to construct key: {err}"))?;
 
         Ok(signer_public_key)
     }
@@ -659,8 +654,7 @@ mod tests {
 
             if tries == 0 {
                 panic!(
-                    "report not synced: reports_signer2:{:?} reports_signer3:{:?}",
-                    reports_signer2, reports_signer3
+                    "report not synced: reports_signer2:{reports_signer2:?} reports_signer3:{reports_signer3:?}"
                 );
             }
             tries -= 1;

--- a/watcher/src/watcher_db.rs
+++ b/watcher/src/watcher_db.rs
@@ -15,6 +15,7 @@ use mc_util_lmdb::{MetadataStore, MetadataStoreSettings};
 use mc_util_repr_bytes::ReprBytes;
 use mc_util_serial::{decode, encode, Message};
 use mc_watcher_api::TimestampResultCode;
+use serde::{Deserialize, Serialize};
 
 use lmdb::{
     Cursor, Database, DatabaseFlags, Environment, EnvironmentFlags, RwTransaction, Transaction,
@@ -93,7 +94,7 @@ pub const POLL_BLOCK_TIMESTAMP_POLLING_FREQUENCY: Duration = Duration::from_mill
 pub const POLL_BLOCK_TIMESTAMP_ERROR_RETRY_FREQUENCY: Duration = Duration::from_millis(1000);
 
 /// Block Signature Data for Signature Store.
-#[derive(Message, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Eq, Message, PartialEq, Serialize)]
 pub struct BlockSignatureData {
     /// The src_url for the archive block.
     #[prost(message, required, tag = "1")]
@@ -383,7 +384,7 @@ impl WatcherDB {
         );
 
         cursor
-            .iter_dup_of(&key_bytes)
+            .iter_dup_of(key_bytes)
             .map(|result| {
                 let (key_bytes2, value_bytes) = result?;
                 // Sanity check.
@@ -574,7 +575,7 @@ impl WatcherDB {
         let mut cursor = db_txn.open_ro_cursor(self.config)?;
 
         cursor
-            .iter_dup_of(&CONFIG_DB_KEY_TX_SOURCE_URLS)
+            .iter_dup_of(CONFIG_DB_KEY_TX_SOURCE_URLS)
             .filter_map(|r| r.ok())
             .map(|(_db_key, db_value)| bytes_to_url(db_value))
             .collect()
@@ -708,9 +709,9 @@ impl WatcherDB {
 
     /// A helper for writing a single (src_url, signer) -> VerificationReport
     /// entry in the database.
-    fn write_verification_report<'env>(
+    fn write_verification_report(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         signer: &Ed25519Public,
         verification_report: Option<&VerificationReport>,
@@ -900,9 +901,9 @@ impl WatcherDB {
     /// Note that this method is not exposed outside of this object. It is used
     /// inside `add_block_signature` to ensure all block signers get queued
     /// up automatically.
-    fn queue_verification_report_poll<'env>(
+    fn queue_verification_report_poll(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         expected_block_signer: &Ed25519Public,
     ) -> Result<(), WatcherDBError> {
@@ -970,9 +971,9 @@ impl WatcherDB {
     }
 
     /// Remove a single entry from the verification report polling queue
-    fn remove_verification_report_poll_from_queue<'env>(
+    fn remove_verification_report_poll_from_queue(
         &self,
-        db_txn: &mut RwTransaction<'env>,
+        db_txn: &mut RwTransaction<'_>,
         src_url: &Url,
         block_signer: &Ed25519Public,
     ) -> Result<(), WatcherDBError> {
@@ -1124,7 +1125,7 @@ pub mod tests {
         let url1 = Url::parse("http://www.my_url1.com").unwrap();
         let url2 = Url::parse("http://www.my_url2.com").unwrap();
         let urls = [url1, url2];
-        let watcher_db = setup_watcher_db(&urls, logger.clone());
+        let watcher_db = setup_watcher_db(&urls, logger);
 
         let blocks = setup_blocks();
 
@@ -1202,7 +1203,7 @@ pub mod tests {
     // Config URL storage should behave as expected.
     #[test_with_logger]
     fn test_config_urls(logger: Logger) {
-        let watcher_db = setup_watcher_db(&[], logger.clone());
+        let watcher_db = setup_watcher_db(&[], logger);
 
         // Initially, the configuration is empty.
         assert!(watcher_db
@@ -1849,7 +1850,7 @@ pub mod tests {
 
         let blocks_data = setup_blocks();
 
-        let watcher_db = setup_watcher_db(&urls, logger.clone());
+        let watcher_db = setup_watcher_db(&urls, logger);
 
         // Removing a URL that has no data should work.
         watcher_db.remove_all_for_source_url(&url1).unwrap();


### PR DESCRIPTION
### Motivation

Periodic roll up of changes from v4.1 to master branch.

- Remove cd triggers for PRs, main and master branches (#3029) 
- add SignedContingentInput proto conversion (#3022) 
- add Clone/serde traits to watcher_db::BlockSignatureData, this makes it easier to expose it over APIs such as in full-service (#3035)
- always include the masked amount version (#3036) 
- support streaming ring signature signing and verification (#2786)
- add account::ViewAccount, keys::{TxOutPublic, TxOutTargetPublic} to core, improve prost support for key types (#2901)
- Cleanup in preparation for 2023-01-04 rust (#3020)
- release/V4.0 - fix(charts): fix blocklist logic (#3048)
- chore: update changelog and bump cargo versions for v4.0.2 (#3050) 
- merge release/v4.0 (4.0.2)
- Merge pull request #3061 from mobilecoinfoundation/merge-release-v4.0-v4-0-2
- release/v4.1 - feat(cd/testing): add ability to manually deploy a test/main network to dev (#3047)

