### PR TITLE
Bump versions to 4.1.0-pre0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1707,7 +1707,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2396,14 +2396,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2486,7 +2486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "bincode",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-net"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-verifier",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2618,7 +2618,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2793,7 +2793,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cargo-emit",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -2983,7 +2983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-common",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "chrono",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest 0.10.5",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest 0.10.5",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest 0.10.5",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand 0.8.5",
@@ -3395,7 +3395,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3424,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.32",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "crossbeam-channel",
@@ -3563,7 +3563,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "assert_cmd",
  "clap 4.0.32",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3718,7 +3718,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "dirs",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-attest-net",
  "mc-blockchain-test-utils",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "digest 0.10.5",
  "displaydoc",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -4054,14 +4054,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -4072,7 +4072,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4136,7 +4136,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4221,7 +4221,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4272,7 +4272,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-attest-core",
  "mc-crypto-digestible",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "clap 4.0.32",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "clap 4.0.32",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "clap 4.0.32",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "digest 0.10.5",
@@ -4515,7 +4515,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "grpcio",
  "mc-attest-core",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -4677,7 +4677,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "dirs",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-api",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "lmdb-rkv",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "clap 4.0.32",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "async-channel",
  "clap 4.0.32",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "grpcio",
  "hex",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5142,7 +5142,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2 0.10.6",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "hex_fmt",
@@ -5159,21 +5159,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5210,18 +5210,18 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-urts"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5232,7 +5232,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "assert_matches",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5396,7 +5396,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "hex",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata 0.15.1",
@@ -5498,7 +5498,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-util-build-info",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -5568,18 +5568,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-account-keys",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "grpcio",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-common",
@@ -5654,11 +5654,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "clap 4.0.32",
@@ -5687,7 +5687,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hex",
  "itertools",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "mc-crypto-keys",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "protobuf",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "itertools",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5813,11 +5813,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-util-uri"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -5843,14 +5843,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "getrandom 0.2.8",
  "mc-account-keys",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.0.32",
  "displaydoc",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "gRPC APIs for encrypted communications with an enclave"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform remote

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = """
 no_std structs used commonly in enclave api's in connection with attestation and key exchange

--- a/attest/net/Cargo.toml
+++ b/attest/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-net"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to communicate with

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform verification of

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating an enclave.

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains the actual implementation of a mobilenode enclave.

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin Consensus Enclave - Application Code"
 edition = "2021"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -726,14 +726,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "bitflags",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1278,11 +1278,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1313,29 +1313,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1364,14 +1364,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1379,11 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -1465,14 +1465,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Stellar Consensus Protocol"
 edition = "2021"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "Apache-2.0"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/dalek/Cargo.toml
+++ b/crypto/dalek/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin Dalek Crypto Configurator Package"
 edition = "2021"

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin multi-signature implementations"
 edition = "2021"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/rand/Cargo.toml
+++ b/crypto/rand/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = '''
 This crate provides a no-std compatible rng called `McRng`.

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Verification of X509 certificate chains"
 edition = "2021"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin Ingest Enclave - Measurement"
 edition = "2021"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -740,14 +740,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1030,7 +1030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1217,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1263,14 +1263,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1377,11 +1377,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1412,36 +1412,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1470,14 +1470,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1485,11 +1485,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1527,7 +1527,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1538,7 +1538,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1571,14 +1571,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1597,14 +1597,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating a ledger enclave.

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the actual implementation of a ledger enclave."

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin Ledger Enclave - Measurement"
 edition = "2021"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -744,14 +744,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -823,7 +823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -862,7 +862,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "rand",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1165,7 +1165,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1227,14 +1227,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1325,11 +1325,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1360,36 +1360,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1418,14 +1418,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1433,11 +1433,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1519,14 +1519,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1545,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Create and verify fog authority signatures"
 edition = "2021"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Create and verify fog report signatures"
 edition = "2021"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "MobileCoin Fog View Enclave - Application Code"
 edition = "2021"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -750,14 +750,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "bitflags",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-dalek"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-rand"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "rand",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-common",
  "mc-crypto-rand",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1188,14 +1188,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
  "signature",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1387,11 +1387,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "sha2",
@@ -1431,36 +1431,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1489,14 +1489,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1504,11 +1504,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-crypto-digestible",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1590,14 +1590,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -1616,14 +1616,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "The MobileCoin Fog user-facing server's enclave entry point."
 edition = "2021"

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Cargo build-script assistance, from MobileCoin."
 edition = "2021"

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"
 edition = "2021"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-ffi"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "A trait for constructing an object from a random number generator."
 edition = "2021"

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "Runtime gRPC Utilities"
 edition = "2021"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/u64-ratio/Cargo.toml
+++ b/util/u64-ratio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-u64-ratio"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "A helper for computing with ratios of u64 numbers"
 edition = "2021"

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 description = "A map object based on heapless Vec"
 edition = "2021"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "4.0.2"
+version = "4.1.0-pre0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
- Bump crate versions to 4.1.0-pre0.

### Motivation

Part of the release process.

