### PR TITLE
Prometheus edit service names

### DIFF
--- a/fog/ingest/server/src/lib.rs
+++ b/fog/ingest/server/src/lib.rs
@@ -36,7 +36,7 @@ use mc_util_metrics::ServiceMetrics;
 
 lazy_static::lazy_static! {
     /// Generates service metrics for tracking
-    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_ingest");
+    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_ingest_service");
 }
 
 // Helper to format a sequence as a comma-separated list

--- a/fog/ledger/server/src/lib.rs
+++ b/fog/ledger/server/src/lib.rs
@@ -20,5 +20,5 @@ pub use server::LedgerServer;
 pub use untrusted_tx_out_service::UntrustedTxOutService;
 
 lazy_static::lazy_static! {
-    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_ledger");
+    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_ledger_service");
 }

--- a/fog/report/server/src/lib.rs
+++ b/fog/report/server/src/lib.rs
@@ -17,5 +17,5 @@ use mc_util_metrics::ServiceMetrics;
 
 lazy_static::lazy_static! {
     /// Generates service metrics for tracking
-    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_report");
+    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_report_service");
 }

--- a/fog/view/server/src/lib.rs
+++ b/fog/view/server/src/lib.rs
@@ -14,5 +14,5 @@ mod counters;
 mod db_fetcher;
 
 lazy_static::lazy_static! {
-    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_view");
+    pub static ref SVC_COUNTERS: ServiceMetrics = ServiceMetrics::new_and_registered("fog_view_service");
 }


### PR DESCRIPTION
[Issue](https://github.com/mobilecoinfoundation/mobilecoin/issues/3281)

This issue was because fog service names were same for OpMetrics and ServiceMetrics. 
Consensus service has different names for the two metrics. 
This PR edits fog service names to be consistent with "consensus_service" in Prometheus. 

<img width="947" alt="Screen Shot 2023-04-20 at 1 02 29 PM" src="https://user-images.githubusercontent.com/102332078/233484341-4a885167-9015-4cf8-8124-58446112531e.png">
<img width="945" alt="Screen Shot 2023-04-20 at 1 09 18 PM" src="https://user-images.githubusercontent.com/102332078/233484352-544f72e4-b9cd-41f1-84f0-3a7ba7ec90bf.png">