### PR TITLE
Add serde traits to light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,6 +4851,7 @@ dependencies = [
  "mc-consensus-scp-types",
  "mc-crypto-keys",
  "mc-transaction-core",
+ "serde",
 ]
 
 [[package]]

--- a/blockchain/types/src/block_id.rs
+++ b/blockchain/types/src/block_id.rs
@@ -13,7 +13,9 @@ use prost::{
 use serde::{Deserialize, Serialize};
 
 #[repr(transparent)]
-#[derive(Clone, Default, Digestible, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(
+    Clone, Default, Digestible, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord,
+)]
 #[digestible(transparent)]
 /// Identifies a block with its hash.
 pub struct BlockID(pub [u8; 32]);

--- a/light-client/verifier/Cargo.toml
+++ b/light-client/verifier/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 displaydoc = "0.2"
+serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 mc-api = { path = "../../api" }
 mc-blockchain-types = { path = "../../blockchain/types" }

--- a/light-client/verifier/src/trusted_validator_set.rs
+++ b/light-client/verifier/src/trusted_validator_set.rs
@@ -4,6 +4,7 @@ use crate::Error;
 use mc_blockchain_types::{BlockID, BlockMetadata};
 use mc_common::NodeID;
 use mc_consensus_scp_types::{QuorumSet, QuorumSetMember};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 /// A trusted validator set consists of:
@@ -19,7 +20,7 @@ use std::collections::HashSet;
 /// * The message signing key signatures of those nodes are valid
 /// * The message signing key signatures were made using the expected keys for
 ///   that responder id.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TrustedValidatorSet {
     /// A quorum set of validator nodes that this light client will trust
     pub quorum_set: QuorumSet,

--- a/light-client/verifier/src/verifier.rs
+++ b/light-client/verifier/src/verifier.rs
@@ -3,7 +3,8 @@
 use crate::{Error, TrustedValidatorSet};
 use mc_blockchain_types::{Block, BlockContents, BlockID, BlockIndex, BlockMetadata};
 use mc_transaction_core::tx::TxOut;
-use std::{collections::HashSet, ops::Range};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, ops::Range};
 
 /// The light client verifier
 ///
@@ -14,7 +15,7 @@ use std::{collections::HashSet, ops::Range};
 /// The verifier does not make network connections and its state does not
 /// change when it verifies things. It needs to be configured with correct
 /// trusted validator sets to give give correct results.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LightClientVerifier {
     /// A quorum configuration and expected signing keys for the validator
     /// network.
@@ -27,7 +28,7 @@ pub struct LightClientVerifier {
     /// A list of known valid block ids, which may appear before
     /// `trusted_validator_set_start_block` and outside of any of the historical
     /// ranges.
-    pub known_valid_block_ids: HashSet<BlockID>,
+    pub known_valid_block_ids: BTreeSet<BlockID>,
 }
 
 // For a simple LightClientVerifier initialization


### PR DESCRIPTION
This should allow constructing the `LightVerifierClient` from a JSON blob. I imagine the verifier configuration would be a JSON file that is loaded by the Axelar node and relayer, and this should make it possible.