### PR TITLE
Add disk persistence for fog-ledger-router, shard size default updates

### DIFF
--- a/.internal-ci/helm/fog-services/templates/fog-ledger-rollout-cr.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-rollout-cr.yaml
@@ -118,6 +118,8 @@ spec:
                 failureThreshold: 2
                 periodSeconds: 10
               volumeMounts:
+              - name: fog-data
+                mountPath: /fog-data
               - name: aesm-socket-dir
                 mountPath: /var/run/aesmd
               - name: supervisor-conf
@@ -182,6 +184,10 @@ spec:
             affinity:
               {{- toYaml .Values.fogLedgerRouter.affinity | nindent 14 }}
             volumes:
+            {{- if eq .Values.fogLedger.persistence.enabled false }}
+            - name: fog-data
+              emptyDir: {}
+            {{- end }}
             - name: aesm-socket-dir
               emptyDir: {}
             - name: supervisor-conf
@@ -197,6 +203,13 @@ spec:
                     name: {{ include "fogServices.fullname" . }}-supervisord-fog-ledger-router
                 - configMap:
                     name: {{ include "fogServices.fullname" . }}-supervisord-admin
+        {{- if .Values.fogLedger.persistence.enabled }}
+        volumeClaimTemplates:
+        - metadata:
+            name: fog-data
+          spec:
+            {{- toYaml .Values.fogLedger.persistence.spec | nindent 10 }}
+        {{- end }}
 
   store:
     containerName: fog-ledger-store

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -52,14 +52,14 @@ blockHeighRetrieval:
   responseJQ: .result.network_status.network_block_height
 
 fogViewStores:
-  shardSize: 200_000
+  shardSize: 400_000
   exceedBlockHeightBy: 200_000
-  shardOverlap: 100_000
+  shardOverlap: 200_000
 
 fogLedgerStores:
-  shardSize: 200_000
+  shardSize: 400_000
   exceedBlockHeightBy: 200_000
-  shardOverlap: 100_000
+  shardOverlap: 200_000
 
 imagePullSecrets:
 - name: docker-credentials
@@ -187,7 +187,7 @@ fogView:
     effect: NoSchedule
 
 fogLedgerRouter:
-  replicaCount: 3
+  replicaCount: 2
   podManagementPolicy: Parallel
 
   podAnnotations:


### PR DESCRIPTION
* Add disk persistence for fog-ledger-store
* Double default shard sizes for ledger and view stores
* Change default of fog-ledger-router replicaCount to 2, matchine fog-view-router

### Motivation

The fog-ledger-router needs disk persistence for storing ledger and watcher databases.  Otherwise a pod restart causes a re-download of the full blockchain.

The shard size defaults were increased.

### Future Work

* Possible further adjustments to shard sizes
