### PR TITLE
add serde and other useful traits to SignedContingentInputError

### DIFF
--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -232,7 +232,7 @@ impl<FPR: FogPubkeyResolver> TransactionBuilder<FPR> {
             return Err(
                 SignedContingentInputError::FeatureNotSupportedAtBlockVersion(
                     *self.block_version,
-                    "partial fills",
+                    "partial fills".into(),
                 ),
             );
         }

--- a/transaction/extra/src/signed_contingent_input.rs
+++ b/transaction/extra/src/signed_contingent_input.rs
@@ -2,7 +2,7 @@
 
 //! A signed contingent input as described in MCIP #31
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use displaydoc::Display;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_ring_signature::{
@@ -193,7 +193,7 @@ impl From<&UnmaskedAmount> for Amount {
 }
 
 /// An error which can occur when validating a signed contingent input
-#[derive(Display, Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Display, Eq, PartialEq, Serialize)]
 pub enum SignedContingentInputError {
     /// The number of required outputs did not match to the number of amounts
     WrongNumberOfRequiredOutputAmounts,
@@ -226,7 +226,7 @@ pub enum SignedContingentInputError {
     /// Revealing TxOut: {0}
     RevealedTxOut(RevealedTxOutError),
     /// Feature is not supported at this block version ({0}): {1}
-    FeatureNotSupportedAtBlockVersion(u32, &'static str),
+    FeatureNotSupportedAtBlockVersion(u32, String),
     /// Block version mismatch: {0} vs. {1}
     BlockVersionMismatch(u32, u32),
     /// Amount: {0}


### PR DESCRIPTION
### Motivation

This will allow services such as DEQS to send the error over RPC calls.
