### PR TITLE
Fix e_tx_out_store

### DIFF
--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -196,8 +196,8 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         // ```
         let data_end = ValueSize::USIZE - value[0] as usize;
         let payload = &value[1..data_end];
-        // Use this instead of payload.len() because the slice `len` method isn't guaranteed to be
-        // constant time.
+        // Use this instead of payload.len() because the slice `len` method isn't
+        // guaranteed to be constant time.
         let payload_length = data_end - 1;
         result.ciphertext[0..payload_length].copy_from_slice(payload);
         result.payload_length = payload_length as u32;

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -141,7 +141,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
             result_code: TxOutSearchResultCode::InternalError as u32,
             ciphertext: vec![0u8; FIXED_CIPHERTEXT_LENGTH],
             // Use FIXED_CIPHERTEXT_LENGTH as the default. This will be updated in every scenario.
-            payload_length: FIXED_CIPHERTEXT_LENGTH as u32,
+            payload_length: 0 as u32,
         };
 
         // Early return for bad search key
@@ -196,7 +196,9 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         // ```
         let data_end = ValueSize::USIZE - value[0] as usize;
         let payload = &value[1..data_end];
-        let payload_length = payload.len();
+        // Use this instead of payload.len() because the slice `len` method isn't guaranteed to be
+        // constant time.
+        let payload_length = data_end - 1;
         result.ciphertext[0..payload_length].copy_from_slice(payload);
         result.payload_length = payload_length as u32;
 

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -140,7 +140,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
             search_key: search_key.to_vec(),
             result_code: TxOutSearchResultCode::InternalError as u32,
             ciphertext: vec![0u8; FIXED_CIPHERTEXT_LENGTH],
-            // Use FIXED_CIPHERTEXT_LENGTH as the default. This will be updated in every scenario.
+            // Use zero as the default. This value will be updated in every scenario.
             payload_length: 0,
         };
 

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -136,12 +136,12 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
 
     // Should this return a FixedTxOutSearchResult or just a TxOutSearchResult?
     pub fn find_record(&mut self, search_key: &[u8]) -> FixedTxOutSearchResult {
-        let payload_length = ValueSize::USIZE - 1 - self.last_ciphertext_size_byte as usize;
         let mut result = FixedTxOutSearchResult {
             search_key: search_key.to_vec(),
             result_code: TxOutSearchResultCode::InternalError as u32,
             ciphertext: vec![0u8; FIXED_CIPHERTEXT_LENGTH],
-            payload_length: payload_length as u32,
+            // Use FIXED_CIPHERTEXT_LENGTH as the default. This will be updated in every scenario.
+            payload_length: FIXED_CIPHERTEXT_LENGTH as u32,
         };
 
         // Early return for bad search key
@@ -189,12 +189,16 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
         // NOTE: As of right now, this code is not constant time and therefore
         // blocks the v5 release.
         // Code to implement:
+        // ```
         // const LENGTH_TO_COPY: usize = core::cmp::min(FIXED_CIPHERTEXT_LENGTH,
-        // ValueSize::USIZE - 1); (&result.ciphertext[..LENGTH_TO_COPY]).
-        // copy_from_slice(&value[1..LENGTH_TO_COPY]);
+        //   ValueSize::USIZE - 1);
+        // (&result.ciphertext[..LENGTH_TO_COPY]).copy_from_slice(&value[1..LENGTH_TO_COPY]);
+        // ```
         let data_end = ValueSize::USIZE - value[0] as usize;
         let payload = &value[1..data_end];
+        let payload_length = payload.len();
         result.ciphertext[0..payload_length].copy_from_slice(payload);
+        result.payload_length = payload_length as u32;
 
         result
     }

--- a/fog/view/enclave/impl/src/e_tx_out_store.rs
+++ b/fog/view/enclave/impl/src/e_tx_out_store.rs
@@ -141,7 +141,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ETxOutStore<OSC>
             result_code: TxOutSearchResultCode::InternalError as u32,
             ciphertext: vec![0u8; FIXED_CIPHERTEXT_LENGTH],
             // Use FIXED_CIPHERTEXT_LENGTH as the default. This will be updated in every scenario.
-            payload_length: 0 as u32,
+            payload_length: 0,
         };
 
         // Early return for bad search key

--- a/fog/view/server/tests/streaming_smoke_tests.rs
+++ b/fog/view/server/tests/streaming_smoke_tests.rs
@@ -407,13 +407,13 @@ fn test_streaming_integration(omap_capacity: u64, store_count: usize, blocks_per
 
         assert_eq!(sort_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_txs[0].result_code, 3);
-        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 255]);
-        assert_eq!(sort_txs[0].padding, vec![0u8; 0]);
+        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 0]);
+        assert_eq!(sort_txs[0].padding, vec![0u8; 255]);
     }
     {
         let mut sort_fixed_txs = result.fixed_tx_out_search_results.clone();
         sort_fixed_txs.sort_by(|x, y| x.search_key.cmp(&y.search_key));
-        let expected_payload_length = 255;
+        let expected_payload_length = 0;
 
         assert_eq!(sort_fixed_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_fixed_txs[0].result_code, 3);
@@ -423,7 +423,7 @@ fn test_streaming_integration(omap_capacity: u64, store_count: usize, blocks_per
         );
         assert_eq!(
             sort_fixed_txs[0].ciphertext[expected_payload_length..],
-            vec![0u8; 0]
+            vec![0u8; 255]
         );
         assert_eq!(
             sort_fixed_txs[0].payload_length as usize,

--- a/fog/view/server/tests/streaming_smoke_tests.rs
+++ b/fog/view/server/tests/streaming_smoke_tests.rs
@@ -407,13 +407,13 @@ fn test_streaming_integration(omap_capacity: u64, store_count: usize, blocks_per
 
         assert_eq!(sort_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_txs[0].result_code, 3);
-        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 232]);
-        assert_eq!(sort_txs[0].padding, vec![0u8; 23]);
+        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 255]);
+        assert_eq!(sort_txs[0].padding, vec![0u8; 0]);
     }
     {
         let mut sort_fixed_txs = result.fixed_tx_out_search_results.clone();
         sort_fixed_txs.sort_by(|x, y| x.search_key.cmp(&y.search_key));
-        let expected_payload_length = 232;
+        let expected_payload_length = 255;
 
         assert_eq!(sort_fixed_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_fixed_txs[0].result_code, 3);
@@ -423,7 +423,7 @@ fn test_streaming_integration(omap_capacity: u64, store_count: usize, blocks_per
         );
         assert_eq!(
             sort_fixed_txs[0].ciphertext[expected_payload_length..],
-            vec![0; 23]
+            vec![0u8; 0]
         );
         assert_eq!(
             sort_fixed_txs[0].payload_length as usize,

--- a/fog/view/server/tests/unary_smoke_tests.rs
+++ b/fog/view/server/tests/unary_smoke_tests.rs
@@ -482,8 +482,8 @@ fn test_view_integration(view_omap_capacity: u64, store_count: usize, blocks_per
         sort_txs.sort_by(|x, y| x.search_key.cmp(&y.search_key));
         assert_eq!(sort_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_txs[0].result_code, 3);
-        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 255]);
-        assert_eq!(sort_txs[0].padding, vec![0u8; 0]);
+        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 0]);
+        assert_eq!(sort_txs[0].padding, vec![0u8; 255]);
     }
     {
         let mut sort_fixed_txs = result.fixed_tx_out_search_results.clone();
@@ -492,7 +492,7 @@ fn test_view_integration(view_omap_capacity: u64, store_count: usize, blocks_per
         assert_eq!(sort_fixed_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_fixed_txs[0].result_code, 3);
         assert_eq!(sort_fixed_txs[0].ciphertext, vec![0u8; 255]);
-        assert_eq!(sort_fixed_txs[0].payload_length, 255);
+        assert_eq!(sort_fixed_txs[0].payload_length, 0);
     }
     assert_eq!(result.missed_block_ranges.len(), 1);
     assert_eq!(result.missed_block_ranges[0], BlockRange::new(3, 4));

--- a/fog/view/server/tests/unary_smoke_tests.rs
+++ b/fog/view/server/tests/unary_smoke_tests.rs
@@ -482,8 +482,8 @@ fn test_view_integration(view_omap_capacity: u64, store_count: usize, blocks_per
         sort_txs.sort_by(|x, y| x.search_key.cmp(&y.search_key));
         assert_eq!(sort_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_txs[0].result_code, 3);
-        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 232]);
-        assert_eq!(sort_txs[0].padding, vec![0u8; 23]);
+        assert_eq!(sort_txs[0].ciphertext, vec![0u8; 255]);
+        assert_eq!(sort_txs[0].padding, vec![0u8; 0]);
     }
     {
         let mut sort_fixed_txs = result.fixed_tx_out_search_results.clone();
@@ -492,7 +492,7 @@ fn test_view_integration(view_omap_capacity: u64, store_count: usize, blocks_per
         assert_eq!(sort_fixed_txs[0].search_key, vec![200u8; 17]);
         assert_eq!(sort_fixed_txs[0].result_code, 3);
         assert_eq!(sort_fixed_txs[0].ciphertext, vec![0u8; 255]);
-        assert_eq!(sort_fixed_txs[0].payload_length, 232);
+        assert_eq!(sort_fixed_txs[0].payload_length, 255);
     }
     assert_eq!(result.missed_block_ranges.len(), 1);
     assert_eq!(result.missed_block_ranges[0], BlockRange::new(3, 4));


### PR DESCRIPTION
### Motivation
The `test-client` test against the locally deployed FVR was failing because the `e_tx_out_store` code panicked during the payload slice copy from the OMAP-returned value and the default ciphertext- these two slices had different lengths. This length mismatched occurred because the default ciphertext had a `payload_length` the size of the **last** TxOut that was processed by `e_tx_out_store`. 

The issue with this approach is that there are differently-sized TxOuts (e.g. some TxOuts have memos, some don't). In this case, the `payload_length` was being initialized to 188 (corresponding to the length of a non-memo TxOut) and then the OMAP-returned `payload_length` was length 210 (because it corresponded to a memo TxOut). 

To fix this issue, we no longer initialize the `paylaod_length` to the previous TxOut ciphertext length. We now set the `payload_length` equal to the length of the `payload` that's being copied. This prevents the slice length mismatch panic.
