### PR TITLE
add a light client cli utility and make some configuration more human-friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4841,18 +4841,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-light-client-cli"
+version = "4.1.0-pre0"
+dependencies = [
+ "clap 4.1.14",
+ "grpcio",
+ "mc-api",
+ "mc-common",
+ "mc-consensus-api",
+ "mc-consensus-scp-types",
+ "mc-light-client-verifier",
+ "mc-util-grpc",
+ "mc-util-uri",
+ "serde_json",
+]
+
+[[package]]
 name = "mc-light-client-verifier"
 version = "4.1.0-pre0"
 dependencies = [
+ "base64 0.21.0",
  "displaydoc",
  "mc-api",
  "mc-blockchain-types",
  "mc-common",
  "mc-consensus-scp-types",
+ "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-transaction-core",
  "mc-util-from-random",
  "mc-util-test-helper",
+ "prost",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
     "ledger/from-archive",
     "ledger/migration",
     "ledger/sync",
+    "light-client/cli",
     "light-client/verifier",
     "mobilecoind",
     "mobilecoind-dev-faucet",

--- a/consensus/scp/types/src/quorum_set.rs
+++ b/consensus/scp/types/src/quorum_set.rs
@@ -53,6 +53,14 @@ impl<ID: GenericNodeId> From<QuorumSetMember<ID>> for QuorumSetMemberWrapper<ID>
     }
 }
 
+impl<ID: GenericNodeId> From<ID> for QuorumSetMemberWrapper<ID> {
+    fn from(src: ID) -> Self {
+        Self {
+            member: Some(QuorumSetMember::Node(src)),
+        }
+    }
+}
+
 impl<ID: GenericNodeId> Deref for QuorumSetMemberWrapper<ID> {
     type Target = Option<QuorumSetMember<ID>>;
 

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "mc-light-client-cli"
+version = "4.1.0-pre0"
+authors = ["MobileCoin"]
+edition = "2021"
+license = "GPL-3.0"
+rust-version = { workspace = true }
+
+[[bin]]
+name = "mc-light-client-cli"
+path = "src/bin/main.rs"
+
+[dependencies]
+mc-api = { path = "../../api" }
+mc-common = { path = "../../common", features = ["log"] }
+mc-consensus-api = { path = "../../consensus/api" }
+mc-consensus-scp-types = { path = "../../consensus/scp/types" }
+mc-light-client-verifier = { path = "../verifier" }
+mc-util-grpc = { path = "../../util/grpc" }
+mc-util-uri = { path = "../../util/uri" }
+
+clap = { version = "4.1", features = ["derive", "env"] }
+grpcio = "0.12.1"
+serde_json = "1.0"

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2018-2023 The MobileCoin Foundation
+
+use clap::{Parser, Subcommand};
+use grpcio::{ChannelBuilder, EnvBuilder};
+use mc_common::{
+    logger::{create_app_logger, o},
+    ResponderId,
+};
+use mc_consensus_api::{
+    consensus_client_grpc::ConsensusClientApiClient, consensus_common_grpc::BlockchainApiClient,
+};
+use mc_consensus_scp_types::QuorumSet;
+use mc_light_client_verifier::{
+    HexKeyNodeID, LightClientVerifierConfig, TrustedValidatorSetConfig,
+};
+use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_util_uri::ConsensusClientUri;
+use std::{str::FromStr, sync::Arc};
+
+#[derive(Subcommand)]
+pub enum Commands {
+    GenerateConfig {
+        #[clap(long = "node", use_value_delimiter = true, env = "MC_NODES")]
+        nodes: Vec<ConsensusClientUri>,
+    },
+}
+
+#[derive(Parser)]
+#[clap(
+    name = "mc-light-client-cli",
+    about = "MobileCoin Light Client CLI utility"
+)]
+pub struct Config {
+    #[clap(subcommand)]
+    pub command: Commands,
+}
+
+fn main() {
+    let (logger, _global_logger_guard) = create_app_logger(o!());
+    let config = Config::parse();
+
+    let env = Arc::new(EnvBuilder::new().name_prefix("light-client-grpc").build());
+
+    match config.command {
+        Commands::GenerateConfig { nodes } => {
+            let (node_configs, last_block_infos): (Vec<_>, Vec<_>) = nodes
+                .iter()
+                .map(|node_uri| {
+                    // TODO should this use ThickClient and chain-id?
+                    let ch = ChannelBuilder::default_channel_builder(env.clone())
+                        .connect_to_uri(node_uri, &logger);
+
+                    let client_api = ConsensusClientApiClient::new(ch.clone());
+                    let config = client_api
+                        .get_node_config(&Default::default())
+                        .expect("get_node_config failed");
+
+                    let blockchain_api = BlockchainApiClient::new(ch);
+                    let last_block_info = blockchain_api
+                        .get_last_block_info(&Default::default())
+                        .expect("get_last_block_info failed");
+
+                    (config, last_block_info)
+                })
+                .unzip();
+
+            let node_ids = node_configs
+                .iter()
+                .map(|node_config| HexKeyNodeID {
+                    responder_id: ResponderId::from_str(node_config.get_peer_responder_id())
+                        .unwrap(),
+                    public_key: node_config
+                        .get_scp_message_signing_key()
+                        .try_into()
+                        .unwrap(),
+                })
+                .collect::<Vec<_>>();
+
+            let quorum_set = QuorumSet {
+                threshold: node_configs.len() as u32,
+                members: node_ids.into_iter().map(Into::into).collect(),
+            };
+
+            let trusted_validator_set = TrustedValidatorSetConfig { quorum_set };
+
+            let trusted_validator_set_start_block = last_block_infos
+                .iter()
+                .map(|last_block_info| last_block_info.index)
+                .max()
+                .unwrap_or_default();
+
+            let light_client_verifier = LightClientVerifierConfig {
+                trusted_validator_set,
+                trusted_validator_set_start_block,
+                historical_validator_sets: Default::default(),
+                known_valid_block_ids: Default::default(),
+            };
+
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&light_client_verifier).unwrap()
+            );
+        }
+    }
+}

--- a/light-client/verifier/Cargo.toml
+++ b/light-client/verifier/Cargo.toml
@@ -7,13 +7,16 @@ license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [dependencies]
+base64 = "0.21"
 displaydoc = "0.2"
+prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 mc-api = { path = "../../api" }
 mc-blockchain-types = { path = "../../blockchain/types" }
 mc-common = { path = "../../common" }
 mc-consensus-scp-types = { path = "../../consensus/scp/types" }
+mc-crypto-digestible = { path = "../../crypto/digestible" }
 mc-crypto-keys = { path = "../../crypto/keys" }
 mc-transaction-core = { path = "../../transaction/core" }
 

--- a/light-client/verifier/src/config.rs
+++ b/light-client/verifier/src/config.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2018-2023 The MobileCoin Foundation
+
+//! Light client configuration.
+
+use crate::{LightClientVerifier, TrustedValidatorSet};
+use mc_blockchain_types::{BlockID, BlockIndex};
+use mc_common::{NodeID, ResponderId};
+use mc_consensus_scp_types::{QuorumSet, QuorumSetMember, QuorumSetMemberWrapper};
+use mc_crypto_digestible::Digestible;
+use mc_crypto_keys::Ed25519Public;
+use prost::Message;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, fmt, ops::Range};
+
+/// A version of `[TrustedValidatorSet]` that uses a quorum set that encodes
+/// node keys as base64 strings. This makes it more pleasant to use in config
+/// files, as well as allowing the key format to match what consensus already
+/// uses.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrustedValidatorSetConfig {
+    pub quorum_set: QuorumSet<HexKeyNodeID>,
+}
+
+impl From<TrustedValidatorSetConfig> for TrustedValidatorSet {
+    fn from(config: TrustedValidatorSetConfig) -> Self {
+        Self {
+            quorum_set: hex_key_node_id_from_node_id_quorum_set(config.quorum_set),
+        }
+    }
+}
+
+/// A version of `[TrustedValidatorSet]` that uses a quorum set that encodes
+/// node keys as base64 strings. This makes it more pleasant to use in config
+/// files, as well as allowing the key format to match what consensus already
+/// uses.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LightClientVerifierConfig {
+    pub trusted_validator_set: TrustedValidatorSetConfig,
+    pub trusted_validator_set_start_block: BlockIndex,
+    pub historical_validator_sets: Vec<(Range<BlockIndex>, TrustedValidatorSetConfig)>,
+    pub known_valid_block_ids: BTreeSet<BlockID>,
+}
+
+impl From<LightClientVerifierConfig> for LightClientVerifier {
+    fn from(config: LightClientVerifierConfig) -> Self {
+        Self {
+            trusted_validator_set: config.trusted_validator_set.into(),
+            trusted_validator_set_start_block: config.trusted_validator_set_start_block,
+            historical_validator_sets: config
+                .historical_validator_sets
+                .into_iter()
+                .map(|(block_range, trusted_validator_set)| {
+                    (block_range, trusted_validator_set.into())
+                })
+                .collect(),
+            known_valid_block_ids: config.known_valid_block_ids,
+        }
+    }
+}
+
+/// A version of `[NodeID]` that encodes the public key as a DER base64 string.
+/// This is similar to how consensus-service encodes it in the `network.toml`
+/// file.
+#[derive(
+    Clone, Deserialize, Digestible, Eq, Hash, Message, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub struct HexKeyNodeID {
+    /// The Responder ID for this node
+    #[prost(message, required, tag = 1)]
+    pub responder_id: ResponderId,
+
+    /// The public message-signing key for this node
+    #[prost(message, required, tag = 2)]
+    #[serde(with = "der_base64_encoding")]
+    pub public_key: Ed25519Public,
+}
+
+impl From<HexKeyNodeID> for NodeID {
+    fn from(src: HexKeyNodeID) -> Self {
+        Self {
+            responder_id: src.responder_id,
+            public_key: src.public_key,
+        }
+    }
+}
+
+impl fmt::Display for HexKeyNodeID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.responder_id, self.public_key)
+    }
+}
+
+fn hex_key_node_id_from_node_id_quorum_set(src: QuorumSet<HexKeyNodeID>) -> QuorumSet<NodeID> {
+    QuorumSet {
+        threshold: src.threshold,
+        members: src
+            .members
+            .into_iter()
+            .map(|member| QuorumSetMemberWrapper {
+                member: match member.member {
+                    Some(QuorumSetMember::Node(node_id)) => {
+                        Some(QuorumSetMember::Node(node_id.into()))
+                    }
+                    Some(QuorumSetMember::InnerSet(set)) => Some(QuorumSetMember::InnerSet(
+                        hex_key_node_id_from_node_id_quorum_set(set),
+                    )),
+                    None => None,
+                },
+            })
+            .collect(),
+    }
+}
+
+mod der_base64_encoding {
+    use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
+    use mc_crypto_keys::{DistinguishedEncoding, Ed25519Public};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(key: &Ed25519Public, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let der_bytes = key.to_der();
+        let hex_str = BASE64_ENGINE.encode(der_bytes);
+        serializer.serialize_str(&hex_str)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Ed25519Public, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let der_bytes = BASE64_ENGINE.decode(s).map_err(serde::de::Error::custom)?;
+        Ed25519Public::try_from_der(&der_bytes).map_err(serde::de::Error::custom)
+    }
+}

--- a/light-client/verifier/src/lib.rs
+++ b/light-client/verifier/src/lib.rs
@@ -2,10 +2,12 @@
 
 #![feature(assert_matches)]
 
+mod config;
 mod error;
 mod trusted_validator_set;
 mod verifier;
 
+pub use config::{HexKeyNodeID, LightClientVerifierConfig, TrustedValidatorSetConfig};
 pub use error::Error;
 pub use trusted_validator_set::TrustedValidatorSet;
 pub use verifier::LightClientVerifier;


### PR DESCRIPTION
It's very likely we're going to standardize a light client verifier configuration file to be used by whoever needs the light client verifier. This file is likely going to be JSON, and ideally it should be human readable and easy to edit/modify.

consensus-service, in its `network.toml` configuration file, represents the message signing keys as DER bytes that are then base64 encoded, e.g.:
```
...
  "broadcast_peers": [
    "mcp://peer1.alpha.development.mobilecoin.com:443/?consensus-msg-key=MCowBQYDK2VwAyEARGQCx0PP9ZDIDFwSq6PPtKSIi2M4pTGdjkPgzKo7LKs=",
    "mcp://peer2.alpha.development.mobilecoin.com:443/?consensus-msg-key=MCowBQYDK2VwAyEA8QeMmzauY4bYixH3WG-pd43xaOUvbqOtPcS4vzUVLtI="
  ],
...
```

This is also the format we use in https://mobilecoin.org/trusted-nodes/

I figured it would be ideal if the config file we use for the light client represents the key in a similar manner. 
Without the stuff in the `config::` module in this PR, the key is represented as an array of bytes - which makes it harder to correlate with a node configuration. I am also not sure we currently have a flow of going from the key file to an array of bytes, and while that's trivial, we obviously do have a way of getting the der-base64-keys since we're putting them in the network.toml files.

So, half of this PR is adding data structures to allow serde-ing a more friendly JSON format.

The other half is the beginning of a utility to generate a config file from current nodes configuration. The plan is to later on add other subcommands such as one to fetch BlockMetadatas, verify blocks, etc. - this should make it easier to play with the light client using real data.

As an example, I ran the following command and this is the output I got:
```
*[light-client-cli][Erans-M1-Pro-2 ~/Projects/mc/internal/mobilecoin]% cat ./gen-config
cargo run --bin mc-light-client-cli -- generate-config \
  --node mc://node1.prod.mobilecoinww.com:443/ \
  --node mc://node2.prod.mobilecoinww.com:443/ \
  --node mc://node3.prod.mobilecoinww.com:443/ \
  --node mc://blockdaemon.mobilecoin.bdnodes.net:443/ \
  --node mc://binance.mobilecoin.bdnodes.net:443/ \
  --node mc://ideasbeyondborders.mobilecoin.bdnodes.net:443/ \
  --node mc://thelongnowfoundation.mobilecoin.bdnodes.net:443/ \
  --node mc://node1.consensus.mob.production.namda.net:443/ \
  --node mc://node2.consensus.mob.production.namda.net:443/ \
  --node mc://ams1-mc-node1.dreamhost.com:3223/ \
*[light-client-cli][Erans-M1-Pro-2 ~/Projects/mc/internal/mobilecoin]% ./gen-config    
{
  "trusted_validator_set": {
    "quorum_set": {
      "threshold": 10,
      "members": [
        {
          "type": "Node",
          "args": {
            "responder_id": "peer1.prod.mobilecoinww.com:443",
            "public_key": "MCowBQYDK2VwAyEAwxHjdoRQBF9Ozp8lE0wq9pppyP48nKphcQ0GeEb4zYg="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "peer2.prod.mobilecoinww.com:443",
            "public_key": "MCowBQYDK2VwAyEAMtTj21PtiL+FQW3YbKZXfcfnFztHlVhnbvwvaiWDFuE="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "peer3.prod.mobilecoinww.com:443",
            "public_key": "MCowBQYDK2VwAyEAXVfN4JQH+6vkFzrzBNezoknl9eCiz3ZbubwyCeOdt/0="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "blockdaemon.mobilecoin.bdnodes.net:8443",
            "public_key": "MCowBQYDK2VwAyEA/wMkv3+3MluopGsqtnZx4rbqzPR2axi7bCiqWWnOq0Q="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "binance.mobilecoin.bdnodes.net:8443",
            "public_key": "MCowBQYDK2VwAyEAE+kgQW/ojERRdqnPFcoN3+e9dfe/eKDbaegmIlRjMRI="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "ideasbeyondborders.mobilecoin.bdnodes.net:8443",
            "public_key": "MCowBQYDK2VwAyEA5FAlOt1v7CFDeJIq/BIrZ1Gph+WQXZpRTW0cGLZGFyo="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "thelongnowfoundation.mobilecoin.bdnodes.net:8443",
            "public_key": "MCowBQYDK2VwAyEAXd4Xyfv0OizkLKB/Jb7HM/KDjd1mMgbF34MStLqd1WY="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "peer1.consensus.mob.production.namda.net:443",
            "public_key": "MCowBQYDK2VwAyEAExKHKhbtJiJxVSxLIsmIza3quRojV3W46y1s4AFTx3c="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "peer2.consensus.mob.production.namda.net:443",
            "public_key": "MCowBQYDK2VwAyEAI8W+znEPauMLeocYpdEy9pPskTshaVBRrHvCEutyYMs="
          }
        },
        {
          "type": "Node",
          "args": {
            "responder_id": "ams1-mc-peer1.dreamhost.com:8443",
            "public_key": "MCowBQYDK2VwAyEA9uEO9eq8TKU0vrKt1R6p4wzkGJX7HbXDXyzs8HEX21g="
          }
        }
      ]
    }
  },
  "trusted_validator_set_start_block": 1656452,
  "historical_validator_sets": [],
  "known_valid_block_ids": []
}
```
