### PR TITLE
Update `local_network.py` to have a default launch

### DIFF
--- a/mint-auditor/README.md
+++ b/mint-auditor/README.md
@@ -55,9 +55,7 @@ To run the integration tests, which live in `mint-auditor/tests/`, there are fou
 ```
 $ cargo build --release
 $ export MC_LOG=info
-$ export LEDGER_BASE=$PWD/target/sample_data/ledger
-$ ./tools/local-network/bootstrap.sh
-$ ./tools/local-network/local_network.py --network-type dense5 --skip-build &
+$ ./tools/local-network/local_network.py --no-build &
 ```
 
 2. Generate and authorize minters.

--- a/mobilecoind-dev-faucet/README.md
+++ b/mobilecoind-dev-faucet/README.md
@@ -108,9 +108,7 @@ It is relatively straightforward to test the faucet locally using the `tools/loc
 ```
 $ cargo build --release
 $ export MC_LOG=info,rocket=error
-$ export LEDGER_BASE=$PWD/target/sample_data/ledger
-$ ./tools/local-network/bootstrap.sh
-$ ./tools/local-network/local_network.py --network-type dense5 --skip-build &
+$ ./tools/local-network/local_network.py --no-build &
 ```
 
 Then, start a faucet and set it to also work in the background:

--- a/tools/fog-local-network/README.md
+++ b/tools/fog-local-network/README.md
@@ -55,7 +55,7 @@ In order to use it, the following steps are necessary.
     LEDGER_BASE=$(pwd)/ledger \
     IAS_SPID="..." \
     IAS_API_KEY="..." \
-    python3 ../tools/fog-local-network/fog_local_network.py --network-type dense5
+    python3 ../tools/fog-local-network/fog_local_network.py
     ```
     Note that all of the above arguments are identical to the mobilecoin local_network.py script.
     The script is known to work with python 3.6 or later

--- a/tools/fog-local-network/fog_local_network.py
+++ b/tools/fog-local-network/fog_local_network.py
@@ -134,7 +134,7 @@ class FogNetwork(Network):
             watcher_db_path = self.mobilecoind.watcher_db,
         )
         self.key_image_store.start()
-        
+
         self.fog_ledger_router = FogLedgerRouter(
             name = 'ledger1',
             ledger_db_path = self.nodes[0].ledger_dir,
@@ -173,9 +173,21 @@ class FogNetwork(Network):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
-    parser.add_argument('--network-type', help='Type of network to create', required=True)
-    parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
+    parser.add_argument('--network-type', help='Type of network to create',
+            choices=['ring5b', 'ring5', 'dense3', 'dense5', 'a-b-c'],
+            default='dense5')
+    # `--skip-build` is kept for backwards compatibility
+    parser.add_argument('--no-build', '--skip-build', dest='build', help="Don't build binaries",
+            action='store_false')
+    parser.add_argument('--build', dest='build', help="Build binaries",
+            action='store_true')
     parser.add_argument('--block-version', help='Set the block version argument', type=int)
+    parser.add_argument('--no-bootstrap-ledger',
+    dest='bootstrap_ledger', help="Don't bootstrap the ledger",
+    action='store_false')
+    parser.add_argument('--bootstrap-ledger', help='Bootstrap the ledger',
+            action='store_true')
     args = parser.parse_args()
 
-    FogNetwork().default_entry_point(args.network_type, args.skip_build, args.block_version)
+    FogNetwork().default_entry_point(args.network_type, args.build,
+            args.block_version, args.bootstrap_ledger)

--- a/tools/local-network/README.md
+++ b/tools/local-network/README.md
@@ -12,14 +12,12 @@ The following sequence is a basic way to start a network locally.
 
 ```
 $ export MC_LOG=info
-$ export LEDGER_BASE=$PWD/target/sample_data/ledger
-$ ./tools/local-network/bootstrap.sh
-$ ./tools/local-network/local_network.py --network-type dense5 &
+$ ./tools/local-network/local_network.py &
 ```
 
-Both `bootstrap.sh` and `local_network.py` will use cargo to build the required binaries.
-You only have to bootstrap once. To take down the network and start up a fresh one,
-kill the `local_network.py` and restart it.
+`local_network.py` will use cargo to build the required binaries. To take down
+the network and start up a fresh one, kill the `local_network.py` and restart
+it.
 
 Stopping the network does not generally wipe out the ledger it generated.
 If you want to also start from a clean ledger, the script's "work directory" is (typically) `target/release/mc-local-network`,
@@ -36,13 +34,13 @@ This is a simple script to bootstrap a test ledger and keys to play with. The sc
 
 This script starts a local mobilecoin consensus network by launching a separate process for each consensus validator and configuring them to communicate via a default set of ports. It takes the following parameters:
 
-- (required) `--network-type` - describes the network topology, one of `dense5`, `dense3`, `a-b-c`, `ring5` or `ring5b`
-- (optional) `--skip-build` - does not rebuild consensus node binaries
+- (optional) `--network-type` - describes the network topology, one of `dense5`, `dense3`, `a-b-c`, `ring5` or `ring5b` (default: dense5)
+- (optional) `--no-build` - does not rebuild consensus node binaries
 - (optional) `--block-version` - specifies local network block version (defaults to highest available if not specified)
 
 It relies on environment variables for configuration:
 
-- (required) `LEDGER_BASE` - Points at the ledger directory to initialize the nodes with (e.g. `./target/sample_data/ledger`).
+- (optional) `LEDGER_BASE` - Points at the ledger directory to initialize the nodes with (default: `./target/sample_data/ledger`).
 - (optional) `IAS_API_KEY` - IAS Api key. (Only needed for IAS prod builds)
 - (optional) `IAS_SPID` - IAS Service Provider ID. (Only needed for IAS prod builds)
 - (optional) `MC_LOG` - Log level configuration.

--- a/tools/local-network/bootstrap.sh
+++ b/tools/local-network/bootstrap.sh
@@ -13,7 +13,7 @@
 # The tool attempts to avoid rebootstrapping if it doesn't appear necessary,
 # which means:
 # - target/sample_data already exists (and conf.json exists)
-# - conf.json has the same parameters as the user requrests
+# - conf.json has the same parameters as the user requests
 #
 # The tool reruns bootstrap and records a new conf.json file
 # jq must be installed to use the tool

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -23,7 +23,7 @@ BASE_ADMIN_HTTP_GATEWAY_PORT = 3500
 MOBILECOIND_PORT = 4444
 
 # TODO make these command line arguments
-LEDGER_BASE = os.path.abspath(os.getenv('LEDGER_BASE'))
+LEDGER_BASE = os.path.abspath(os.getenv('LEDGER_BASE', default="target/sample_data/ledger"))
 IAS_API_KEY = os.getenv('IAS_API_KEY', default='0'*64) # 32 bytes
 IAS_SPID = os.getenv('IAS_SPID', default='0'*32) # 16 bytes
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -466,6 +466,10 @@ class Network:
             pass
         os.makedirs(WORK_DIR)
 
+    def bootstrap_ledger(self):
+        print('Bootstrapping ledger...')
+        subprocess.run(f'cd {PROJECT_DIR} && tools/local-network/bootstrap.sh', shell=True, check=True)
+
     def build_binaries(self):
         print('Building binaries...')
         enclave_pem = os.path.join(PROJECT_DIR, 'Enclave_private.pem')
@@ -572,7 +576,8 @@ class Network:
                 raise
 
 
-    def default_entry_point(self, network_type, skip_build=False, block_version=None):
+    def default_entry_point(self, network_type, build=False, block_version=None,
+            bootstrap_ledger=False):
         self.block_version = block_version
 
         if network_type == 'dense5':
@@ -621,7 +626,10 @@ class Network:
         else:
             raise Exception('Invalid network type')
 
-        if not skip_build:
+        if bootstrap_ledger:
+            self.bootstrap_ledger()
+
+        if build:
             self.build_binaries()
 
         self.start()
@@ -630,9 +638,21 @@ class Network:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Local network tester')
-    parser.add_argument('--network-type', help='Type of network to create', required=True)
-    parser.add_argument('--skip-build', help='Skip building binaries', action='store_true')
+    parser.add_argument('--network-type', help='Type of network to create',
+            choices=['ring5b', 'ring5', 'dense3', 'dense5', 'a-b-c'],
+            default='dense5')
+    # `--skip-build` is kept for backwards compatibility
+    parser.add_argument('--no-build', '--skip-build', dest='build', help="Don't build binaries",
+            action='store_false')
+    parser.add_argument('--build', dest='build', help="Build binaries",
+            action='store_true')
     parser.add_argument('--block-version', help='Set the block version argument', type=int)
+    parser.add_argument('--no-bootstrap-ledger',
+    dest='bootstrap_ledger', help="Don't bootstrap the ledger",
+    action='store_false')
+    parser.add_argument('--bootstrap-ledger', help='Bootstrap the ledger',
+            action='store_true')
     args = parser.parse_args()
 
-    Network().default_entry_point(args.network_type, args.skip_build, args.block_version)
+    Network().default_entry_point(args.network_type, args.build,
+            args.block_version, args.bootstrap_ledger)


### PR DESCRIPTION
Previously the `local_network.py` script required manually bootstrapping
a ledger and specifying a network type. Now the `local_network.py`
script will bootstrap the ledger, unless the `--no-bootstrap-ledger`
option is provided. The network type defaults to the `dense5` network.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
