### PR TITLE
Make it possible to access the port a GRPC server is listening on

### DIFF
--- a/util/uri/src/uri.rs
+++ b/util/uri/src/uri.rs
@@ -50,6 +50,16 @@ pub struct Uri<Scheme: UriScheme> {
     _scheme: PhantomData<Scheme>,
 }
 
+impl<Scheme: UriScheme> Uri<Scheme> {
+    /// Change the port number of this URI.
+    pub fn set_port(&mut self, port: u16) {
+        self.url
+            .set_port(Some(port))
+            .expect("should never fail on valid url");
+        self.port = port;
+    }
+}
+
 impl<Scheme: UriScheme> ConnectionUri for Uri<Scheme> {
     fn url(&self) -> &Url {
         &self.url


### PR DESCRIPTION
### Motivation

It used to be the case (prior to some `grpcio` version bump) that it was easy to get the addresses a GRPC server is listening on after the server is created. That was useful when asked to listen on port 0, which causes the system to bind some random free port number. This is a functionality we often use in tests to avoid hard-coding port numbers.

I'd like to make it possible to reuse the TLS credentials setup code while still making it possible to get the chosen port. The scenario that makes me want it is the following:
1) I have an app object, that amongst other things, creates a GRPC server and configures it to listen on some host:port using a URI passed to it on its initialization (and this [Uri](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/util/uri/src/uri.rs#L30) could either imply TLS or no TLS)
2) I want to write a unit test for this object and for that I need to know which port it listens on, which is currently impossible if I pass it a Uri with port 0. Right now, if I want to work around this, I need to duplicate the `ServerCredentials` creation code that takes a `Uri` and figured out what to do with it.

Another thing I ran into, is if the URIs are passed using our [Uri](https://github.com/mobilecoinfoundation/mobilecoin/blob/master/util/uri/src/uri.rs#L30) object, I have no way to change the port. This is useful when for example I pass `"insecure-service://127.0.0.1:0/"` as the listening uri to this app server object mentioned above. It would then be nice to have a method such as `.get_listen_uri()` that will then return `"insecure-service://127.0.0.1:12345"`, where 12345 is the port that was randomly chosen. This is useful, since this can then be easily passed into a Client objects (e.g. https://github.com/mobilecoinfoundation/mobilecoin/blob/master/fog/view/connection/src/lib.rs#L48, a pattern repeats itself in pretty much all of our GRPC client objects).

