### PR TITLE
Port fog local network and conformance tests to use ledger router

### DIFF
--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::HashMap,
     env,
-    str::FromStr,
     sync::{Arc, RwLock},
 };
 
@@ -14,10 +13,8 @@ use mc_common::logger::log;
 use mc_fog_api::ledger_grpc::KeyImageStoreApiClient;
 use mc_fog_ledger_enclave::{LedgerSgxEnclave, ENCLAVE_FILE};
 use mc_fog_ledger_server::{LedgerRouterConfig, LedgerRouterServer};
-use mc_fog_uri::{KeyImageStoreScheme, KeyImageStoreUri};
 use mc_ledger_db::LedgerDB;
 use mc_util_grpc::ConnectionUriGrpcioChannel;
-use mc_util_uri::UriScheme;
 use mc_watcher::watcher_db::WatcherDB;
 
 fn main() {
@@ -64,14 +61,7 @@ fn main() {
             .name_prefix("Main-RPC".to_string())
             .build(),
     );
-    for i in 0..50 {
-        let shard_uri_string = format!(
-            "{}://node{}.test.mobilecoin.com:3225",
-            KeyImageStoreScheme::SCHEME_INSECURE,
-            i
-        );
-        let shard_uri = KeyImageStoreUri::from_str(&shard_uri_string)
-            .unwrap_or_else(|_| panic!("Invalid shard URI string {shard_uri_string}!"));
+    for shard_uri in config.shard_uris.clone() {
         let ledger_store_grpc_client = KeyImageStoreApiClient::new(
             ChannelBuilder::default_channel_builder(grpc_env.clone())
                 .connect_to_uri(&shard_uri, &logger),

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -1,20 +1,13 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use std::{
-    collections::HashMap,
-    env,
-    sync::{Arc, RwLock},
-};
+use std::env;
 
 use clap::Parser;
-use grpcio::ChannelBuilder;
 use mc_attest_net::{Client, RaClient};
 use mc_common::logger::log;
-use mc_fog_api::ledger_grpc::KeyImageStoreApiClient;
 use mc_fog_ledger_enclave::{LedgerSgxEnclave, ENCLAVE_FILE};
 use mc_fog_ledger_server::{LedgerRouterConfig, LedgerRouterServer};
 use mc_ledger_db::LedgerDB;
-use mc_util_grpc::ConnectionUriGrpcioChannel;
 use mc_watcher::watcher_db::WatcherDB;
 
 fn main() {
@@ -55,35 +48,13 @@ fn main() {
         logger.clone(),
     );
 
-    let mut ledger_store_grpc_clients = HashMap::new();
-    let grpc_env = Arc::new(
-        grpcio::EnvBuilder::new()
-            .name_prefix("Main-RPC".to_string())
-            .build(),
-    );
-    for shard_uri in config.shard_uris.clone() {
-        let ledger_store_grpc_client = KeyImageStoreApiClient::new(
-            ChannelBuilder::default_channel_builder(grpc_env.clone())
-                .connect_to_uri(&shard_uri, &logger),
-        );
-        ledger_store_grpc_clients.insert(shard_uri, Arc::new(ledger_store_grpc_client));
-    }
-    let ledger_store_grpc_clients = Arc::new(RwLock::new(ledger_store_grpc_clients));
-
     let ledger_db = LedgerDB::open(&config.ledger_db).expect("Could not read ledger DB");
     let watcher_db =
         WatcherDB::open_ro(&config.watcher_db, logger.clone()).expect("Could not open watcher DB");
 
     let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
-    let mut router_server = LedgerRouterServer::new(
-        config,
-        enclave,
-        ias_client,
-        ledger_store_grpc_clients,
-        ledger_db,
-        watcher_db,
-        logger,
-    );
+    let mut router_server =
+        LedgerRouterServer::new(config, enclave, ias_client, ledger_db, watcher_db, logger);
     router_server.start();
 
     loop {

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -105,6 +105,10 @@ pub struct LedgerRouterConfig {
     #[clap(long, env = "MC_CLIENT_LISTEN_URI")]
     pub client_listen_uri: FogLedgerUri,
 
+    /// gRPC listening URIs for preconfigured Key Image Stores.
+    #[clap(long, env = "MC_KEY_IMAGE_SHARD_URIS")]
+    pub shard_uris: Vec<KeyImageStoreUri>,
+
     /// Router admin listening URI.
     #[clap(long, env = "MC_ADMIN_LISTEN_URI")]
     pub admin_listen_uri: AdminUri,

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -106,7 +106,7 @@ pub struct LedgerRouterConfig {
     pub client_listen_uri: FogLedgerUri,
 
     /// gRPC listening URIs for preconfigured Key Image Stores.
-    #[clap(long, env = "MC_KEY_IMAGE_SHARD_URIS")]
+    #[clap(long, use_value_delimiter = true, env = "MC_KEY_IMAGE_SHARD_URIS")]
     pub shard_uris: Vec<KeyImageStoreUri>,
 
     /// Router admin listening URI.

--- a/fog/ledger/server/tests/connection.rs
+++ b/fog/ledger/server/tests/connection.rs
@@ -32,7 +32,6 @@ use mc_util_from_random::FromRandom;
 use mc_util_grpc::{GrpcRetryConfig, CHAIN_ID_MISMATCH_ERR_MSG};
 use mc_util_test_helper::{CryptoRng, RngCore, RngType, SeedableRng};
 use mc_watcher::watcher_db::WatcherDB;
-
 use std::{path::PathBuf, str::FromStr, sync::Arc, thread::sleep, time::Duration};
 use tempdir::TempDir;
 use url::Url;

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -4,7 +4,6 @@
 //! grpc API
 
 use futures::executor::block_on;
-use grpcio::ChannelBuilder;
 use mc_account_keys::{AccountKey, PublicAddress};
 use mc_api::watcher::TimestampResultCode;
 use mc_attest_net::{Client as AttestClient, RaClient};
@@ -15,7 +14,7 @@ use mc_common::{
     time::SystemTimeProvider,
 };
 use mc_crypto_keys::{CompressedRistrettoPublic, Ed25519Pair};
-use mc_fog_api::{ledger::TxOutResultCode, ledger_grpc::KeyImageStoreApiClient};
+use mc_fog_api::ledger::TxOutResultCode;
 use mc_fog_ledger_connection::{
     Error, FogKeyImageGrpcClient, FogMerkleProofGrpcClient, FogUntrustedLedgerGrpcClient,
     KeyImageResultExtension, LedgerGrpcClient, OutputResultExtension,
@@ -33,18 +32,11 @@ use mc_transaction_core::{
     Token,
 };
 use mc_util_from_random::FromRandom;
-use mc_util_grpc::{ConnectionUriGrpcioChannel, GrpcRetryConfig, CHAIN_ID_MISMATCH_ERR_MSG};
+use mc_util_grpc::{GrpcRetryConfig, CHAIN_ID_MISMATCH_ERR_MSG};
 use mc_util_test_helper::{CryptoRng, RngCore, RngType, SeedableRng};
 use mc_util_uri::AdminUri;
 use mc_watcher::watcher_db::WatcherDB;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    str::FromStr,
-    sync::{Arc, RwLock},
-    thread::sleep,
-    time::Duration,
-};
+use std::{path::PathBuf, str::FromStr, sync::Arc, thread::sleep, time::Duration};
 use tempdir::TempDir;
 use url::Url;
 
@@ -162,7 +154,6 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
                 config,
                 enclave,
                 ra_client,
-                Arc::new(RwLock::new(HashMap::new())),
                 ledger.clone(),
                 watcher.clone(),
                 logger.clone(),
@@ -437,7 +428,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
 
             let ra_client =
                 AttestClient::new(&router_config.ias_api_key).expect("Could not create IAS client");
-            let mut router_server = LedgerRouterServer::new_from_config(
+            let mut router_server = LedgerRouterServer::new(
                 router_config,
                 enclave,
                 ra_client,
@@ -643,7 +634,6 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
             config,
             enclave,
             ra_client,
-            Arc::new(RwLock::new(HashMap::new())),
             ledger.clone(),
             watcher.clone(),
             logger.clone(),
@@ -809,7 +799,6 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
             config,
             enclave,
             ra_client,
-            Arc::new(RwLock::new(HashMap::new())),
             ledger.clone(),
             watcher.clone(),
             logger.clone(),
@@ -981,17 +970,6 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 logger.clone(),
             );
 
-            // Make Key Image Store client
-            let grpc_env = Arc::new(grpcio::EnvBuilder::new().build());
-
-            let store_client = KeyImageStoreApiClient::new(
-                ChannelBuilder::default_channel_builder(grpc_env.clone())
-                    .connect_to_uri(&store_uri, &logger),
-            );
-            let mut store_clients = HashMap::new();
-            store_clients.insert(store_uri.clone(), Arc::new(store_client));
-            let shards = Arc::new(RwLock::new(store_clients));
-
             // Make Router Server
             let router_client_listen_uri = FogLedgerUri::from_str(&format!(
                 "insecure-fog-ledger://127.0.0.1:{}",
@@ -1034,7 +1012,6 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 router_config,
                 enclave,
                 ra_client,
-                shards,
                 ledger.clone(),
                 watcher.clone(),
                 logger.clone(),
@@ -1053,6 +1030,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             let mut verifier = Verifier::default();
             verifier.mr_signer(mr_signer_verifier).debug(DEBUG_ENCLAVE);
 
+            let grpc_env = Arc::new(grpcio::EnvBuilder::new().build());
             let mut client = FogKeyImageGrpcClient::new(
                 String::default(),
                 router_client_listen_uri,

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -506,7 +506,9 @@ class FogConformanceTest:
             admin_port = BASE_KEY_IMAGE_STORE_ADMIN_PORT,
             admin_http_gateway_port = BASE_KEY_IMAGE_STORE_ADMIN_HTTP_GATEWAY_PORT,
             release = self.release,
-            sharding_strategy = 'default'
+            sharding_strategy = 'default',
+            ledger_db_path = ledger2.ledger_db_path,
+            watcher_db_path = ledger2.watcher_db_path,
         )
         self.key_image_store.start()
 

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -512,12 +512,12 @@ class FogConformanceTest:
 
         self.fog_ledger_router = FogLedgerRouter(
             name = 'ledger1',
-            ledger_db_path = self.nodes[0].ledger_dir,
+            ledger_db_path = ledger2.ledger_db_path,
             client_responder_id = f'localhost:{BASE_NGINX_CLIENT_PORT}',
             client_port = BASE_LEDGER_CLIENT_PORT,
             admin_port = BASE_LEDGER_ADMIN_PORT,
             admin_http_gateway_port = BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT,
-            watcher_db_path = self.mobilecoind.watcher_db,
+            watcher_db_path = ledger2.watcher_db_path,
             shard_uris = [self.key_image_store.get_client_listen_uri()],
             release = self.release,
         )

--- a/tools/fog-local-network/fog_conformance_tests.py
+++ b/tools/fog-local-network/fog_conformance_tests.py
@@ -392,7 +392,8 @@ class FogConformanceTest:
         self.fog_view_router = None
         # TODO: Add more fog view instances with sharding.
         self.fog_view_store = None
-        self.fog_ledger = None
+        self.fog_ledger_router = None
+        self.key_image_store = None
         self.fog_report = None
         self.multi_balance_checker = None
 
@@ -499,17 +500,28 @@ class FogConformanceTest:
         )
         self.fog_view_router.start()
 
-        self.fog_ledger = FogLedger(
-            name = 'ledger_server1',
-            ledger_db_path = ledger2.ledger_db_path,
+        self.key_image_store = FogKeyImageStore(
+            name = 'keyimage1',
+            client_port = BASE_KEY_IMAGE_STORE_PORT,
+            admin_port = BASE_KEY_IMAGE_STORE_ADMIN_PORT,
+            admin_http_gateway_port = BASE_KEY_IMAGE_STORE_ADMIN_HTTP_GATEWAY_PORT,
+            release = self.release,
+            sharding_strategy = 'default'
+        )
+        self.key_image_store.start()
+
+        self.fog_ledger_router = FogLedgerRouter(
+            name = 'ledger1',
+            ledger_db_path = self.nodes[0].ledger_dir,
             client_responder_id = f'localhost:{BASE_NGINX_CLIENT_PORT}',
             client_port = BASE_LEDGER_CLIENT_PORT,
             admin_port = BASE_LEDGER_ADMIN_PORT,
             admin_http_gateway_port = BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT,
-            watcher_db_path = ledger2.watcher_db_path,
+            watcher_db_path = self.mobilecoind.watcher_db,
+            shard_uris = [self.key_image_store.get_client_listen_uri()],
             release = self.release,
         )
-        self.fog_ledger.start()
+        self.fog_ledger_router.start()
 
         self.fog_report = FogReport(
             name = 'report1',
@@ -1029,8 +1041,11 @@ class FogConformanceTest:
         if self.multi_balance_checker:
             self.multi_balance_checker.stop()
 
-        if self.fog_ledger:
-            self.fog_ledger.stop()
+        if self.fog_ledger_router:
+            self.fog_ledger_router.stop()
+        
+        if self.key_image_store:
+            self.key_image_store.stop()
 
         if self.fog_report:
             self.fog_report.stop()

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -129,7 +129,9 @@ class FogNetwork(Network):
             admin_port = BASE_KEY_IMAGE_STORE_ADMIN_PORT,
             admin_http_gateway_port = BASE_KEY_IMAGE_STORE_ADMIN_HTTP_GATEWAY_PORT,
             release = True,
-            sharding_strategy = 'default'
+            sharding_strategy = 'default',
+            ledger_db_path = self.nodes[0].ledger_dir,
+            watcher_db_path = self.mobilecoind.watcher_db,
         )
         self.key_image_store.start()
         

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -123,17 +123,28 @@ class FogNetwork(Network):
         )
         self.fog_report.start()
 
-        self.fog_ledger = FogLedger(
-            'ledger1',
-            self.nodes[0].ledger_dir,
-            f'localhost:{BASE_NGINX_CLIENT_PORT}',
-            BASE_LEDGER_CLIENT_PORT,
-            BASE_LEDGER_ADMIN_PORT,
-            BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT,
-            self.mobilecoind.watcher_db,
-            release=True,
+        self.key_image_store = FogKeyImageStore(
+            name = 'keyimage1',
+            client_port = BASE_KEY_IMAGE_STORE_PORT,
+            admin_port = BASE_KEY_IMAGE_STORE_ADMIN_PORT,
+            admin_http_gateway_port = BASE_KEY_IMAGE_STORE_ADMIN_HTTP_GATEWAY_PORT,
+            release = True,
+            sharding_strategy = 'default'
         )
-        self.fog_ledger.start()
+        self.key_image_store.start()
+        
+        self.fog_ledger_router = FogLedgerRouter(
+            name = 'ledger1',
+            ledger_db_path = self.nodes[0].ledger_dir,
+            client_responder_id = f'localhost:{BASE_NGINX_CLIENT_PORT}',
+            client_port = BASE_LEDGER_CLIENT_PORT,
+            admin_port = BASE_LEDGER_ADMIN_PORT,
+            admin_http_gateway_port = BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT,
+            watcher_db_path = self.mobilecoind.watcher_db,
+            shard_uris = [self.key_image_store.get_client_listen_uri()],
+            release = True,
+        )
+        self.fog_ledger_router.start()
 
         # Tell the ingest server to activate, giving it a little time for RPC to wakeup
         time.sleep(15)
@@ -151,7 +162,8 @@ class FogNetwork(Network):
             if server is not None:
                 server.stop()
 
-        stop_server("fog_ledger")
+        stop_server("key_image_store")
+        stop_server("fog_ledger_router")
         stop_server("fog_report")
         stop_server("fog_view_store")
         stop_server("fog_view_router")

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -389,7 +389,7 @@ class FogLedgerRouter:
 
 
 class FogKeyImageStore:
-    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release, sharding_strategy):
+    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release, sharding_strategy, ledger_db_path, watcher_db_path):
         self.name = name
         
         self.client_port = client_port
@@ -397,6 +397,8 @@ class FogKeyImageStore:
         self.sharding_strategy = sharding_strategy
         self.client_listen_url = f'insecure-key-image-store://{LISTEN_HOST}:{self.client_port}/?sharding_strategy={self.sharding_strategy}'
         self.sharding_strategy = sharding_strategy
+        self.ledger_db_path = ledger_db_path
+        self.watcher_db_path = watcher_db_path
         
         self.admin_port = admin_port
         self.admin_http_gateway_port = admin_http_gateway_port
@@ -423,6 +425,8 @@ class FogKeyImageStore:
             f'--client-listen-uri={self.client_listen_url}',
             f'--client-responder-id={self.client_responder_id}',
             f'--sharding-strategy={self.sharding_strategy}',
+            f'--ledger-db={self.ledger_db_path}',
+            f'--watcher-db={self.watcher_db_path}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -25,6 +25,9 @@ BASE_REPORT_ADMIN_HTTP_GATEWAY_PORT = 6500
 BASE_LEDGER_CLIENT_PORT = 7200
 BASE_LEDGER_ADMIN_PORT = 7400
 BASE_LEDGER_ADMIN_HTTP_GATEWAY_PORT = 7500
+BASE_KEY_IMAGE_STORE_PORT = 7600
+BASE_KEY_IMAGE_STORE_ADMIN_PORT = 7700
+BASE_KEY_IMAGE_STORE_ADMIN_HTTP_GATEWAY_PORT = 7800
 
 BASE_NGINX_CLIENT_PORT = 8200
 
@@ -329,8 +332,8 @@ class FogReport:
             self.admin_http_gateway_process = None
 
 
-class FogLedger:
-    def __init__(self, name, ledger_db_path, client_responder_id, client_port, admin_port, admin_http_gateway_port, watcher_db_path, release):
+class FogLedgerRouter:
+    def __init__(self, name, ledger_db_path, client_responder_id, client_port, admin_port, admin_http_gateway_port, watcher_db_path, shard_uris, release):
         self.name = name
         self.ledger_db_path = ledger_db_path
         self.watcher_db_path = watcher_db_path
@@ -341,11 +344,13 @@ class FogLedger:
 
         self.admin_port = admin_port
         self.admin_http_gateway_port = admin_http_gateway_port
+        
+        self.shard_uris = shard_uris
 
         self.release = release
         self.target_dir = os.path.join(PROJECT_DIR, target_dir(self.release))
 
-        self.ledger_server_process = None
+        self.ledger_router_process = None
         self.admin_http_gateway_process = None
 
     def __repr__(self):
@@ -358,24 +363,79 @@ class FogLedger:
 
         print(f'Starting fog ledger {self.name}')
         cmd = ' '.join([
-            f'exec {self.target_dir}/ledger_server',
+            f'exec {self.target_dir}/ledger_router',
             f'--ledger-db={self.ledger_db_path}',
             f'--client-listen-uri={self.client_listen_url}',
             f'--client-responder-id={self.client_responder_id}',
             f'--ias-api-key={IAS_API_KEY}',
             f'--ias-spid={IAS_SPID}',
+            f'--shard-uris={",".join(self.shard_uris)}',
             f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
             f'--watcher-db {self.watcher_db_path}',
         ])
-        self.ledger_server_process = log_and_popen_shell(cmd)
+        self.ledger_router_process = log_and_popen_shell(cmd)
 
-        print(f'Starting admin http gateway for fog ledger')
+        print(f'Starting admin http gateway for fog ledger router')
         self.admin_http_gateway_process = start_admin_http_gateway(self.admin_http_gateway_port, self.admin_port, self.target_dir)
 
     def stop(self):
-        if self.ledger_server_process and self.ledger_server_process.poll() is None:
-            self.ledger_server_process.terminate()
-            self.ledger_server_process = None
+        if self.ledger_router_process and self.ledger_router_process.poll() is None:
+            self.ledger_router_process.terminate()
+            self.ledger_router_process = None
+
+        if self.admin_http_gateway_process and self.admin_http_gateway_process.poll() is None:
+            self.admin_http_gateway_process.terminate()
+            self.admin_http_gateway_process = None
+
+
+class FogKeyImageStore:
+    def __init__(self, name, client_port, admin_port, admin_http_gateway_port, release, sharding_strategy):
+        self.name = name
+        
+        self.client_port = client_port
+        self.client_responder_id = f'{LISTEN_HOST}:{self.client_port}'
+        self.sharding_strategy = sharding_strategy
+        self.client_listen_url = f'insecure-key-image-store://{LISTEN_HOST}:{self.client_port}/?sharding_strategy={self.sharding_strategy}'
+        self.sharding_strategy = sharding_strategy
+        
+        self.admin_port = admin_port
+        self.admin_http_gateway_port = admin_http_gateway_port
+        
+        self.release = release
+        self.target_dir = os.path.join(PROJECT_DIR, target_dir(self.release))
+
+        self.key_image_store_process = None
+        self.admin_http_gateway_process = None
+
+    def __repr__(self):
+        return self.name
+
+    def get_client_listen_uri(self):
+        return self.client_listen_url
+
+    def start(self):
+        self.stop()
+
+        print(f'Starting key image store {self.name}')
+        cmd = ' '.join([
+            DATABASE_URL_ENV,
+            f'exec {self.target_dir}/key_image_store',
+            f'--client-listen-uri={self.client_listen_url}',
+            f'--client-responder-id={self.client_responder_id}',
+            f'--sharding-strategy={self.sharding_strategy}',
+            f'--ias-api-key={IAS_API_KEY}',
+            f'--ias-spid={IAS_SPID}',
+            f'--admin-listen-uri=insecure-mca://{LISTEN_HOST}:{self.admin_port}/',
+        ])
+        self.key_image_store_process = log_and_popen_shell(cmd)
+
+        print(f'Starting admin http gateway for key image store')
+        self.admin_http_gateway_process = start_admin_http_gateway(self.admin_http_gateway_port, self.admin_port, self.target_dir)
+
+    def stop(self):
+        if self.key_image_store_process and self.key_image_store_process.poll() is None:
+            self.key_image_store_process.terminate()
+            self.key_image_store_process = None
 
         if self.admin_http_gateway_process and self.admin_http_gateway_process.poll() is None:
             self.admin_http_gateway_process.terminate()

--- a/tools/fog-local-network/local_fog.py
+++ b/tools/fog-local-network/local_fog.py
@@ -361,7 +361,7 @@ class FogLedgerRouter:
         assert os.path.exists(os.path.join(self.watcher_db_path, 'data.mdb')), self.watcher_db_path
         self.stop()
 
-        print(f'Starting fog ledger {self.name}')
+        print(f'Starting fog ledger router {self.name}')
         cmd = ' '.join([
             f'exec {self.target_dir}/ledger_router',
             f'--ledger-db={self.ledger_db_path}',


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
Fog Local Network and Fog Conformance are two of our most comprehensive Fog tests. It's important that they exercise the binaries we intend to actually deploy, which, in the near future, will be the Fog Ledger Router version. This PR ports those tests to exercise the Ledger Router.

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->
In the future, the Ledger Router should be exercised with multiple stores (#3160). Also, the streaming API should be used instead of (or in addition to) the unary API (#3161).



[Soundtrack of this PR]()
