### PR TITLE
Defragmentation Memos

### DIFF
--- a/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
+++ b/fog/sample-paykit/src/cached_tx_data/memo_handler.rs
@@ -149,6 +149,13 @@ impl MemoHandler {
                     Err(MemoHandlerError::FailedSubaddressValidation)
                 }
             }
+            MemoType::Defragmentation(_) => {
+                if subaddress_matches_tx_out(account_key, CHANGE_SUBADDRESS_INDEX, tx_out)? {
+                    Ok(Some(memo_type))
+                } else {
+                    Err(MemoHandlerError::FailedSubaddressValidation)
+                }
+            }
         }
     }
 }

--- a/transaction/builder/src/lib.rs
+++ b/transaction/builder/src/lib.rs
@@ -22,8 +22,9 @@ pub mod test_utils;
 pub use error::{SignedContingentInputBuilderError, TxBuilderError};
 pub use input_credentials::InputCredentials;
 pub use memo_builder::{
-    BurnRedemptionMemoBuilder, EmptyMemoBuilder, GiftCodeCancellationMemoBuilder,
-    GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder, MemoBuilder, RTHMemoBuilder,
+    BurnRedemptionMemoBuilder, DefragmentationMemoBuilder, EmptyMemoBuilder,
+    GiftCodeCancellationMemoBuilder, GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder,
+    MemoBuilder, RTHMemoBuilder,
 };
 pub use reserved_subaddresses::ReservedSubaddresses;
 pub use signed_contingent_input_builder::SignedContingentInputBuilder;

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -11,11 +11,11 @@ use mc_transaction_extra::{DefragmentationMemo, DefragmentationMemoError};
 
 /// This memo buidler builds the DefragmentationMemo (0x0003).
 ///
-/// The DefragmentationMemo denotes defragmentation transactions. It contains three
-/// pieces of information: the fee, the total outlay, and an optional defragmentation
-/// ID number. If no defragmentation ID is specified, 0 is used. The fee and
-/// defragmentation ID can be set using this builder. The total outlay is set when
-/// the the memo for the main output is written.
+/// The DefragmentationMemo denotes defragmentation transactions. It contains
+/// three pieces of information: the fee, the total outlay, and an optional
+/// defragmentation ID number. If no defragmentation ID is specified, 0 is used.
+/// The fee and defragmentation ID can be set using this builder. The total
+/// outlay is set when the memo for the main output is written.
 ///
 /// This builder will write a memo for both the main and change outputs of a
 /// defragmentation transaction. The main output will get the fee and outlay of

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -129,14 +129,8 @@ impl MemoBuilder for DefragmentationMemoBuilder {
             return Err(NewMemoError::DefragWithChange);
         }
 
-        match DefragmentationMemo::new(0, 0, self.defrag_id.unwrap_or(0)) {
-            Ok(memo) => {
-                self.wrote_main_memo = true;
-                Ok(memo.into())
-            }
-            Err(err) => match err {
-                DefragmentationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
-            },
-        }
+        let memo = DefragmentationMemo::new(0, 0, self.defrag_id.unwrap_or(0))?;
+        self.wrote_main_memo = true;
+        Ok(memo.into())
     }
 }

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -9,7 +9,7 @@ use mc_account_keys::PublicAddress;
 use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
 use mc_transaction_extra::{DefragmentationMemo, DefragmentationMemoError};
 
-/// This memo buidler builds the DefragmentationMemo (0x0003).
+/// This memo builder builds the [`DefragmentationMemo`] (0x0003).
 ///
 /// The DefragmentationMemo denotes defragmentation transactions. It contains
 /// three pieces of information: the fee, the total outlay, and an optional

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -7,7 +7,7 @@ use super::MemoBuilder;
 use crate::ReservedSubaddresses;
 use mc_account_keys::PublicAddress;
 use mc_transaction_core::{tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token};
-use mc_transaction_extra::{DefragmentationMemo, DefragmentationMemoError};
+use mc_transaction_extra::DefragmentationMemo;
 
 /// This memo builder builds the [`DefragmentationMemo`] (0x0003).
 ///

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -11,7 +11,18 @@ use mc_transaction_core::{
 };
 use mc_transaction_extra::{DefragmentationMemo, DefragmentationMemoError};
 
-///TODO: doc
+/// This memo buidler builds the DefragmentationMemo (0x0003).
+/// 
+/// The DefragmentationMemo denotes defragmentation transactions. It contains three
+/// pieces of information: the fee, the total outlay, and an optional defragmentation
+/// ID number. If no defragmentation ID is specified, 0 is used. The fee and
+/// defragmentation ID can be set using this builder. The total outlay is set when
+/// the the memo for the main output is written.
+/// 
+/// This builder will write a memo for both the main and change outputs of a
+/// defragmentation transaction. The main output will get the fee and outlay of the
+/// transaction. The change output (if present) will get a defragmentation memo with
+/// the same defragmentation ID number, but 0 fee and outlay.
 #[derive(Clone, Debug)]
 pub struct DefragmentationMemoBuilder {
     // Defragmentation transaction fee
@@ -37,19 +48,21 @@ impl Default for DefragmentationMemoBuilder {
 
 impl DefragmentationMemoBuilder {
 
-    /// TODO: doc
+    /// Creates a new DefragmentationMemoBuilder with the specified defragmentation ID
     pub fn new(defrag_id: u64) -> Self {
         let mut result = DefragmentationMemoBuilder::default();
         result.set_defrag_id(defrag_id);
         result
     }
 
-    /// TODO: doc
+    /// Sets the defragmentation ID
     pub fn set_defrag_id(&mut self, value: u64) {
         self.defrag_id = Some(value);
     }
 
-    /// TODO: doc
+    /// Clears the defragmentation ID
+    /// If the memo is built without a specified defragmentation ID, it will default
+    /// to 0.
     pub fn clear_defrag_id(&mut self) {
         self.defrag_id = None;
     }
@@ -59,6 +72,7 @@ impl DefragmentationMemoBuilder {
 impl MemoBuilder for DefragmentationMemoBuilder {
 
     /// Set the fee
+    /// Throws an error if the specified value cannot be represented in 56 bits
     fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
         if self.wrote_main_memo {// Since the main memo includes the fee, check for main, not change
             return Err(NewMemoError::FeeAfterChange);

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -72,8 +72,8 @@ impl MemoBuilder for DefragmentationMemoBuilder {
     /// Set the fee
     /// Throws an error if the specified value cannot be represented in 56 bits
     fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        // Since the main memo includes the fee, check for main, not change
         if self.wrote_main_memo {
-            // Since the main memo includes the fee, check for main, not change
             return Err(NewMemoError::FeeAfterChange);
         }
         self.fee = fee;

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -58,7 +58,6 @@ impl DefragmentationMemoBuilder {
         self.defrag_id = value;
         self
     }
-
 }
 
 impl MemoBuilder for DefragmentationMemoBuilder {

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -26,7 +26,7 @@ pub struct DefragmentationMemoBuilder {
     // Defragmentation transaction fee
     fee: Amount,
     // Defragmentation ID
-    defrag_id: Option<u64>,
+    defrag_id: u64,
     // Tracks whether or not the main defrag memo was already written
     wrote_main_memo: bool,
     // Tracks whether or not the change (0 value) defrag memo was already written
@@ -37,7 +37,7 @@ impl Default for DefragmentationMemoBuilder {
     fn default() -> Self {
         Self {
             fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
-            defrag_id: None,
+            defrag_id: 0,
             wrote_main_memo: false,
             wrote_decoy_memo: false,
         }
@@ -55,17 +55,10 @@ impl DefragmentationMemoBuilder {
 
     /// Sets the defragmentation ID
     pub fn set_defrag_id(&mut self, value: u64) -> &mut Self {
-        self.defrag_id = Some(value);
+        self.defrag_id = value;
         self
     }
 
-    /// Clears the defragmentation ID
-    /// If the memo is built without a specified defragmentation ID, it　will
-    /// default　to 0.
-    pub fn clear_defrag_id(&mut self) -> &mut Self {
-        self.defrag_id = None;
-        self
-    }
 }
 
 impl MemoBuilder for DefragmentationMemoBuilder {
@@ -103,7 +96,7 @@ impl MemoBuilder for DefragmentationMemoBuilder {
                 .value
                 .checked_add(amount.value)
                 .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?,
-            self.defrag_id.unwrap_or(0),
+            self.defrag_id,
         )?;
         self.wrote_main_memo = true;
         Ok(memo.into())
@@ -129,7 +122,7 @@ impl MemoBuilder for DefragmentationMemoBuilder {
             return Err(NewMemoError::DefragWithChange);
         }
 
-        let memo = DefragmentationMemo::new(0, 0, self.defrag_id.unwrap_or(0))?;
+        let memo = DefragmentationMemo::new(0, 0, self.defrag_id)?;
         self.wrote_main_memo = true;
         Ok(memo.into())
     }

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -45,7 +45,6 @@ impl Default for DefragmentationMemoBuilder {
 }
 
 impl DefragmentationMemoBuilder {
-
     /// Creates a new DefragmentationMemoBuilder with the specified
     /// defragmentation ID
     pub fn new(defrag_id: u64) -> Self {
@@ -68,7 +67,6 @@ impl DefragmentationMemoBuilder {
 }
 
 impl MemoBuilder for DefragmentationMemoBuilder {
-
     /// Set the fee
     /// Throws an error if the specified value cannot be represented in 56 bits
     fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -54,15 +54,17 @@ impl DefragmentationMemoBuilder {
     }
 
     /// Sets the defragmentation ID
-    pub fn set_defrag_id(&mut self, value: u64) {
+    pub fn set_defrag_id(&mut self, value: u64) -> &mut Self {
         self.defrag_id = Some(value);
+        self
     }
 
     /// Clears the defragmentation ID
     /// If the memo is built without a specified defragmentation ID, it　will
     /// default　to 0.
-    pub fn clear_defrag_id(&mut self) {
+    pub fn clear_defrag_id(&mut self) -> &mut Self {
         self.defrag_id = None;
+        self
     }
 }
 

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -97,22 +97,16 @@ impl MemoBuilder for DefragmentationMemoBuilder {
             return Err(NewMemoError::MixedTokenIds);
         }
 
-        match DefragmentationMemo::new(
+        let memo = DefragmentationMemo::new(
             self.fee.value,
             self.fee
                 .value
                 .checked_add(amount.value)
                 .ok_or(NewMemoError::LimitsExceeded("total_outlay"))?,
             self.defrag_id.unwrap_or(0),
-        ) {
-            Ok(memo) => {
-                self.wrote_main_memo = true;
-                Ok(memo.into())
-            }
-            Err(err) => match err {
-                DefragmentationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
-            },
-        }
+        )?;
+        self.wrote_main_memo = true;
+        Ok(memo.into())
     }
 
     /// Build the memo for the change output (zero amount)

--- a/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
+++ b/transaction/builder/src/memo_builder/defragmentation_memo_builder.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2018-2023 The MobileCoin Foundation
+
+//! Defines the DefragmentationMemoBuilder
+//! This memo builder implements DefragmentationMemos defined in MCIP #61
+
+use super::MemoBuilder;
+use crate::ReservedSubaddresses;
+use mc_account_keys::PublicAddress;
+use mc_transaction_core::{
+    tokens::Mob, Amount, MemoContext, MemoPayload, NewMemoError, Token,
+};
+use mc_transaction_extra::{DefragmentationMemo, DefragmentationMemoError};
+
+///TODO: doc
+#[derive(Clone, Debug)]
+pub struct DefragmentationMemoBuilder {
+    // Defragmentation transaction fee
+    fee: Amount,
+    // Fee + defragmentation transaction amount
+    total_outlay: u64,
+    // Defragmentation ID
+    defrag_id: Option<u64>,
+    // Tracks whether or not the main defrag memo was already written
+    wrote_main_memo: bool,
+    // Tracks whether or not the change (0 value) defrag memo was already written
+    wrote_decoy_memo: bool,
+}
+
+impl Default for DefragmentationMemoBuilder {
+    fn default() -> Self {
+        Self {
+            fee: Amount::new(Mob::MINIMUM_FEE, Mob::ID),
+            total_outlay: Mob::MINIMUM_FEE,
+            defrag_id: None,
+            wrote_main_memo: false,
+            wrote_decoy_memo: false,
+        }
+    }
+}
+
+impl DefragmentationMemoBuilder {
+
+    /// TODO: doc
+    pub fn set_total_outlay(&mut self, value: u64) {
+        self.total_outlay = value;
+    }
+
+    /// TODO: doc
+    pub fn set_defrag_id(&mut self, value: u64) {
+        self.defrag_id = Some(value);
+    }
+
+    /// TODO: doc
+    pub fn clear_defrag_id(&mut self) {
+        self.defrag_id = None;
+    }
+
+}
+
+impl MemoBuilder for DefragmentationMemoBuilder {
+
+    /// Set the fee
+    fn set_fee(&mut self, fee: Amount) -> Result<(), NewMemoError> {
+        if self.wrote_main_memo {
+            return Err(NewMemoError::FeeAfterChange);
+        }
+        self.fee = fee;
+        Ok(())
+    }
+
+    /// Build the memo for the main defrag output (non-zero amount)
+    fn make_memo_for_output(
+        &mut self,
+        amount: Amount,
+        _recipient: &PublicAddress,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+
+        if self.wrote_main_memo {
+            return Err(NewMemoError::MultipleDefragOutputs);
+        }
+        if self.wrote_decoy_memo {
+            return Err(NewMemoError::OutputsAfterChange);
+        }
+        if amount.token_id != self.fee.token_id {
+            return Err(NewMemoError::MixedTokenIds);
+        }
+
+        match DefragmentationMemo::new(
+            self.fee.value,
+            self.total_outlay,
+            self.defrag_id.unwrap_or(0),
+        ) {
+            Ok(memo) => {
+                self.wrote_main_memo = true;
+                Ok(memo.into())
+            }
+            Err(err) => match err {
+                DefragmentationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
+            },
+        }
+
+    }
+
+    /// Build the memo for the change output (zero amount)
+    fn make_memo_for_change_output(
+        &mut self,
+        amount: Amount,
+        _change_destination: &ReservedSubaddresses,
+        _memo_context: MemoContext,
+    ) -> Result<MemoPayload, NewMemoError> {
+
+        if self.wrote_decoy_memo {
+            return Err(NewMemoError::MultipleChangeOutputs);
+        }
+        if amount.token_id != self.fee.token_id {
+            return Err(NewMemoError::MixedTokenIds);
+        }
+
+        match DefragmentationMemo::new(
+            0,
+            0,
+            self.defrag_id.unwrap_or(0),
+        ) {
+            Ok(memo) => {
+                self.wrote_main_memo = true;
+                Ok(memo.into())
+            }
+            Err(err) => match err {
+                DefragmentationMemoError::FeeTooLarge => Err(NewMemoError::LimitsExceeded("fee")),
+            },
+        }
+
+    }
+
+}

--- a/transaction/builder/src/memo_builder/mod.rs
+++ b/transaction/builder/src/memo_builder/mod.rs
@@ -11,12 +11,14 @@ use mc_transaction_core::{Amount, MemoContext, MemoPayload, NewMemoError};
 use mc_transaction_extra::UnusedMemo;
 
 mod burn_redemption_memo_builder;
+mod defragmentation_memo_builder;
 mod gift_code_cancellation_memo_builder;
 mod gift_code_funding_memo_builder;
 mod gift_code_sender_memo_builder;
 mod rth_memo_builder;
 
 pub use burn_redemption_memo_builder::BurnRedemptionMemoBuilder;
+pub use defragmentation_memo_builder::DefragmentationMemoBuilder;
 pub use gift_code_cancellation_memo_builder::GiftCodeCancellationMemoBuilder;
 pub use gift_code_funding_memo_builder::GiftCodeFundingMemoBuilder;
 pub use gift_code_sender_memo_builder::GiftCodeSenderMemoBuilder;

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4360,7 +4360,7 @@ pub mod transaction_builder_tests {
 
             // Defrag output should have a defrag memo
             let ss = get_tx_out_shared_secret(
-                &sender.view_private_key(),
+                sender.view_private_key(),
                 &RistrettoPublic::try_from(&main_output.public_key).unwrap(),
             );
             let memo = main_output.e_memo.unwrap().decrypt(&ss);
@@ -4451,7 +4451,7 @@ pub mod transaction_builder_tests {
 
             // Defrag output should have a defrag memo
             let ss = get_tx_out_shared_secret(
-                &sender.view_private_key(),
+                sender.view_private_key(),
                 &RistrettoPublic::try_from(&main_output.public_key).unwrap(),
             );
             let memo = main_output.e_memo.unwrap().decrypt(&ss);

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4130,4 +4130,360 @@ pub mod transaction_builder_tests {
             );
         }
     }
+
+    #[test]
+    // Transaction builder with Burn Redemption memo builder
+    fn test_transaction_builder_defragmentation_memos() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let block_version = BlockVersion::MAX;
+        let token_id = TokenId::from(62);
+        let fog_resolver = MockFogResolver::default();
+        let sender = AccountKey::random(&mut rng);
+        let change_address = sender.change_subaddress();
+        let change_destination = ReservedSubaddresses::from(&sender);
+
+        // Adding two defrag outputs is not allowed.
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder
+                .add_output(Amount::new(100, token_id), &change_address, &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.add_output(
+                Amount::new(100, token_id),
+                &change_address,
+                &mut rng,
+            );
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MultipleOutputs
+                )))
+            );
+        }
+
+        // Adding the change output before a defrag output is not allowed.
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            let result = transaction_builder.add_change_output(
+                Amount::new(0, token_id),
+                &change_destination,
+                &mut rng,
+            );
+
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MissingOutput
+                )))
+            );
+        }
+
+        // Setting fee after change output has been written is not allowed.
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(113, token_id),
+                &sender,
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            transaction_builder
+                .add_output(Amount::new(113, token_id), &change_address, &mut rng)
+                .unwrap();
+
+            transaction_builder
+                .add_change_output(Amount::new(0, token_id), &change_destination, &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.set_fee(1235);
+            assert_matches!(
+                result,
+                Err(TxBuilderError::Memo(NewMemoError::FeeAfterChange))
+            );
+        }
+
+        // Change in a different token is not allowed.
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, Mob::ID),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder
+                .add_output(Amount::new(100, Mob::ID), &change_address, &mut rng)
+                .unwrap();
+
+            let result = transaction_builder.add_change_output(
+                Amount::new(0, token_id),
+                &change_destination,
+                &mut rng,
+            );
+
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::MixedTokenIds
+                )))
+            );
+        }
+
+        // Defrag change output should always be 0
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(113, token_id),
+                &sender,
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            transaction_builder
+                .add_output(Amount::new(113, token_id), &change_address, &mut rng)
+                .unwrap();
+            let result =  transaction_builder
+                .add_change_output(Amount::new(43, token_id), &change_destination, &mut rng);
+
+                assert_matches!(
+                    result,
+                    Err(TxBuilderError::NewTx(NewTxError::Memo(
+                        NewMemoError::DefragWithChange
+                    )))
+                );
+        }
+
+        // Test builds memos with no ID
+        {
+            let memo_builder = DefragmentationMemoBuilder::default();
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(432, token_id),
+                &sender,
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let TxOutContext {
+                tx_out: defrag_tx_out,
+                ..
+            } = transaction_builder
+                .add_output(Amount::new(429, token_id), &change_address, &mut rng)
+                .unwrap();
+
+            let TxOutContext {
+                tx_out: decoy_tx_out,
+                ..
+            } = transaction_builder
+                .add_change_output(Amount::new(0, token_id), &change_destination, &mut rng)
+                .unwrap();
+
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .expect("build tx");
+
+            assert_eq!(tx.prefix.outputs.len(), 2);
+
+            let main_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == defrag_tx_out.public_key)
+                .expect("Didn't find recipient's output");
+            let decoy_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == decoy_tx_out.public_key)
+                .expect("Didn't find sender's output");
+
+            // Defrag output should have a defrag memo
+            let ss = get_tx_out_shared_secret(
+                &sender.view_private_key(),
+                &RistrettoPublic::try_from(&main_output.public_key).unwrap(),
+            );
+            let memo = main_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Defragmentation(memo) => {
+                    assert_eq!(memo.get_defrag_id(), 0u64);
+                    assert_eq!(memo.get_fee(), 3u64);
+                    assert_eq!(memo.get_total_outlay(), 432u64);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+
+            // Change output should have a 0 value defrag memo
+            let ss = get_tx_out_shared_secret(
+                sender.view_private_key(),
+                &RistrettoPublic::try_from(&decoy_output.public_key).unwrap(),
+            );
+            let memo = decoy_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Defragmentation(memo) => {
+                    assert_eq!(memo.get_defrag_id(), 0u64);
+                    assert_eq!(memo.get_fee(), 0u64);
+                    assert_eq!(memo.get_total_outlay(), 0u64);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+        }
+
+        // Test builds memos with ID
+        {
+            let memo_builder = DefragmentationMemoBuilder::new(64);
+
+            let mut transaction_builder = TransactionBuilder::new(
+                block_version,
+                Amount::new(10, token_id),
+                fog_resolver.clone(),
+                memo_builder,
+            )
+            .unwrap();
+
+            transaction_builder.set_fee(3).unwrap();
+
+            let input_credentials = get_input_credentials(
+                block_version,
+                Amount::new(432, token_id),
+                &sender,
+                &fog_resolver,
+                &mut rng,
+            );
+            transaction_builder.add_input(input_credentials);
+
+            let TxOutContext {
+                tx_out: defrag_tx_out,
+                ..
+            } = transaction_builder
+                .add_output(Amount::new(429, token_id), &change_address, &mut rng)
+                .unwrap();
+
+            let TxOutContext {
+                tx_out: decoy_tx_out,
+                ..
+            } = transaction_builder
+                .add_change_output(Amount::new(0, token_id), &change_destination, &mut rng)
+                .unwrap();
+
+            let tx = transaction_builder
+                .build(&NoKeysRingSigner {}, &mut rng)
+                .expect("build tx");
+
+            assert_eq!(tx.prefix.outputs.len(), 2);
+
+            let main_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == defrag_tx_out.public_key)
+                .expect("Didn't find recipient's output");
+            let decoy_output = tx
+                .prefix
+                .outputs
+                .iter()
+                .find(|tx_out| tx_out.public_key == decoy_tx_out.public_key)
+                .expect("Didn't find sender's output");
+
+            // Defrag output should have a defrag memo
+            let ss = get_tx_out_shared_secret(
+                &sender.view_private_key(),
+                &RistrettoPublic::try_from(&main_output.public_key).unwrap(),
+            );
+            let memo = main_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Defragmentation(memo) => {
+                    assert_eq!(memo.get_defrag_id(), 64u64);
+                    assert_eq!(memo.get_fee(), 3u64);
+                    assert_eq!(memo.get_total_outlay(), 432u64);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+
+            // Change output should have a 0 value defrag memo
+            let ss = get_tx_out_shared_secret(
+                sender.view_private_key(),
+                &RistrettoPublic::try_from(&decoy_output.public_key).unwrap(),
+            );
+            let memo = decoy_output.e_memo.unwrap().decrypt(&ss);
+            match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
+                MemoType::Defragmentation(memo) => {
+                    assert_eq!(memo.get_defrag_id(), 64u64);
+                    assert_eq!(memo.get_fee(), 0u64);
+                    assert_eq!(memo.get_total_outlay(), 0u64);
+                }
+                _ => {
+                    panic!("unexpected memo type")
+                }
+            }
+        }
+
+    }
+
 }

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4366,9 +4366,9 @@ pub mod transaction_builder_tests {
             let memo = main_output.e_memo.unwrap().decrypt(&ss);
             match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                 MemoType::Defragmentation(memo) => {
-                    assert_eq!(memo.get_defrag_id(), 0u64);
-                    assert_eq!(memo.get_fee(), 3u64);
-                    assert_eq!(memo.get_total_outlay(), 432u64);
+                    assert_eq!(memo.defrag_id(), 0u64);
+                    assert_eq!(memo.fee(), 3u64);
+                    assert_eq!(memo.total_outlay(), 432u64);
                 }
                 _ => {
                     panic!("unexpected memo type")
@@ -4383,9 +4383,9 @@ pub mod transaction_builder_tests {
             let memo = decoy_output.e_memo.unwrap().decrypt(&ss);
             match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                 MemoType::Defragmentation(memo) => {
-                    assert_eq!(memo.get_defrag_id(), 0u64);
-                    assert_eq!(memo.get_fee(), 0u64);
-                    assert_eq!(memo.get_total_outlay(), 0u64);
+                    assert_eq!(memo.defrag_id(), 0u64);
+                    assert_eq!(memo.fee(), 0u64);
+                    assert_eq!(memo.total_outlay(), 0u64);
                 }
                 _ => {
                     panic!("unexpected memo type")
@@ -4457,9 +4457,9 @@ pub mod transaction_builder_tests {
             let memo = main_output.e_memo.unwrap().decrypt(&ss);
             match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                 MemoType::Defragmentation(memo) => {
-                    assert_eq!(memo.get_defrag_id(), 64u64);
-                    assert_eq!(memo.get_fee(), 3u64);
-                    assert_eq!(memo.get_total_outlay(), 432u64);
+                    assert_eq!(memo.defrag_id(), 64u64);
+                    assert_eq!(memo.fee(), 3u64);
+                    assert_eq!(memo.total_outlay(), 432u64);
                 }
                 _ => {
                     panic!("unexpected memo type")
@@ -4474,9 +4474,9 @@ pub mod transaction_builder_tests {
             let memo = decoy_output.e_memo.unwrap().decrypt(&ss);
             match MemoType::try_from(&memo).expect("Couldn't decrypt memo") {
                 MemoType::Defragmentation(memo) => {
-                    assert_eq!(memo.get_defrag_id(), 64u64);
-                    assert_eq!(memo.get_fee(), 0u64);
-                    assert_eq!(memo.get_total_outlay(), 0u64);
+                    assert_eq!(memo.defrag_id(), 64u64);
+                    assert_eq!(memo.fee(), 0u64);
+                    assert_eq!(memo.total_outlay(), 0u64);
                 }
                 _ => {
                     panic!("unexpected memo type")

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -925,8 +925,9 @@ pub mod transaction_builder_tests {
     use super::*;
     use crate::{
         test_utils::{create_output, get_input_credentials, get_ring, get_transaction},
-        BurnRedemptionMemoBuilder, EmptyMemoBuilder, GiftCodeCancellationMemoBuilder,
-        GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder, RTHMemoBuilder,
+        BurnRedemptionMemoBuilder, DefragmentationMemoBuilder, EmptyMemoBuilder,
+        GiftCodeCancellationMemoBuilder, GiftCodeFundingMemoBuilder, GiftCodeSenderMemoBuilder,
+        RTHMemoBuilder,
     };
     use alloc::{string::ToString, vec};
     use assert_matches::assert_matches;

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4276,8 +4276,6 @@ pub mod transaction_builder_tests {
             )
             .unwrap();
 
-            transaction_builder.set_fee(3).unwrap();
-
             let input_credentials = get_input_credentials(
                 block_version,
                 Amount::new(113, token_id),

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4291,15 +4291,18 @@ pub mod transaction_builder_tests {
             transaction_builder
                 .add_output(Amount::new(113, token_id), &change_address, &mut rng)
                 .unwrap();
-            let result =  transaction_builder
-                .add_change_output(Amount::new(43, token_id), &change_destination, &mut rng);
+            let result =  transaction_builder.add_change_output(
+                Amount::new(43, token_id),
+                &change_destination,
+                &mut rng,
+            );
 
-                assert_matches!(
-                    result,
-                    Err(TxBuilderError::NewTx(NewTxError::Memo(
-                        NewMemoError::DefragWithChange
-                    )))
-                );
+            assert_matches!(
+                result,
+                Err(TxBuilderError::NewTx(NewTxError::Memo(
+                    NewMemoError::DefragWithChange
+                )))
+            );
         }
 
         // Test builds memos with no ID
@@ -4483,7 +4486,5 @@ pub mod transaction_builder_tests {
                 }
             }
         }
-
     }
-
 }

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4291,7 +4291,7 @@ pub mod transaction_builder_tests {
             transaction_builder
                 .add_output(Amount::new(113, token_id), &change_address, &mut rng)
                 .unwrap();
-            let result =  transaction_builder.add_change_output(
+            let result = transaction_builder.add_change_output(
                 Amount::new(43, token_id),
                 &change_destination,
                 &mut rng,

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -4132,8 +4132,7 @@ pub mod transaction_builder_tests {
     }
 
     #[test]
-    // Transaction builder with Burn Redemption memo builder
-    fn test_transaction_builder_defragmentation_memos() {
+    fn transaction_builder_defragmentation_memos() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let block_version = BlockVersion::MAX;
         let token_id = TokenId::from(62);

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -98,8 +98,8 @@ pub enum NewMemoError {
     MaxFeeExceeded(u64, u64),
     /// Payment request and intent ID both are set
     RequestAndIntentIdSet,
-    /// More than one non-change output from a defrag transaction
-    MultipleDefragOutputs,
+    /// Defragmentation transaction with non-zero change
+    DefragWithChange,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/core/src/tx_error.rs
+++ b/transaction/core/src/tx_error.rs
@@ -98,6 +98,8 @@ pub enum NewMemoError {
     MaxFeeExceeded(u64, u64),
     /// Payment request and intent ID both are set
     RequestAndIntentIdSet,
+    /// More than one non-change output from a defrag transaction
+    MultipleDefragOutputs,
     /// Other: {0}
     Other(String),
 }

--- a/transaction/extra/src/lib.rs
+++ b/transaction/extra/src/lib.rs
@@ -23,9 +23,9 @@ pub use memo::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentIntentIdMemo,
     AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo, DefragmentationMemo,
     DefragmentationMemoError, DestinationMemo, DestinationMemoError,
-    DestinationWithPaymentIntentIdMemo, DestinationWithPaymentRequestIdMemo, GiftCodeCancellationMemo,
-    GiftCodeFundingMemo, GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType,
-    SenderMemoCredential, UnusedMemo,
+    DestinationWithPaymentIntentIdMemo, DestinationWithPaymentRequestIdMemo,
+    GiftCodeCancellationMemo, GiftCodeFundingMemo, GiftCodeSenderMemo, MemoDecodingError, MemoType,
+    RegisteredMemoType, SenderMemoCredential, UnusedMemo,
 };
 pub use signed_contingent_input::{
     SignedContingentInput, SignedContingentInputError, UnmaskedAmount,

--- a/transaction/extra/src/lib.rs
+++ b/transaction/extra/src/lib.rs
@@ -21,10 +21,11 @@ mod unsigned_tx;
 
 pub use memo::{
     AuthenticatedSenderMemo, AuthenticatedSenderWithPaymentIntentIdMemo,
-    AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo, DestinationMemo,
-    DestinationMemoError, DestinationWithPaymentIntentIdMemo, DestinationWithPaymentRequestIdMemo,
-    GiftCodeCancellationMemo, GiftCodeFundingMemo, GiftCodeSenderMemo, MemoDecodingError, MemoType,
-    RegisteredMemoType, SenderMemoCredential, UnusedMemo,
+    AuthenticatedSenderWithPaymentRequestIdMemo, BurnRedemptionMemo, DefragmentationMemo,
+    DefragmentationMemoError, DestinationMemo, DestinationMemoError,
+    DestinationWithPaymentIntentIdMemo, DestinationWithPaymentRequestIdMemo, GiftCodeCancellationMemo,
+    GiftCodeFundingMemo, GiftCodeSenderMemo, MemoDecodingError, MemoType, RegisteredMemoType,
+    SenderMemoCredential, UnusedMemo,
 };
 pub use signed_contingent_input::{
     SignedContingentInput, SignedContingentInputError, UnmaskedAmount,

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -66,7 +66,7 @@ impl DefragmentationMemo {
     }
 
     /// Returns the fee recorded in this memo
-    pub fn get_fee(&self) -> u64 {
+    pub fn fee(&self) -> u64 {
         self.fee
     }
 

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -35,7 +35,6 @@ pub struct DefragmentationMemo {
     /// to compress the memo into 32 bytes.
     fee: u64,
     /// The fee plus the amount sent in the defragmentation transaction
-    /// (picoMOB)
     total_outlay: u64,
     /// The defragmentation ID used to group multiple rounds together
     defrag_id: u64,

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -7,6 +7,7 @@
 use super::RegisteredMemoType;
 use crate::impl_memo_type_conversions;
 use displaydoc::Display;
+use mc_transaction_core::NewMemoError;
 
 /// Memo denoting a defragmentation transaction. This memo contains
 /// the amount and fee of a defragmentation transaction as well as
@@ -134,10 +135,18 @@ impl From<DefragmentationMemo> for [u8; DefragmentationMemo::MEMO_DATA_LEN] {
 }
 
 /// An error that can occur when configuring a defragmentation memo
-#[derive(Display, Debug)]
+#[derive(Display, Debug, PartialEq)]
 pub enum DefragmentationMemoError {
     /// The fee amount is too large to be represented in the DefragmentationMemo
     FeeTooLarge,
+}
+
+impl From<DefragmentationMemoError> for NewMemoError {
+    fn from(src: DefragmentationMemoError) -> Self {
+        match src {
+            DefragmentationMemoError::FeeTooLarge => NewMemoError::LimitsExceeded("fee"),
+        }
+    }
 }
 
 impl_memo_type_conversions! { DefragmentationMemo }

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -122,11 +122,6 @@ impl From<&[u8; DefragmentationMemo::MEMO_DATA_LEN]> for DefragmentationMemo {
             total_outlay,
             defrag_id,
         }
-        Self {
-            fee,
-            total_outlay,
-            defrag_id,
-        }
     }
 }
 
@@ -167,7 +162,7 @@ mod test {
     fn getters_and_setters() {
         let mut memo = DefragmentationMemo::new(48237, 9001, 3405697037).unwrap();
 
-        assert_eq!(48237, memo.get_fee());
+        assert_eq!(48237, memo.fee());
         assert_eq!(9001, memo.get_total_outlay());
         assert_eq!(3405697037, memo.get_defrag_id());
 
@@ -175,7 +170,7 @@ mod test {
         memo.set_total_outlay(8999);
         memo.set_defrag_id(10);
 
-        assert_eq!(73284, memo.get_fee());
+        assert_eq!(73284, memo.fee());
         assert_eq!(8999, memo.get_total_outlay());
         assert_eq!(10, memo.get_defrag_id());
     }
@@ -183,7 +178,7 @@ mod test {
     #[test]
     fn max_fee_succeeds() {
         let memo = DefragmentationMemo::new(MAX_FEE, 0, 0).unwrap();
-        assert_eq!(MAX_FEE, memo.get_fee());
+        assert_eq!(MAX_FEE, memo.fee());
     }
 
     #[test]

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2018-2023 The MobileCoin Foundation
+
+//! Object for 0x0003 Defragmentation memo type
+//!
+//! This was proposed for standardization in mobilecoinfoundation/mcips/pull/61
+
+use super::RegisteredMemoType;
+use crate::impl_memo_type_conversions;
+use displaydoc::Display;
+
+/// TODO: doc
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct DefragmentationMemo {
+    /// TODO: doc
+    fee: u64,
+    /// TODO: doc
+    total_outlay: u64,
+    /// TODO: doc
+    defrag_id: u64,
+}
+
+impl RegisteredMemoType for DefragmentationMemo {
+    const MEMO_TYPE_BYTES: [u8; 2] = [0x00, 0x03];
+}
+
+impl DefragmentationMemo {
+    /// The length of the custom memo data.
+    pub const MEMO_DATA_LEN: usize = 64;
+
+    /// TODO: doc
+    pub fn new(
+        fee: u64,
+        total_outlay: u64,
+        defrag_id: u64,
+    ) -> Result<Self, DefragmentationMemoError> {
+        let mut result = Self {
+            fee: 0,
+            total_outlay,
+            defrag_id,
+        };
+        result.set_fee(fee)?;
+        Ok(result)
+    }
+
+    /// TODO: doc
+    pub fn get_fee(&self) -> u64 {
+        self.fee
+    }
+
+    /// TODO: doc
+    pub fn set_fee(&mut self, value: u64) -> Result<(), DefragmentationMemoError> {
+        if value.to_be_bytes()[0] != 0u8 {
+            return Err(DefragmentationMemoError::FeeTooLarge);
+        }
+        self.fee = value;
+        Ok(())
+    }
+
+    /// TODO: doc
+    pub fn get_total_outlay(&self) -> u64 {
+        self.total_outlay
+    }
+
+    /// TODO: doc
+    pub fn set_total_outlay(&mut self, value: u64) {
+        self.total_outlay = value;
+    }
+
+    /// TODO: doc
+    pub fn get_defrag_id(&self) -> u64 {
+        self.defrag_id
+    }
+
+    /// TODO: doc
+    pub fn set_defrag_id(&mut self, value: u64) {
+        self.defrag_id = value;
+    }
+
+}
+
+impl From<&[u8; DefragmentationMemo::MEMO_DATA_LEN]> for DefragmentationMemo {
+    // The layout of the memo data in 64 bytes is:
+    // [0-7): fee
+    // [7-15): total outlay
+    // [15-23): defrag ID
+    // [23-64) unused
+    fn from(src: &[u8; DefragmentationMemo::MEMO_DATA_LEN]) -> Self {
+        let fee = {
+            let mut fee_bytes = [0u8; 8];
+            fee_bytes[1..].copy_from_slice(&src[..7]);
+            u64::from_be_bytes(fee_bytes)
+        };
+        let total_outlay = u64::from_be_bytes(src[7..15].try_into().expect("BUG! arithmetic error"));
+        let defrag_id = u64::from_be_bytes(src[15..23].try_into().expect("BUG! arithmetic error"));
+        Self {
+            fee,
+            total_outlay,
+            defrag_id,
+        }
+    }
+}
+
+impl From<DefragmentationMemo> for [u8; DefragmentationMemo::MEMO_DATA_LEN] {
+    fn from(src: DefragmentationMemo) -> [u8; DefragmentationMemo::MEMO_DATA_LEN] {
+        let mut memo_data = [0u8; DefragmentationMemo::MEMO_DATA_LEN];
+        memo_data[..7].copy_from_slice(&src.fee.to_be_bytes()[1..]);
+        memo_data[7..15].copy_from_slice(&src.total_outlay.to_be_bytes());
+        memo_data[15..23].copy_from_slice(&src.defrag_id.to_be_bytes());
+        memo_data
+    }
+}
+
+/// An error that can occur when configuring a destination memo
+#[derive(Display, Debug)]
+pub enum DefragmentationMemoError {
+    /// The fee amount is too large to be represented in the DefragmentationMemo
+    FeeTooLarge,
+}
+
+impl_memo_type_conversions! { DefragmentationMemo }

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -108,14 +108,20 @@ impl From<&[u8; DefragmentationMemo::MEMO_DATA_LEN]> for DefragmentationMemo {
     // [15-23): defrag ID
     // [23-64) unused
     fn from(src: &[u8; DefragmentationMemo::MEMO_DATA_LEN]) -> Self {
-        let fee = {
-            let mut fee_bytes = [0u8; 8];
-            fee_bytes[1..].copy_from_slice(&src[..7]);
-            u64::from_be_bytes(fee_bytes)
-        };
-        let total_outlay =
-            u64::from_be_bytes(src[7..15].try_into().expect("BUG! arithmetic error"));
-        let defrag_id = u64::from_be_bytes(src[15..23].try_into().expect("BUG! arithmetic error"));
+        let mut u64_bytes = [0u8; 8];
+        u64_bytes[1..].copy_from_slice(&src[..7]);
+        let fee = u64::from_be_bytes(u64_bytes);
+
+        u64_bytes.copy_from_slice(&src[7..15]);
+        let total_outlay = u64::from_be_bytes(u64_bytes);
+
+        u64_bytes.copy_from_slice(&src[15..23]);
+        let defrag_id = u64::from_be_bytes(u64_bytes);
+        Self {
+            fee,
+            total_outlay,
+            defrag_id,
+        }
         Self {
             fee,
             total_outlay,

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -134,7 +134,7 @@ impl From<DefragmentationMemo> for [u8; DefragmentationMemo::MEMO_DATA_LEN] {
     }
 }
 
-/// An error that can occur when configuring a destination memo
+/// An error that can occur when configuring a defragmentation memo
 #[derive(Display, Debug)]
 pub enum DefragmentationMemoError {
     /// The fee amount is too large to be represented in the DefragmentationMemo

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -30,7 +30,7 @@ use displaydoc::Display;
 /// defragmentation ID.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DefragmentationMemo {
-    /// The fee paid to perform the defragmentation transaction (picoMOB)
+    /// The fee paid to perform the defragmentation transaction.
     /// We assume that the high order byte of fee is zero, and use this
     /// to compress the memo into 32 bytes.
     fee: u64,

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -141,3 +141,61 @@ pub enum DefragmentationMemoError {
 }
 
 impl_memo_type_conversions! { DefragmentationMemo }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const MAX_FEE: u64 = 0x00FFFFFF_FFFFFFFF;
+
+    #[test]
+    fn getters_and_setters() {
+        let mut memo = DefragmentationMemo::new(48237, 9001, 3405697037).unwrap();
+
+        assert_eq!(48237, memo.get_fee());
+        assert_eq!(9001, memo.get_total_outlay());
+        assert_eq!(3405697037, memo.get_defrag_id());
+
+        memo.set_fee(73284).unwrap();
+        memo.set_total_outlay(8999);
+        memo.set_defrag_id(10);
+
+        assert_eq!(73284, memo.get_fee());
+        assert_eq!(8999, memo.get_total_outlay());
+        assert_eq!(10, memo.get_defrag_id());
+    }
+
+    #[test]
+    fn max_fee_succeeds() {
+        let memo = DefragmentationMemo::new(MAX_FEE, 0, 0).unwrap();
+        assert_eq!(MAX_FEE, memo.get_fee());
+    }
+
+    #[test]
+    fn exceeding_max_fee_fails() {
+        let mut memo = DefragmentationMemo::new(0, 0u64, 0u64).unwrap();
+        assert_eq!(
+            memo.set_fee(MAX_FEE + 1),
+            Err(DefragmentationMemoError::FeeTooLarge)
+        );
+    }
+
+    #[test]
+    fn new_propagates_error() {
+        assert_eq!(
+            DefragmentationMemo::new(MAX_FEE + 1, 0u64, 0u64),
+            Err(DefragmentationMemoError::FeeTooLarge)
+        );
+    }
+
+    #[test]
+    fn serialization() {
+        let memo = DefragmentationMemo::new(2525, 36, 80).unwrap();
+
+        let memo_bytes: [u8; DefragmentationMemo::MEMO_DATA_LEN] = memo.clone().into();
+        let deserialized_memo = DefragmentationMemo::from(&memo_bytes);
+
+        assert_eq!(memo, deserialized_memo);
+    }
+}
+

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -81,7 +81,7 @@ impl DefragmentationMemo {
     }
 
     /// Returns the total outlay of the defragmentation transaction
-    pub fn get_total_outlay(&self) -> u64 {
+    pub fn total_outlay(&self) -> u64 {
         self.total_outlay
     }
 
@@ -91,7 +91,7 @@ impl DefragmentationMemo {
     }
 
     /// Returns the defragmentation ID
-    pub fn get_defrag_id(&self) -> u64 {
+    pub fn defrag_id(&self) -> u64 {
         self.defrag_id
     }
 
@@ -156,23 +156,23 @@ impl_memo_type_conversions! { DefragmentationMemo }
 mod test {
     use super::*;
 
-    const MAX_FEE: u64 = 0x00FFFFFF_FFFFFFFF;
+    const MAX_FEE: u64 = 0x00FF_FFFF_FFFF_FFFF;
 
     #[test]
     fn getters_and_setters() {
         let mut memo = DefragmentationMemo::new(48237, 9001, 3405697037).unwrap();
 
         assert_eq!(48237, memo.fee());
-        assert_eq!(9001, memo.get_total_outlay());
-        assert_eq!(3405697037, memo.get_defrag_id());
+        assert_eq!(9001, memo.total_outlay());
+        assert_eq!(3405697037, memo.defrag_id());
 
         memo.set_fee(73284).unwrap();
         memo.set_total_outlay(8999);
         memo.set_defrag_id(10);
 
         assert_eq!(73284, memo.fee());
-        assert_eq!(8999, memo.get_total_outlay());
-        assert_eq!(10, memo.get_defrag_id());
+        assert_eq!(8999, memo.total_outlay());
+        assert_eq!(10, memo.defrag_id());
     }
 
     #[test]

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -18,7 +18,7 @@ use displaydoc::Display;
 /// from the three memos with matching defragmentation ID. If used,
 /// the defragmentation ID should be selected randomly. If unused, this
 /// value defaults to 0. This memo has type bytes 0x0003.
-/// 
+///
 /// This memo is written to both the main defragmentation TxOut as well
 /// as the change TxOut (which has 0 value in a defragmentation
 /// transaction). The memo written to the main TxOut will have the fee
@@ -34,7 +34,8 @@ pub struct DefragmentationMemo {
     /// We assume that the high order byte of fee is zero, and use this
     /// to compress the memo into 32 bytes.
     fee: u64,
-    /// The fee plus the amount sent in the defragmentation transaction (picoMOB)
+    /// The fee plus the amount sent in the defragmentation transaction
+    /// (picoMOB)
     total_outlay: u64,
     /// The defragmentation ID used to group multiple rounds together
     defrag_id: u64,
@@ -98,7 +99,6 @@ impl DefragmentationMemo {
     pub fn set_defrag_id(&mut self, value: u64) {
         self.defrag_id = value;
     }
-
 }
 
 impl From<&[u8; DefragmentationMemo::MEMO_DATA_LEN]> for DefragmentationMemo {
@@ -113,7 +113,8 @@ impl From<&[u8; DefragmentationMemo::MEMO_DATA_LEN]> for DefragmentationMemo {
             fee_bytes[1..].copy_from_slice(&src[..7]);
             u64::from_be_bytes(fee_bytes)
         };
-        let total_outlay = u64::from_be_bytes(src[7..15].try_into().expect("BUG! arithmetic error"));
+        let total_outlay =
+            u64::from_be_bytes(src[7..15].try_into().expect("BUG! arithmetic error"));
         let defrag_id = u64::from_be_bytes(src[15..23].try_into().expect("BUG! arithmetic error"));
         Self {
             fee,

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -208,4 +208,3 @@ mod test {
         assert_eq!(memo, deserialized_memo);
     }
 }
-

--- a/transaction/extra/src/memo/defragmentation.rs
+++ b/transaction/extra/src/memo/defragmentation.rs
@@ -36,7 +36,7 @@ pub struct DefragmentationMemo {
     fee: u64,
     /// The fee plus the amount sent in the defragmentation transaction
     total_outlay: u64,
-    /// The defragmentation ID used to group multiple rounds together
+    /// The defragmentation ID used to group multiple transactions together
     defrag_id: u64,
 }
 

--- a/transaction/extra/src/memo/mod.rs
+++ b/transaction/extra/src/memo/mod.rs
@@ -460,6 +460,11 @@ mod tests {
                 ).is_ok()
             );
 
+            let memo_bytes: [u8; DefragmentationMemo::MEMO_DATA_LEN] = uut.clone().into();
+            let deserialized_memo: DefragmentationMemo = (&memo_bytes).into();
+
+            assert_eq!(uut, deserialized_memo);
+
     }
 
 }

--- a/transaction/extra/src/memo/mod.rs
+++ b/transaction/extra/src/memo/mod.rs
@@ -422,49 +422,27 @@ mod tests {
 
     #[test]
     fn test_defragmentation_memo() {
+        let mut uut = DefragmentationMemo::new(48237u64, 9001u64, 3405697037u64).unwrap();
 
-        let mut uut =
-            DefragmentationMemo::new(48237u64, 9001u64, 3405697037u64).unwrap();
+        assert_eq!(48237u64, uut.get_fee());
+        assert_eq!(9001u64, uut.get_total_outlay());
+        assert_eq!(3405697037u64, uut.get_defrag_id());
 
-            assert_eq!(48237u64, uut.get_fee());
-            assert_eq!(9001u64, uut.get_total_outlay());
-            assert_eq!(3405697037u64, uut.get_defrag_id());
+        uut.set_fee(73284u64).unwrap();
+        uut.set_total_outlay(8999u64);
+        uut.set_defrag_id(!3405697037u64);
 
-            uut.set_fee(73284u64).unwrap();
-            uut.set_total_outlay(8999u64);
-            uut.set_defrag_id(!3405697037u64);
+        assert_eq!(73284u64, uut.get_fee());
+        assert_eq!(8999u64, uut.get_total_outlay());
+        assert_eq!(!3405697037u64, uut.get_defrag_id());
 
-            assert_eq!(73284u64, uut.get_fee());
-            assert_eq!(8999u64, uut.get_total_outlay());
-            assert_eq!(!3405697037u64, uut.get_defrag_id());
+        assert!(DefragmentationMemo::new(!0u64, 0u64, 0u64).is_err());
+        assert!(DefragmentationMemo::new(72057594037927936u64, 0u64, 0u64).is_err());
+        assert!(DefragmentationMemo::new(72057594037927935u64, 0u64, 0u64).is_ok());
 
-            assert!(
-                DefragmentationMemo::new(
-                    !0u64,
-                    0u64,
-                    0u64,
-                ).is_err()
-            );
-            assert!(
-                DefragmentationMemo::new(
-                    72057594037927936u64,
-                    0u64,
-                    0u64,
-                ).is_err()
-            );
-            assert!(
-                DefragmentationMemo::new(
-                    72057594037927935u64,
-                    0u64,
-                    0u64,
-                ).is_ok()
-            );
+        let memo_bytes: [u8; DefragmentationMemo::MEMO_DATA_LEN] = uut.clone().into();
+        let deserialized_memo: DefragmentationMemo = (&memo_bytes).into();
 
-            let memo_bytes: [u8; DefragmentationMemo::MEMO_DATA_LEN] = uut.clone().into();
-            let deserialized_memo: DefragmentationMemo = (&memo_bytes).into();
-
-            assert_eq!(uut, deserialized_memo);
-
+        assert_eq!(uut, deserialized_memo);
     }
-
 }

--- a/transaction/extra/src/memo/mod.rs
+++ b/transaction/extra/src/memo/mod.rs
@@ -37,6 +37,7 @@
 //! | 0x0000          | Unused                                            |
 //! | 0x0001          | Burn Redemption Memo                              |
 //! | 0x0002          | Gift Code Sender Memo                             |
+//! | 0x0003          | Defragmentation Memo                              |
 //! | 0x0100          | Authenticated Sender Memo                         |
 //! | 0x0101          | Authenticated Sender With Payment Request Id Memo |
 //! | 0x0102          | Authenticated Sender With Payment Intent Id Memo  |
@@ -53,6 +54,7 @@ pub use self::{
     authenticated_sender_with_payment_request_id::AuthenticatedSenderWithPaymentRequestIdMemo,
     burn_redemption::BurnRedemptionMemo,
     credential::SenderMemoCredential,
+    defragmentation::{DefragmentationMemo, DefragmentationMemoError},
     destination::{DestinationMemo, DestinationMemoError},
     destination_with_payment_intent_id::DestinationWithPaymentIntentIdMemo,
     destination_with_payment_request_id::DestinationWithPaymentRequestIdMemo,
@@ -68,6 +70,7 @@ mod authenticated_sender_with_payment_intent_id;
 mod authenticated_sender_with_payment_request_id;
 mod burn_redemption;
 mod credential;
+mod defragmentation;
 mod destination;
 mod destination_with_payment_intent_id;
 mod destination_with_payment_request_id;
@@ -107,6 +110,7 @@ impl_memo_enum! { MemoType,
     AuthenticatedSenderWithPaymentRequestId(AuthenticatedSenderWithPaymentRequestIdMemo),
     AuthenticatedSenderWithPaymentIntentId(AuthenticatedSenderWithPaymentIntentIdMemo),
     BurnRedemption(BurnRedemptionMemo),
+    Defragmentation(DefragmentationMemo),
     Destination(DestinationMemo),
     DestinationWithPaymentRequestId(DestinationWithPaymentRequestIdMemo),
     DestinationWithPaymentIntentId(DestinationWithPaymentIntentIdMemo),
@@ -415,4 +419,47 @@ mod tests {
         assert_eq!(memo.get_fee(), 17u64);
         assert_eq!(memo.get_num_recipients(), 4);
     }
+
+    #[test]
+    fn test_defragmentation_memo() {
+
+        let mut uut =
+            DefragmentationMemo::new(48237u64, 9001u64, 3405697037u64).unwrap();
+
+            assert_eq!(48237u64, uut.get_fee());
+            assert_eq!(9001u64, uut.get_total_outlay());
+            assert_eq!(3405697037u64, uut.get_defrag_id());
+
+            uut.set_fee(73284u64).unwrap();
+            uut.set_total_outlay(8999u64);
+            uut.set_defrag_id(!3405697037u64);
+
+            assert_eq!(73284u64, uut.get_fee());
+            assert_eq!(8999u64, uut.get_total_outlay());
+            assert_eq!(!3405697037u64, uut.get_defrag_id());
+
+            assert!(
+                DefragmentationMemo::new(
+                    !0u64,
+                    0u64,
+                    0u64,
+                ).is_err()
+            );
+            assert!(
+                DefragmentationMemo::new(
+                    72057594037927936u64,
+                    0u64,
+                    0u64,
+                ).is_err()
+            );
+            assert!(
+                DefragmentationMemo::new(
+                    72057594037927935u64,
+                    0u64,
+                    0u64,
+                ).is_ok()
+            );
+
+    }
+
 }

--- a/transaction/extra/src/memo/mod.rs
+++ b/transaction/extra/src/memo/mod.rs
@@ -419,30 +419,4 @@ mod tests {
         assert_eq!(memo.get_fee(), 17u64);
         assert_eq!(memo.get_num_recipients(), 4);
     }
-
-    #[test]
-    fn test_defragmentation_memo() {
-        let mut uut = DefragmentationMemo::new(48237u64, 9001u64, 3405697037u64).unwrap();
-
-        assert_eq!(48237u64, uut.get_fee());
-        assert_eq!(9001u64, uut.get_total_outlay());
-        assert_eq!(3405697037u64, uut.get_defrag_id());
-
-        uut.set_fee(73284u64).unwrap();
-        uut.set_total_outlay(8999u64);
-        uut.set_defrag_id(!3405697037u64);
-
-        assert_eq!(73284u64, uut.get_fee());
-        assert_eq!(8999u64, uut.get_total_outlay());
-        assert_eq!(!3405697037u64, uut.get_defrag_id());
-
-        assert!(DefragmentationMemo::new(!0u64, 0u64, 0u64).is_err());
-        assert!(DefragmentationMemo::new(72057594037927936u64, 0u64, 0u64).is_err());
-        assert!(DefragmentationMemo::new(72057594037927935u64, 0u64, 0u64).is_ok());
-
-        let memo_bytes: [u8; DefragmentationMemo::MEMO_DATA_LEN] = uut.clone().into();
-        let deserialized_memo: DefragmentationMemo = (&memo_bytes).into();
-
-        assert_eq!(uut, deserialized_memo);
-    }
 }


### PR DESCRIPTION
* Added DefragmentationMemoBuilder
* Added DefragmentationMemo

### Motivation

This PR implements changes outlined in [MCIP #61](https://github.com/mobilecoinfoundation/mcips/pull/61).

[MCIP #61](https://github.com/mobilecoinfoundation/mcips/pull/61) proposes a new memo type: the defragmentation memo. This memo type is used to denote defragmentation transactions. It also includes an ID field that can be used to easily group together multiple rounds of one defragmentation session together for the purpose of reporting total paid in fees and total amount defragmented. The full implementation details and rationale for defragmentation memos can be found [here](https://github.com/dolanbernard/mcips/blob/defrag-memo/text/0061-defrag-memos.md).
