### PR TITLE
Disable keepalives for Ledger to Store communications in Fog

### DIFF
--- a/fog/ledger/server/src/router_admin_service.rs
+++ b/fog/ledger/server/src/router_admin_service.rs
@@ -61,6 +61,7 @@ impl LedgerRouterAdminService {
         );
         let key_image_store_client = KeyImageStoreApiClient::new(
             ChannelBuilder::default_channel_builder(grpc_env)
+                .keepalive_permit_without_calls(false)
                 .connect_to_uri(&key_image_store_uri, logger),
         );
         shard_clients.insert(key_image_store_uri, Arc::new(key_image_store_client));

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -388,6 +388,7 @@ async fn authenticate_ledger_store<E: LedgerEnclaveProxy>(
     );
     let ledger_store_client = KeyImageStoreApiClient::new(
         ChannelBuilder::default_channel_builder(grpc_env)
+            .keepalive_permit_without_calls(false)
             .connect_to_uri(&ledger_store_url, &logger),
     );
 

--- a/fog/ledger/server/src/router_server.rs
+++ b/fog/ledger/server/src/router_server.rs
@@ -67,6 +67,7 @@ where
         for shard_uri in config.shard_uris.clone() {
             let ledger_store_grpc_client = ledger_grpc::KeyImageStoreApiClient::new(
                 ChannelBuilder::default_channel_builder(grpc_env.clone())
+                    .keepalive_permit_without_calls(false)
                     .connect_to_uri(&shard_uri, &logger),
             );
             ledger_store_grpc_clients.insert(shard_uri, Arc::new(ledger_store_grpc_client));

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -50,6 +50,7 @@ fn main() {
     for shard_uri in config.shard_uris.clone() {
         let fog_view_store_grpc_client = FogViewStoreApiClient::new(
             ChannelBuilder::default_channel_builder(grpc_env.clone())
+                .keepalive_permit_without_calls(false)
                 .connect_to_uri(&shard_uri, &logger),
         );
 

--- a/fog/view/server/src/router_admin_service.rs
+++ b/fog/view/server/src/router_admin_service.rs
@@ -59,6 +59,7 @@ impl FogViewRouterAdminService {
         );
         let view_store_client = FogViewStoreApiClient::new(
             ChannelBuilder::default_channel_builder(grpc_env)
+                .keepalive_permit_without_calls(false)
                 .connect_to_uri(&view_store_uri, logger),
         );
         let epoch_sharding_strategy = EpochShardingStrategy::try_from(view_store_uri.clone())

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -289,7 +289,9 @@ async fn authenticate_view_store<E: ViewEnclaveProxy>(
             .build(),
     );
     let view_store_client = FogViewStoreApiClient::new(
-        ChannelBuilder::default_channel_builder(grpc_env).connect_to_uri(&view_store_url, &logger),
+        ChannelBuilder::default_channel_builder(grpc_env)
+            .keepalive_permit_without_calls(false)
+            .connect_to_uri(&view_store_url, &logger),
     );
 
     let auth_unary_receiver = view_store_client.auth_async(&nonce_auth_request.into())?;

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -157,7 +157,9 @@ mod tests {
         );
 
         let grpc_client = FogViewStoreApiClient::new(
-            ChannelBuilder::default_channel_builder(grpc_env).connect_to_uri(&uri, &logger),
+            ChannelBuilder::default_channel_builder(grpc_env)
+                .keepalive_permit_without_calls(false)
+                .connect_to_uri(&uri, &logger),
         );
 
         Shard::new(uri, Arc::new(grpc_client), block_range)

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -287,6 +287,7 @@ impl RouterTestEnvironment {
             );
             let store_client = FogViewStoreApiClient::new(
                 ChannelBuilder::default_channel_builder(grpc_env)
+                    .keepalive_permit_without_calls(false)
                     .connect_to_uri(&store_uri, &logger),
             );
             let shard = Shard::new(store_uri, Arc::new(store_client), store_block_range);


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

We are seeing errors in the Fog Ledger to Key Image Store connection which relate to keepalive pings. We believe this is because the load balancers acting as "shards" cannot handle gRPC keepalive messages the way they would need to. Since we control both sides of the connection, we can just disable keepalives for these internal messages which should hopefully fix the issues we're having.

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
