### PR TITLE
Update rust-toolchain to toml format

### DIFF
--- a/docker/rust-toolchain
+++ b/docker/rust-toolchain
@@ -1,1 +1,2 @@
-nightly-2023-01-04
+[toolchain]
+channel = "nightly-2023-01-22"

--- a/util/build/sgx/src/config.rs
+++ b/util/build/sgx/src/config.rs
@@ -11,18 +11,13 @@ use std::{
 
 /// An enumeration of TCS policy options.
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum TcsPolicy {
     /// Thread control structures are bound to untrusted threads
     Bound = 0,
     /// Thread control structures are not bound to untrusted threads
+    #[default]
     Unbound = 1,
-}
-
-impl Default for TcsPolicy {
-    fn default() -> Self {
-        TcsPolicy::Unbound
-    }
 }
 
 /// This builder creates the Enclave.config.xml config file used by sgx_sign.


### PR DESCRIPTION
Previously the rust-toolchain file was using the legacy one line toolchain version format from https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file. Now the rust-toolchain file uses toml format and updates the nightly version to the last nightly that contained 1.68.

### Motivation

Dependabot has been updated to only read the toml format of the rust-toolchain file.

Keeping the changes targeted on the dependabot fix, the rust-toolchain file was not renamed to the newer `rust-toolchain.toml`.

The nightly version was bumped to the last nightly that was 1.68. This was to bring in the https/sparse crates.io logic that came in 1.68 which dependabot relies on for 1.68 toolchain versions. This was only moved a little to minimize other clippy and format changes that might be needed.

For reference the nightly dates and version transitions:
| Date | rustc version | 
| -- | -- |
| 2023-01-04 | 1.68.0-nightly |
| 2023-01-22 | 1.68.0-nightly |
| 2023-01-23 | 1.69.0-nightly |
| 2023-03-04 | 1.69.0-nightly |
| 2023-03-05 | 1.70.0-nightly |
| 2023-04-15 | 1.70.0-nightly |
| 2023-04-16 | 1.71.0-nightly |
| 2023-04-21 | 1.71.0-nightly |

2023-01-04 was the previous nightly version used.
