### PR TITLE
Make find_record constant time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "mc-sgx-compat",
  "mc-sgx-report-cache-api",
  "mc-util-serial",
+ "static_assertions",
 ]
 
 [[package]]

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -8,6 +8,8 @@ license = "GPL-3.0"
 [dependencies]
 aes-gcm = "0.10.1"
 aligned-cmov = "2.2"
+static_assertions = "1.1.0"
+
 mc-attest-ake = { path = "../../../../attest/ake", default-features = false }
 mc-attest-core = { path = "../../../../attest/core", default-features = false }
 mc-attest-enclave-api = { path = "../../../../attest/enclave-api", default-features = false }

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![no_std]
 #![allow(clippy::result_large_err)]
+#![feature(const_cmp)]
 
 extern crate alloc;
 

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![no_std]
 #![allow(clippy::result_large_err)]
-#![feature(const_cmp)]
 
 extern crate alloc;
 

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "mc-sgx-compat",
  "mc-sgx-report-cache-api",
  "mc-util-serial",
+ "static_assertions",
 ]
 
 [[package]]


### PR DESCRIPTION
###
This PR makes the `e_tx_out_store`'s `find_record` method constant time. This is necessary in order to preserve our obliviousness guraantees. 