### PR TITLE
make the pre-commit hook check the year itself

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -147,7 +147,8 @@ fi
 
 # Similarly, check if copyright statements are missing and offer to add them if they are
 printf "${PREFIX} Checking copyright statements ... "
-COPYRIGHT_LINE="// Copyright (c) 2018-2022 The MobileCoin Foundation"
+YEAR=$(date +%Y)
+COPYRIGHT_LINE="// Copyright (c) 2018-${YEAR} The MobileCoin Foundation"
 diff=""
 for file in $(git diff --name-only --cached --diff-filter=d | egrep -v '^sgx/sgx_(tcrypto|urts|types)');
 do


### PR DESCRIPTION
this avoids annoying copyright nonsense when moving commits from master to release/v4.1, (2023 vs 2022)