### PR TITLE
mobilecoind: fix a bug in swap generation

### DIFF
--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1378,9 +1378,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
 
         // Build sci.
-        sci_builder
+        let mut result = sci_builder
             .build(&NoKeysRingSigner {}, rng)
-            .map_err(|err| Error::TxBuild(format!("build tx failed: {err}")))
+            .map_err(|err| Error::TxBuild(format!("build tx failed: {err}")))?;
+
+        result.tx_out_global_indices = global_indices;
+        Ok(result)
     }
 }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3815,6 +3815,12 @@ mod test {
             let sci = SignedContingentInput::try_from(sci).unwrap();
 
             sci.validate().unwrap();
+            assert_eq!(sci.tx_out_global_indices.len(), 11);
+            // Indices should be distinct
+            assert_eq!(
+                HashSet::from_iter(sci.tx_out_global_indices.iter()).len(),
+                11
+            );
 
             let unmasked_amount = sci.required_output_amounts[0].clone();
             assert_eq!(unmasked_amount.value, 999_999);


### PR DESCRIPTION
    The `SignedContingentInputBuilder` does not know the TxOut global
    indices of the ring elements, they usually aren't supplied to it
    unless merkle proofs of membership were supplied to it.
    It usually ends up setting `tx_out_global_indices` to a list of zeroes.
    Then the originator is supposed to set these correctly,
    and it falls to the counterparty to find proofs of membership.
    
    I forgot to do this in `generate_swap_impl`, so `mobilecoind` was
    leaving `tx_out_global_indices` with an incorrect setting. This
    commit fixes it and adds a test.

this bug was introduced a few days ago here: https://github.com/mobilecoinfoundation/mobilecoin/pull/3212