### PR TITLE
add async_test_with_logger macro

### DIFF
--- a/common/src/logger/loggers/mod.rs
+++ b/common/src/logger/loggers/mod.rs
@@ -7,7 +7,7 @@ const CHANNEL_SIZE: usize = 100_000;
 const TRIM_MARKER: &str = "... <trimmed>";
 
 /// Macros to ease with tests/benches that require a Logger instance.
-pub use mc_util_logger_macros::{bench_with_logger, test_with_logger};
+pub use mc_util_logger_macros::{async_test_with_logger, bench_with_logger, test_with_logger};
 
 use super::*;
 

--- a/util/logger-macros/src/lib.rs
+++ b/util/logger-macros/src/lib.rs
@@ -47,3 +47,34 @@ fn impl_with_logger(item: TokenStream, params: TokenStream2, args: TokenStream2)
     }
     .into()
 }
+
+#[proc_macro_attribute]
+pub fn async_test_with_logger(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut original_fn = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let orig_ident = original_fn.sig.ident.clone();
+    let orig_name = orig_ident.to_string();
+
+    let new_ident = quote::format_ident!("__wrapped_{}", orig_ident);
+    original_fn.sig.ident = new_ident.clone();
+
+    let mut new_fn: syn::ItemFn = syn::parse_quote! {
+        #[tokio::test]
+        async fn #orig_ident() {
+            let test_name = format!("{}::{}", module_path!(), #orig_name);
+            let logger = mc_common::logger::create_test_logger(test_name);
+            mc_common::logger::slog_scope::scope(
+                &logger.clone(),
+                || async { #new_ident(logger).await }
+            ).await;
+        }
+    };
+    // Move other attributes to the new method.
+    new_fn.attrs.append(&mut original_fn.attrs);
+
+    quote! {
+        #new_fn
+        #original_fn
+    }
+    .into()
+}


### PR DESCRIPTION
### Motivation

We currently have a `#[test_with_logger]` macro that makes it convenient to write tests that require a `Logger` instance.
It is useful to have an async version of that, in case we want to test async code.