### PR TITLE
update fog-view load test to report more useful metrics and actually work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.0.0-rc.1"
 source = "git+https://github.com/dalek-cryptography/curve25519-dalek?rev=99c0520aa79401b69fb51d38172cd58c6a256cfb#99c0520aa79401b69fb51d38172cd58c6a256cfb"
@@ -4595,8 +4605,8 @@ name = "mc-fog-view-load-test"
 version = "4.1.0-pre0"
 dependencies = [
  "clap 4.1.14",
+ "ctrlc",
  "grpcio",
- "mc-account-keys",
  "mc-attest-verifier",
  "mc-common",
  "mc-fog-kex-rng",
@@ -4605,8 +4615,9 @@ dependencies = [
  "mc-fog-view-enclave-measurement",
  "mc-fog-view-protocol",
  "mc-util-cli",
+ "mc-util-from-random",
  "mc-util-grpc",
- "mc-util-keyfile",
+ "rand",
 ]
 
 [[package]]
@@ -6073,6 +6084,18 @@ dependencies = [
  "tokio",
  "tokio-util",
  "version_check",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -13,15 +13,16 @@ path = "src/main.rs"
 [dependencies]
 # third party
 clap = { version = "4.1", features = ["derive", "env"] }
+ctrlc = "3.2"
 grpcio = "0.12.1"
+rand = "0.8"
 
 # mobilecoin
-mc-account-keys = { path = "../../../account-keys" }
 mc-attest-verifier = { path = "../../../attest/verifier" }
 mc-common = { path = "../../../common", features = ["log"] }
 mc-util-cli = { path = "../../../util/cli" }
+mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-grpc = { path = "../../../util/grpc" }
-mc-util-keyfile = { path = "../../../util/keyfile" }
 
 # fog
 mc-fog-kex-rng = { path = "../../kex_rng" }

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -42,6 +42,10 @@ struct Config {
     /// Grpc retry config
     #[clap(flatten)]
     pub grpc_retry_config: GrpcRetryConfig,
+
+    /// Max number of requests before the test ends (without ctrl-c)
+    #[clap(long, default_value = "0", env = "MC_MAX_REQUESTS")]
+    pub max_requests: usize,
 }
 
 /// Metrics that we aggregate for the load test
@@ -181,6 +185,12 @@ fn main() {
             );
             last_display = now;
             last_counters = current_counters;
+        }
+
+        // terminate test if we have exceeded maximum number of requests to perform, and
+        // this max is not zero.
+        if config.max_requests != 0 && current_counters.num_requests >= config.max_requests {
+            stop_requested.store(true, Ordering::SeqCst);
         }
     }
 

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -35,7 +35,7 @@ struct Config {
     #[clap(long, default_value = "1", env = "MC_NUM_WORKERS")]
     pub num_workers: usize,
 
-    /// Number of search keys to include in request
+    /// Number of search keys to include in each request
     #[clap(long, default_value = "1", env = "MC_NUM_SEARCH_KEYS")]
     pub num_search_keys: usize,
 
@@ -191,7 +191,7 @@ fn main() {
         total_duration.as_secs_f64()
     );
     println!("{}", counters.lock().unwrap());
-    println!("Config: {:?}", config);
+    println!("Config: {config:?}");
 }
 
 fn build_fog_view_conn(

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -117,7 +117,7 @@ fn worker_thread(
     while !stop_requested.load(Ordering::SeqCst) {
         let start = Instant::now();
         let result = fog_view_client.request(0, 0, search_keys.clone());
-        let duration = Instant::now().duration_since(start);
+        let duration = start.elapsed();
 
         let mut counters = counters.lock().unwrap();
         counters.num_requests += 1;

--- a/fog/view/load-test/src/main.rs
+++ b/fog/view/load-test/src/main.rs
@@ -45,7 +45,7 @@ struct Config {
 
     /// Max number of requests before the test ends (without ctrl-c)
     #[clap(long, default_value = "0", env = "MC_MAX_REQUESTS")]
-    pub max_requests: usize,
+    pub max_requests: u64,
 }
 
 /// Metrics that we aggregate for the load test
@@ -184,7 +184,7 @@ fn main() {
                 diff.avg_latency()
             );
             last_display = now;
-            last_counters = current_counters;
+            last_counters = current_counters.clone();
         }
 
         // terminate test if we have exceeded maximum number of requests to perform, and


### PR DESCRIPTION
Here's example output against testnet (at version 4.1) right now:

I tried running it wtih several settings for the number of threads, and number of search keys per request.

```
chris@0c3432ad3654:/tmp/mobilenode$ ./target/docker/release/fog-view-load-test --view-uri fog-view://fog.test.mobilecoin.com
{ requests per second: 0.9999198644222255, errors per second: 0, avg latency (seconds) 0.131 }
{ requests per second: 7.997252791718241, errors per second: 0, avg latency (seconds) 0.134 }
{ requests per second: 3.999508924296239, errors per second: 0, avg latency (seconds) 0.23 }
{ requests per second: 2.998778999150032, errors per second: 0, avg latency (seconds) 0.133 }
{ requests per second: 6.999309133192008, errors per second: 0, avg latency (seconds) 0.244 }
{ requests per second: 4.999550195468464, errors per second: 0, avg latency (seconds) 0.177 }
{ requests per second: 3.999318899994055, errors per second: 0, avg latency (seconds) 0.24 }
{ requests per second: 7.998541761855771, errors per second: 0, avg latency (seconds) 0.138 }
{ requests per second: 6.998797627563978, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 6.998998058432945, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 4.999224435318778, errors per second: 0, avg latency (seconds) 0.223 }
{ requests per second: 6.998599489260406, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 6.998634097579078, errors per second: 0, avg latency (seconds) 0.132 }
{ requests per second: 6.998464858739377, errors per second: 0, avg latency (seconds) 0.153 }
^C{ requests per second: 2.999368659891411, errors per second: 0, avg latency (seconds) 0.149 }
Total test time (seconds): 15.002826746
{ 83 requests, 0 errors, 0.164 avg latency (seconds) }
Config: Config { view_uri: "fog-view://fog.test.mobilecoin.com", num_workers: 1, num_search_keys: 1, grpc_retry_config: GrpcRetryConfig { grpc_retry_count: 3, grpc_retry_millis: 20 } }
chris@0c3432ad3654:/tmp/mobilenode$ ./target/docker/release/fog-view-load-test --view-uri fog-view://fog.test.mobilecoin.com --num-workers 30
{ requests per second: 23.997621643714137, errors per second: 0, avg latency (seconds) 0.164 }
{ requests per second: 212.97105659449562, errors per second: 0, avg latency (seconds) 0.139 }
{ requests per second: 137.9738150534315, errors per second: 0, avg latency (seconds) 0.218 }
{ requests per second: 192.96336397571554, errors per second: 0, avg latency (seconds) 0.152 }
{ requests per second: 213.95875837952855, errors per second: 0, avg latency (seconds) 0.137 }
{ requests per second: 226.97312297764262, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 147.9723398264609, errors per second: 0, avg latency (seconds) 0.198 }
{ requests per second: 204.9609744056683, errors per second: 0, avg latency (seconds) 0.147 }
{ requests per second: 222.9650415341029, errors per second: 0, avg latency (seconds) 0.134 }
{ requests per second: 213.96030651185652, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 131.97616035429823, errors per second: 0, avg latency (seconds) 0.197 }
{ requests per second: 184.93399446829835, errors per second: 0, avg latency (seconds) 0.184 }
{ requests per second: 220.96756991556893, errors per second: 0, avg latency (seconds) 0.134 }
{ requests per second: 227.95903712878217, errors per second: 0, avg latency (seconds) 0.134 }
{ requests per second: 149.97027963983237, errors per second: 0, avg latency (seconds) 0.194 }
{ requests per second: 191.93000773250014, errors per second: 0, avg latency (seconds) 0.158 }
{ requests per second: 213.97173005502515, errors per second: 0, avg latency (seconds) 0.138 }
{ requests per second: 207.96567776047377, errors per second: 0, avg latency (seconds) 0.136 }
{ requests per second: 171.9647535882103, errors per second: 0, avg latency (seconds) 0.157 }
{ requests per second: 140.93317202662206, errors per second: 0, avg latency (seconds) 0.245 }
{ requests per second: 198.97538535200425, errors per second: 0, avg latency (seconds) 0.15 }
{ requests per second: 203.93985711643705, errors per second: 0, avg latency (seconds) 0.144 }
{ requests per second: 129.95584672134135, errors per second: 0, avg latency (seconds) 0.218 }
{ requests per second: 138.97716021553586, errors per second: 0, avg latency (seconds) 0.224 }
^C{ requests per second: 155.93303331138017, errors per second: 0, avg latency (seconds) 0.141 }
Total test time (seconds): 25.00543695
{ 4470 requests, 0 errors, 0.159 avg latency (seconds) }
Config: Config { view_uri: "fog-view://fog.test.mobilecoin.com", num_workers: 30, num_search_keys: 1, grpc_retry_config: GrpcRetryConfig { grpc_retry_count: 3, grpc_retry_millis: 20 } }
chris@0c3432ad3654:/tmp/mobilenode$ ./target/docker/release/fog-view-load-test --view-uri fog-view://fog.test.mobilecoin.com --num-workers 30 --num-search-keys 20
{ requests per second: 16.997314322353184, errors per second: 0, avg latency (seconds) 0.172 }
{ requests per second: 158.9685455297702, errors per second: 0, avg latency (seconds) 0.174 }
{ requests per second: 140.98166279708332, errors per second: 0, avg latency (seconds) 0.188 }
{ requests per second: 104.98095320067986, errors per second: 0, avg latency (seconds) 0.305 }
{ requests per second: 80.96608015134747, errors per second: 0, avg latency (seconds) 0.333 }
{ requests per second: 149.97463134118473, errors per second: 0, avg latency (seconds) 0.22 }
{ requests per second: 121.95935558124027, errors per second: 0, avg latency (seconds) 0.216 }
{ requests per second: 78.96971985062048, errors per second: 0, avg latency (seconds) 0.36 }
{ requests per second: 110.96043206472788, errors per second: 0, avg latency (seconds) 0.332 }
{ requests per second: 103.97435108720205, errors per second: 0, avg latency (seconds) 0.26 }
{ requests per second: 73.9797439762006, errors per second: 0, avg latency (seconds) 0.34 }
{ requests per second: 111.98683303611894, errors per second: 0, avg latency (seconds) 0.327 }
{ requests per second: 113.98697151712955, errors per second: 0, avg latency (seconds) 0.255 }
{ requests per second: 115.98087637721765, errors per second: 0, avg latency (seconds) 0.236 }
{ requests per second: 111.97894370338392, errors per second: 0, avg latency (seconds) 0.287 }
{ requests per second: 98.9805122218512, errors per second: 0, avg latency (seconds) 0.252 }
{ requests per second: 166.97004373748302, errors per second: 0, avg latency (seconds) 0.218 }
{ requests per second: 194.9624428249391, errors per second: 0, avg latency (seconds) 0.155 }
{ requests per second: 115.977706881161, errors per second: 0, avg latency (seconds) 0.198 }
{ requests per second: 176.97000960035305, errors per second: 0, avg latency (seconds) 0.208 }
{ requests per second: 188.98243049241955, errors per second: 0, avg latency (seconds) 0.156 }
{ requests per second: 183.98047764753633, errors per second: 0, avg latency (seconds) 0.159 }
{ requests per second: 163.96980135374508, errors per second: 0, avg latency (seconds) 0.182 }
{ requests per second: 173.96573901339295, errors per second: 0, avg latency (seconds) 0.174 }
{ requests per second: 191.977589304135, errors per second: 0, avg latency (seconds) 0.157 }
{ requests per second: 190.97169245699877, errors per second: 0, avg latency (seconds) 0.157 }
{ requests per second: 136.97375692396344, errors per second: 0, avg latency (seconds) 0.188 }
{ requests per second: 136.97337073304905, errors per second: 0, avg latency (seconds) 0.246 }
{ requests per second: 171.96721324702395, errors per second: 0, avg latency (seconds) 0.157 }
^C{ requests per second: 82.98570314007732, errors per second: 0, avg latency (seconds) 0.22 }
Total test time (seconds): 30.005993456
{ 3974 requests, 0 errors, 0.215 avg latency (seconds) }
Config: Config { view_uri: "fog-view://fog.test.mobilecoin.com", num_workers: 30, num_search_keys: 20, grpc_retry_config: GrpcRetryConfig { grpc_retry_count: 3, grpc_retry_millis: 20 } }
chris@0c3432ad3654:/tmp/mobilenode$ ./target/docker/release/fog-view-load-test --view-uri fog-view://fog.test.mobilecoin.com --num-workers 30 --num-search-keys 100
{ requests per second: 22.49806151077508, errors per second: 0, avg latency (seconds) 0.613 }
{ requests per second: 44.99550530898368, errors per second: 0, avg latency (seconds) 0.605 }
{ requests per second: 46.99464622891766, errors per second: 0, avg latency (seconds) 0.646 }
{ requests per second: 43.994561172375064, errors per second: 0, avg latency (seconds) 0.645 }
{ requests per second: 40.994591050673, errors per second: 0, avg latency (seconds) 0.814 }
{ requests per second: 48.99283837386503, errors per second: 0, avg latency (seconds) 0.578 }
{ requests per second: 42.99543078957913, errors per second: 0, avg latency (seconds) 0.655 }
{ requests per second: 44.99316216418009, errors per second: 0, avg latency (seconds) 0.683 }
{ requests per second: 44.995160455526886, errors per second: 0, avg latency (seconds) 0.751 }
{ requests per second: 42.995169879620555, errors per second: 0, avg latency (seconds) 0.591 }
{ requests per second: 45.99294137130186, errors per second: 0, avg latency (seconds) 0.696 }
{ requests per second: 42.99552347807756, errors per second: 0, avg latency (seconds) 0.665 }
{ requests per second: 36.99338225384861, errors per second: 0, avg latency (seconds) 0.818 }
{ requests per second: 52.99192954109861, errors per second: 0, avg latency (seconds) 0.584 }
{ requests per second: 43.99735707876028, errors per second: 0, avg latency (seconds) 0.664 }
{ requests per second: 43.99331939448336, errors per second: 0, avg latency (seconds) 0.665 }
{ requests per second: 39.99567246823894, errors per second: 0, avg latency (seconds) 0.764 }
{ requests per second: 50.992596537886456, errors per second: 0, avg latency (seconds) 0.602 }
{ requests per second: 45.995104603031784, errors per second: 0, avg latency (seconds) 0.614 }
{ requests per second: 43.99379001257699, errors per second: 0, avg latency (seconds) 0.691 }
{ requests per second: 46.99097834304085, errors per second: 0, avg latency (seconds) 0.721 }
{ requests per second: 44.99339627423543, errors per second: 0, avg latency (seconds) 0.562 }
{ requests per second: 45.993555474993954, errors per second: 0, avg latency (seconds) 0.667 }
{ requests per second: 44.99181949739534, errors per second: 0, avg latency (seconds) 0.67 }
{ requests per second: 43.99523835135799, errors per second: 0, avg latency (seconds) 0.681 }
{ requests per second: 49.99270456462288, errors per second: 0, avg latency (seconds) 0.637 }
{ requests per second: 44.99117871456297, errors per second: 0, avg latency (seconds) 0.657 }
{ requests per second: 43.994891005292224, errors per second: 0, avg latency (seconds) 0.672 }
{ requests per second: 28.996706583063002, errors per second: 0, avg latency (seconds) 0.79 }
{ requests per second: 57.993310993516694, errors per second: 0, avg latency (seconds) 0.693 }
{ requests per second: 41.995558549727775, errors per second: 0, avg latency (seconds) 0.624 }
{ requests per second: 43.99566651483962, errors per second: 0, avg latency (seconds) 0.68 }
{ requests per second: 45.99614032587683, errors per second: 0, avg latency (seconds) 0.68 }
^C{ requests per second: 49.98861474307196, errors per second: 0, avg latency (seconds) 0.601 }
Total test time (seconds): 35.004568427
{ 1530 requests, 0 errors, 0.663 avg latency (seconds) }
Config: Config { view_uri: "fog-view://fog.test.mobilecoin.com", num_workers: 30, num_search_keys: 100, grpc_retry_config: GrpcRetryConfig { grpc_retry_count: 3, grpc_retry_millis: 20 } }
```