### PR TITLE
Make shard uris delimiter be a comma

### DIFF
--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -55,7 +55,7 @@ fn main() {
 
         // TODO: update this logic once we introduce other types of sharding strategies.
         let epoch_sharding_strategy = EpochShardingStrategy::try_from(shard_uri.clone())
-            .expect("Could not get sharding strategy");
+            .expect("Could not get sharding strategy for uri: {shard_uri:?}");
         let block_range = epoch_sharding_strategy.get_block_range();
         let shard = Shard::new(shard_uri, Arc::new(fog_view_store_grpc_client), block_range);
         shards.push(shard);

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -54,8 +54,9 @@ fn main() {
         );
 
         // TODO: update this logic once we introduce other types of sharding strategies.
-        let epoch_sharding_strategy = EpochShardingStrategy::try_from(shard_uri.clone())
-            .expect("Could not get sharding strategy for uri: {shard_uri:?}");
+        let epoch_sharding_strategy = EpochShardingStrategy::try_from(shard_uri.clone()).expect(
+            &format!("Could not get sharding strategy for uri: {shard_uri:?}"),
+        );
         let block_range = epoch_sharding_strategy.get_block_range();
         let shard = Shard::new(shard_uri, Arc::new(fog_view_store_grpc_client), block_range);
         shards.push(shard);

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -54,9 +54,8 @@ fn main() {
         );
 
         // TODO: update this logic once we introduce other types of sharding strategies.
-        let epoch_sharding_strategy = EpochShardingStrategy::try_from(shard_uri.clone()).expect(
-            &format!("Could not get sharding strategy for uri: {shard_uri:?}"),
-        );
+        let epoch_sharding_strategy = EpochShardingStrategy::try_from(shard_uri.clone())
+            .unwrap_or_else(|_| panic!("Could not get sharding strategy for uri: {shard_uri:?}"));
         let block_range = epoch_sharding_strategy.get_block_range();
         let shard = Shard::new(shard_uri, Arc::new(fog_view_store_grpc_client), block_range);
         shards.push(shard);

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -123,7 +123,7 @@ pub struct FogViewRouterConfig {
 
     /// gRPC listening URI for Fog View Stores. Should be indexed the same as
     /// the `sharding_strategies` field.
-    #[clap(long, env = "MC_VIEW_SHARD_URIS", value_delimiter = ",")]
+    #[clap(long, use_value_delimiter = true, env = "MC_VIEW_SHARD_URIS")]
     pub shard_uris: Vec<FogViewStoreUri>,
 
     /// PEM-formatted keypair to send with an Attestation Request.

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -123,7 +123,7 @@ pub struct FogViewRouterConfig {
 
     /// gRPC listening URI for Fog View Stores. Should be indexed the same as
     /// the `sharding_strategies` field.
-    #[clap(long, env = "MC_VIEW_SHARD_URIS")]
+    #[clap(long, env = "MC_VIEW_SHARD_URIS", value_delimiter = ",")]
     pub shard_uris: Vec<FogViewStoreUri>,
 
     /// PEM-formatted keypair to send with an Attestation Request.

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -115,11 +115,10 @@ impl FromStr for EpochShardingStrategy {
         if s.eq("default") {
             return Ok(EpochShardingStrategy::default());
         }
-        if let Ok(block_range) = BlockRange::from_str(s) {
-            return Ok(Self::new(block_range));
+        match BlockRange::from_str(s) {
+            Ok(block_range) => Ok(Self::new(block_range)),
+            Err(e) => Err("Invalid epoch sharding strategy: {e}".to_string()),
         }
-
-        Err("Invalid epoch sharding strategy.".to_string())
     }
 }
 

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -117,7 +117,7 @@ impl FromStr for EpochShardingStrategy {
         }
         match BlockRange::from_str(s) {
             Ok(block_range) => Ok(Self::new(block_range)),
-            Err(e) => Err("Invalid epoch sharding strategy: {e}".to_string()),
+            Err(e) => Err(format!("Invalid epoch sharding strategy: {e}")),
         }
     }
 }


### PR DESCRIPTION
### Motivation
Allows ops to pass `shard_uri` with a comma delimiter.
