### PR TITLE
add retries to mobilecoind when it submits transactions

### DIFF
--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -41,6 +41,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
+    time::Duration,
 };
 
 /// Default number of blocks used for calculating transaction tombstone block
@@ -832,6 +833,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         //   100 / min in place in production.
         let retry_iterator = (&[50, 500, 500, 750, 1000])
             .iter()
+            .cloned()
             .map(Duration::from_millis);
 
         // Try and submit.

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -831,7 +831,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         //   re-attest, and this attestation is successful. So that takes 50 ms.
         // * After that, we back off to 500 ms, because there are rate limits of about
         //   100 / min in place in production.
-        let retry_iterator = (&[50, 500, 500, 750, 1000])
+        let retry_iterator = [50, 500, 500, 750, 1000]
             .iter()
             .cloned()
             .map(Duration::from_millis);

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -33,7 +33,6 @@ use mc_transaction_extra::{
 };
 use mc_util_uri::FogUri;
 use rand::Rng;
-use retry::delay::Fibonacci;
 use std::{
     cmp::{max, Reverse},
     collections::BTreeMap,


### PR DESCRIPTION
i'm finding that sometimes it fails with attestation permission denied errors otherwise

---

feel free to leave comments about how you would like this to be more configurable or use exponential backoff or something, let's decide exactly how it should work during review