### PR TITLE
fix: add logic to wait for signatures (watcher db) to finish syncing

### DIFF
--- a/.github/workflows/refresh-ledger-bootstrap.yaml
+++ b/.github/workflows/refresh-ledger-bootstrap.yaml
@@ -4,14 +4,20 @@
 
 name: Refresh ledger bootstrap
 
-on: {}
-  # schedule:
-  # - cron: '0 0 * * *'
+on:
+  schedule:
+  - cron: '0 0 * * *'
 
 # Start mobilecoind
 # Monitor mobilecoind until ledger has finished syncing
 # Stop mobilecoind
 # Copy ledger/watcher to azure blob
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   refresh-ledger:
@@ -45,10 +51,10 @@ jobs:
 
     - name: Download latest linux release
       env:
-        GH_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         mkdir -p "${DOWNLOAD_DIR}"
-        gh release download \
+        gh release download v5.0.2 \
             -p '${{ matrix.network.chain_id }}net-mobilecoind-linux-x86_64-*.tar.gz' \
             -O "${DOWNLOAD_DIR}/linux.tar.gz"
 
@@ -119,8 +125,9 @@ jobs:
         echo "ledger is in sync, stop mobilecoind"
         kill ${mcj_pid}
         kill ${mc_pid}
-        md5sum ${MC_LEDGER_DIR}/data.mdb
-        md5sum ${MC_WATCHER_DIR}/data.mdb
+
+        md5sum "${MC_LEDGER_DB}/data.mdb"
+        md5sum "${MC_WATCHER_DB}/data.mdb"
         echo "mobilecoind shutdown successfully"
 
     - name: copy ledger/watcher data.mdb to Azure Blob Storage

--- a/.internal-ci/util/wait-for-mobilecoind.sh
+++ b/.internal-ci/util/wait-for-mobilecoind.sh
@@ -6,28 +6,47 @@ set -e
 set -o pipefail
 shopt -s inherit_errexit
 
-echo "Checking block height - wait for mobilecoind to start"
-sleep 15
-
 get_block_info()
 {
-    curl --connect-timeout 2 -sSL -X POST -H 'Content-type: application/json' "${BLOCK_INFO_URL:?}" 2>/dev/null
+    echo "  - get ${BLOCK_INFO_URL:?}" >&2
+    curl --connect-timeout 2 -fsSL -X POST -H 'Content-type: application/json' "${BLOCK_INFO_URL:?}"
 }
 
 get_mcd_ledger()
 {
-    curl --connect-timeout 2 -sSL http://localhost:9090/ledger/local 2>/dev/null
+    echo "  - get http://localhost:9090/ledger/local" >&2
+    curl --connect-timeout 2 -fsSL http://localhost:9090/ledger/local
 }
 
-# wait for blocks
+get_mcd_block_details()
+{
+    echo "  - get http://localhost:9090/ledger/blocks/${1}/" >&2
+    curl --connect-timeout 2 -fsSL "http://localhost:9090/ledger/blocks/${1}/"
+}
+
+# wait for mobilecoind-json
+echo "Waiting for mobilecoind to start"
+while ! get_mcd_ledger | jq -r .block_count >/dev/null 2>&1
+do
+    echo "- mobilecoind has not yet started, sleeping"
+    sleep 10
+done
+
+# wait for Ledger DB
+echo "Get mobilecoind block height"
 mcd_json=$(get_mcd_ledger)
+echo "Get current block height"
 network_block_info=$(get_block_info)
 
 network_block_height=$(echo "${network_block_info}" | jq -r .index)
+network_block_height=$((network_block_height + 1))
 local_block_height=$(echo "${mcd_json}" | jq -r .block_count)
+
+echo "Network: ${network_block_height}, Mobilecoind: ${local_block_height}"
 
 while [[ "${local_block_height}" != "${network_block_height}" ]]
 do
+    sleep 10
     echo "- Waiting for blocks to download ${local_block_height} of ${network_block_height}"
 
     mcd_json=$(get_mcd_ledger)
@@ -37,8 +56,23 @@ do
     local_block_height=$(echo "${mcd_json}" | jq -r .block_count)
     # network block height seems to be an index
     network_block_height=$((network_block_height + 1))
+done
 
+echo "Waiting for watcher db to sync - this may take a while"
+signatures=0
+while [[ ${signatures} -lt 10 ]]
+do
     sleep 10
+
+    # get current block
+    # .block_count is height, but when we query for blocks it needs to be an index
+    local_block_height=$(get_mcd_ledger | jq -r .block_count)
+    local_block_height=$((local_block_height - 1))
+
+    # get number of signatures for the current block
+    signatures=$(get_mcd_block_details "${local_block_height}" | jq '.signatures | length')
+
+    echo "- Latest block ${local_block_height} has ${signatures} of 10 signatures"
 done
 
 echo "mobilecoind sync is done"


### PR DESCRIPTION
### Motivation

This PR adds logic to the ledger refresh job to wait for the mobilecoind watcher process to finish syncing. 


