### PR TITLE
Extend b58-decoder to print public address hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5421,6 +5421,7 @@ version = "4.1.0-pre0"
 dependencies = [
  "clap 4.1.11",
  "hex",
+ "mc-account-keys",
  "mc-api",
 ]
 

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -11,6 +11,7 @@ name = "mc-util-b58-decoder"
 path = "src/bin/main.rs"
 
 [dependencies]
+mc-account-keys = { path = "../../account-keys" }
 mc-api = { path = "../../api" }
 
 clap = { version = "4.1", features = ["derive", "env"] }

--- a/util/b58-decoder/src/bin/main.rs
+++ b/util/b58-decoder/src/bin/main.rs
@@ -89,7 +89,7 @@ fn print_public_address(pub_addr: &PublicAddressProto) {
             println!("Address hash: {}", &address_hash);
         }
         Err(err) => {
-            println!("Failed to validate PublicAddress struct: {}", err);
+            println!("Failed to validate PublicAddress struct: {err}");
         }
     }
 }

--- a/util/b58-decoder/src/bin/main.rs
+++ b/util/b58-decoder/src/bin/main.rs
@@ -4,7 +4,8 @@
 //! A utility for decoding b58 strings
 
 use clap::Parser;
-use mc_api::{external::PublicAddress, printable::PrintableWrapper};
+use mc_account_keys::{PublicAddress, ShortAddressHash};
+use mc_api::{external::PublicAddress as PublicAddressProto, printable::PrintableWrapper};
 
 #[derive(Parser)]
 struct Config {
@@ -63,7 +64,7 @@ fn main() {
     }
 }
 
-fn print_public_address(pub_addr: &PublicAddress) {
+fn print_public_address(pub_addr: &PublicAddressProto) {
     println!(
         "View public key: {}",
         hex::encode(pub_addr.get_view_public_key().get_data())
@@ -78,4 +79,17 @@ fn print_public_address(pub_addr: &PublicAddress) {
         "Fog authority sig: {}",
         hex::encode(pub_addr.get_fog_authority_sig())
     );
+
+    let parse_result = PublicAddress::try_from(pub_addr);
+    match parse_result {
+        Ok(parsed_addr) => {
+            println!("Validated: {:?}", &parsed_addr);
+
+            let address_hash = ShortAddressHash::from(&parsed_addr);
+            println!("Address hash: {}", &address_hash);
+        }
+        Err(err) => {
+            println!("Failed to validate PublicAddress struct: {}", err);
+        }
+    }
 }


### PR DESCRIPTION
Provide a helper to compute the hash for a public address, to facilitate spot-checking RTH and T3 entries.

Sample output:
```
B58 decoded successfully to a PrintableWrapper with a PublicAddress
View public key: ec4836064f75a531074e304d3bd37d0c3bd2f2a657d8318208c86d3f152e9c05
Spend public key: 22dd62976a5963d14c382e75c26d15a7a96088f77998186fb187884282bd7331
Fog report URL: fog://fog.prod.mobilecoinww.com
Fog report id: 
Fog authority sig: c4d4c09752c323217f64848b39babde7b34fa9df22fe9bdcd7a07fc54e7eff0c278ed743f879cf019d53336d4595285914f818933998b47f00783f2dfe671180
Validated: PublicAddress { view_public_key: RistrettoPublic(ec4836064f75a531074e304d3bd37d0c3bd2f2a657d8318208c86d3f152e9c05), spend_public_key: RistrettoPublic(22dd62976a5963d14c382e75c26d15a7a96088f77998186fb187884282bd7331), fog_report_url: "fog://fog.prod.mobilecoinww.com", fog_report_id: "", fog_authority_sig: [196, 212, 192, 151, 82, 195, 35, 33, 127, 100, 132, 139, 57, 186, 189, 231, 179, 79, 169, 223, 34, 254, 155, 220, 215, 160, 127, 197, 78, 126, 255, 12, 39, 142, 215, 67, 248, 121, 207, 1, 157, 83, 51, 109, 69, 149, 40, 89, 20, 248, 24, 147, 57, 152, 180, 127, 0, 120, 63, 45, 254, 103, 17, 128] }
Address hash: fa4126c788eded5375ab5e34292fb027
```