### PR TITLE
Test to ensure consensus session tracking gets populated

### DIFF
--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -1694,4 +1694,86 @@ mod client_api_tests {
 
         assert!(submitted_values.lock().unwrap().is_empty());
     }
+
+    // Very simple test of the session-tracking feature 
+    #[test_with_logger]
+    #[serial(counters)]
+    fn test_session_tracking_gets_populated(logger: Logger) {
+        let mut consensus_enclave = MockConsensusEnclave::new();
+        {
+            // Return a TxContext that contains some KeyImages.
+            let tx_context = TxContext {
+                key_images: vec![KeyImage::default(), KeyImage::default()],
+                ..Default::default()
+            };
+
+            consensus_enclave
+                .expect_client_tx_propose()
+                .times(1)
+                .return_const(Ok(tx_context));
+        }
+
+        let scp_client_value_sender = Arc::new(
+            |_value: ConsensusValue,
+             _node_id: Option<&NodeID>,
+             _responder_id: Option<&ResponderId>| {
+                // TODO: store inputs for inspection.
+            },
+        );
+
+        let num_blocks = 5;
+        let mut ledger = MockLedger::new();
+        // The service should request num_blocks.
+        ledger
+            .expect_num_blocks()
+            .times(1)
+            .return_const(Ok(num_blocks));
+
+        let mut tx_manager = MockTxManager::new();
+        tx_manager
+            .expect_insert()
+            .times(1)
+            .return_const(Ok(TxHash::default()));
+        tx_manager.expect_validate().times(1).return_const(Ok(()));
+
+        let is_serving_fn = Arc::new(|| -> bool { true });
+
+        let authenticator = AnonymousAuthenticator::default();
+
+        let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
+
+        let instance = ClientApiService::new(
+            get_config(),
+            Arc::new(consensus_enclave),
+            scp_client_value_sender,
+            Arc::new(ledger),
+            Arc::new(tx_manager),
+            Arc::new(MockMintTxManager::new()),
+            is_serving_fn,
+            Arc::new(authenticator),
+            logger,
+            // Clone this, maintaining our own ARC reference into the tracked
+            // sessions structure so that we can inspect it later. 
+            tracked_sessions.clone(),
+        );
+
+        // gRPC client and server.
+        let (client, _server) = get_client_server(instance);
+        let message = Message::default();
+        // Make sure there are no tracked sessions right up until we actually propose a tx. 
+        let tracker = tracked_sessions.lock().expect("Attempt to lock session-tracking mutex failed.");
+        assert!(tracker.is_empty());
+        drop(tracker);
+
+        match client.client_tx_propose(&message) {
+            Ok(propose_tx_response) => {
+                assert_eq!(propose_tx_response.get_result(), ProposeTxResult::Ok);
+                assert_eq!(propose_tx_response.get_block_count(), num_blocks);
+            }
+            Err(e) => panic!("Unexpected error: {e:?}"),
+        }
+        // Inspect our session-tracking 
+        let tracker = tracked_sessions.lock().expect("Attempt to lock session-tracking mutex failed.");
+        assert_eq!(tracker.len(), 1);
+    }
 }


### PR DESCRIPTION
Creates a test, `test_session_tracking_gets_populated()`, to ensure client tx proposals from unfamiliar clients adds that client's session to the session tracking list.

### Motivation

Code existed to add sessions to a tracker, but there were no tests making sure this actually works as intended. With this test we should be able to tell at any given time if new client interactions do add a new entry to the session tracker. 

### Future Work

This test could be expanded upon to ensure least-recently-touched sessions are dropped properly when the LRU cache's capacity is met. Also, another test will be needed when specific information to track is actually added rather than just having an empty cell for the session - right now, `ClientSessionTracking` is just a stub.  
