### PR TITLE
include necessary optional dep when the serde feature is enabled

### DIFF
--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = { workspace = true }
 
 [features]
 alloc = ["base64/alloc", "curve25519-dalek/alloc", "ed25519-dalek/alloc", "mc-crypto-digestible/alloc", "mc-crypto-digestible-signature/alloc", "mc-util-repr-bytes/alloc"]
-serde = ["dep:serde", "ed25519/serde", "curve25519-dalek/serde", "ed25519-dalek/serde", "mc-util-repr-bytes/serde"]
+serde = ["dep:serde", "dep:mc-util-serial", "ed25519/serde", "curve25519-dalek/serde", "ed25519-dalek/serde", "mc-util-repr-bytes/serde"]
 prost = ["alloc", "mc-util-repr-bytes/prost"]
-default = ["alloc", "serde", "prost", "mc-util-repr-bytes/default", "curve25519-dalek/default", "mc-util-serial"]
+default = ["alloc", "serde", "prost", "mc-util-repr-bytes/default", "curve25519-dalek/default", "dep:mc-util-serial"]
 
 [dependencies]
 


### PR DESCRIPTION
### Motivation

https://github.com/mobilecoinfoundation/mobilecoin/blob/master/crypto/keys/src/ed25519.rs#L40-L41 gates a `use` statement for the `mc_util_serial` crate behind the `serde` feature, but the `serde` feature as currently configured in this crate's `Cargo.toml` does not include the `mc_util_serial` crate when enabled.