### PR TITLE
update year in the expected copyright line in commit hook script

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -147,7 +147,7 @@ fi
 
 # Similarly, check if copyright statements are missing and offer to add them if they are
 printf "${PREFIX} Checking copyright statements ... "
-COPYRIGHT_LINE="// Copyright (c) 2018-2022 The MobileCoin Foundation"
+COPYRIGHT_LINE="// Copyright (c) 2018-2023 The MobileCoin Foundation"
 diff=""
 for file in $(git diff --name-only --cached --diff-filter=d | egrep -v '^sgx/sgx_(tcrypto|urts|types)');
 do


### PR DESCRIPTION
this has been causing me to put 2022 in a lot of files, and I think others also