### PR TITLE
Remove use of `set-output` in GHA CI

### DIFF
--- a/.github/actions/run-mc-tests/action.yml
+++ b/.github/actions/run-mc-tests/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         NEXTEST_PRESENT=$(command -v cargo-nextest >/dev/null && echo true || echo false)
-        echo ::set-output name=nextest_present::$NEXTEST_PRESENT
+        echo "nextest_present=$NEXTEST_PRESENT" >> $GITHUB_OUTPUT
     - name: Install cargo nextest
       if: steps.meta.outputs.nextest_present != 'true'
       uses: taiki-e/install-action@nextest

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -52,7 +52,7 @@ runs:
         echo "HOST_TARGET_TRIPLE=$HOST_TARGET_TRIPLE" >> $GITHUB_ENV
 
         CARGO_PRESENT=$(command -v cargo >/dev/null && echo true || echo false)
-        echo ::set-output name=cargo_present::$CARGO_PRESENT
+        echo "cargo_present=$CARGO_PRESENT" >> $GITHUB_OUTPUT
 
     # Install rust per `rust-toolchain`. No-op most of the time.
     - name: Install Rust


### PR DESCRIPTION
Previously `set-output` was used to propagate values from Github actions
to the Github CI jobs, now the variable `GITHUB_OUTPUT` is used to
propagate these values.

This change was made in response to the deprecation of `set-output` by
github,
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

