### PR TITLE
Track failed tx proposals in consensus

### DIFF
--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -142,14 +142,12 @@ impl ClientApiService {
 
                 let tracking_window = Duration::from_secs(5); // TODO, placeholder before draft PR gets published.
                 let mut tracker = self.tracked_sessions.lock().expect("Mutex poisoned");
-                let record = if let Some(record) = tracker.get_mut(&session_id) {
-                    record
-                } else {
-                    tracker.put(session_id.clone(), ClientSessionTracking::new());
-                    tracker
-                        .get_mut(&session_id)
-                        .expect("Adding session-tracking record should be atomic.")
-                };
+                if !tracker.contains(&session_id) {
+                  tracker.put(session_id.clone(), ClientSessionTracking::new());
+                }
+                let record = 
+                  tracker.get_mut(&session_id).expect("Session id {session_id} should be tracked.");
+   
                 let _recent_failure_count =
                     record.fail_tx_proposal(&Instant::now(), &tracking_window);
                 // TODO: drop session when recent_failure_count reaches some

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -277,9 +277,9 @@ impl ConsensusClientApi for ClientApiService {
         {
             let session = ClientSession::from(msg.channel_id.clone());
             let mut tracker = self.tracked_sessions.lock().expect("Mutex poisoned");
-            // Calling get() on the LRU bumps the entry to show up as more 
+            // Calling get() on the LRU bumps the entry to show up as more
             // recently-used.
-            if tracker.get(&session).is_none() { 
+            if tracker.get(&session).is_none() {
                 tracker.put(session, ClientSessionTracking::new());
             }
         }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -130,12 +130,26 @@ impl ClientApiService {
         msg: Message,
     ) -> Result<ProposeTxResponse, ConsensusGrpcError> {
         counters::ADD_TX_INITIATED.inc();
+        let session_id = ClientSession::from(msg.channel_id.clone());
         let tx_context = self.enclave.client_tx_propose(msg.into())?;
 
         // Cache the transaction. This performs the well-formedness checks.
         let tx_hash = self.tx_manager.insert(tx_context).map_err(|err| {
             if let TxManagerError::TransactionValidation(cause) = &err {
                 counters::TX_VALIDATION_ERROR_COUNTER.inc(&format!("{cause:?}"));
+
+                let tracking_window = Duration::from_secs(5); // TODO, placeholder before draft PR gets published. 
+                let mut tracker = self.tracked_sessions.lock().expect("Mutex poisoned");
+                let record = if let Some(record) = tracker.get_mut(&session_id) {
+                    record
+                } else {
+                    tracker.put(session_id.clone(), ClientSessionTracking::new());
+                    tracker.get_mut(&session_id)
+                        .expect("Adding session-tracking record should be atomic.")
+                    
+                };
+                let _recent_failure_count = record.fail_tx_proposal(&Instant::now(), &tracking_window);
+                // TODO: drop session when recent_failure_count reaches some number
             }
             err
         })?;
@@ -256,16 +270,6 @@ impl ConsensusClientApi for ClientApiService {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
 
-        {
-            let session = ClientSession::from(msg.channel_id.clone());
-            let mut tracker = self.tracked_sessions.lock().expect("Mutex poisoned");
-            if let Some(_session_info) = tracker.get(&session) {
-                // TODO: Update fields
-            } else {
-                // TODO: Populate new session metadata
-                tracker.put(session, ClientSessionTracking::new());
-            }
-        }
         if let Err(err) = check_request_chain_id(&self.config.chain_id, &ctx) {
             return send_result(ctx, sink, Err(err), &self.logger);
         }

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -69,9 +69,8 @@ impl ClientSessionTracking {
     /// have existed for longer than this value will be dropped when this
     /// method is called.
     pub fn fail_tx_proposal(&mut self, now: Instant, tracking_window: Duration) -> usize {
-        self.tx_proposal_failures.retain(|past_failure| {
-            now.saturating_duration_since(*past_failure) <= tracking_window
-        });
+        self.tx_proposal_failures
+            .retain(|past_failure| now.saturating_duration_since(*past_failure) <= tracking_window);
         self.tx_proposal_failures.push_back(now);
         self.tx_proposal_failures.len()
     }
@@ -145,11 +144,12 @@ impl ClientApiService {
                 let tracking_window = Duration::from_secs(60);
                 let mut tracker = self.tracked_sessions.lock().expect("Mutex poisoned");
                 if !tracker.contains(&session_id) {
-                  tracker.put(session_id.clone(), ClientSessionTracking::new());
+                    tracker.put(session_id.clone(), ClientSessionTracking::new());
                 }
-                let record = 
-                  tracker.get_mut(&session_id).expect("Session id {session_id} should be tracked.");
-   
+                let record = tracker
+                    .get_mut(&session_id)
+                    .expect("Session id {session_id} should be tracked.");
+
                 let _recent_failure_count =
                     record.fail_tx_proposal(Instant::now(), tracking_window);
                 // Dropping the client after a limit has been reached will be

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -70,7 +70,7 @@ impl ClientSessionTracking {
         self.tx_proposal_failures.retain(|past_failure| {
             now.saturating_duration_since(*past_failure) <= *tracking_window
         });
-        self.tx_proposal_failures.push_back(now.clone());
+        self.tx_proposal_failures.push_back(*now);
         self.tx_proposal_failures.len()
     }
 }


### PR DESCRIPTION
* Adds a field, `tx_proposal_failures` to `ClientSessionTracking`
* Implements the method `fail_tx_proposal()` on `ClientSessionTracking`
* Invokes `session.fail_tx_proposal(now)` when a tx proposal is found to be invalid.

## Motivation

This will be used to track how many failed tx proposals have been sent recently, so that bad connections can be dropped, to prevent attacks and harmful behavior from buggy clients. See: https://github.com/mobilecoinfoundation/mobilecoin/issues/2977

### Future Work
* Actually drop clients
* Prometheus metrics related to this system.
* Code to determine if a particular client / IP address needs to be blocked temporarily or indefinitely. 

