### PR TITLE
Optelemetry tracing for FLR

### DIFF
--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -67,10 +67,9 @@ where
 {
     let tracer = tracer!();
     match request.request_data {
-        Some(LedgerRequest_oneof_request_data::auth(request)) => tracer
-            .in_span("auth", |_cx| {
-                handle_auth_request(enclave, request, logger)
-            }),
+        Some(LedgerRequest_oneof_request_data::auth(request)) => {
+            tracer.in_span("auth", |_cx| handle_auth_request(enclave, request, logger))
+        }
         Some(LedgerRequest_oneof_request_data::check_key_images(request)) => {
             handle_query_request(
                 request,
@@ -233,7 +232,10 @@ where
             .into();
         let clients_and_responses =
             route_query(&multi_ledger_store_query_request, shards_to_query.clone())
-                .with_context(create_context(tracer, "send_multi_key_image_request_to_shards"))
+                .with_context(create_context(
+                    tracer,
+                    "send_multi_key_image_request_to_shards",
+                ))
                 .await
                 .map_err(|err| {
                     router_server_err_to_rpc_status(

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -19,7 +19,7 @@ use mc_fog_api::{
 use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
 use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
-use mc_util_telemetry::{tracer, Tracer, FutureExt, create_context, BoxedTracer};
+use mc_util_telemetry::{create_context, tracer, BoxedTracer, FutureExt, Tracer};
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
 /// Handles a series of requests sent by the Fog Ledger Router client,
@@ -67,22 +67,21 @@ where
 {
     let tracer = tracer!();
     match request.request_data {
-        Some(LedgerRequest_oneof_request_data::auth(request)) => {
-            tracer.in_span("router_auth", |_cx| {
-                handle_auth_request(enclave, request, logger) 
-            })
-        }
+        Some(LedgerRequest_oneof_request_data::auth(request)) => tracer
+            .in_span("router_auth", |_cx| {
+                handle_auth_request(enclave, request, logger)
+            }),
         Some(LedgerRequest_oneof_request_data::check_key_images(request)) => {
             handle_query_request(
-                    request,
-                    enclave,
-                    shard_clients,
-                    query_retries,
-                    logger,
-                    &tracer
-                )
-                .with_context(create_context(&tracer, "router_query"))
-                .await
+                request,
+                enclave,
+                shard_clients,
+                query_retries,
+                logger,
+                &tracer,
+            )
+            .with_context(create_context(&tracer, "router_query"))
+            .await
         }
         None => {
             let rpc_status = rpc_invalid_arg_error(
@@ -219,18 +218,19 @@ where
     // remaining_retries and loop
     let mut remaining_retries = query_retries;
     while remaining_retries > 0 {
-        let multi_ledger_store_query_request = 
-            tracer.in_span("router_create_multi_key_image_store_query_data", |_cx| {
-                enclave.create_multi_key_image_store_query_data(
-                    sealed_query.clone()
-                ).map_err(|err| {
-                    router_server_err_to_rpc_status(
-                        "Key Images Query: internal encryption error",
-                        err.into(),
-                        logger.clone(),
-                    )
-                })
-        })?.into();
+        let multi_ledger_store_query_request = tracer
+            .in_span("router_create_multi_key_image_store_query_data", |_cx| {
+                enclave
+                    .create_multi_key_image_store_query_data(sealed_query.clone())
+                    .map_err(|err| {
+                        router_server_err_to_rpc_status(
+                            "Key Images Query: internal encryption error",
+                            err.into(),
+                            logger.clone(),
+                        )
+                    })
+            })?
+            .into();
         let clients_and_responses =
             route_query(&multi_ledger_store_query_request, shards_to_query.clone())
                 .with_context(create_context(tracer, "router_route_query"))
@@ -245,14 +245,14 @@ where
 
         let processed_shard_response_data =
             tracer.in_span("router_process_shard_responses", |_cx| {
-            process_shard_responses(clients_and_responses, logger.clone()).map_err(|err| {
-                router_server_err_to_rpc_status(
-                    "Key Images Query: internal query response processing",
-                    err,
-                    logger.clone(),
-                )
-            })
-        })?;
+                process_shard_responses(clients_and_responses, logger.clone()).map_err(|err| {
+                    router_server_err_to_rpc_status(
+                        "Key Images Query: internal query response processing",
+                        err,
+                        logger.clone(),
+                    )
+                })
+            })?;
 
         for (store_responder_id, new_query_response) in processed_shard_response_data
             .new_query_responses
@@ -289,9 +289,9 @@ where
         ));
     }
 
-    let query_response = 
-        tracer.in_span("router_collate_shard_query_responses", |_cx| {
-            enclave.collate_shard_query_responses(sealed_query, query_responses)
+    let query_response = tracer.in_span("router_collate_shard_query_responses", |_cx| {
+        enclave
+            .collate_shard_query_responses(sealed_query, query_responses)
             .map_err(|err| {
                 router_server_err_to_rpc_status(
                     "Key Images Query: shard response collation error",
@@ -299,8 +299,7 @@ where
                     logger.clone(),
                 )
             })
-        }
-    )?;
+    })?;
 
     let mut response = LedgerResponse::new();
     response.set_check_key_image_response(query_response.into());

--- a/fog/ledger/server/src/router_service.rs
+++ b/fog/ledger/server/src/router_service.rs
@@ -106,7 +106,7 @@ where
         shard_clients,
         query_retries,
         scope_logger.clone(),
-        &tracer
+        &tracer,
     )
     .await;
 

--- a/fog/ledger/server/src/router_service.rs
+++ b/fog/ledger/server/src/router_service.rs
@@ -15,6 +15,7 @@ use mc_fog_api::{
 use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::KeyImageStoreUri;
 use mc_util_grpc::{rpc_internal_error, rpc_logger};
+use mc_util_telemetry::tracer;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
@@ -98,12 +99,14 @@ async fn unary_check_key_image_impl<E>(
 where
     E: LedgerEnclaveProxy,
 {
+    let tracer = tracer!();
     let result = handle_query_request(
         request,
         enclave,
         shard_clients,
         query_retries,
         scope_logger.clone(),
+        &tracer
     )
     .await;
 


### PR DESCRIPTION
Adds optelemetry tracing calls to router_handlers.rs and router_service.rs. 

### Motivation

For all of the reasons metrics tracking is useful in general, we've needed to implement optelemmetry metrics for the Fog Ledger Router. This is modeled after a similar pull request, #2979 for Fog View Router.

### Future Work
\* Since this pull request is, for the most part, a simple copying-over of work from #2979 from the Fog View Router to the Fog Ledger Router, no finer-grained metrics specific to the Fog Ledger Router are present yet. In particular, these metrics do not differentiate between key-image requests and other types of request such as merkle proofs and block service. Optelemmetry calls in those preexisting services probably already cover this, but it might be worth double-checking.  
\* There is no testing in place, at present, to ensure the information expected is actually being emitted for these metrics. 