### PR TITLE
add serde traits to SignedContingentInput

### DIFF
--- a/transaction/extra/src/signed_contingent_input.rs
+++ b/transaction/extra/src/signed_contingent_input.rs
@@ -36,7 +36,7 @@ pub struct UnmaskedAmount {
 /// A signed contingent input is a "transaction fragment" which can be
 /// incorporated into a transaction signed by a counterparty. See MCIP #31 for
 /// motivation.
-#[derive(Clone, Digestible, Eq, Message, PartialEq, Zeroize)]
+#[derive(Clone, Deserialize, Digestible, Eq, Message, PartialEq, Serialize, Zeroize)]
 pub struct SignedContingentInput {
     /// The block version rules we used when making the signature
     #[prost(uint32, required, tag = 1)]


### PR DESCRIPTION
### Motivation

It is useful to be able to serialize a `SignedContingentInput` so that it can be stored/sent over various mediums.
