### PR TITLE
Add dependabot for go-grpc-gateway

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,12 @@ updates:
   open-pull-requests-limit: 2
   reviewers:
     - "mobilecoinfoundation/coredev"
+- package-ecosystem: gomod
+  directory: /go-grpc-gateway
+  schedule:
+    interval: daily
+    time: "04:00"
+    timezone: "America/Los_Angeles"
+  reviewers:
+    - "cbeck88"
+    - "mobilecoinfoundation/coredev"


### PR DESCRIPTION
- Add dependabot for go-grpc-gateway
- Set coredev + cbeck88 as reviewers

### Motivation

Right now we're not updating any dependencies in go-grpc-gateway, but we should.

