### PR TITLE
Make Fog Ledger Store return externally-addressable URI to Router

### DIFF
--- a/fog/ledger/server/src/key_image_store_server.rs
+++ b/fog/ledger/server/src/key_image_store_server.rs
@@ -97,8 +97,15 @@ where
     ) -> KeyImageStoreServer<E, SS, RC> {
         let shared_state = Arc::new(Mutex::new(DbPollSharedState::default()));
 
+        let use_tls = client_listen_uri.use_tls();
+        let responder_id = client_listen_uri
+            .responder_id()
+            .expect("Could not get store responder ID");
+        let uri = KeyImageStoreUri::try_from_responder_id(responder_id, use_tls)
+            .expect("Could not create URI from Responder ID");
+
         let key_image_service = KeyImageService::new(
-            KeyImageClientListenUri::Store(client_listen_uri.clone()),
+            KeyImageClientListenUri::Store(uri),
             chain_id,
             ledger,
             watcher,

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -125,7 +125,7 @@ pub fn process_shard_responses(
         let store_uri = KeyImageStoreUri::from_str(response.get_store_uri())?;
         match response.get_status() {
             MultiKeyImageStoreResponseStatus::SUCCESS => {
-                let store_responder_id = store_uri.responder_id()?;
+                let store_responder_id = store_uri.host_and_port_responder_id()?;
                 new_query_responses.push((store_responder_id, response.take_query_response()));
             }
             MultiKeyImageStoreResponseStatus::AUTHENTICATION_ERROR => {


### PR DESCRIPTION
<!-- List changes here -->

### Motivation
Pulling in changes discovered by Fog View Router leading to PR #3081. Returning remotely-accessible Responder ID URI from Key Image Stores rather than local bind address.
