### PR TITLE
Bump enclave security version numbers for release

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.19.100.3";
 
 const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
-const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 7;
+const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 8;
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.19.100.3";
 
 const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
-const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 6;
+const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const INGEST_ENCLAVE_NAME: &str = "ingest-enclave";
 const INGEST_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.19.100.3";
 
 const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
-const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 6;
+const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const LEDGER_ENCLAVE_NAME: &str = "ledger-enclave";
 const LEDGER_ENCLAVE_DIR: &str = "../trusted";
 

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -13,7 +13,7 @@ use std::{env::var, path::PathBuf};
 const SGX_VERSION: &str = "2.19.100.3";
 
 const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
-const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 6;
+const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const VIEW_ENCLAVE_NAME: &str = "view-enclave";
 const VIEW_ENCLAVE_DIR: &str = "../trusted";
 


### PR DESCRIPTION
Bumping the enclave security versions (ISVSVN) for the 5.0 release
