### PR TITLE
fix mobilecoind sci generation and add a test

### DIFF
--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1465,7 +1465,12 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             }
         };
 
-        let membership_proofs: Vec<TxOutMembershipProof> = vec![Default::default(); ring.len()];
+        let membership_proofs: Vec<TxOutMembershipProof> = global_indices.into_iter().map(|index| {
+            TxOutMembershipProof {
+                index,
+                ..Default::default()
+            }
+        }).collect();
 
         // Create input credentials
         let input_credentials = {
@@ -1570,11 +1575,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         }
 
         // Build sci.
-        let mut result = sci_builder
+        let result = sci_builder
             .build(&NoKeysRingSigner {}, rng)
             .map_err(|err| Error::TxBuild(format!("build tx failed: {err}")))?;
 
-        result.tx_out_global_indices = global_indices;
         Ok(result)
     }
 }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3901,6 +3901,16 @@ mod test {
                 .unwrap();
             assert_eq!(amount.value, 123);
             assert_eq!(amount.token_id, TokenId::from(1));
+
+            // Validate ring vs. indices, as deqs does
+            let indices = &sci.tx_out_global_indices;
+            let ring = &sci.tx_in.ring;
+            for (index, tx_out) in indices.iter().zip(ring.iter()) {
+                let real_tx_out =
+                    ledger_db
+                    .get_tx_out_by_index(*index).unwrap();
+                assert_eq!(&real_tx_out, tx_out, "Mismatch at index {index}");
+            }
         }
 
         // Test the happy flow for eUSD -> MOB, non partial fill swap
@@ -3951,6 +3961,16 @@ mod test {
             let unmasked_amount = sci.required_output_amounts[0].clone();
             assert_eq!(unmasked_amount.value, 999_999);
             assert_eq!(unmasked_amount.token_id, *Mob::ID);
+
+            // Validate ring vs. indices, as deqs does
+            let indices = &sci.tx_out_global_indices;
+            let ring = &sci.tx_in.ring;
+            for (index, tx_out) in indices.iter().zip(ring.iter()) {
+                let real_tx_out =
+                    ledger_db
+                    .get_tx_out_by_index(*index).unwrap();
+                assert_eq!(&real_tx_out, tx_out, "Mismatch at index {index}");
+            }
         }
 
         // Invalid input scenarios should result in an error.


### PR DESCRIPTION
Previously, I had tried to fix this by recording tx out indices outside of the calls to the SCI builder, because it was producing tx out global indices lists of all zeroes.

However, the scis the mobilecoind was returning actually had the wrong indices, because they didn't match up with the ring members. The problem is the sci builder sorts the ring elements, but my indices list was not getting similarly sorted.

Looking at the sci builder code, it actually sorts the proofs with the ring elements, and initializes the tx_out_global_indices itself based on the proof.index elements. So what we do now is pass it all defaulted proofs with the right proof.index element, and then the sorting is done correctly by the sci builder.

This also adds a unit test that checks that the same test enforced by the deqs is working.