### PR TITLE
Create common measurement types for attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,6 +2546,7 @@ dependencies = [
 name = "mc-attest-verifier-config"
 version = "4.0.2"
 dependencies = [
+ "assert_matches",
  "displaydoc",
  "hex",
  "hex-literal",

--- a/attest/verifier/config/Cargo.toml
+++ b/attest/verifier/config/Cargo.toml
@@ -20,4 +20,5 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 mc-common = { path = "../../../common", features = ["std"] }
 mc-util-logger-macros = { path = "../../../util/logger-macros" }
 
+assert_matches = "1.5"
 hex-literal = "0.3.4"

--- a/attest/verifier/config/README.md
+++ b/attest/verifier/config/README.md
@@ -5,13 +5,11 @@ A JSON schema for basic attestation configs.
 
 This crate defines a schema for storing a set of trusted measurements for SGX
 enclaves in json. These measurements can be grouped by version, and named.
-Then, a helper function can produce an `mc-attest-verifier::Verifier`
-which is appropriate for a given enclave name.
 
 This crate simply provides a serialization format and organizational schema over
 the data that is martialed into a Verifier using the builder format.
 
-This is meant to help clients that connect to several mobilecoin enclaves to configure their verifiers
+This is meant to help clients that connect to several MobileCoin enclaves to configure their verifiers
 appropriately. Thus, it has more to do with clients than the actual attestation implementation.
 
 Format
@@ -81,27 +79,11 @@ The use of `MRSIGNER` is also supported, but the product id and minimum SVN (sec
 }
 ```
 
-It is also possible to specify `mitigated_config_advisories`.
-
-```json
-{
-  "v3": {
-    "fog-ingest": {
-        "MRSIGNER": "2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e",
-        "product_id": 1,
-        "minimum_svn": 5,
-        "mitigated_config_advisories": ["INTEL-SA-XXXXX"],
-        "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"],
-    }
-  }
-}
-```
-
 Suggestions for use
 -------------------
 
 It is suggested that clients such as full-service might take the `trusted-measurements.json` file as a startup parameter,
 or have a search location.
 
-For mobile clients, it may be more convenient if they take the bake this json is as a string literal and update it with each release.
-Both approaches are reasonable.
+For mobile clients, it may be more convenient if they bake this json is as a string literal and update it with each
+release. Both approaches are reasonable.

--- a/attest/verifier/config/README.md
+++ b/attest/verifier/config/README.md
@@ -79,6 +79,22 @@ The use of `MRSIGNER` is also supported, but the product id and minimum SVN (sec
 }
 ```
 
+It is also possible to specify `mitigated_config_advisories`.
+
+```json
+{
+  "v3": {
+    "fog-ingest": {
+        "MRSIGNER": "2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e",
+        "product_id": 1,
+        "minimum_svn": 5,
+        "mitigated_config_advisories": ["INTEL-SA-XXXXX"],
+        "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"],
+    }
+  }
+}
+```
+
 Suggestions for use
 -------------------
 

--- a/attest/verifier/config/src/lib.rs
+++ b/attest/verifier/config/src/lib.rs
@@ -6,94 +6,137 @@
 
 extern crate alloc;
 
-use alloc::{borrow::ToOwned, collections::BTreeMap, string::String, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use displaydoc::Display;
-use mc_attest_core::{MrEnclave, MrSigner};
-use mc_attest_verifier::{MrEnclaveVerifier, MrSignerVerifier, Verifier, DEBUG_ENCLAVE};
 use serde::{Deserialize, Serialize};
 
-/// Defines a json schema for an individual attestation status verifier.
-/// This is either a MRENCLAVE or MRSIGNER type, and the type is inferred by
-/// the presence of these fields.
-/// Unknown fields are flagged as an error.
+/// Trusted measurement for MRENCLAVE values.
+///
+/// The MRENCLAVE is the hash over the enclave pages loaded into the SGX
+/// protected memory. Whenever the contents of the signed enclave have changed,
+/// its MRENCLAVE will change.
+///
+/// This measurement is also referred to as "Strict Enclave Modification
+/// Policy".
+///
+/// Supports de/serialization to/from JSON. Unknown JSON fields are flagged as
+/// an error.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
 #[serde(deny_unknown_fields)]
-pub enum StatusVerifierConfig {
-    /// A MRENCLAVE-based status verifier
-    Mrenclave {
-        /// The hex-encoded bytes of the MRENCLAVE measurement. This is
-        /// enclavehash in the .css file
-        #[serde(with = "hex", rename = "MRENCLAVE")]
-        mr_enclave: [u8; 32],
-        /// The list of config advisories that are known to be mitigated in
-        /// software at this enclave revision.
-        #[serde(default)]
-        mitigated_config_advisories: Vec<String>,
-        /// The list of hardening advisories that are known to be mitigated in
-        /// software at this enclave revision.
-        #[serde(default)]
-        mitigated_hardening_advisories: Vec<String>,
-    },
-    /// A MRSIGNER-based status verifier
-    Mrsigner {
-        /// The hex-encoded bytes of the MRSIGNER measurement. This is a digest
-        /// of the modulus in the .css file. Use a tool to see what it is.
-        #[serde(with = "hex", rename = "MRSIGNER")]
-        mr_signer: [u8; 32],
-        /// The product id that this verifier checks for.
-        product_id: u16,
-        /// The minimum security version number that is considered valid by this
-        /// verifier.
-        minimum_svn: u16,
-        /// The list of config advisories that are known to be mitigated in
-        /// software at this enclave revision.
-        #[serde(default)]
-        mitigated_config_advisories: Vec<String>,
-        /// The list of hardening advisories that are known to be mitigated in
-        /// software at this enclave revision.
-        #[serde(default)]
-        mitigated_hardening_advisories: Vec<String>,
-    },
+pub struct TrustedMrEnclaveMeasurement {
+    /// The MRENCLAVE measurement
+    ///
+    /// For JSON this will be hex-encoded bytes.
+    #[serde(with = "hex", rename = "MRENCLAVE")]
+    mr_enclave: [u8; 32],
+    /// The list of hardening advisories that are known to be mitigated in
+    /// software at this enclave revision.
+    #[serde(default)]
+    mitigated_hardening_advisories: Vec<String>,
 }
 
-impl StatusVerifierConfig {
-    /// Build status verifier corresponding to ourself, and add it to a given
-    /// verifier
-    pub fn add_to_verifier(&self, verifier: &mut Verifier) {
-        match self {
-            Self::Mrenclave {
-                mr_enclave,
-                mitigated_config_advisories,
-                mitigated_hardening_advisories,
-            } => {
-                let mut mr_enclave_verifier = MrEnclaveVerifier::new(MrEnclave::from(*mr_enclave));
-                for advisory in mitigated_config_advisories.iter() {
-                    mr_enclave_verifier.allow_config_advisory(advisory);
-                }
-                for advisory in mitigated_hardening_advisories.iter() {
-                    mr_enclave_verifier.allow_hardening_advisory(advisory);
-                }
-                verifier.mr_enclave(mr_enclave_verifier);
-            }
-            Self::Mrsigner {
-                mr_signer,
-                product_id,
-                minimum_svn,
-                mitigated_config_advisories,
-                mitigated_hardening_advisories,
-            } => {
-                let mut mr_signer_verifier =
-                    MrSignerVerifier::new(MrSigner::from(*mr_signer), *product_id, *minimum_svn);
-                for advisory in mitigated_config_advisories.iter() {
-                    mr_signer_verifier.allow_config_advisory(advisory);
-                }
-                for advisory in mitigated_hardening_advisories.iter() {
-                    mr_signer_verifier.allow_hardening_advisory(advisory);
-                }
-                verifier.mr_signer(mr_signer_verifier);
-            }
+impl TrustedMrEnclaveMeasurement {
+    /// Create a new instance.
+    pub fn new<'a, E, I>(mr_enclave: &[u8; 32], advisories: I) -> Self
+    where
+        I: IntoIterator<Item = &'a E>,
+        E: ToString + 'a + ?Sized,
+    {
+        Self {
+            mr_enclave: *mr_enclave,
+            mitigated_hardening_advisories: advisories
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
         }
+    }
+}
+
+impl TrustedMrSignerMeasurement {
+    /// Create a new instance.
+    pub fn new<'a, E, I>(
+        mr_signer: &[u8; 32],
+        product_id: u16,
+        minimum_svn: u16,
+        advisories: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = &'a E>,
+        E: ToString + 'a + ?Sized,
+    {
+        Self {
+            mr_signer: *mr_signer,
+            product_id,
+            minimum_svn,
+            mitigated_hardening_advisories: advisories
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+        }
+    }
+}
+
+/// Trusted measurement for MRSIGNER values.
+///
+/// The MRSIGNER is the hash of the public portion of the key used to sign the
+/// enclave. The product ID is used to distinguish different enclaves signed
+/// with the same key. Using the MRSIGNER + product ID allows for the same
+/// measurements to be used for updates to the enclave. A security version
+/// number (SVN) is also used to distinguish different versions of the same
+/// enclave.
+///
+/// This measurement is also referred to as "Security Enclave Modification
+/// Policy".
+///
+/// Supports de/serialization to/from JSON. Unknown JSON fields are flagged as
+/// an error.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedMrSignerMeasurement {
+    /// The MRSIGNER measurement
+    ///
+    /// For JSON this will be hex-encoded bytes.
+    #[serde(with = "hex", rename = "MRSIGNER")]
+    mr_signer: [u8; 32],
+    /// The product ID that this verifier checks for.
+    product_id: u16,
+    /// The minimum security version number that is considered valid by this
+    /// verifier.
+    minimum_svn: u16,
+    /// The list of hardening advisories that are known to be mitigated in
+    /// software at this enclave revision.
+    #[serde(default)]
+    mitigated_hardening_advisories: Vec<String>,
+}
+
+/// Trusted measurement for an enclave.
+///
+/// Either a MRENCLAVE or MRSIGNER type, and the type is inferred by
+///
+/// Supports de/serialization to/from JSON.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum TrustedMeasurement {
+    /// MRENCLAVE measurement type
+    MrEnclave(TrustedMrEnclaveMeasurement),
+    /// MRSIGNER measurement type
+    MrSigner(TrustedMrSignerMeasurement),
+}
+
+impl From<TrustedMrEnclaveMeasurement> for TrustedMeasurement {
+    fn from(mr_enclave: TrustedMrEnclaveMeasurement) -> Self {
+        Self::MrEnclave(mr_enclave)
+    }
+}
+
+impl From<TrustedMrSignerMeasurement> for TrustedMeasurement {
+    fn from(mr_signer: TrustedMrSignerMeasurement) -> Self {
+        Self::MrSigner(mr_signer)
     }
 }
 
@@ -112,7 +155,7 @@ impl StatusVerifierConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct TrustedMeasurementSet {
-    table: BTreeMap<String, BTreeMap<String, StatusVerifierConfig>>,
+    table: BTreeMap<String, BTreeMap<String, TrustedMeasurement>>,
 }
 
 // Allow TrustedMeasurementSet to be logged nicely in json format
@@ -128,29 +171,24 @@ impl core::fmt::Display for TrustedMeasurementSet {
 }
 
 impl TrustedMeasurementSet {
-    /// Create a verifier from this measurement set for a given enclave name.
-    pub fn create_verifier(&self, enclave_name: impl AsRef<str>) -> Result<Verifier, Error> {
+    /// Get the measurements for a given enclave name.
+    pub fn measurements(
+        &self,
+        enclave_name: impl AsRef<str>,
+    ) -> Result<Vec<TrustedMeasurement>, Error> {
         let enclave_name = enclave_name.as_ref();
-        let mut count = 0usize;
+        let mut measurements = vec![];
 
-        let mut verifier = Verifier::default();
-        verifier.debug(DEBUG_ENCLAVE);
-
-        for measurements in self.table.values() {
-            if let Some(measurement) = measurements.get(enclave_name) {
-                // TODO: it would be nice to add the release name in also as like
-                // a debug string somewhere that would show up in error messages
-                // when attestation fails?
-                measurement.add_to_verifier(&mut verifier);
-                count += 1;
+        for row in self.table.values() {
+            if let Some(measurement) = row.get(enclave_name) {
+                measurements.push(measurement.clone());
             }
         }
 
-        if count == 0 {
-            return Err(Error::NoMeasurementsFound(enclave_name.to_owned()));
+        match measurements.len() {
+            0 => Err(Error::NoMeasurementsFound(enclave_name.to_string())),
+            _ => Ok(measurements),
         }
-
-        Ok(verifier)
     }
 }
 
@@ -167,7 +205,6 @@ mod tests {
 
     use super::*;
 
-    use alloc::{string::ToString, vec};
     use hex_literal::hex;
 
     const TEST_DATA: &str = r#"{
@@ -217,108 +254,89 @@ mod tests {
         let v3 = tms.table.get("v3").unwrap();
         assert_eq!(v3.len(), 4);
         let v3_consensus = v3.get("consensus").unwrap();
-        let expected_consensus = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("207c9705bf640fdb960034595433ee1ff914f9154fbe4bc7fc8a97e912961e5c"),
-            mitigated_config_advisories: vec![],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-            ],
-        };
+        let expected_consensus = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("207c9705bf640fdb960034595433ee1ff914f9154fbe4bc7fc8a97e912961e5c"),
+            ["INTEL-SA-00334", "INTEL-SA-00615"],
+        ));
         assert_eq!(v3_consensus, &expected_consensus);
         let v3_fog_view = v3.get("fog-view").unwrap();
-        let expected_fog_view = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("dca7521ce4564cc2e54e1637e533ea9d1901c2adcbab0e7a41055e719fb0ff9d"),
-            mitigated_config_advisories: vec![],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-            ],
-        };
+        let expected_fog_view = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("dca7521ce4564cc2e54e1637e533ea9d1901c2adcbab0e7a41055e719fb0ff9d"),
+            ["INTEL-SA-00334", "INTEL-SA-00615"],
+        ));
         assert_eq!(v3_fog_view, &expected_fog_view);
 
         let v4 = tms.table.get("v4").unwrap();
         assert_eq!(v4.len(), 4);
         let v4_consensus = v4.get("consensus").unwrap();
-        let expected_consensus = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("e35bc15ee92775029a60a715dca05d310ad40993f56ad43bca7e649ccc9021b5"),
-            mitigated_config_advisories: vec![],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-                "INTEL-SA-00657".to_string(),
-            ],
-        };
+        let expected_consensus = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("e35bc15ee92775029a60a715dca05d310ad40993f56ad43bca7e649ccc9021b5"),
+            ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"],
+        ));
         assert_eq!(v4_consensus, &expected_consensus);
 
         let v4_fog_view = v4.get("fog-view").unwrap();
-        let expected_fog_view = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("8c80a2b95a549fa8d928dd0f0771be4f3d774408c0f98bf670b1a2c390706bf3"),
-            mitigated_config_advisories: vec![],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-                "INTEL-SA-00657".to_string(),
-            ],
-        };
+        let expected_fog_view = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("8c80a2b95a549fa8d928dd0f0771be4f3d774408c0f98bf670b1a2c390706bf3"),
+            ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"],
+        ));
         assert_eq!(v4_fog_view, &expected_fog_view);
 
-        let _ = tms.create_verifier("consensus").unwrap();
-        let _ = tms.create_verifier("fog-ingest").unwrap();
-        let _ = tms.create_verifier("fog-ledger").unwrap();
-        let _ = tms.create_verifier("fog-view").unwrap();
+        assert_eq!(
+            tms.measurements("consensus").unwrap(),
+            vec![v3_consensus.clone(), v4_consensus.clone()]
+        );
+        assert_eq!(
+            tms.measurements("fog-view").unwrap(),
+            vec![v3_fog_view.clone(), v4_fog_view.clone()]
+        );
 
-        assert!(tms.create_verifier("impostor").is_err());
+        assert!(matches!(
+            tms.measurements("impostor"),
+            Err(Error::NoMeasurementsFound(_))
+        ));
     }
 
     const TEST_DATA2: &str = r#"{
     "v3": {
        "consensus": {
            "MRENCLAVE": "207c9705bf640fdb960034595433ee1ff914f9154fbe4bc7fc8a97e912961e5c",
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"]
        },
        "fog-ingest": {
            "MRSIGNER": "2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e",
            "product_id": 1,
            "minimum_svn": 4,
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"]
        },
        "fog-ledger": {
            "MRSIGNER": "2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e",
            "product_id": 2,
            "minimum_svn": 4,
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"]
        },
        "fog-view": {
            "MRSIGNER": "2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e",
            "product_id": 3,
            "minimum_svn": 4,
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615"]
        }
     },
     "v4": {
        "consensus": {
            "MRENCLAVE": "e35bc15ee92775029a60a715dca05d310ad40993f56ad43bca7e649ccc9021b5",
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"]
        },
        "fog-ingest": {
            "MRENCLAVE": "a8af815564569aae3558d8e4e4be14d1bcec896623166a10494b4eaea3e1c48c",
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"]
        },
        "fog-ledger": {
            "MRENCLAVE": "da209f4b24e8f4471bd6440c4e9f1b3100f1da09e2836d236e285b274901ed3b",
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"]
        },
        "fog-view": {
            "MRENCLAVE": "8c80a2b95a549fa8d928dd0f0771be4f3d774408c0f98bf670b1a2c390706bf3",
-           "mitigated_config_advisories": ["FOO"],
            "mitigated_hardening_advisories": ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"]
        }
     }
@@ -332,61 +350,50 @@ mod tests {
         let v3 = tms.table.get("v3").unwrap();
         assert_eq!(v3.len(), 4);
         let v3_consensus = v3.get("consensus").unwrap();
-        let expected_consensus = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("207c9705bf640fdb960034595433ee1ff914f9154fbe4bc7fc8a97e912961e5c"),
-            mitigated_config_advisories: vec!["FOO".to_string()],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-            ],
-        };
+        let expected_consensus = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("207c9705bf640fdb960034595433ee1ff914f9154fbe4bc7fc8a97e912961e5c"),
+            ["INTEL-SA-00334", "INTEL-SA-00615"],
+        ));
         assert_eq!(v3_consensus, &expected_consensus);
 
         let v3_fog_view = v3.get("fog-view").unwrap();
-        let expected_fog_view = StatusVerifierConfig::Mrsigner {
-            mr_signer: hex!("2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e"),
-            product_id: 3,
-            minimum_svn: 4,
-            mitigated_config_advisories: vec!["FOO".to_string()],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-            ],
-        };
+        let expected_fog_view = TrustedMeasurement::from(TrustedMrSignerMeasurement::new(
+            &hex!("2c1a561c4ab64cbc04bfa445cdf7bed9b2ad6f6b04d38d3137f3622b29fdb30e"),
+            3,
+            4,
+            ["INTEL-SA-00334", "INTEL-SA-00615"],
+        ));
         assert_eq!(v3_fog_view, &expected_fog_view);
 
         let v4 = tms.table.get("v4").unwrap();
         assert_eq!(v4.len(), 4);
         let v4_consensus = v4.get("consensus").unwrap();
-        let expected_consensus = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("e35bc15ee92775029a60a715dca05d310ad40993f56ad43bca7e649ccc9021b5"),
-            mitigated_config_advisories: vec!["FOO".to_string()],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-                "INTEL-SA-00657".to_string(),
-            ],
-        };
+        let expected_consensus = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("e35bc15ee92775029a60a715dca05d310ad40993f56ad43bca7e649ccc9021b5"),
+            ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"],
+        ));
         assert_eq!(v4_consensus, &expected_consensus);
 
         let v4_fog_view = v4.get("fog-view").unwrap();
-        let expected_fog_view = StatusVerifierConfig::Mrenclave {
-            mr_enclave: hex!("8c80a2b95a549fa8d928dd0f0771be4f3d774408c0f98bf670b1a2c390706bf3"),
-            mitigated_config_advisories: vec!["FOO".to_string()],
-            mitigated_hardening_advisories: vec![
-                "INTEL-SA-00334".to_string(),
-                "INTEL-SA-00615".to_string(),
-                "INTEL-SA-00657".to_string(),
-            ],
-        };
+        let expected_fog_view = TrustedMeasurement::from(TrustedMrEnclaveMeasurement::new(
+            &hex!("8c80a2b95a549fa8d928dd0f0771be4f3d774408c0f98bf670b1a2c390706bf3"),
+            ["INTEL-SA-00334", "INTEL-SA-00615", "INTEL-SA-00657"],
+        ));
         assert_eq!(v4_fog_view, &expected_fog_view);
 
-        let _ = tms.create_verifier("consensus").unwrap();
-        let _ = tms.create_verifier("fog-ingest").unwrap();
-        let _ = tms.create_verifier("fog-ledger").unwrap();
-        let _ = tms.create_verifier("fog-view").unwrap();
+        assert_eq!(
+            tms.measurements("consensus").unwrap(),
+            vec![v3_consensus.clone(), v4_consensus.clone()]
+        );
+        assert_eq!(
+            tms.measurements("fog-view").unwrap(),
+            vec![v3_fog_view.clone(), v4_fog_view.clone()]
+        );
 
-        assert!(tms.create_verifier("impostor").is_err());
+        assert!(matches!(
+            tms.measurements("impostor"),
+            Err(Error::NoMeasurementsFound(_))
+        ));
     }
 
     #[test]

--- a/attest/verifier/config/src/lib.rs
+++ b/attest/verifier/config/src/lib.rs
@@ -57,30 +57,6 @@ impl TrustedMrEnclaveMeasurement {
     }
 }
 
-impl TrustedMrSignerMeasurement {
-    /// Create a new instance.
-    pub fn new<'a, E, I>(
-        mr_signer: &[u8; 32],
-        product_id: u16,
-        minimum_svn: u16,
-        advisories: I,
-    ) -> Self
-    where
-        I: IntoIterator<Item = &'a E>,
-        E: ToString + 'a + ?Sized,
-    {
-        Self {
-            mr_signer: *mr_signer,
-            product_id,
-            minimum_svn,
-            mitigated_hardening_advisories: advisories
-                .into_iter()
-                .map(ToString::to_string)
-                .collect(),
-        }
-    }
-}
-
 /// Trusted measurement for MRSIGNER values.
 ///
 /// The MRSIGNER is the hash of the public portion of the key used to sign the
@@ -112,6 +88,30 @@ pub struct TrustedMrSignerMeasurement {
     /// software at this enclave revision.
     #[serde(default)]
     mitigated_hardening_advisories: Vec<String>,
+}
+
+impl TrustedMrSignerMeasurement {
+    /// Create a new instance.
+    pub fn new<'a, E, I>(
+        mr_signer: &[u8; 32],
+        product_id: u16,
+        minimum_svn: u16,
+        advisories: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = &'a E>,
+        E: ToString + 'a + ?Sized,
+    {
+        Self {
+            mr_signer: *mr_signer,
+            product_id,
+            minimum_svn,
+            mitigated_hardening_advisories: advisories
+                .into_iter()
+                .map(ToString::to_string)
+                .collect(),
+        }
+    }
 }
 
 /// Trusted measurement for an enclave.
@@ -202,8 +202,8 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
+    use assert_matches::assert_matches;
 
     use hex_literal::hex;
 
@@ -291,10 +291,10 @@ mod tests {
             vec![v3_fog_view.clone(), v4_fog_view.clone()]
         );
 
-        assert!(matches!(
+        assert_matches!(
             tms.measurements("impostor"),
             Err(Error::NoMeasurementsFound(_))
-        ));
+        );
     }
 
     const TEST_DATA2: &str = r#"{


### PR DESCRIPTION
~The underlying implementation of
`mc-attest-verifier-config::TrustedMeasurementSet` has been changed to
no longer support a dedicated config advisory entry.~ The config advisories have been kept. After further investigation it feels like an unnecessary breaking change to remove them.

The creation of a verifier from the `TrustedMeasurementSet` has 
been removed.

`mc-attest-verifier-config::StatusVerifierConfig` has been renamed to
`mc-attest-verifier-config::TrustedMeasurement`

### Motivation

Preparation of a common type to use for trusted measurements. In order for clients to support EPID and DCAP attestation they need to lose knowledge of the verifier implementation and instead pass the trusted measurement values to functionality that can determine how to attest the enclave based on the format of the provided attestation evidence.

### Future Work

Update the interfaces that are passing a verifier to pass this new trusted measurement type.
