### PR TITLE
bump to mc-oblivious release 2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-cmov"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09d3ea1089af7eb2784eca92ed14a41168352d47565f1eb1bdd23460909ba1"
+checksum = "618b842c70f8bbf37d814e3216dccdcedb5e4995e81fbb42f709cd10116df6f2"
 dependencies = [
  "aligned-array",
  "generic-array",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "balanced-tree-index"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31868e43a6cb114c4924fdf682ca8caa4649f2e1968e38951d2ee9e9087a35c1"
+checksum = "9cb637edbca91c1be6b05b38c94fbd173d8e92ba2317e2368ee1f70fe1d83244"
 dependencies = [
  "aligned-cmov",
  "rand_core",
@@ -4901,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-map"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a5d3ec41e27ef685e5aa261d3de25c42354771015865af874a5fbb0ceb1a87"
+checksum = "4c82467a05c5a181f3113f181a0df2a01aa66c87072081071ee2652ccc5858e3"
 dependencies = [
  "aligned-array",
  "aligned-cmov",
@@ -4915,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-ram"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85056a9110ea75a46f1d3ae58b67d90c70bed41b42509814cf4533673fe98d17"
+checksum = "86b391b564c9f19123eaa078531b89858fa1764b8e92edf5c59c1e3460d3aadc"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",
@@ -4927,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-traits"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3282b221fd65da0ce7c0749c21c41a73db062a1bde1bd57eafb3cdd2ac5ab848"
+checksum = "56a0bf3928f85cb40f30954d0882f595b0543343e978f5d7e24afd392bd5e127"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -23,10 +23,10 @@ mc-util-from-random = { path = "../../../../util/from-random" }
 mc-util-serial = { path = "../../../../util/serial" }
 
 # mc-oblivious
-aligned-cmov = "2.2"
-mc-oblivious-map = "2.2"
-mc-oblivious-ram = "2.2"
-mc-oblivious-traits = "2.2"
+aligned-cmov = "2.3"
+mc-oblivious-map = "2.3"
+mc-oblivious-ram = "2.3"
+mc-oblivious-traits = "2.3"
 
 # fog
 mc-fog-ingest-enclave-api = { path = "../api", default-features = false }

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-cmov"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09d3ea1089af7eb2784eca92ed14a41168352d47565f1eb1bdd23460909ba1"
+checksum = "618b842c70f8bbf37d814e3216dccdcedb5e4995e81fbb42f709cd10116df6f2"
 dependencies = [
  "aligned-array",
  "generic-array",
@@ -92,9 +92,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "balanced-tree-index"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31868e43a6cb114c4924fdf682ca8caa4649f2e1968e38951d2ee9e9087a35c1"
+checksum = "9cb637edbca91c1be6b05b38c94fbd173d8e92ba2317e2368ee1f70fe1d83244"
 dependencies = [
  "aligned-cmov",
  "rand_core",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-map"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a5d3ec41e27ef685e5aa261d3de25c42354771015865af874a5fbb0ceb1a87"
+checksum = "4c82467a05c5a181f3113f181a0df2a01aa66c87072081071ee2652ccc5858e3"
 dependencies = [
  "aligned-array",
  "aligned-cmov",
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-ram"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85056a9110ea75a46f1d3ae58b67d90c70bed41b42509814cf4533673fe98d17"
+checksum = "86b391b564c9f19123eaa078531b89858fa1764b8e92edf5c59c1e3460d3aadc"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-traits"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3282b221fd65da0ce7c0749c21c41a73db062a1bde1bd57eafb3cdd2ac5ab848"
+checksum = "56a0bf3928f85cb40f30954d0882f595b0543343e978f5d7e24afd392bd5e127"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -23,10 +23,10 @@ mc-util-serial = { path = "../../../../util/serial" }
 mc-watcher-api = { path = "../../../../watcher/api" }
 
 # mc-oblivious
-aligned-cmov = "2.2"
-mc-oblivious-map = "2.2"
-mc-oblivious-ram = "2.2"
-mc-oblivious-traits = "2.2"
+aligned-cmov = "2.3"
+mc-oblivious-map = "2.3"
+mc-oblivious-ram = "2.3"
+mc-oblivious-traits = "2.3"
 
 # fog
 mc-fog-ledger-enclave-api = { path = "../api", default-features = false }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-cmov"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09d3ea1089af7eb2784eca92ed14a41168352d47565f1eb1bdd23460909ba1"
+checksum = "618b842c70f8bbf37d814e3216dccdcedb5e4995e81fbb42f709cd10116df6f2"
 dependencies = [
  "aligned-array",
  "generic-array",
@@ -92,9 +92,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "balanced-tree-index"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31868e43a6cb114c4924fdf682ca8caa4649f2e1968e38951d2ee9e9087a35c1"
+checksum = "9cb637edbca91c1be6b05b38c94fbd173d8e92ba2317e2368ee1f70fe1d83244"
 dependencies = [
  "aligned-cmov",
  "rand_core",
@@ -1215,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-map"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a5d3ec41e27ef685e5aa261d3de25c42354771015865af874a5fbb0ceb1a87"
+checksum = "4c82467a05c5a181f3113f181a0df2a01aa66c87072081071ee2652ccc5858e3"
 dependencies = [
  "aligned-array",
  "aligned-cmov",
@@ -1229,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-ram"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85056a9110ea75a46f1d3ae58b67d90c70bed41b42509814cf4533673fe98d17"
+checksum = "86b391b564c9f19123eaa078531b89858fa1764b8e92edf5c59c1e3460d3aadc"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-traits"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3282b221fd65da0ce7c0749c21c41a73db062a1bde1bd57eafb3cdd2ac5ab848"
+checksum = "56a0bf3928f85cb40f30954d0882f595b0543343e978f5d7e24afd392bd5e127"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -9,8 +9,8 @@ rust-version = { workspace = true }
 
 [dependencies]
 # mc-oblivious
-aligned-cmov = "2.2"
-mc-oblivious-traits = "2.2"
+aligned-cmov = "2.3"
+mc-oblivious-traits = "2.3"
 
 # fog
 mc-fog-ocall-oram-storage-trusted = { path = "../trusted" }

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -12,9 +12,9 @@ rust-version = { workspace = true }
 mc-sgx-compat = { path = "../../../sgx/compat" }
 
 # mc-oblivious
-aligned-cmov = "2.2"
-balanced-tree-index = "2.2"
-mc-oblivious-traits = "2.2"
+aligned-cmov = "2.3"
+balanced-tree-index = "2.3"
+mc-oblivious-traits = "2.3"
 
 # third-party
 aes = "0.8.2"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -19,10 +19,10 @@ mc-sgx-report-cache-api = { path = "../../../../sgx/report-cache/api" }
 mc-util-serial = { path = "../../../../util/serial", default-features = false }
 
 # mc-oblivious
-aligned-cmov = "2.2"
-mc-oblivious-map = "2.2"
-mc-oblivious-ram = "2.2"
-mc-oblivious-traits = "2.2"
+aligned-cmov = "2.3"
+mc-oblivious-map = "2.3"
+mc-oblivious-ram = "2.3"
+mc-oblivious-traits = "2.3"
 
 # fog
 mc-fog-recovery-db-iface = { path = "../../../recovery_db_iface" }

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-cmov"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac09d3ea1089af7eb2784eca92ed14a41168352d47565f1eb1bdd23460909ba1"
+checksum = "618b842c70f8bbf37d814e3216dccdcedb5e4995e81fbb42f709cd10116df6f2"
 dependencies = [
  "aligned-array",
  "generic-array",
@@ -92,9 +92,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "balanced-tree-index"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31868e43a6cb114c4924fdf682ca8caa4649f2e1968e38951d2ee9e9087a35c1"
+checksum = "9cb637edbca91c1be6b05b38c94fbd173d8e92ba2317e2368ee1f70fe1d83244"
 dependencies = [
  "aligned-cmov",
  "rand_core",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-map"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a5d3ec41e27ef685e5aa261d3de25c42354771015865af874a5fbb0ceb1a87"
+checksum = "4c82467a05c5a181f3113f181a0df2a01aa66c87072081071ee2652ccc5858e3"
 dependencies = [
  "aligned-array",
  "aligned-cmov",
@@ -1291,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-ram"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85056a9110ea75a46f1d3ae58b67d90c70bed41b42509814cf4533673fe98d17"
+checksum = "86b391b564c9f19123eaa078531b89858fa1764b8e92edf5c59c1e3460d3aadc"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "mc-oblivious-traits"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3282b221fd65da0ce7c0749c21c41a73db062a1bde1bd57eafb3cdd2ac5ab848"
+checksum = "56a0bf3928f85cb40f30954d0882f595b0543343e978f5d7e24afd392bd5e127"
 dependencies = [
  "aligned-cmov",
  "balanced-tree-index",

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -20,7 +20,7 @@ mc-fog-ingest-enclave-api = { path = "../../fog/ingest/enclave/api" }
 mc-fog-ingest-enclave-impl = { path = "../../fog/ingest/enclave/impl" }
 mc-fog-types = { path = "../../fog/types" }
 mc-fog-view-protocol = { path = "../../fog/view/protocol" }
-mc-oblivious-traits = "2.2"
+mc-oblivious-traits = "2.3"
 mc-test-vectors-definitions = { path = "../definitions" }
 mc-transaction-builder = { path = "../../transaction/builder" }
 mc-transaction-core = { path = "../../transaction/core" }


### PR DESCRIPTION
this helps unblock grapevine, because fog-ocall-oram-storage depends on mc-oblivious-traits, and grapevine needs both