### PR TITLE
bump ci docker image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   build-dev:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -42,7 +42,7 @@ jobs:
 
   build-prod:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -63,7 +63,7 @@ jobs:
 
   build-and-test-wasm:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -78,7 +78,7 @@ jobs:
 
   lint-rust:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -95,7 +95,7 @@ jobs:
 
   build-and-test-go:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -135,7 +135,7 @@ jobs:
 
   docs:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -154,7 +154,7 @@ jobs:
 
   mc-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     strategy:
       matrix:
@@ -197,7 +197,7 @@ jobs:
 
   consensus-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     strategy:
       matrix:
@@ -230,7 +230,7 @@ jobs:
 
   fog-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     strategy:
       matrix:
@@ -281,7 +281,7 @@ jobs:
 
   fog-ingest-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -304,7 +304,7 @@ jobs:
 
   fog-conformance-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -344,7 +344,7 @@ jobs:
 
   fog-local-network-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code
@@ -531,7 +531,7 @@ jobs:
 
   minting-and-burning-tests:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     steps:
       - name: Check out code

--- a/.github/workflows/dependent-repos.yml
+++ b/.github/workflows/dependent-repos.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   android-bindings:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     permissions:
       pull-requests: write
@@ -30,7 +30,7 @@ jobs:
 
   full-service:
     runs-on: [self-hosted, Linux, large]
-    container: mobilecoin/builder-install:v0.0.21
+    container: mobilecoin/builder-install:v0.0.23
 
     permissions:
       pull-requests: write

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -73,7 +73,7 @@ jobs:
     - generate-metadata
     runs-on: [self-hosted, Linux, large-cd]
     container:
-      image: mobilecoin/rust-sgx-base:v0.0.21
+      image: mobilecoin/rust-sgx-base:v0.0.23
 
     env:
       ENCLAVE_SIGNING_KEY_PATH: ${{ github.workspace }}/.tmp/enclave_signing.pem


### PR DESCRIPTION
This is a follow on to c4d01f1fb1509fd0775c68b369e4807c706d4364 which bumped the docker version for mob prompt to the latest image. This change also changes it for the CI/CD workflows, so that everything is on the new image.