### PR TITLE
feat: (helm) add ingress switch to fog-services for blue/green style deployments.

### DIFF
--- a/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-grpc-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -49,3 +50,4 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-ledger-router
             port:
               name: ledger-grpc
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-http-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -49,3 +50,4 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-ledger-router
             port:
               name: ledger-http
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 {{- $hosts := split "\n" (include "fogServices.fogReportHosts" . | trim) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -33,3 +34,4 @@ spec:
             port:
               name: report-grpc
   {{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 {{- $hosts := split "\n" (include "fogServices.fogReportHosts" . | trim) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -33,3 +34,4 @@ spec:
             port:
               name: report-http
   {{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,3 +29,4 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-view-router
             port:
               name: view-grpc
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,3 +29,4 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-view-router
             port:
               name: view-http
+{{- end }}

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -86,6 +86,9 @@ global:
     enabled: "false"
     pattern: patterns/blocked-countries
 
+ingress:
+  enabled: true
+
 ### Fog Report Service
 fogReport:
   replicaCount: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [5.0.5]
+
+### Fixed
+
+#### Deployments
+
+- fix: remove client-auth-token from store configs ([#3387])
+- feat: (helm) add ingress switch to fog-services for blue/green style deployments. ([#3389])
+
 ## [5.0.4]
 
 ### Fixed


### PR DESCRIPTION
### Motivation

Since view/ledger deployments take a long time to load, add `ingress.enabled=(true|false)` option to the chart so we can launch a set of services and allow them to load without serving traffic to them.
