### PR TITLE
light-client-cli: add command to fetch archive blocks and verify them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,14 +674,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.2.2",
  "indexmap",
- "textwrap 0.15.1",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -742,6 +742,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "clio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f8d4adf1833f1d75ee8b5af282fe742de6631f6741d1b02656c3c5c46b7206"
+dependencies = [
+ "cfg-if 1.0.0",
+ "clap 4.1.14",
+ "libc",
+ "tempfile",
+ "walkdir",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -865,7 +879,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.22",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -4845,6 +4859,7 @@ name = "mc-light-client-cli"
 version = "4.1.0-pre0"
 dependencies = [
  "clap 4.1.14",
+ "clio",
  "grpcio",
  "mc-api",
  "mc-blockchain-types",
@@ -8087,9 +8102,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,7 +4821,6 @@ dependencies = [
  "mc-common",
  "mc-connection",
  "mc-connection-test-utils",
- "mc-consensus-enclave-measurement",
  "mc-consensus-scp",
  "mc-ledger-db",
  "mc-peers-test-utils",
@@ -4847,12 +4846,15 @@ dependencies = [
  "clap 4.1.14",
  "grpcio",
  "mc-api",
+ "mc-blockchain-types",
  "mc-common",
  "mc-consensus-api",
  "mc-consensus-scp-types",
+ "mc-ledger-sync",
  "mc-light-client-verifier",
  "mc-util-grpc",
  "mc-util-uri",
+ "protobuf",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,6 +4821,7 @@ dependencies = [
  "mc-common",
  "mc-connection",
  "mc-connection-test-utils",
+ "mc-consensus-enclave-measurement",
  "mc-consensus-scp",
  "mc-ledger-db",
  "mc-peers-test-utils",

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 [[bin]]
 name = "ledger-sync-test-app"
 path = "src/test_app/main.rs"
+required-features = ["mc-consensus-enclave-measurement"]
 
 [dependencies]
 mc-account-keys = { path = "../../account-keys" }
@@ -19,6 +20,7 @@ mc-blockchain-test-utils = { path = "../../blockchain/test-utils" }
 mc-blockchain-types = { path = "../../blockchain/types" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-connection = { path = "../../connection" }
+mc-consensus-enclave-measurement = { path = "../../consensus/enclave/measurement", optional = true }
 mc-consensus-scp = { path = "../../consensus/scp" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-transaction-core = { path = "../../transaction/core" }

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -19,7 +19,6 @@ mc-blockchain-test-utils = { path = "../../blockchain/test-utils" }
 mc-blockchain-types = { path = "../../blockchain/types" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-connection = { path = "../../connection" }
-mc-consensus-enclave-measurement = { path = "../../consensus/enclave/measurement" }
 mc-consensus-scp = { path = "../../consensus/scp" }
 mc-ledger-db = { path = "../../ledger/db" }
 mc-transaction-core = { path = "../../transaction/core" }

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -12,13 +12,16 @@ path = "src/bin/main.rs"
 
 [dependencies]
 mc-api = { path = "../../api" }
+mc-blockchain-types = { path = "../../blockchain/types" }
 mc-common = { path = "../../common", features = ["log"] }
 mc-consensus-api = { path = "../../consensus/api" }
 mc-consensus-scp-types = { path = "../../consensus/scp/types" }
+mc-ledger-sync = { path = "../../ledger/sync" }
 mc-light-client-verifier = { path = "../verifier" }
 mc-util-grpc = { path = "../../util/grpc" }
 mc-util-uri = { path = "../../util/uri" }
 
 clap = { version = "4.1", features = ["derive", "env"] }
 grpcio = "0.12.1"
+protobuf = "2.27.1"
 serde_json = "1.0"

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -22,6 +22,7 @@ mc-util-grpc = { path = "../../util/grpc" }
 mc-util-uri = { path = "../../util/uri" }
 
 clap = { version = "4.1", features = ["derive", "env"] }
+clio = { version = "0.3.1", features = ["clap-parse"] }
 grpcio = "0.12.1"
 protobuf = "2.27.1"
 serde_json = "1.0"

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -2,26 +2,55 @@
 
 use clap::{Parser, Subcommand};
 use grpcio::{ChannelBuilder, EnvBuilder};
+use mc_api::blockchain::ArchiveBlocks;
+use mc_blockchain_types::BlockIndex;
 use mc_common::{
-    logger::{create_app_logger, o},
+    logger::{create_app_logger, log, o, Logger},
     ResponderId,
 };
 use mc_consensus_api::{
     consensus_client_grpc::ConsensusClientApiClient, consensus_common_grpc::BlockchainApiClient,
 };
 use mc_consensus_scp_types::QuorumSet;
+use mc_ledger_sync::ReqwestTransactionsFetcher;
 use mc_light_client_verifier::{
     HexKeyNodeID, LightClientVerifierConfig, TrustedValidatorSetConfig,
 };
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use mc_util_uri::ConsensusClientUri;
-use std::{str::FromStr, sync::Arc};
+use protobuf::Message;
+use std::{fs, path::PathBuf, str::FromStr, sync::Arc};
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Generate a light client verifier config from a list of nodes.
+    /// This does not include any historical data.
     GenerateConfig {
+        /// Node URIs to use for generating the config.
         #[clap(long = "node", use_value_delimiter = true, env = "MC_NODES")]
         nodes: Vec<ConsensusClientUri>,
+    },
+
+    /// Fetch one or more `[ArchiveBlock]`s from a list of tx source urls and
+    /// store them in a Protobuf file.
+    FetchArchiveBlocks {
+        /// URLs to use for fetching blocks.
+        ///
+        /// For example: https://ledger.mobilecoinww.com/node1.prod.mobilecoinww.com
+        #[clap(
+            long = "tx-source-url",
+            use_value_delimiter = true,
+            env = "MC_TX_SOURCE_URL"
+        )]
+        tx_source_urls: Vec<String>,
+
+        /// Block index we are interested in.
+        #[clap(long, env = "MC_BLOCK_INDEX")]
+        block_index: BlockIndex,
+
+        /// File to write the fetched ArchiveBlocks protobuf to.
+        #[clap(long, env = "MC_OUT_FILE")]
+        out_file: PathBuf,
     },
 }
 
@@ -39,67 +68,110 @@ fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
     let config = Config::parse();
 
-    let env = Arc::new(EnvBuilder::new().name_prefix("light-client-grpc").build());
-
     match config.command {
         Commands::GenerateConfig { nodes } => {
-            let (node_configs, last_block_infos): (Vec<_>, Vec<_>) = nodes
-                .iter()
-                .map(|node_uri| {
-                    // TODO should this use ThickClient and chain-id?
-                    let ch = ChannelBuilder::default_channel_builder(env.clone())
-                        .connect_to_uri(node_uri, &logger);
+            cmd_generate_config(nodes, logger);
+        }
 
-                    let client_api = ConsensusClientApiClient::new(ch.clone());
-                    let config = client_api
-                        .get_node_config(&Default::default())
-                        .expect("get_node_config failed");
-
-                    let blockchain_api = BlockchainApiClient::new(ch);
-                    let last_block_info = blockchain_api
-                        .get_last_block_info(&Default::default())
-                        .expect("get_last_block_info failed");
-
-                    (config, last_block_info)
-                })
-                .unzip();
-
-            let node_ids = node_configs
-                .iter()
-                .map(|node_config| HexKeyNodeID {
-                    responder_id: ResponderId::from_str(node_config.get_peer_responder_id())
-                        .unwrap(),
-                    public_key: node_config
-                        .get_scp_message_signing_key()
-                        .try_into()
-                        .unwrap(),
-                })
-                .collect::<Vec<_>>();
-
-            let quorum_set = QuorumSet {
-                threshold: node_configs.len() as u32,
-                members: node_ids.into_iter().map(Into::into).collect(),
-            };
-
-            let trusted_validator_set = TrustedValidatorSetConfig { quorum_set };
-
-            let trusted_validator_set_start_block = last_block_infos
-                .iter()
-                .map(|last_block_info| last_block_info.index)
-                .max()
-                .unwrap_or_default();
-
-            let light_client_verifier = LightClientVerifierConfig {
-                trusted_validator_set,
-                trusted_validator_set_start_block,
-                historical_validator_sets: Default::default(),
-                known_valid_block_ids: Default::default(),
-            };
-
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&light_client_verifier).unwrap()
-            );
+        Commands::FetchArchiveBlocks {
+            tx_source_urls,
+            block_index,
+            out_file,
+        } => {
+            cmd_fetch_archive_blocks(tx_source_urls, block_index, out_file, logger);
         }
     }
+}
+
+fn cmd_generate_config(nodes: Vec<ConsensusClientUri>, logger: Logger) {
+    let env = Arc::new(EnvBuilder::new().name_prefix("light-client-grpc").build());
+
+    let (node_configs, last_block_infos): (Vec<_>, Vec<_>) = nodes
+        .iter()
+        .map(|node_uri| {
+            // TODO should this use ThickClient and chain-id?
+            let ch = ChannelBuilder::default_channel_builder(env.clone())
+                .connect_to_uri(node_uri, &logger);
+
+            let client_api = ConsensusClientApiClient::new(ch.clone());
+            let config = client_api
+                .get_node_config(&Default::default())
+                .expect("get_node_config failed");
+
+            let blockchain_api = BlockchainApiClient::new(ch);
+            let last_block_info = blockchain_api
+                .get_last_block_info(&Default::default())
+                .expect("get_last_block_info failed");
+
+            (config, last_block_info)
+        })
+        .unzip();
+
+    let node_ids = node_configs
+        .iter()
+        .map(|node_config| HexKeyNodeID {
+            responder_id: ResponderId::from_str(node_config.get_peer_responder_id()).unwrap(),
+            public_key: node_config
+                .get_scp_message_signing_key()
+                .try_into()
+                .unwrap(),
+        })
+        .collect::<Vec<_>>();
+
+    let quorum_set = QuorumSet {
+        threshold: node_configs.len() as u32,
+        members: node_ids.into_iter().map(Into::into).collect(),
+    };
+
+    let trusted_validator_set = TrustedValidatorSetConfig { quorum_set };
+
+    let trusted_validator_set_start_block = last_block_infos
+        .iter()
+        .map(|last_block_info| last_block_info.index)
+        .max()
+        .unwrap_or_default();
+
+    let light_client_verifier = LightClientVerifierConfig {
+        trusted_validator_set,
+        trusted_validator_set_start_block,
+        historical_validator_sets: Default::default(),
+        known_valid_block_ids: Default::default(),
+    };
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&light_client_verifier).unwrap()
+    );
+}
+
+fn cmd_fetch_archive_blocks(
+    tx_source_urls: Vec<String>,
+    block_index: u64,
+    out_file: PathBuf,
+    logger: Logger,
+) {
+    let block_datas = tx_source_urls
+        .into_iter()
+        .map(|url| {
+            log::info!(logger, "Fetching block data from {}", url);
+            let rts = ReqwestTransactionsFetcher::new(vec![url], logger.clone())
+                .expect("failed creating ReqwestTransactionsFetcher");
+            rts.get_block_data_by_index(block_index, None)
+                .expect("failed fetching block data")
+        })
+        .collect::<Vec<_>>();
+
+    let archive_blocks = ArchiveBlocks::from(&block_datas[..]);
+    let bytes = archive_blocks
+        .write_to_bytes()
+        .expect("failed serializing ArchiveBlocks");
+    fs::write(&out_file, bytes).expect("failed writing ArchiveBlocks to file");
+    log::info!(
+        logger,
+        "Wrote ArchiveBlocks to file {}",
+        out_file.to_string_lossy()
+    );
+
+    // Give the logger time to flush :/
+    std::thread::sleep(std::time::Duration::from_millis(100));
 }

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -187,9 +187,9 @@ fn cmd_fetch_archive_blocks(
             fs::read_to_string(path).expect("failed reading LightClientVerifierConfig file");
         let light_client_verifier_config: LightClientVerifierConfig =
             serde_json::from_str(&json_data).expect("failed parsing LightClientVerifierConfig");
-        let light_client_verifer = LightClientVerifier::from(light_client_verifier_config);
+        let light_client_verifier = LightClientVerifier::from(light_client_verifier_config);
 
-        light_client_verifer
+        light_client_verifier
             .verify_block_data(&block_data[..])
             .expect("failed verifying block data");
     }

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -157,7 +157,7 @@ fn cmd_generate_config(nodes: Vec<ConsensusClientUri>, mut out_file: Output, log
 
     out_file
         .write_all(
-            &serde_json::to_string_pretty(&light_client_verifier)
+            serde_json::to_string_pretty(&light_client_verifier)
                 .unwrap()
                 .as_bytes(),
         )

--- a/light-client/verifier/src/error.rs
+++ b/light-client/verifier/src/error.rs
@@ -19,4 +19,8 @@ pub enum Error {
     BlockContentHashMismatch(BlockContentsHash),
     /// TxOut (public key {0:?}) was not found among the block contents
     TxOutNotFound([u8; 32]),
+    /// Not all BlockDatas point at the same block
+    BlockDataMismatch,
+    /// No block data was provided
+    NoBlockData,
 }

--- a/light-client/verifier/src/verifier.rs
+++ b/light-client/verifier/src/verifier.rs
@@ -413,4 +413,93 @@ mod tests {
         drop(txo2);
         drop(txo3);
     }
+
+    #[test]
+    fn test_verify_block_data() {
+        let mut rng = get_seeded_rng();
+
+        let lcv = get_light_client_verifier(Default::default());
+
+        let txo1 = TxOut::new(
+            Default::default(),
+            Amount::new(1, 0.into()),
+            &FromRandom::from_random(&mut rng),
+            &FromRandom::from_random(&mut rng),
+            EncryptedFogHint::fake_onetime_hint(&mut rng),
+        )
+        .unwrap();
+
+        let txo2 = TxOut::new(
+            Default::default(),
+            Amount::new(2, 0.into()),
+            &FromRandom::from_random(&mut rng),
+            &FromRandom::from_random(&mut rng),
+            EncryptedFogHint::fake_onetime_hint(&mut rng),
+        )
+        .unwrap();
+
+        let txo3 = TxOut::new(
+            Default::default(),
+            Amount::new(2, 0.into()),
+            &FromRandom::from_random(&mut rng),
+            &FromRandom::from_random(&mut rng),
+            EncryptedFogHint::fake_onetime_hint(&mut rng),
+        )
+        .unwrap();
+
+        let bc = BlockContents {
+            outputs: vec![txo1, txo2],
+            ..Default::default()
+        };
+
+        let block9999 = Block::new(
+            Default::default(),
+            &Default::default(),
+            9999,
+            9999,
+            &Default::default(),
+            &bc,
+        );
+
+        let metadata = sign_block_id_for_test_node_ids(&block9999.id, &[1, 2, 3]);
+
+        let block_datas = metadata
+            .into_iter()
+            .map(|metadata| BlockData::new(block9999.clone(), bc.clone(), None, Some(metadata)))
+            .collect::<Vec<_>>();
+
+        // Calling verify_block_data without any block data returns an error.
+        assert_matches!(lcv.verify_block_data(&[]), Err(Error::NoBlockData));
+
+        // Calling verify_block_data with block data that differs from each other
+        // returns an error.
+        let different_block_data = block_datas[0].clone();
+        let different_block_data =
+            different_block_data.mutate(|_, contents, _, _| contents.outputs.push(txo3));
+
+        assert_matches!(
+            lcv.verify_block_data(&[block_datas[0].clone(), different_block_data]),
+            Err(Error::BlockDataMismatch)
+        );
+
+        // Passing the correct block metadata verifies successfully and returns the
+        // block and its contents.
+        let (block, block_contents) = lcv.verify_block_data(&block_datas[..]).unwrap();
+
+        assert_eq!(block, block9999);
+        assert_eq!(block_contents, bc);
+
+        // Omitting one of the block data entries should still succeed since we need 2
+        // out of 3.
+        let (block, block_contents) = lcv.verify_block_data(&block_datas[1..]).unwrap();
+
+        assert_eq!(block, block9999);
+        assert_eq!(block_contents, bc);
+
+        // Omitting two of the block data entries should fail since we need 2 out of 3.
+        assert_matches!(
+            lcv.verify_block_data(&block_datas[2..]),
+            Err(Error::NotAQuorum)
+        );
+    }
 }


### PR DESCRIPTION
Small iteration on the light-client-cli tool to retrieve stored blocks from S3 and store them inside a protobuf, while also verifying fetched blocks.
This lets me take the protobuf and use it for testing in my go bindings endeavor. 