### PR TITLE
Prometheus metrics for FLR

### DIFF
--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use crate::error::{router_server_err_to_rpc_status, RouterServerError};
+use crate::{error::{router_server_err_to_rpc_status, RouterServerError}, SVC_COUNTERS};
 use futures::{future::try_join_all, SinkExt, TryStreamExt};
 use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
 use mc_attest_api::attest;
@@ -18,12 +18,14 @@ use mc_fog_api::{
 };
 use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
-use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel};
+use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel, ResponseStatus};
+use mc_util_metrics::GrpcMethodName;
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
 /// Handles a series of requests sent by the Fog Ledger Router client,
 /// routing them out to shards.
 pub async fn handle_requests<E>(
+    method_name: GrpcMethodName,
     shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
     enclave: E,
     mut requests: RequestStream<LedgerRequest>,
@@ -35,6 +37,12 @@ where
     E: LedgerEnclaveProxy,
 {
     while let Some(request) = requests.try_next().await? {
+        // Per the comment thread on pull request #2976, this should be
+        // req_impl() and not req().
+        // This is so that one call of the original request() method is
+        // reported per each actual request the client sends.
+        let _timer = SVC_COUNTERS.req_impl(&method_name);
+
         let result = handle_request(
             request,
             shard_clients.clone(),
@@ -43,6 +51,11 @@ where
             logger.clone(),
         )
         .await;
+
+        let response_status = ResponseStatus::from(&result);
+        SVC_COUNTERS.resp_impl(&method_name, response_status.is_success);
+        SVC_COUNTERS.status_code_impl(&method_name, response_status.code);
+
         match result {
             Ok(response) => responses.send((response, WriteFlags::default())).await?,
             Err(rpc_status) => return responses.fail(rpc_status).await,

--- a/fog/ledger/server/src/router_service.rs
+++ b/fog/ledger/server/src/router_service.rs
@@ -15,6 +15,7 @@ use mc_fog_api::{
 use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::KeyImageStoreUri;
 use mc_util_grpc::{rpc_internal_error, rpc_logger};
+use mc_util_metrics::ServiceMetrics;
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
@@ -68,7 +69,10 @@ where
             let logger = logger.clone();
 
             let shards = self.shards.read().expect("RwLock poisoned");
+            let method_name = ServiceMetrics::get_method_name(&ctx);
+            
             let future = router_handlers::handle_requests(
+                method_name,
                 shards.values().cloned().collect(),
                 self.enclave.clone(),
                 requests,


### PR DESCRIPTION
Adds Prometheus metrics calls to router_handlers.rs and router_service.rs.

### Motivation

For all of the reasons metrics tracking is useful in general, we've needed to implement optelemmetry metrics for the Fog Ledger Router. This is modeled after a similar pull request, #2976, for Fog View Router.

### Future Work
There is no testing in place, at present, to ensure the information expected is actually being emitted for these metrics.
