### PR TITLE
give more helpful error messages for SGX_MODE and IAS_MODE settings

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -61,7 +61,9 @@ These are set by environment variables, and they must be the same for all artifa
 even those that don't depend directly on SGX. E.g. `mobilecoind` must have the same configuration
 as `consensus_service` for Intel Remote Attestation to work, otherwise an error will occur at runtime.
 
-For testing, you should usually use `SGX_MODE=SW` and `IAS_MODE=DEV`.
+For local testing, you should usually use `SGX_MODE=SW` and `IAS_MODE=DEV`.
+If you are seeking to build a client that you can test against MobileCoin's official testnet,
+you must use `SGX_MODE=HW` and `IAS_MODE=PROD`, because testnet is configured as a production environment.
 
 #### SGX_MODE
 

--- a/util/build/sgx/src/env.rs
+++ b/util/build/sgx/src/env.rs
@@ -13,10 +13,10 @@ pub const ENV_SGX_MODE: &str = "SGX_MODE";
 /// environments
 #[derive(Display)]
 pub enum Error {
-    /// The IAS mode '{0}' is unknown
+    /// The IAS mode '{0}' is unknown. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
     UnknownIasMode(String),
 
-    /// The SGX mode '{0}' is unknown
+    /// The SGX mode '{0}' is unknown. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
     UnknownSgxMode(String),
 
     /// There was an error reading an environment variable {0}: {1}. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.

--- a/util/build/sgx/src/env.rs
+++ b/util/build/sgx/src/env.rs
@@ -19,7 +19,7 @@ pub enum Error {
     /// The SGX mode '{0}' is unknown. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
     UnknownSgxMode(String),
 
-    /// There was an error reading an environment variable {0}: {1}. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
+    /// There was an error reading an environment variable '{0}': {1}. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
     Variable(&'static str, VarError),
 }
 

--- a/util/build/sgx/src/env.rs
+++ b/util/build/sgx/src/env.rs
@@ -4,14 +4,14 @@
 
 use displaydoc::Display;
 use mc_util_build_script::Environment;
-use std::{env::VarError, result::Result as StdResult};
+use std::{env::VarError, fmt, result::Result as StdResult};
 
 pub const ENV_IAS_MODE: &str = "IAS_MODE";
 pub const ENV_SGX_MODE: &str = "SGX_MODE";
 
 /// An enumeration of environment errors which occur when parsing SGX
 /// environments
-#[derive(Debug, Display)]
+#[derive(Display)]
 pub enum Error {
     /// The IAS mode '{0}' is unknown
     UnknownIasMode(String),
@@ -21,6 +21,14 @@ pub enum Error {
 
     /// There was an error reading an environment variable {0}: {1}. Please see https://github.com/mobilecoinfoundation/mobilecoin/blob/master/BUILD.md#build-configuration for more information.
     Variable(&'static str, VarError),
+}
+
+// Implement Debug by forwarding to Display so that .expect() shows the Display
+// text
+impl fmt::Debug for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, fmt)
+    }
 }
 
 type Result<T> = StdResult<T, Error>;


### PR DESCRIPTION
Many projects submodule mobilecoin.git and do not have it's BUILD.md document which describes how to set these variables.

It frequently happens that newly onboarded developers, or partners like copper, run into a build error that looks like this:

```
   Compiling libp2p-plaintext v0.37.0
   Compiling libp2p-floodsub v0.40.1
   Compiling slog-envlogger v2.2.0
error: failed to run custom build command for `mc-attest-core v4.0.2 (/home/chris/mobilecoinofficial/deqs/mobilecoin/attest/core)`

Caused by:
  process didn't exit successfully: `/home/chris/mobilecoinofficial/deqs/target/debug/build/mc-attest-core-fa6d778110b3deb5/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Could not parse SGX environment: Variable(NotPresent)', mobilecoin/attest/core/build.rs:8:41
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This error doesn't contain enough information for them to understand and fix the problem, so they end up asking us for help.

We can follow the rust tradition of trying to make build-time errors contain enough information to understand how to address the problem.

This commit tries to make the message say what variable was not present, and also contain a link to the mobilecoin.git BUILD.md so that they can learn more.