### PR TITLE
adjust readiness criteria for fog view

### DIFF
--- a/fog/view/server/src/db_fetcher.rs
+++ b/fog/view/server/src/db_fetcher.rs
@@ -225,11 +225,7 @@ impl<DB: RecoveryDb + Clone + Send + Sync + 'static> DbFetcherThread<DB> {
 
             // If we got this far, then self.load_block_data() must have returned false.
             // This means that at some point no new data was available and it was all
-            // loaded into the queue. For a large data set, this also implies that
-            // the enclave thread has drained the queue many times and actually loaded
-            // most of the data into ORAM.
-            // It might take some more time before it is all actually loaded into the
-            // enclave, but we are very nearly ready now.
+            // loaded into the queue.
             self.readiness_indicator.set_ready();
 
             sleep(DB_POLL_INTERNAL);

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -391,6 +391,13 @@ where
     /// Keeps track of which blocks we have fed into the enclave.
     enclave_block_tracker: BlockTracker,
 
+    /// Flag which the db fetcher sets to indicate when it has exhausted it's
+    /// initial work.
+    db_fetcher_readiness_indicator: ReadinessIndicator,
+
+    /// Flag which we set to indicate when the server as a whole is read.
+    server_readiness_indicator: ReadinessIndicator,
+
     /// Keeps track how long ago it since we made progress, (or complained about
     /// not making progress) When this gets too distant in the past, we log
     /// a warning
@@ -420,21 +427,27 @@ where
         enclave: E,
         db: DB,
         shared_state: Arc<Mutex<DbPollSharedState>>,
-        readiness_indicator: ReadinessIndicator,
+        server_readiness_indicator: ReadinessIndicator,
         logger: Logger,
     ) -> Self {
+        let db_fetcher_readiness_indicator = ReadinessIndicator::default();
+
+        let db_fetcher = DbFetcher::new(
+            db.clone(),
+            db_fetcher_readiness_indicator.clone(),
+            config.block_query_batch_size,
+            logger.clone(),
+        );
+
         Self {
             stop_requested,
             enclave,
-            db: db.clone(),
+            db,
             shared_state,
-            db_fetcher: DbFetcher::new(
-                db,
-                readiness_indicator,
-                config.block_query_batch_size,
-                logger.clone(),
-            ),
+            db_fetcher,
             enclave_block_tracker: BlockTracker::new(logger.clone()),
+            db_fetcher_readiness_indicator,
+            server_readiness_indicator,
             last_unblocked_at: Instant::now(),
             logger,
         }
@@ -455,6 +468,16 @@ where
         let fetch_start = std::time::SystemTime::now();
         let fetched_records_list = self.db_fetcher.get_pending_fetched_records();
         let fetch_end = std::time::SystemTime::now();
+
+        // Readiness: If
+        // * db_fetcher reports readiness (at some point, there was no more data to
+        //   load)
+        // * we have no more work to do loading things into the enclave
+        // then at that point we declare the server ready, and there is no code path
+        // on which it becomes unready after that.
+        if fetched_records_list.is_empty() && self.db_fetcher_readiness_indicator.ready() {
+            self.server_readiness_indicator.set_ready()
+        }
 
         for fetched_records in fetched_records_list.into_iter() {
             // Early exit if stop as requested.

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -395,7 +395,7 @@ where
     /// initial work.
     db_fetcher_readiness_indicator: ReadinessIndicator,
 
-    /// Flag which we set to indicate when the server as a whole is read.
+    /// Flag which we set to indicate when the server as a whole is ready.
     server_readiness_indicator: ReadinessIndicator,
 
     /// Keeps track how long ago it since we made progress, (or complained about


### PR DESCRIPTION
Jason reported that fog view is now declaring itself ready well before the highest-processed-block-count is close to the block height.

In the past, the main bottleneck was loading the data from Postgres, but now it's actually putting the data into ORAM.

In this commit, we refine the readiness criteria, so that both the db fetcher and the enclave loading thread have to run out of work before the server declares itself ready.