### PR TITLE
CI/CD: use cluster wide star cert for dev environments.

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -63,7 +63,7 @@ jobs:
         do
           aws s3 cp --only-show-errors --recursive --acl public-read \
             "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
-            "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com"
+            "s3://${BUCKET}/node${i}-${NAMESPACE}.dev.mc.dance"
         done
 
   setup-environment:

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -77,7 +77,10 @@ jobs:
         image:
           org: ${{ inputs.docker_image_org }}
         global:
-          certManagerClusterIssuer: zerossl-prod-http
+          ingress:
+            tls:
+              # use cluster default cert
+              enabled: false
         node:
           resources:
             limits:
@@ -86,8 +89,8 @@ jobs:
               intel.com/sgx: 2000
           persistence:
             enabled: false
-          client:
-            attest:
+          ingress:
+            clientAttest:
               rateLimits:
                 enabled: false
         EOF
@@ -140,7 +143,10 @@ jobs:
         image:
           org: ${{ inputs.docker_image_org }}
         global:
-          certManagerClusterIssuer: zerossl-prod-http
+          ingress:
+            tls:
+              # use cluster default cert
+              enabled: false
         fogLedger:
           resources:
             limits:
@@ -258,14 +264,14 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           # Get fog report
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
+          /test/check-ingress-ready.sh --url "https://fog-${{ inputs.namespace }}.mc.dance/gw/report.ReportAPI/GetReports"
 
           # Get fog ledger
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks"
+          /test/check-ingress-ready.sh --url "https://fog-${{ inputs.namespace }}.dev.mc.dance/gw/fog_ledger.FogBlockAPI/GetBlocks"
 
           # Get consensus client ports
-          /test/check-ingress-ready.sh --url "https://node1.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node2.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node3.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
+          /test/check-ingress-ready.sh --url "https://node1-${{ inputs.namespace }}.dev.mc.dance/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
+          /test/check-ingress-ready.sh --url "https://node2-${{ inputs.namespace }}.dev.mc.dance/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
+          /test/check-ingress-ready.sh --url "https://node3-${{ inputs.namespace }}.dev.mc.dance/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
 
           # no unauthenticated endpoints for view :(

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -162,7 +162,8 @@ jobs:
         echo -n "${{ secrets.DEV_KEYS_SEED_MNEMONIC_FOG }}" > "${SEEDS_BASE_PATH}/MNEMONIC_FOG_KEYS_SEED"
         echo -n "${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT"
         echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT_PATH"
-        echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_URL"
+        echo -n "fog://fog-${{ inputs.namespace }}.dev.mc.dance:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_URL"
+        echo -n "dev.mc.dance" > "${SEEDS_BASE_PATH}/BASE_DOMAIN"
 
     - name: Create wallet key secrets
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -99,6 +99,7 @@ jobs:
       V3_DST_FOG_KEYS_DIR: /tmp/3-testing/fog_keys
       START_KEYS: '494'
       END_KEYS: '499'
+      BASE_DOMAIN: dev.mc.dance
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -127,7 +128,7 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           INITIALIZE_LEDGER="true" \
-          FOG_REPORT_URL="fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" \
+          FOG_REPORT_URL="fog://fog-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}:443" \
           /util/generate_origin_data.sh
 
     - name: Test - fog-distribution
@@ -156,15 +157,15 @@ jobs:
         command: |
           test_client \
             --key-dir /tmp/sample_data/fog_keys \
-            --consensus mc://node1.${{ inputs.namespace }}.development.mobilecoin.com/ \
-            --consensus mc://node2.${{ inputs.namespace }}.development.mobilecoin.com/ \
-            --consensus mc://node3.${{ inputs.namespace }}.development.mobilecoin.com/ \
+            --consensus mc://node1-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}/ \
+            --consensus mc://node2-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}/ \
+            --consensus mc://node3-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}/ \
             --num-clients 6 \
             --num-transactions 32 \
             --consensus-wait 300 \
             --transfer-amount 20 \
-            --fog-view fog-view://fog.${{ inputs.namespace }}.development.mobilecoin.com:443 \
-            --fog-ledger fog-ledger://fog.${{ inputs.namespace }}.development.mobilecoin.com:443
+            --fog-view fog-view://fog-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}:443 \
+            --fog-ledger fog-ledger://fog-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}:443
 
     - name: Test - block-v0 - mobilecoind-grpc (previously Wallet Integration)
       if: inputs.testing_block_v0
@@ -229,8 +230,9 @@ jobs:
             JSON_FLAG="--json"
           fi
           /test/minting-config-tx-test.sh \
-            $JSON_FLAG \
-            --token-id 8192
+            "${JSON_FLAG}" \
+            --token-id 8192 \
+            --node node1-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}
 
     - name: Test - block-v2 - Minting tx
       if: inputs.testing_block_v2
@@ -245,7 +247,8 @@ jobs:
         command: |
           /test/minting-tx-test.sh \
             --key-dir ${{ env.V2_DST_KEYS_DIR }} \
-            --token-id 8192
+            --token-id 8192 \
+            --node node1-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}
 
     - name: Test - block-v2 - mobilecoind-json integration
       if: inputs.testing_block_v2
@@ -358,8 +361,9 @@ jobs:
             JSON_FLAG="--json"
           fi
           /test/minting-config-tx-test.sh \
-            $JSON_FLAG \
-            --token-id 8192
+            "${JSON_FLAG}" \
+            --token-id 8192 \
+            --node node1-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}
 
     - name: Test - block-v3 - Minting tx
       if: inputs.testing_block_v3
@@ -374,7 +378,8 @@ jobs:
         command: |
           /test/minting-tx-test.sh \
             --key-dir ${{ env.V3_DST_KEYS_DIR }} \
-            --token-id 8192
+            --token-id 8192 \
+            --node node1-${{ inputs.namespace }}.${{ env.BASE_DOMAIN }}
 
     - name: Test - block-v3 - mobilecoind-json integration
       if: inputs.testing_block_v3

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-attest-ingress.yaml
@@ -17,10 +17,12 @@ metadata:
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "consensusNode.clientHostname" . }}
     secretName: {{ include "consensusNode.fullname" . }}-ingress-tls
+{{- end }}
   rules:
   - host: {{ include "consensusNode.clientHostname" . }}
     http:

--- a/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-grpc-ingress.yaml
@@ -12,10 +12,12 @@ metadata:
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "consensusNode.clientHostname" . }}
     secretName: {{ include "consensusNode.fullname" . }}-ingress-tls
+{{- end }}
   rules:
   - host: {{ include "consensusNode.clientHostname" . }}
     http:

--- a/.internal-ci/helm/consensus-node/templates/client-http-attest-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-http-attest-ingress.yaml
@@ -17,10 +17,12 @@ metadata:
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "consensusNode.clientHostname" . }}
     secretName: {{ include "consensusNode.fullname" . }}-ingress-tls
+{{- end }}
   rules:
   - host: {{ include "consensusNode.clientHostname" . }}
     http:

--- a/.internal-ci/helm/consensus-node/templates/client-http-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/client-http-ingress.yaml
@@ -12,10 +12,12 @@ metadata:
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "consensusNode.clientHostname" . }}
     secretName: {{ include "consensusNode.fullname" . }}-ingress-tls
+{{- end }}
   rules:
   - host: {{ include "consensusNode.clientHostname" . }}
     http:

--- a/.internal-ci/helm/consensus-node/templates/ingress-tls-certificate.yaml
+++ b/.internal-ci/helm/consensus-node/templates/ingress-tls-certificate.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.global.ingress.tls.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -17,3 +18,4 @@ spec:
   issuerRef:
     name: {{ .Values.global.certManagerClusterIssuer }}
     kind: ClusterIssuer
+{{- end }}

--- a/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
+++ b/.internal-ci/helm/consensus-node/templates/peer-grpc-ingress.yaml
@@ -12,10 +12,12 @@ metadata:
   labels:
     {{- include "consensusNode.labels" . | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "consensusNode.peerHostname" . }}
     secretName: {{ include "consensusNode.fullname" . }}-ingress-tls
+{{- end }}
   rules:
   - host: {{ include "consensusNode.peerHostname" . }}
     http:

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -12,6 +12,11 @@ image:
 global:
   certManagerClusterIssuer: letsencrypt-production-http
 
+  ingress:
+    tls:
+      # if true use cert-manager tls, false use ingress default certificate.
+      enabled: true
+
   # Shared across all instances of consensusNodeConfig config.
   node:
     ledgerDistribution:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
@@ -13,10 +13,12 @@ metadata:
     {{ toYaml (tpl .Values.fogLedger.ingress.common.annotations . | fromYaml) | nindent 4 }}
     {{ toYaml (tpl .Values.fogLedger.ingress.grpc.annotations . | fromYaml) | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "fogServices.fogPublicFQDN" . }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   - host: {{ include "fogServices.fogPublicFQDN" . }}
     http:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
@@ -13,10 +13,12 @@ metadata:
     {{ toYaml (tpl .Values.fogLedger.ingress.common.annotations . | fromYaml) | nindent 4 }}
     {{ toYaml (tpl .Values.fogLedger.ingress.http.annotations . | fromYaml) | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "fogServices.fogPublicFQDN" . }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   - host: {{ include "fogServices.fogPublicFQDN" . }}
     http:

--- a/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
@@ -14,12 +14,14 @@ metadata:
     {{- toYaml .Values.fogReport.ingress.common.annotations | nindent 4 }}
     {{- toYaml .Values.fogReport.ingress.grpc.annotations | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     {{- range $hosts }}
     - {{ . }}
     {{- end }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   {{- range $hosts }}
   - host: {{ . }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
@@ -14,12 +14,14 @@ metadata:
     {{- toYaml .Values.fogReport.ingress.common.annotations | nindent 4 }}
     {{- toYaml .Values.fogReport.ingress.http.annotations | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     {{- range $hosts }}
     - {{ . }}
     {{- end }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   {{- range $hosts }}
   - host: {{ . }}

--- a/.internal-ci/helm/fog-services/templates/fog-tls-certificate.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-tls-certificate.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 # fogServices.fogReportHosts contains all the hostnames for all the fog services.
 # 1 cert for all the sans.
+{{- if .Values.global.ingress.tls.enabled }}
 {{- $hosts := split "\n" (include "fogServices.fogReportHosts" . | trim) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -21,3 +22,4 @@ spec:
   issuerRef:
     name: {{ .Values.global.certManagerClusterIssuer }}
     kind: ClusterIssuer
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
@@ -13,10 +13,12 @@ metadata:
     {{ toYaml (tpl .Values.fogView.ingress.common.annotations . | fromYaml) | nindent 4 }}
     {{ toYaml (tpl .Values.fogView.ingress.grpc.annotations . | fromYaml) | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "fogServices.fogPublicFQDN" . }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   - host: {{ include "fogServices.fogPublicFQDN" . }}
     http:

--- a/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
@@ -13,10 +13,12 @@ metadata:
     {{ toYaml (tpl .Values.fogView.ingress.common.annotations . | fromYaml) | nindent 4 }}
     {{ toYaml (tpl .Values.fogView.ingress.http.annotations . | fromYaml) | nindent 4 }}
 spec:
+{{- if .Values.global.ingress.tls.enabled }}
   tls:
   - hosts:
     - {{ include "fogServices.fogPublicFQDN" . }}
     secretName: {{ include "fogServices.fullname" . }}-fog-tls
+{{- end }}
   rules:
   - host: {{ include "fogServices.fogPublicFQDN" . }}
     http:

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -26,6 +26,10 @@ global:
   blocklist:
     enabled: "false"
     pattern: patterns/blocked-countries
+  ingress:
+    tls:
+      # if true use cert-manager tls, false use ingress default certificate.
+      enabled: true
 
 ### Fog Report Service
 fogReport:
@@ -45,6 +49,7 @@ fogReport:
       name: fog-report-signing-cert
     crt: ''
     key: ''
+
   ingress:
     common:
       annotations:

--- a/.internal-ci/helm/mc-core-dev-env-setup/values.yaml
+++ b/.internal-ci/helm/mc-core-dev-env-setup/values.yaml
@@ -1,6 +1,8 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
 
 global:
+  baseDomain: dev.mc.dance
+
   node:
     ledgerDistribution:
       awsRegion: eu-central-1
@@ -12,22 +14,22 @@ global:
       peers:
         1:
           peer:
-            hostname: '{{ printf "peer1.%s.development.mobilecoin.com" .Release.Namespace }}'
+            hostname: '{{ printf "peer1-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
             port: '443'
           signerPublicKey: ''
-          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
         2:
           peer:
-            hostname: '{{ printf "peer2.%s.development.mobilecoin.com" .Release.Namespace }}'
+            hostname: '{{ printf "peer2-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
             port: '443'
           signerPublicKey: ''
-          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2-%s.%s" $.Release.Namespace $.Values.global.baseDomain $.Values.global.baseDomain) }}{{ end }}'
         3:
           peer:
-            hostname: '{{ printf "peer3.%s.development.mobilecoin.com" .Release.Namespace }}'
+            hostname: '{{ printf "peer3-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
             port: '443'
           signerPublicKey: ''
-          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+          ledgerArchiveLocation: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3-%s.%s" $.Release.Namespace $.Values.global.baseDomain $.Values.global.baseDomain) }}{{ end }}'
 
     # Add signed tokens.json with --set-file=global.node.tokensConfig."tokens\.signed\.json"=tokens.signed.json
     tokensConfig:
@@ -46,42 +48,42 @@ mcCoreCommonConfig:
   mobilecoind:
     threshold: '2'
     nodes:
-    - client: '{{ printf "node1.%s.development.mobilecoin.com:443" .Release.Namespace }}'
-      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-    - client: '{{ printf "node2.%s.development.mobilecoin.com:443" .Release.Namespace }}'
-      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
-    - client: '{{ printf "node3.%s.development.mobilecoin.com:443" .Release.Namespace }}'
-      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+    - client: '{{ printf "node1-%s.%s:443" .Release.Namespace .Values.global.baseDomain }}'
+      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
+    - client: '{{ printf "node2-%s.%s:443" .Release.Namespace .Values.global.baseDomain }}'
+      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
+    - client: '{{ printf "node3-%s.%s:443" .Release.Namespace .Values.global.baseDomain }}'
+      txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
 
 consensusNodeConfig1:
   enabled: true
   fullnameOverride: consensus-node-1
   node:
     client:
-      hostname: '{{ printf "node1.%s.development.mobilecoin.com" .Release.Namespace }}'
+      hostname: '{{ printf "node1-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
     peer:
-      hostname: '{{ printf "peer1.%s.development.mobilecoin.com" .Release.Namespace }}'
-    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+      hostname: '{{ printf "peer1-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
+    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node1-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
 
 consensusNodeConfig2:
   enabled: true
   fullnameOverride: consensus-node-2
   node:
     client:
-      hostname: '{{ printf "node2.%s.development.mobilecoin.com" .Release.Namespace }}'
+      hostname: '{{ printf "node2-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
     peer:
-      hostname: '{{ printf "peer2.%s.development.mobilecoin.com" .Release.Namespace }}'
-    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+      hostname: '{{ printf "peer2-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
+    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node2-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
 
 consensusNodeConfig3:
   enabled: true
   fullnameOverride: 'consensus-node-3'
   node:
     client:
-      hostname: '{{ printf "node3.%s.development.mobilecoin.com" .Release.Namespace }}'
+      hostname: '{{ printf "node3-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
     peer:
-      hostname: '{{ printf "peer3.%s.development.mobilecoin.com" .Release.Namespace }}'
-    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3.%s.development.mobilecoin.com" $.Release.Namespace) }}{{ end }}'
+      hostname: '{{ printf "peer3-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
+    txSourceUrl: '{{ with .Values.global.node.ledgerDistribution }}{{ printf "https://s3-%s.amazonaws.com/%s/%s/" .awsRegion .s3Bucket (printf "node3-%s.%s" $.Release.Namespace $.Values.global.baseDomain) }}{{ end }}'
 
 fogIngestConfig:
   enabled: true
@@ -97,5 +99,5 @@ fogServicesConfig:
     configMap:
       enabled: true
   fogPublicFQDN:
-    domainname: '{{ printf "fog.%s.development.mobilecoin.com" .Release.Namespace }}'
-    fogReportSANs: '{{ printf "fog-report.%s.development.mobilecoin.com" .Release.Namespace }}'
+    domainname: '{{ printf "fog-%s.%s" .Release.Namespace .Values.global.baseDomain }}'
+    fogReportSANs: '{{ printf "fog-report-%s.%s" .Release.Namespace .Values.global.baseDomain }}'

--- a/.internal-ci/test/fog-distribution-test.sh
+++ b/.internal-ci/test/fog-distribution-test.sh
@@ -17,9 +17,9 @@ fi
 touch "${run_file}"
 
 fog-distribution --sample-data-dir /tmp/sample_data \
-    --peer "mc://node1.${NAMESPACE}.development.mobilecoin.com:443" \
-    --peer "mc://node2.${NAMESPACE}.development.mobilecoin.com:443" \
-    --peer "mc://node3.${NAMESPACE}.development.mobilecoin.com:443" \
+    --peer "mc://node1-${NAMESPACE}.${BASE_DOMAIN}:443" \
+    --peer "mc://node2-${NAMESPACE}.${BASE_DOMAIN}:443" \
+    --peer "mc://node3-${NAMESPACE}.${BASE_DOMAIN}:443" \
     --num-tx-to-send 20
 
 

--- a/.internal-ci/test/fog-test-client.sh
+++ b/.internal-ci/test/fog-test-client.sh
@@ -54,6 +54,7 @@ done
 is_set key_dir
 is_set token_ids
 is_set NAMESPACE
+is_set BASE_DOMAIN
 
 if [ -n "${CLIENT_AUTH_TOKEN_SECRET}" ]
 then
@@ -77,13 +78,13 @@ fi
 export RUST_LOG=info
 test_client \
     --key-dir "${key_dir}" \
-    --consensus "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
-    --consensus "mc://node2.${NAMESPACE}.development.mobilecoin.com/" \
-    --consensus "mc://node3.${NAMESPACE}.development.mobilecoin.com/" \
+    --consensus "mc://node1-${NAMESPACE}.${BASE_DOMAIN}/" \
+    --consensus "mc://node2-${NAMESPACE}.${BASE_DOMAIN}/" \
+    --consensus "mc://node3-${NAMESPACE}.${BASE_DOMAIN}/" \
     ${token_opt} \
     --num-clients 6 \
     --num-transactions 32 \
     --consensus-wait 300 \
     --transfer-amount 20 \
-    --fog-view "fog-view://${user}fog.${NAMESPACE}.development.mobilecoin.com:443" \
-    --fog-ledger "fog-ledger://${user}fog.${NAMESPACE}.development.mobilecoin.com:443"
+    --fog-view "fog-view://${user}fog-${NAMESPACE}.${BASE_DOMAIN}:443" \
+    --fog-ledger "fog-ledger://${user}fog-${NAMESPACE}.${BASE_DOMAIN}:443"

--- a/.internal-ci/test/minting-config-tx-test.sh
+++ b/.internal-ci/test/minting-config-tx-test.sh
@@ -46,6 +46,10 @@ do
             json_flag="1"
             shift 1
             ;;
+        --node )
+            node="${2}"
+            shift 2
+            ;;
         *)
             echo "${1} unknown option"
             usage
@@ -68,7 +72,7 @@ token_signer_key="/minting-keys/token_${token_id}_signer_1.public.pem"
 
 if [ "$json_flag" == "0" ]; then
     mc-consensus-mint-client generate-and-submit-mint-config-tx \
-        --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
+        --node "mc://${node}/" \
         --signing-key "${governor_signer_key}" \
         --token-id "${token_id}" \
         --config "1000000000:1:${token_signer_key}" \
@@ -89,10 +93,10 @@ else
     echo $json
 
     json_file="/tmp/mint-config.${token_id}.json"
-    echo $json > ${json_file}
+    echo $json > "${json_file}"
 
     mc-consensus-mint-client generate-and-submit-mint-config-tx \
-        --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
+        --node "mc://${node}/" \
         --signing-key "${governor_signer_key}" \
         --mint-config-tx-file "${json_file}"
 fi

--- a/.internal-ci/test/minting-tx-test.sh
+++ b/.internal-ci/test/minting-tx-test.sh
@@ -39,6 +39,10 @@ do
             token_id="${2}"
             shift 2
             ;;
+        --node )
+            node="${2}"
+            shift 2
+            ;;
         *)
             echo "${1} unknown option"
             usage
@@ -49,6 +53,7 @@ done
 
 is_set key_dir
 is_set token_id
+is_set node
 is_set NAMESPACE
 
 # These should be populated by volume in toolbox container.
@@ -68,7 +73,7 @@ do
     echo "-- sending mint tx for account key ${k}"
 
     mc-consensus-mint-client generate-and-submit-mint-tx \
-        --node "mc://node1.${NAMESPACE}.development.mobilecoin.com/" \
+        --node "mc://${node}/" \
         --signing-key "${token_signer_key}" \
         --recipient "$(cat "${k}")" \
         --token-id "${token_id}" \

--- a/.internal-ci/util/metadata.sh
+++ b/.internal-ci/util/metadata.sh
@@ -101,8 +101,10 @@ EOF
         run_number_len=${#GITHUB_RUN_NUMBER}
         # number of separators in tag
         dots=3
+        # 6 chars for node/peer name now that we need to use star certs.
+        node_name=6
 
-        cutoff=$((label_limit - version_len - sha_len - run_number_len - dots))
+        cutoff=$((label_limit - version_len - sha_len - run_number_len - dots - node_name))
 
         if [[ ${#normalized_branch} -gt ${cutoff} ]]
         then

--- a/.internal-ci/util/print_details.sh
+++ b/.internal-ci/util/print_details.sh
@@ -18,23 +18,20 @@ https://kibana.logit.io/app/kibana#/discover?_g=()&_a=(columns:!(_source),filter
 
 --- Consensus Endpoints ---
 
-node1.${NAMESPACE}.development.mobilecoin.com
-node2.${NAMESPACE}.development.mobilecoin.com
-node3.${NAMESPACE}.development.mobilecoin.com
-node4.${NAMESPACE}.development.mobilecoin.com
-node5.${NAMESPACE}.development.mobilecoin.com
+node1-${NAMESPACE}.${BASE_DOMAIN}
+node2-${NAMESPACE}.${BASE_DOMAIN}
+node3-${NAMESPACE}.${BASE_DOMAIN}
+
 
 --- Consensus S3 Buckets ---
 
-https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node1.${NAMESPACE}.development.mobilecoin.com/
-https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node2.${NAMESPACE}.development.mobilecoin.com/
-https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node3.${NAMESPACE}.development.mobilecoin.com/
-https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node4.${NAMESPACE}.development.mobilecoin.com/
-https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node5.${NAMESPACE}.development.mobilecoin.com/
+https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node1-${NAMESPACE}.${BASE_DOMAIN}/
+https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node2-${NAMESPACE}.${BASE_DOMAIN}/
+https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node3-${NAMESPACE}.${BASE_DOMAIN}/
 
 --- Fog Endpoint ---
 
-fog.${NAMESPACE}.development.mobilecoin.com
+fog-${NAMESPACE}.${BASE_DOMAIN}
 
 --- mobilecoind ---
 
@@ -50,18 +47,13 @@ Then Connect to localhost:<port>
 
 --- mobilecoind config options ---
 
---peer mc://node1.${NAMESPACE}.development.mobilecoin.com:443/ \
---tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node1.${NAMESPACE}.development.mobilecoin.com/ \
---peer mc://node2.${NAMESPACE}.development.mobilecoin.com:443/ \
---tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node2.${NAMESPACE}.development.mobilecoin.com/ \
---peer mc://node3.${NAMESPACE}.development.mobilecoin.com:443/ \
---tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node3.${NAMESPACE}.development.mobilecoin.com/ \
---peer mc://node4.${NAMESPACE}.development.mobilecoin.com:443/ \
---tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node4.${NAMESPACE}.development.mobilecoin.com/ \
---peer mc://node5.${NAMESPACE}.development.mobilecoin.com:443/ \
---tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node5.${NAMESPACE}.development.mobilecoin.com/ \
---poll-interval 1 \
---quorum-set '{ "threshold": 3, "members": [{"args":"node1.${NAMESPACE}.development.mobilecoin.com:443","type":"Node"},{"args":"node2.${NAMESPACE}.development.mobilecoin.com:443","type":"Node"},{"args":"node3.${NAMESPACE}.development.mobilecoin.com:443","type":"Node"},{"args":"node4.${NAMESPACE}.development.mobilecoin.com:443","type":"Node"},{"args":"node5.${NAMESPACE}.development.mobilecoin.com:443","type":"Node"}] }'
+--peer mc://node1-${NAMESPACE}.${BASE_DOMAIN}:443/ \
+--tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node1-${NAMESPACE}.${BASE_DOMAIN}/ \
+--peer mc://node2-${NAMESPACE}.${BASE_DOMAIN}:443/ \
+--tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node2-${NAMESPACE}.${BASE_DOMAIN}/ \
+--peer mc://node3-${NAMESPACE}.${BASE_DOMAIN}:443/ \
+--tx-source-url https://s3-eu-central-1.amazonaws.com/mobilecoin.eu.development.chain/node3-${NAMESPACE}.${BASE_DOMAIN}/ \
+--quorum-set '{ "threshold": 3, "members": [{"args":"node1-${NAMESPACE}.${BASE_DOMAIN}:443","type":"Node"},{"args":"node2-${NAMESPACE}.${BASE_DOMAIN}:443","type":"Node"},{"args":"node3-${NAMESPACE}.${BASE_DOMAIN}:443","type":"Node"}] }'
 
 --- Get key seeds ---
 
@@ -81,7 +73,7 @@ kubectl -n ${NAMESPACE} get secrets sample-keys-seeds -ojsonpath='{.data.FOG_REP
 
 # Regenerate keys to /tmp/sample_keys:
 docker run -it --rm \
-  --env FOG_REPORT_URL="fog://fog.${NAMESPACE}.development.mobilecoin.com" \
+  --env FOG_REPORT_URL="fog://fog-${NAMESPACE}.${BASE_DOMAIN}" \
   --env FOG_REPORT_SIGNING_CA_CERT="\$(cat fog_report_signing_ca_cert.pem)" \
   --env FOG_KEYS_SEED \
   --env INITIAL_KEYS_SEED \


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

As we have grown, we have struggled with our various SSL certificate providers. First we hit the 50 certs per base domain limit with LetsEncrypt. We switched over to a paid account with ZeroSSL because they had no limits. Well they recently introduced a rate-limit on their ACME API endpoint.  This is causing random delays in issuing Ingress endpoint certificates, which in turn causes random failure or delays in the integration testing. We tried optimizing the certificate issuance by using certificates with SANs for each consensus node and one for the fog services.  This still was too many calls all at once to ZeroSSL

Ideally each endpoint hostname has their own certificate issued. For production we are still doing this, but for development and testing this PR moves to using a star certificate that is issued for the entire cluster. The star certificate is issued from LetsEncrypt and uses the *.dev.mc.dance domain so we keep development and testing separate from our production mobilecoin.com domains.

- Make TLS definitions optional when deploying to development.  With out a specific `tls:` section the Ingress will use the default certificate defined in the ingress-controller configuration.
- move hostnames from `<service>.<namespace>.development.mobilecoin.com` to `<service>-<namespace>.dev.mc.dance`. Note that namespace is no longer a subdomain, but are part of the hostname. Star certificates only match the one subdomain level deep.
- Adjust metadata script to take in account the service name length as part of the domainname/namespace limits.
- Minor fix on disabling rate-limits in development.  Not sure where that mismatch on values was introduced.

### Future Work
* CBB:  There are a lot of places where the base domain name is hard coded, make those places a variable.

