### PR TITLE
WIP: make a way to store hardening advisory data with sigstructs and load it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,6 +2533,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-attest-verifier-config"
+version = "4.0.2"
+dependencies = [
+ "displaydoc",
+ "mc-attest-verifier",
+ "mc-common",
+ "mc-sgx-css",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mc-attest-verifier-types"
 version = "4.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "attest/trusted",
     "attest/untrusted",
     "attest/verifier",
+    "attest/verifier/config",
     "attest/verifier/types",
     "blockchain/types",
     "blockchain/validators",

--- a/attest/verifier/config/Cargo.toml
+++ b/attest/verifier/config/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mc-attest-verifier-config"
+version = "4.0.2"
+authors = ["MobileCoin"]
+edition = "2021"
+description = '''
+This crate specifies and implements a method for loading remote attestation "trust roots"
+from the filesystem, for one of several possible enclaves, and configuring an mc-attest-verifier::Verifier
+based on this. These data consist of signed .css "SIGSTRUCT" objects as well as .json which indicate
+which hardening advisories were mitigated in software for these enclaves, and more such data.
+This is meant to help clients that connect to several mobilecoin enclaves to configure their verifiers
+appropriately.
+'''
+readme = "README.md"
+
+[dependencies]
+mc-attest-verifier = { path = ".." }
+mc-common = { path = "../../../common" }
+mc-sgx-css = { path = "../../../sgx/css" }
+
+displaydoc = "0.2"
+serde = "1"
+serde_json = "1"

--- a/attest/verifier/config/README.md
+++ b/attest/verifier/config/README.md
@@ -1,0 +1,100 @@
+attest-verifier-config
+======================
+
+This crate specifies and implements a method for configuring an attestation
+verifier based on sigstructs and other configuration data, which it finds using
+a search path which is given to it. This search path is called the "attestation
+trust root search path".
+
+This is loosely based on how OS'es like linux often have a designated path where SSL trust roots are stored,
+e.g. `/etc/ssl/certs`, `/usr/local/share/certs`. This is a bit different in that,
+we're not assuming that there's an OS level path for mobilecoin attestation roots,
+rather it's expected that when a mobilecoin client installs itself, somewhere in its installation
+path it would do this, and the app would then pass this path to the code in this crate.
+So, these trust roots would be private to an installation of the app.
+
+Directory-layout
+----------------
+
+The files in the attestation trust root search path are expected to be laid out
+according to a specific schema.
+
+The schema we propose here is:
+
+* The outermost directory contains subdirectories, named for releases. This is
+  for organizational purposes and makes it a little easier update the trust set
+  to exclude old releases.
+* Each release directory contains `.css` files, one for each enclave that was released,
+  and `.json` files, which contain information about the manner in which we trust
+  that enclave, for example, a list of hardening advisories that apply to it.
+* Each `.css` file must have a corresponding `.json` file, or it is considered
+  invalid. (At the level of `mc-attest-verifier` code, the `.css` and the `.json`
+  can together be used to create a `StatusVerifier`, and the `.json` format is
+  meant to be extensible for future configuration options.)
+
+For example, the file tree under the search-path may look like this:
+
+```mermaid
+graph LR;
+    search-path-->release-v3;
+    search-path-->release-v4;
+    release-v3-->1[consensus-enclave.css]
+    release-v3-->2[consensus-enclave.json]
+    release-v3-->3[ingest-enclave.css]
+    release-v3-->4[ingest-enclave.json]
+    release-v3-->5[ledger-enclave.css]
+    release-v3-->6[ledger-enclave.json]
+    release-v3-->7[view-enclave.css]
+    release-v3-->8[view-enclave.json]
+    release-v4-->consensus-enclave.css
+    release-v4-->consensus-enclave.json
+    release-v4-->ingest-enclave.css
+    release-v4-->ingest-enclave.json
+    release-v4-->ledger-enclave.css
+    release-v4-->ledger-enclave.json
+    release-v4-->view-enclave.css
+    release-v4-->view-enclave.json
+```
+
+Given an attestation trust root search path and an enclave name, the procedure
+implemented here searches all subdirectories of the search path (to one level) for
+valid `.css` and `.json` files matching that name, and builds appropriate `StatusVerifier`'s.
+
+The `.json` files have the following schema:
+
+```
+{
+    "identity_check": "MRENCLAVE",
+    "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"],
+}
+```
+
+* `identity_check`: This should be either `"MRENCLAVE"` or `"MRSIGNER"`, and indicates which identity we are checking during attestation verification.
+* `mitigated_hardening_advisories`: This is the list of Intel SGX hardening advisories that are known to have been mitigated in this signed revision of the enclave.
+
+Pros and cons
+-------------
+
+The advantages of this scheme are:
+
+* We do not embed the `.css` file data into another data format, so we can continue to use Intel's
+  tools and `mc-sgx-css-dump` easily.
+* Use names of files in the filesystem to associate related files. This is fairly intuitive
+  and avoids the need to create a manifest file of some kind that explicitly glues things together.
+* We can fairly easily inspect a directory like this and see which releases it is supposed to have
+  css files for, and we can use simple text editors to look at the individual json files.
+* Pretty easy to point a binary at a directory like this, and doesn't cause an explosion of command
+  line arguments to configure attestation.
+* Pretty easy to update when a new release is made, we just delete the oldest release's subdirectory
+  and add a new subdirectory for the new release.
+
+The disadvantages of the scheme are:
+
+* Many small files instead of one self-contained file.
+* Probably want to think about permissions settings on this directory when installed.
+  (Generally if an attacker can tamper with your wallet software installation,
+  you are already in big trouble, even if everything is bundled into one binary.)
+* Assumes the presence of a filesystem. This is likely valid on windows/mac/linux/ios/android.
+  You might be able to fake this on wasm. For embedded devices, it probably isn't valid,
+  and you'll have to figure something else out. However, I'm not sure that we expect embedded
+  devices to be capable of directly talking to mobilecoin mainnet or fog right now.

--- a/attest/verifier/config/src/lib.rs
+++ b/attest/verifier/config/src/lib.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2018-2022 The MobileCoin Foundation
+
+//! This crate provides a `load_attestation_trust_roots_for_enclave` function
+//! which searches a search path for attestation trust roots corresponding to
+//! an enclave of a given name, then configures an attestation verifier to trust
+//! all matching trust roots.
+
+#![deny(missing_docs)]
+
+use displaydoc::Display;
+use mc_attest_verifier::{MrEnclaveVerifier, MrSignerVerifier, Verifier};
+use mc_common::logger::{log, Logger};
+use mc_sgx_css::{Error as CssError, Signature};
+use serde::{Deserialize, Serialize};
+use serde_json::Error as SerdeJsonError;
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Load attestation trust roots from the filesystem for a particular enclave.
+///
+/// The search path is expected to contain subdirectories, each corresponding to
+/// a release. Each subdirectory is searched for files matching
+/// "{enclave_name}.css" and "{enclave_name}.json". If one is present but not
+/// the other, this is an error. When both are present, a corresponding
+/// StatusVerifier is created and appended to the verifier.
+///
+/// Arguments:
+/// * enclave_name: The name of the enclave that we are creating a verifier for
+/// * search_path: The directory to search for trust roots
+/// * verifier: The verifier object to which we will append our findings
+/// * logger
+///
+/// Returns:
+/// A count of the number of trust roots loaded for this enclave, or an error.
+/// If an error occurs the verifier should be abandoned.
+pub fn load_attestation_trust_roots_for_enclave(
+    enclave_name: &'static str,
+    search_path: impl AsRef<Path>,
+    verifier: &mut Verifier,
+    logger: &Logger,
+) -> Result<usize, Error> {
+    let mut count = 0;
+
+    log::debug!(
+        logger,
+        "Searching for attestation trust roots for '{}' in: {}",
+        enclave_name,
+        search_path.as_ref().display()
+    );
+
+    let search_path = search_path.as_ref();
+    if !search_path.is_dir() {
+        return Err(Error::NotADirectory(search_path.to_path_buf()));
+    }
+
+    for entry in
+        fs::read_dir(search_path).map_err(|err| Error::Io(search_path.to_path_buf(), err))?
+    {
+        let entry = entry.map_err(|err| Error::Io(search_path.to_path_buf(), err))?;
+        let path = entry.path();
+        if path.file_name() == Some(OsStr::new(".")) || path.file_name() == Some(OsStr::new("..")) {
+            continue;
+        }
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        log::debug!(logger, "Searching in subdirectory: {}", path.display());
+
+        // Add a path element corresponding to enclave_name, and see if we find css and
+        // json files for this
+        let css_path = path.join(enclave_name).with_extension("css");
+        let json_path = path.join(enclave_name).with_extension("json");
+
+        if css_path.is_file() && json_path.is_file() {
+            // TODO: Check if both files are readonly?
+
+            let signature = {
+                let bytes = fs::read(&css_path).map_err(|err| Error::Io(css_path.clone(), err))?;
+                Signature::try_from(&bytes[..])
+                    .map_err(|err| Error::Signature(css_path.clone(), err))?
+            };
+
+            let json: AttestConfigJson = {
+                let bytes =
+                    fs::read(&json_path).map_err(|err| Error::Io(json_path.clone(), err))?;
+                serde_json::from_slice(&bytes[..])
+                    .map_err(|err| Error::Json(json_path.clone(), err))?
+            };
+
+            log::debug!(
+                logger,
+                "Found attestation trust root: {}, {}",
+                css_path.display(),
+                json_path.display()
+            );
+
+            let hardening_advisories: Vec<&str> = json
+                .mitigated_hardening_advisories
+                .iter()
+                .map(|x| x.as_str())
+                .collect();
+
+            match json.identity_check {
+                IdentityCheck::Mrenclave => {
+                    let mut mr_enclave_verifier = MrEnclaveVerifier::from(signature);
+                    mr_enclave_verifier.allow_hardening_advisories(&hardening_advisories);
+                    verifier.mr_enclave(mr_enclave_verifier);
+                }
+                IdentityCheck::Mrsigner => {
+                    let mut mr_signer_verifier = MrSignerVerifier::from(signature);
+                    mr_signer_verifier.allow_hardening_advisories(&hardening_advisories);
+                    verifier.mr_signer(mr_signer_verifier);
+                }
+            };
+
+            count += 1;
+        } else if css_path.is_file() {
+            return Err(Error::CssWithoutMatchingJson(css_path));
+        } else if json_path.is_file() {
+            return Err(Error::JsonWithoutMatchingCss(json_path));
+        }
+    }
+
+    Ok(count)
+}
+
+/// An error which can occur when trying to load attestation trust roots from a
+/// search path
+#[derive(Display, Debug)]
+pub enum Error {
+    /// Io: {0:?}
+    Io(PathBuf, std::io::Error),
+
+    /// Error reading css signature file {0:?}: {1}
+    Signature(PathBuf, CssError),
+
+    /// Error reading json file {0:?}: {1}
+    Json(PathBuf, SerdeJsonError),
+
+    /// .css file without matching json: {0:?}
+    CssWithoutMatchingJson(PathBuf),
+
+    /// .json file without matching css: {0:?}
+    JsonWithoutMatchingCss(PathBuf),
+
+    /// Search path was not a directory: {0:?}
+    NotADirectory(PathBuf),
+}
+
+/// The schema of a json file which lives adjacent to a .css sigstruct file,
+/// and informs how to configure the associated status verifier.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AttestConfigJson {
+    /// Whether we are checking the enclave identity or the signer identity
+    pub identity_check: IdentityCheck,
+    /// What hardening advisories are known to be mitigated for this enclave
+    pub mitigated_hardening_advisories: Vec<String>,
+}
+
+/// The possibilities for the `identity_check` field in the AttestConfigJson
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum IdentityCheck {
+    /// Indicates to use MRENCLAVE verification
+    Mrenclave,
+    /// Indicates to use MRSIGNER verification
+    Mrsigner,
+}


### PR DESCRIPTION
[Rendered README](https://github.com/mobilecoinfoundation/mobilecoin/blob/attest-verifier-config/attest/verifier/config/README.md)

This is meant to address comments on PR #3078, and allow that a client can load multiple MRENCLAVE measurements on startup and also apply different sets of hardening advisories to these as appropriate.

The idea is that there is a directory containing subdirectories with `.css` sigstruct files and associated `.json` files. A client binary can walk this directory and configure `MRENCLAVE` or `MRSIGNER` verifiers using additional data obtained from the json files. We can ship the whole bundle with the client, and it gets installed on the user's filesystem with the app.

There is a lot of ambiguity here. Mostly we are optimizing towards, reducing the amount of new tools we will have to create and use, and particularly, avoiding creating a file format that embeds Intel's sigstruct binary data.

If there is approval we will try to redevelop PR #3078 based on this.