### PR TITLE
Failure limit on tx proposals

### DIFF
--- a/consensus/api/proto/consensus_config.proto
+++ b/consensus/api/proto/consensus_config.proto
@@ -69,4 +69,24 @@ message ConsensusNodeConfig {
 
     // SCP message signing key.
     external.Ed25519Public scp_message_signing_key = 8;
+
+    // Maximum number of client session tracking structures to retain in
+    // a least-recently-used cache.
+    //
+    // This corresponds to Config::client_tracking_capacity
+    uint64 client_tracking_capacity = 9;
+
+    // How many seconds to retain instances of proposed-transaction
+    // failures, per-client. This is used to implement DOS-protection,
+    // protecting against clients who make too many failed
+    // transaction proposals within this span.
+    uint64 tx_failure_window_seconds = 10;
+
+    // How many tx proposal failures within the rolling window are required
+    // before it's treated as concerning, thereby tripping denial-of-service
+    // protection?
+    // In other words, how many failed transaction proposals are permitted
+    // within the last tx_failure_window_seconds before a user is
+    // disconnected or temporarily blocked?
+    uint32 tx_failure_limit = 11;
 }

--- a/consensus/service/config/src/lib.rs
+++ b/consensus/service/config/src/lib.rs
@@ -136,6 +136,24 @@ pub struct Config {
     /// config setting to match.
     #[clap(long, default_value = "10000", env = "MC_CLIENT_TRACKING_CAPACITY")]
     pub client_tracking_capacity: usize,
+
+    /// How many seconds to retain instances of proposed-transaction
+    /// failures, per-client. This is used to implement DOS-protection, 
+    /// along the lines of kicking clients who make too many failed transaction
+    /// proposals within the span of tx_failure_window
+    // TODO: slam-testing to derive reasonable default
+    #[clap(long, default_value = "30", value_parser = parse_duration_in_seconds, env = "MC_CLIENT_TX_FAILURE_WINDOW")]
+    pub tx_failure_window: Duration,
+
+    /// How many tx proposal failures within the rolling window are required
+    /// before it's treated as concerning, thereby tripping denial-of-service
+    /// protection?
+    /// In other words, how many failed transaction proposals are permitted
+    /// within the last tx_failure_window seconds before a user is
+    /// disconnected or temporarily blocked?
+    // TODO: slam-testing to derive reasonable default
+    #[clap(long, default_value = "16384", env = "MC_CLIENT_TX_FAILURE_LIMIT")]
+    pub tx_failure_limit: u32,
 }
 
 impl Config {
@@ -224,6 +242,9 @@ mod tests {
             tokens_path: None,
             block_version: BlockVersion::ZERO,
             client_tracking_capacity: 4096,
+            tx_failure_window: Duration::from_secs(30),
+            tx_failure_limit: 16384,
+            
         };
 
         assert_eq!(
@@ -293,6 +314,8 @@ mod tests {
             tokens_path: None,
             block_version: BlockVersion::ZERO,
             client_tracking_capacity: 4096,
+            tx_failure_window: Duration::from_secs(30),
+            tx_failure_limit: 16384,
         };
 
         assert_eq!(


### PR DESCRIPTION
* Detects when a client has submitted excessive invalid tx proposals within a configurable rolling window
* Adds `tx_failure_window` and `tx_failure_limit` fields to the consensus service config Rust structure (for use with `clap`). 
* Adds `tx_failure_window_seconds` and `tx_failure_limit`, as well as previously-missed `client_tracking_capacity` to the `ConsensusNodeConfig` protobuf, and amends `get_node_config` to add those values to that configuration export.

### Motivation

This will be used to track how many failed tx proposals have been sent recently, so that bad connections can be dropped, to prevent attacks and harmful behavior from buggy clients. See: https://github.com/mobilecoinfoundation/mobilecoin/issues/2977

### Future Work
* Slam-testing to determine reasonable defaults for `tx_failure_window` and `tx_failure_limit`
