### PR TITLE
Derive RistrettoPrivate from arbitrary bytes safely

### DIFF
--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -110,7 +110,12 @@ impl RistrettoPrivate {
     pub fn to_bytes(&self) -> [u8; 32] {
         *self.0.as_bytes()
     }
-
+    /// This function should be used instead of the from_bytes() function if the
+    /// bytes are **anything** other than the result of calling to_bytes() on a
+    /// RistrettoPrivate.
+    pub fn unchecked_from_bytes(bytes: [u8; 32]) -> Self {
+        Self(Scalar::from_bytes_mod_order(bytes))
+    }
     /// Sign the given bytes using a deterministic scheme based on Schnorrkel.
     pub fn sign_schnorrkel(&self, context: &[u8], message: &[u8]) -> RistrettoSignature {
         // Create a deterministic nonce using a merlin transcript. See this crate's


### PR DESCRIPTION
# Changes in this PR
    
* Adds a function unchecked_from_bytes to RistrettoPrivate: this safely derives a private key from 
    an arbitrary array of 32 bytes. It wraps the function [curve25519::scalar::Scalar::from_bytes_mod_order()](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/scalar/struct.Scalar.html#method.from_bytes_mod_order).  

## Motivation

* The RistrettoPrivate class is a wrapper around [curve25519_dalek::scalar::Scalar](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/scalar/struct.Scalar.html): this scalar is an integer modulo the order of the Ristretto group.
    The from_bytes() function in the RistrettoPrivate class wraps a call to 
    [curve25519_dalek::scalar::from_canonical_bytes](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/scalar/struct.Scalar.html#method.from_canonical_bytes)
    This function assumes that the input is the *canonical* byte representation of the scalar, so it can only be safely used if the input is the result of calling
    RistrettoPrivate::to_bytes(). 
* The ability to construct a Ristretto private key from an arbitrary array of 32 bytes is useful if we want to build a private key from another secret, e.g. to 
    convert from other key formats (such as Ed25519) or to create a "child" key from a "parent" key.
* This is the purpose of the function 
    [curve25519::scalar::Scalar::from_bytes_mod_order()](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/scalar/struct.Scalar.html#method.from_bytes_mod_order), but this function is not currently exposed by this crate. 

[Soundtrack of this PR](https://www.youtube.com/watch?v=lKcpodt0YCU)
