### PR TITLE
Use "unknown" for `GIT_COMMIT` failures.

### DIFF
--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -9,6 +9,7 @@ use std::{
 
 /// Get git revision by running `git describe` in a given directory.
 fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
+    const UNKNOWN_COMMIT: &str = "unknown";
     match Command::new("git")
         .args(["describe", "--always", "--dirty=-modified"])
         .current_dir(current_dir)
@@ -16,7 +17,7 @@ fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
     {
         Err(err) => {
             eprintln!("Couldn't run git: {err}");
-            "??????".to_string()
+            UNKNOWN_COMMIT.to_string()
         }
         Ok(proc_output) => {
             if !proc_output.status.success() {
@@ -24,7 +25,7 @@ fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
                     "git describe failed: {}",
                     String::from_utf8(proc_output.stderr.clone()).expect("utf8-error")
                 );
-                String::from_utf8(proc_output.stderr[0..24].to_vec()).expect("utf8-error")
+                UNKNOWN_COMMIT.to_string()
             } else {
                 String::from_utf8(proc_output.stdout)
                     .expect("utf8-error")

--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -23,7 +23,7 @@ fn get_git_commit(current_dir: impl AsRef<Path>) -> String {
             if !proc_output.status.success() {
                 eprintln!(
                     "git describe failed: {}",
-                    String::from_utf8(proc_output.stderr.clone()).expect("utf8-error")
+                    String::from_utf8(proc_output.stderr).expect("utf8-error")
                 );
                 UNKNOWN_COMMIT.to_string()
             } else {


### PR DESCRIPTION
Previously `?????` would be returned for an inability to run git and
the git error would be returned for a failure running git, when trying
to determine the git commit during build. Now "unknown" will always be
returned in either failure condition.

The drive for this is to prevent log messages of the form
`"GIT_COMMIT" : "fatal: detected dubious "` which can happen in some CI
systems due to newer git `safe.directory` settings.

