### PR TITLE
disable ledger sync cronjob until after 5.0.2 release

### DIFF
--- a/.github/workflows/refresh-ledger-bootstrap.yaml
+++ b/.github/workflows/refresh-ledger-bootstrap.yaml
@@ -4,9 +4,9 @@
 
 name: Refresh ledger bootstrap
 
-on:
-  schedule:
-  - cron: '0 0 * * *'
+on: {}
+  # schedule:
+  # - cron: '0 0 * * *'
 
 # Start mobilecoind
 # Monitor mobilecoind until ledger has finished syncing


### PR DESCRIPTION
### Motivation

We have a :chicken: :egg: issue with this job.  We need features in the 5.0.2 release for this job, but it looks for the "latest" release.  

We're going to disable this scheduled job for now and make it a manual run until we get 5.x released and running. 

### Future Work

Re-enable this daily job with better logic for determining when the watcher db is up to date.

