### PR TITLE
This comments out the "grafana push" part of the prometheus yml template

### DIFF
--- a/tools/local-network/prometheus.yml.template
+++ b/tools/local-network/prometheus.yml.template
@@ -11,11 +11,11 @@ global:
   #    monitor: 'example'
   #
 
-remote_write:
-- url: https://prometheus-us-central1.grafana.net/api/prom/push
-  basic_auth:
-    username: 8687
-    password: ${GRAFANA_PASSWORD}
+#remote_write:
+#- url: https://prometheus-us-central1.grafana.net/api/prom/push
+#  basic_auth:
+#    username: 8687
+#    password: ${GRAFANA_PASSWORD}
 
 # Load and evaluate rules in this file every 'evaluation_interval' seconds.
 rule_files:


### PR DESCRIPTION
AFAIK this grafana push stuff, for the local network script, hasn't been used by anyone in a few years, and it requires you to do additional setup in grafana. If you just want to talk to prometheus web interface, you have to comment this out or you get logspam.

I feel like it makes sense to comment this out, and let people put it back if they actually want to push from local network to grafana, but lmk if you'd rather leave it in, not a big deal.