### PR TITLE
Fix Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,7 +7405,7 @@ checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.12",
 ]
 
 [[package]]


### PR DESCRIPTION
- Run cargo-check against the repo.

### Motivation

The master branch is broken after updating serde due to a weird revert in the Cargo.lock file.

