### PR TITLE
write additional helpful data in the json slam report

### DIFF
--- a/mobilecoind-dev-faucet/src/data_types.rs
+++ b/mobilecoind-dev-faucet/src/data_types.rs
@@ -307,14 +307,15 @@ pub struct JsonSlamReport {
 
 impl From<SlamReport> for JsonSlamReport {
     fn from(src: SlamReport) -> JsonSlamReport {
+        let submit_time_ms = src.submit_time.as_millis().try_into().unwrap_or(0);
         Self {
             num_prepared_utxos: src.num_prepared_utxos,
             num_submitted_txs: src.num_submitted_txs,
             prepare_time_ms: src.prepare_time.as_millis().try_into().unwrap_or(0),
-            submit_time_ms: src.submit_time.as_millis().try_into().unwrap_or(0),
+            submit_time_ms,
             avg_slam_rate_tx_per_second: format!(
                 "{:.4}",
-                (num_submitted_txs as f64) / (submit_time_ms as f64 * 1000f64)
+                (src.num_submitted_txs as f64) / (submit_time_ms as f64 * 1000f64)
             ),
         }
     }

--- a/mobilecoind-dev-faucet/src/data_types.rs
+++ b/mobilecoind-dev-faucet/src/data_types.rs
@@ -298,9 +298,11 @@ pub struct JsonSlamReport {
     /// Num txs submitted
     pub num_submitted_txs: u32,
     /// Prepare duration in milliseconds
-    pub prepare_time: u32,
+    pub prepare_time_ms: u32,
     /// Submit duration in milliseconds
-    pub submit_time: u32,
+    pub submit_time_ms: u32,
+    /// Average slam rate in tx per second
+    pub avg_slam_rate_tx_per_second: String,
 }
 
 impl From<SlamReport> for JsonSlamReport {
@@ -308,8 +310,12 @@ impl From<SlamReport> for JsonSlamReport {
         Self {
             num_prepared_utxos: src.num_prepared_utxos,
             num_submitted_txs: src.num_submitted_txs,
-            prepare_time: src.prepare_time.as_millis().try_into().unwrap_or(0),
-            submit_time: src.submit_time.as_millis().try_into().unwrap_or(0),
+            prepare_time_ms: src.prepare_time.as_millis().try_into().unwrap_or(0),
+            submit_time_ms: src.submit_time.as_millis().try_into().unwrap_or(0),
+            avg_slam_rate_tx_per_second: format!(
+                "{:.4}",
+                (num_submitted_txs as f64) / (submit_time_ms as f64 * 1000f64)
+            ),
         }
     }
 }


### PR DESCRIPTION
this stores the units of the "prepare_time" and "submit_time" in the names of these json elements.

it also computes the average throughput of the slam operation -- total transactions divided by total time. this is a rough approximation to the peak tx/s that should be reasonably accurate for a sustained slam.

this number is obtained programmatically from the tool conducting the slam, rather than by humans looking at graphs, and so doesn't have the fuzziness of people judging lines, which in my mind gives it some merit to be worth reporting.
(not that it should replace the number we normally use)