### PR TITLE
expose Schnorrkel Error from mc-crypto-keys

### DIFF
--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -76,7 +76,7 @@ pub(crate) use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 
 pub use digest::Digest;
 pub use mc_util_repr_bytes::{typenum::Unsigned, GenericArray, LengthMismatch, ReprBytes};
-pub use schnorrkel_og::{SignatureError as SchnorrkelError};
+pub use schnorrkel_og::SignatureError as SchnorrkelError;
 pub use signature::{
     DigestSigner, DigestVerifier, Error as SignatureError, Signature, Signer, Verifier,
 };

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::{
     ed25519::{Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature},
     ristretto::{
         CompressedRistrettoPublic, Ristretto, RistrettoEphemeralPrivate, RistrettoPrivate,
-        RistrettoPublic, RistrettoSecret, RistrettoSignature, SchnorrkelError,
+        RistrettoPublic, RistrettoSecret, RistrettoSignature,
     },
     traits::{
         DistinguishedEncoding, Fingerprintable, Kex, KexEphemeralPrivate, KexPrivate, KexPublic,
@@ -76,6 +76,7 @@ pub(crate) use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 
 pub use digest::Digest;
 pub use mc_util_repr_bytes::{typenum::Unsigned, GenericArray, LengthMismatch, ReprBytes};
+pub use schnorrkel_og::{SignatureError as SchnorrkelError};
 pub use signature::{
     DigestSigner, DigestVerifier, Error as SignatureError, Signature, Signer, Verifier,
 };

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
+// Copyright (c) 2018-2023 The MobileCoin Foundation
 
 //! A thin wrapper around Dalek libraries for key handling.
 //!
@@ -60,7 +60,7 @@ pub use crate::{
     ed25519::{Ed25519Pair, Ed25519Private, Ed25519Public, Ed25519Signature},
     ristretto::{
         CompressedRistrettoPublic, Ristretto, RistrettoEphemeralPrivate, RistrettoPrivate,
-        RistrettoPublic, RistrettoSecret, RistrettoSignature,
+        RistrettoPublic, RistrettoSecret, RistrettoSignature, SchnorrkelError,
     },
     traits::{
         DistinguishedEncoding, Fingerprintable, Kex, KexEphemeralPrivate, KexPrivate, KexPublic,


### PR DESCRIPTION
This type is already exposed in public APIs of RistrettoPublic and various conversions, but it is not actually exported from the crate, so there is no way for downstream to name the type.

This commit re-exports the type at crate level, which is already part of the public API anyways.