### PR TITLE
Make Fog View Store return externally-addressable URI to Router

### DIFF
--- a/fog/types/src/view.rs
+++ b/fog/types/src/view.rs
@@ -697,7 +697,7 @@ mod tests {
     fn tx_out_search_result_conversion(payload_length: usize) {
         let fixed_tx_out_search_results = (0..10)
             .map(|i| {
-                let payload = vec![i; payload_length as usize];
+                let payload = vec![i; payload_length];
                 FixedTxOutSearchResult::new(vec![i], &payload, TxOutSearchResultCode::Found)
             })
             .collect::<Vec<_>>();

--- a/fog/view/enclave/impl/src/types.rs
+++ b/fog/view/enclave/impl/src/types.rs
@@ -157,13 +157,11 @@ fn are_all_remaining_blocks_missing(
     remaining_block_range: BlockRange,
     missed_block_ranges: &[BlockRange],
 ) -> bool {
-    (remaining_block_range.start_block..remaining_block_range.end_block)
-        .into_iter()
-        .all(|block_index| {
-            missed_block_ranges
-                .iter()
-                .any(|missed_block_range| missed_block_range.contains(block_index))
-        })
+    (remaining_block_range.start_block..remaining_block_range.end_block).all(|block_index| {
+        missed_block_ranges
+            .iter()
+            .any(|missed_block_range| missed_block_range.contains(block_index))
+    })
 }
 
 impl From<&[DecryptedMultiViewStoreQueryResponse]> for LastKnownData {

--- a/fog/view/server/src/block_tracker.rs
+++ b/fog/view/server/src/block_tracker.rs
@@ -217,7 +217,7 @@ mod tests {
 
     #[test_with_logger]
     fn next_blocks_empty(logger: Logger) {
-        let block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         assert_eq!(block_tracker.next_blocks(&[]).len(), 0);
     }
 
@@ -527,7 +527,7 @@ mod tests {
     // highest_fully_processed_block_count behaves as expected
     #[test_with_logger]
     fn highest_fully_processed_block_count_all_empty(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
 
         assert_eq!(
             block_tracker.highest_fully_processed_block_count(&[]),
@@ -538,7 +538,7 @@ mod tests {
     // Check with a key that hasn't yet processed anything.
     #[test_with_logger]
     fn highest_fully_processed_block_missing_blocks_nothing_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -561,7 +561,7 @@ mod tests {
     // are processed when the start block is 0.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed1(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
 
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
@@ -596,7 +596,7 @@ mod tests {
     // when the start block is greater than zero
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let rec = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -631,7 +631,7 @@ mod tests {
     // then the key is reported lost
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_block_processed3(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -677,7 +677,7 @@ mod tests {
     // When the slow one is marked lost, that unblocks progress.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -773,7 +773,7 @@ mod tests {
     // key is loaded
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_multiple_recs_some_lost2(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -886,7 +886,7 @@ mod tests {
     /// key, makes progress
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_followed_by_gap(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -980,7 +980,7 @@ mod tests {
     /// when everything works.
     #[test_with_logger]
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active(logger: Logger) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),
@@ -1119,7 +1119,7 @@ mod tests {
     fn highest_fully_processed_block_tracks_retired_key_concurrent_with_active_both_lost(
         logger: Logger,
     ) {
-        let mut block_tracker = BlockTracker::new(logger.clone(), EpochShardingStrategy::default());
+        let mut block_tracker = BlockTracker::new(logger, EpochShardingStrategy::default());
         let mut rng: StdRng = SeedableRng::from_seed([123u8; 32]);
         let mut rec1 = IngressPublicKeyRecord {
             key: CompressedRistrettoPublic::from_random(&mut rng),

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -187,6 +187,6 @@ impl FromStr for RouterClientListenUri {
             return Ok(RouterClientListenUri::Streaming(fog_view_router_uri));
         }
 
-        Err(format!("Incorrect ClientListenUri string: {}.", input))
+        Err(format!("Incorrect ClientListenUri string: {input}."))
     }
 }

--- a/fog/view/server/src/error.rs
+++ b/fog/view/server/src/error.rs
@@ -17,19 +17,19 @@ pub enum RouterServerError {
 
 impl From<grpcio::Error> for RouterServerError {
     fn from(src: grpcio::Error) -> Self {
-        RouterServerError::ViewStoreError(format!("{}", src))
+        RouterServerError::ViewStoreError(format!("{src}"))
     }
 }
 
 impl From<mc_common::ResponderIdParseError> for RouterServerError {
     fn from(src: mc_common::ResponderIdParseError) -> Self {
-        RouterServerError::ViewStoreError(format!("{}", src))
+        RouterServerError::ViewStoreError(src.to_string())
     }
 }
 
 impl From<mc_util_uri::UriParseError> for RouterServerError {
     fn from(src: mc_util_uri::UriParseError) -> Self {
-        RouterServerError::ViewStoreError(format!("{}", src))
+        RouterServerError::ViewStoreError(src.to_string())
     }
 }
 
@@ -52,11 +52,9 @@ pub fn router_server_err_to_rpc_status(
 ) -> RpcStatus {
     match src {
         RouterServerError::ViewStoreError(_) => {
-            rpc_internal_error(context, format!("{}", src), &logger)
+            rpc_internal_error(context, src.to_string(), &logger)
         }
-        RouterServerError::Enclave(_) => {
-            rpc_permissions_error(context, format!("{}", src), &logger)
-        }
+        RouterServerError::Enclave(_) => rpc_permissions_error(context, src.to_string(), &logger),
     }
 }
 

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -102,7 +102,7 @@ where
                 );
                 let rpc_permissions_error = rpc_permissions_error(
                     "fontend_accept",
-                    format!("Permission denied: {}", frontend_error),
+                    format!("Permission denied: {frontend_error}"),
                     logger,
                 );
                 Err(rpc_permissions_error)
@@ -119,7 +119,7 @@ where
         let query_request_aad: QueryRequestAAD = mc_util_serial::decode(aad).map_err(|err| {
             RpcStatus::with_message(
                 RpcStatusCode::INVALID_ARGUMENT,
-                format!("AAD deserialization error: {}", err),
+                format!("AAD deserialization error: {err}"),
             )
         })?;
 

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -202,7 +202,11 @@ where
     ) -> MultiViewStoreQueryResponse {
         let mut response = MultiViewStoreQueryResponse::new();
         let fog_view_store_uri_string = fog_view_store_uri.url().to_string();
-        log::info!(self.logger, "fog_view_store_uri_string is: {}", fog_view_store_uri_string);
+        log::info!(
+            self.logger,
+            "fog_view_store_uri_string is: {}",
+            fog_view_store_uri_string
+        );
         response.set_store_uri(fog_view_store_uri_string);
         let block_range = BlockRange::from(&self.sharding_strategy.get_block_range());
         response.set_block_range(block_range);

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -202,11 +202,6 @@ where
     ) -> MultiViewStoreQueryResponse {
         let mut response = MultiViewStoreQueryResponse::new();
         let fog_view_store_uri_string = fog_view_store_uri.url().to_string();
-        log::info!(
-            self.logger,
-            "fog_view_store_uri_string is: {}",
-            fog_view_store_uri_string
-        );
         response.set_store_uri(fog_view_store_uri_string);
         let block_range = BlockRange::from(&self.sharding_strategy.get_block_range());
         response.set_block_range(block_range);

--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -201,7 +201,9 @@ where
         queries: Vec<attest::NonceMessage>,
     ) -> MultiViewStoreQueryResponse {
         let mut response = MultiViewStoreQueryResponse::new();
-        response.set_store_uri(fog_view_store_uri.url().to_string());
+        let fog_view_store_uri_string = fog_view_store_uri.url().to_string();
+        log::info!(self.logger, "fog_view_store_uri_string is: {}", fog_view_store_uri_string);
+        response.set_store_uri(fog_view_store_uri_string);
         let block_range = BlockRange::from(&self.sharding_strategy.get_block_range());
         response.set_block_range(block_range);
         for query in queries.into_iter() {

--- a/fog/view/server/src/router_admin_service.rs
+++ b/fog/view/server/src/router_admin_service.rs
@@ -36,7 +36,7 @@ impl FogViewRouterAdminService {
         let view_store_uri = FogViewStoreUri::from_str(shard_uri).map_err(|_| {
             rpc_invalid_arg_error(
                 "add_shard",
-                format!("Shard uri string {} is invalid", shard_uri),
+                format!("Shard uri string {shard_uri} is invalid"),
                 logger,
             )
         })?;
@@ -47,7 +47,7 @@ impl FogViewRouterAdminService {
         {
             let error = rpc_precondition_error(
                 "add_shard",
-                format!("Shard uri {} already exists in the shard list", shard_uri),
+                format!("Shard uri {shard_uri} already exists in the shard list"),
                 logger,
             );
             return Err(error);

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -225,8 +225,7 @@ where
         return Err(router_server_err_to_rpc_status(
             "Query: timed out connecting to view stores",
             RouterServerError::ViewStoreError(format!(
-                "Received {} responses which failed to advance the MultiViewStoreRequest",
-                RETRY_COUNT
+                "Received {RETRY_COUNT} responses which failed to advance the MultiViewStoreRequest"
             )),
             logger.clone(),
         ));
@@ -296,7 +295,6 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
     let auth_unary_receiver = view_store_client.auth_async(&nonce_auth_request.into())?;
     let nonce_auth_response = auth_unary_receiver.await?;
 
-    let result = enclave.view_store_connect(view_store_id, nonce_auth_response.into())?;
-
-    Ok(result)
+    enclave.view_store_connect(view_store_id, nonce_auth_response.into())?;
+    Ok(())
 }

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -282,7 +282,7 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
     view_store_url: FogViewStoreUri,
     logger: Logger,
 ) -> Result<(), RouterServerError> {
-    let view_store_id = view_store_url.responder_id()?;
+    let view_store_id = view_store_url.host_and_port_responder_id()?;
     let nonce_auth_request = enclave.view_store_init(view_store_id.clone())?;
     let grpc_env = Arc::new(
         grpcio::EnvBuilder::new()

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -9,7 +9,7 @@ use futures::{future::try_join_all, SinkExt, TryStreamExt};
 use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
 use mc_attest_api::attest;
 use mc_attest_enclave_api::SealedClientMessage;
-use mc_common::logger::{log, Logger};
+use mc_common::logger::Logger;
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse, MultiViewStoreQueryRequest},
     view_grpc::FogViewStoreApiClient,
@@ -283,7 +283,6 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
     logger: Logger,
 ) -> Result<(), RouterServerError> {
     let view_store_id = view_store_url.host_and_port_responder_id()?;
-    log::info!(logger, "view_store_id: {}", view_store_id);
     let nonce_auth_request = enclave.view_store_init(view_store_id.clone())?;
     let grpc_env = Arc::new(
         grpcio::EnvBuilder::new()

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -9,7 +9,7 @@ use futures::{future::try_join_all, SinkExt, TryStreamExt};
 use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
 use mc_attest_api::attest;
 use mc_attest_enclave_api::SealedClientMessage;
-use mc_common::logger::Logger;
+use mc_common::logger::{log, Logger};
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse, MultiViewStoreQueryRequest},
     view_grpc::FogViewStoreApiClient,
@@ -283,6 +283,7 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
     logger: Logger,
 ) -> Result<(), RouterServerError> {
     let view_store_id = view_store_url.host_and_port_responder_id()?;
+    log::info!(logger, "view_store_id: {}", view_store_id);
     let nonce_auth_request = enclave.view_store_init(view_store_id.clone())?;
     let grpc_env = Arc::new(
         grpcio::EnvBuilder::new()

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -113,6 +113,8 @@ where
         let uri = FogViewStoreUri::try_from_responder_id(responder_id, use_tls)
             .expect("Could not create uri from responder id");
 
+        log::debug!(logger, "Fog View Store URI is: {}", uri);
+
         let fog_view_service = view_grpc::create_fog_view_store_api(FogViewService::new(
             enclave.clone(),
             Arc::new(recovery_db),

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -112,8 +112,7 @@ where
             .expect("Could not get store responder id");
         let uri = FogViewStoreUri::try_from_responder_id(responder_id, use_tls)
             .expect("Could not create uri from responder id");
-
-        log::debug!(logger, "Fog View Store URI is: {}", uri);
+        log::info!(logger, "Fog View Store URI is: {}", uri);
 
         let fog_view_service = view_grpc::create_fog_view_store_api(FogViewService::new(
             enclave.clone(),

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -112,7 +112,6 @@ where
             .expect("Could not get store responder id");
         let uri = FogViewStoreUri::try_from_responder_id(responder_id, use_tls)
             .expect("Could not create uri from responder id");
-        log::info!(logger, "Fog View Store URI is: {}", uri);
 
         let fog_view_service = view_grpc::create_fog_view_store_api(FogViewService::new(
             enclave.clone(),

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -68,6 +68,8 @@ pub fn process_shard_responses(
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::AuthenticationError => {
                 shards_for_retry.push(shard);
                 let uri = FogViewStoreUri::from_str(&response.store_uri)?;
+                view_store_uris_for_authentication
+                    .push(FogViewStoreUri::from_str(&response.store_uri)?);
                 log::info!(logger, "process_shard_responses uri is: {}", uri);
             }
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -69,8 +69,6 @@ pub fn process_shard_responses(
                 shards_for_retry.push(shard);
                 let uri = FogViewStoreUri::from_str(&response.store_uri)?;
                 log::info!(logger, "process_shard_responses uri is: {}", uri);
-                view_store_uris_for_authentication
-                    .push(uri);
             }
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,
             // hasn't returned a new query response, and shouldn't be retried yet.

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -70,7 +70,6 @@ pub fn process_shard_responses(
                 let uri = FogViewStoreUri::from_str(&response.store_uri)?;
                 view_store_uris_for_authentication
                     .push(FogViewStoreUri::from_str(&response.store_uri)?);
-                log::info!(logger, "process_shard_responses uri is: {}", uri);
             }
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,
             // hasn't returned a new query response, and shouldn't be retried yet.

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -172,7 +172,7 @@ mod tests {
         let successful_mvq_response = create_successful_mvq_response(shard_index, block_range);
         let shards_and_responses = vec![(shard, successful_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -189,7 +189,7 @@ mod tests {
         let successful_mvq_response = create_successful_mvq_response(shard_index, block_range);
         let shards_and_responses = vec![(shard, successful_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -206,7 +206,7 @@ mod tests {
         let successful_mvq_response = create_successful_mvq_response(shard_index, block_range);
         let shards_and_responses = vec![(shard, successful_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -227,7 +227,7 @@ mod tests {
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -248,7 +248,7 @@ mod tests {
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -269,7 +269,7 @@ mod tests {
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -290,7 +290,7 @@ mod tests {
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -311,7 +311,7 @@ mod tests {
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -331,7 +331,7 @@ mod tests {
             mc_fog_api::view::MultiViewStoreQueryResponseStatus::NOT_READY,
         );
         let shards_and_responses = vec![(shard, failed_mvq_response)];
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_ok());
 
@@ -363,7 +363,7 @@ mod tests {
             shards_and_clients.push((shard, successful_mvq_response));
         }
 
-        let result = process_shard_responses(shards_and_clients, logger.clone());
+        let result = process_shard_responses(shards_and_clients, logger);
         assert!(result.is_ok());
         let processed_shard_response_data = result.unwrap();
 
@@ -395,7 +395,7 @@ mod tests {
         let response = create_successful_mvq_response(shard_index, response_block_range);
         let shards_and_responses = vec![(shard, response)];
 
-        let result = process_shard_responses(shards_and_responses, logger.clone());
+        let result = process_shard_responses(shards_and_responses, logger);
 
         assert!(result.is_err());
     }

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -67,8 +67,10 @@ pub fn process_shard_responses(
             // Store.
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::AuthenticationError => {
                 shards_for_retry.push(shard);
+                let uri = FogViewStoreUri::from_str(&response.store_uri)?;
+                log::info!(logger, "process_shard_responses uri is: {}", uri);
                 view_store_uris_for_authentication
-                    .push(FogViewStoreUri::from_str(&response.store_uri)?);
+                    .push(uri);
             }
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,
             // hasn't returned a new query response, and shouldn't be retried yet.

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -67,7 +67,6 @@ pub fn process_shard_responses(
             // Store.
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::AuthenticationError => {
                 shards_for_retry.push(shard);
-                let uri = FogViewStoreUri::from_str(&response.store_uri)?;
                 view_store_uris_for_authentication
                     .push(FogViewStoreUri::from_str(&response.store_uri)?);
             }

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -231,7 +231,7 @@ impl RouterTestEnvironment {
                 let responder_id = ResponderId::from_str(&format!("127.0.0.1:{port}"))
                     .expect("Could not create responder id");
                 let uri = FogViewStoreUri::from_str(&format!(
-                    "insecure-fog-view-store://127.0.0.1:{port}?responder_id={};sharding_strategy={}",
+                    "insecure-fog-view-store://127.0.0.1:{port}?responder-id={};sharding_strategy={}",
                     responder_id,
                     epoch_sharding_strategy.to_string()
                 ))

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -9,6 +9,7 @@ use mc_blockchain_types::{Block, BlockID, BlockIndex};
 use mc_common::{
     logger::{log, Logger},
     time::SystemTimeProvider,
+    ResponderId,
 };
 use mc_fog_api::view_grpc::FogViewStoreApiClient;
 use mc_fog_recovery_db_iface::{AddBlockDataStatus, IngestInvocationId, RecoveryDb};
@@ -227,8 +228,11 @@ impl RouterTestEnvironment {
             let (store, store_uri) = {
                 let port = portpicker::pick_unused_port().expect("pick_unused_port");
                 let epoch_sharding_strategy = EpochShardingStrategy::new(store_block_range.clone());
+                let responder_id = ResponderId::from_str(&format!("127.0.0.1:{port}"))
+                    .expect("Could not create responder id");
                 let uri = FogViewStoreUri::from_str(&format!(
-                    "insecure-fog-view-store://127.0.0.1:{port}?sharding_strategy={}",
+                    "insecure-fog-view-store://127.0.0.1:{port}?responder_id={};sharding_strategy={}",
+                    responder_id,
                     epoch_sharding_strategy.to_string()
                 ))
                 .unwrap();

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -231,7 +231,7 @@ impl RouterTestEnvironment {
                 let responder_id = ResponderId::from_str(&format!("127.0.0.1:{port}"))
                     .expect("Could not create responder id");
                 let uri = FogViewStoreUri::from_str(&format!(
-                    "insecure-fog-view-store://127.0.0.1:{port}?responder-id={};sharding_strategy={}",
+                    "insecure-fog-view-store://127.0.0.1:{port}?responder-id={}&sharding_strategy={}",
                     responder_id,
                     epoch_sharding_strategy.to_string()
                 ))

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -76,11 +76,11 @@ impl RouterTestEnvironment {
             Self::create_view_stores(omap_capacity, store_block_ranges, logger.clone());
         let port = portpicker::pick_unused_port().expect("pick_unused_port");
         let router_uri =
-            FogViewRouterUri::from_str(&format!("insecure-fog-view-router://127.0.0.1:{}", port))
+            FogViewRouterUri::from_str(&format!("insecure-fog-view-router://127.0.0.1:{port}"))
                 .unwrap();
         let port = portpicker::pick_unused_port().expect("pick_unused_port");
         let admin_listen_uri =
-            AdminUri::from_str(&format!("insecure-mca://127.0.0.1:{}", port)).unwrap();
+            AdminUri::from_str(&format!("insecure-mca://127.0.0.1:{port}")).unwrap();
         let config = FogViewRouterConfig {
             chain_id: "local".to_string(),
             client_responder_id: router_uri
@@ -116,10 +116,10 @@ impl RouterTestEnvironment {
             Self::create_view_stores(omap_capacity, store_block_ranges, logger.clone());
         let port = portpicker::pick_unused_port().expect("pick_unused_port");
         let router_uri =
-            FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{}", port)).unwrap();
+            FogViewUri::from_str(&format!("insecure-fog-view://127.0.0.1:{port}")).unwrap();
         let port = portpicker::pick_unused_port().expect("pick_unused_port");
         let admin_listen_uri =
-            AdminUri::from_str(&format!("insecure-mca://127.0.0.1:{}", port)).unwrap();
+            AdminUri::from_str(&format!("insecure-mca://127.0.0.1:{port}")).unwrap();
         let chain_id = "local".to_string();
         let config = FogViewRouterConfig {
             chain_id: chain_id.clone(),
@@ -282,7 +282,7 @@ impl RouterTestEnvironment {
 
             let grpc_env = Arc::new(
                 grpcio::EnvBuilder::new()
-                    .name_prefix(format!("view-store-{}", i))
+                    .name_prefix(format!("view-store-{i}"))
                     .build(),
             );
             let store_client = FogViewStoreApiClient::new(
@@ -409,8 +409,7 @@ pub fn wait_for_highest_block_to_load(
         let server_num_blocks = get_highest_processed_block_count(store_servers);
         if server_num_blocks > db_num_blocks {
             panic!(
-                "Server num blocks should never be larger than db num blocks: {} > {}",
-                server_num_blocks, db_num_blocks
+                "Server num blocks should never be larger than db num blocks: {server_num_blocks} > {db_num_blocks}"
             );
         }
         if server_num_blocks == db_num_blocks {

--- a/fog/view/server/tests/unary_smoke_tests.rs
+++ b/fog/view/server/tests/unary_smoke_tests.rs
@@ -643,7 +643,7 @@ fn test_start_with_missing_range(store_count: usize, blocks_per_store: u64) {
     let store_block_ranges =
         mc_fog_view_server_test_utils::create_block_ranges(store_count, blocks_per_store);
     let mut test_environment =
-        RouterTestEnvironment::new_unary(VIEW_OMAP_CAPACITY, store_block_ranges, logger.clone());
+        RouterTestEnvironment::new_unary(VIEW_OMAP_CAPACITY, store_block_ranges, logger);
     let db = test_environment
         .db_test_context
         .as_ref()
@@ -705,7 +705,7 @@ fn test_middle_missing_range_with_decommission(store_count: usize, blocks_per_st
     let store_block_ranges =
         mc_fog_view_server_test_utils::create_block_ranges(store_count, blocks_per_store);
     let mut test_environment =
-        RouterTestEnvironment::new_unary(VIEW_OMAP_CAPACITY, store_block_ranges, logger.clone());
+        RouterTestEnvironment::new_unary(VIEW_OMAP_CAPACITY, store_block_ranges, logger);
     let db = test_environment
         .db_test_context
         .as_ref()

--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -2,6 +2,7 @@
 
 use crate::traits::{ConnectionUri, UriScheme};
 use displaydoc::Display;
+use mc_common::ResponderId;
 use percent_encoding::percent_decode_str;
 use std::{
     fmt::{Display, Formatter, Result as FmtResult},
@@ -77,6 +78,22 @@ impl<Scheme: UriScheme> ConnectionUri for Uri<Scheme> {
 
     fn password(&self) -> String {
         self.password.clone()
+    }
+}
+
+impl<Scheme: UriScheme> Uri<Scheme> {
+    /// Creates a `Uri` from a `ResponderId`
+    pub fn try_from_responder_id(
+        responder_id: ResponderId,
+        use_tls: bool,
+    ) -> Result<Self, UriParseError> {
+        let scheme = match use_tls {
+            true => Scheme::SCHEME_SECURE,
+            false => Scheme::SCHEME_INSECURE,
+        };
+        let uri_string = format!("{scheme}://{responder_id}");
+
+        Self::from_str(&uri_string)
     }
 }
 


### PR DESCRIPTION
### Motivation
When deploying Fog View Router to a local network, we discovered that the router was trying to contact the store via a url with host == `0.0.0.0`. This occurred because the store used its `client_listen_url` to construct the URI that it gave to the router during the auth process. The router was unable to contact the store because it operated on a different host, not the same host as the router.

To fix this, I added a `responder_id` query param to the `FogViewStoreUri`, and the value is the externally addressable responder_id in "{HOST}:{PORT}" format. This enables the router to contact the store running in the same local network on a different machine.