### PR TITLE
fix enclave panic reporting so that it always shows the error

### DIFF
--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -15,8 +15,18 @@ pub unsafe extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
 
 fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
     match str::from_utf8(panic_msg_bytes) {
+        // We log to both STDERR and the slog interface, which goes to STDOUT.
+        // The reasoning is, we want most stuff to be directed at slog, because
+        // that's what our production logging is picking up right now, and
+        // those logs will have timing, source data, etc.
+        // However, when running locally in SGX_MODE=SW, what typically happens
+        // during an enclave panic is that the process crashes almost immediately
+        // after this OCALL returns, and slog doesn't manage to flush its buffer
+        // before the process dies, which makes it hard for a dev to debug.
+        // By logging to STDERR also we make sure the message gets to an OS
+        // buffer before the process dies.
         Ok(v) => {
-            eprintln!("Enclave panic:\n{}\n", v);
+            eprintln!("Enclave panic:\n{}", v);
             global_log::crit!("Enclave panic:\n{}\n", v)
         },
         Err(e) => {

--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
+// Copyright (c) 2018-2023 The MobileCoin Foundation
 
 // Mobilenode-side support for sgx_panic crate impl
 //
@@ -15,11 +15,14 @@ pub unsafe extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
 
 fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
     match str::from_utf8(panic_msg_bytes) {
-        Ok(v) => global_log::crit!("Enclave panic:\n{}\n", v),
-        Err(e) => global_log::crit!(
+        Ok(v) => { eprintln!("Enclave panic:\n{}\n", v); global_log::crit!("Enclave panic:\n{}\n", v)},
+        Err(e) => {
+            eprintln!("Enclave panic message contained invalid utf8:\n{}\n{:?}", e, panic_msg_bytes);
+            global_log::crit!(
             "Enclave panic message contained invalid utf8:\n{}\n{:?}",
             e,
             panic_msg_bytes
-        ),
+        )
+        },
     }
 }

--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -15,14 +15,17 @@ pub unsafe extern "C" fn report_panic_message(msg: *const u8, msg_len: usize) {
 
 fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
     match str::from_utf8(panic_msg_bytes) {
-        Ok(v) => { eprintln!("Enclave panic:\n{}\n", v); global_log::crit!("Enclave panic:\n{}\n", v)},
+        Ok(v) => {
+            eprintln!("Enclave panic:\n{}\n", v);
+            global_log::crit!("Enclave panic:\n{}\n", v)
+        },
         Err(e) => {
             eprintln!("Enclave panic message contained invalid utf8:\n{}\n{:?}", e, panic_msg_bytes);
             global_log::crit!(
-            "Enclave panic message contained invalid utf8:\n{}\n{:?}",
-            e,
-            panic_msg_bytes
-        )
+                "Enclave panic message contained invalid utf8:\n{}\n{:?}",
+                e,
+                panic_msg_bytes
+            )
         },
     }
 }


### PR DESCRIPTION
Most of the time when an enclave panics, particularly during local development, the process dies with a hard abort before slog gets a chance to flush it's buffer.

This commit makes it emit the panic message on STDERR first, using eprintln, which means it will be in an OS buffer before the process ends. We continue to write it as well as to slog, which writes to STDOUT.

I see no reason not to do this, it's a massive quality of life improvement for anyone actually working on enclave-impl's.

Without this patch, 100% of the time i do not get panic messages from the enclave, and just a core dumped (aborted) message.