### PR TITLE
small improvements to light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,8 +1023,18 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+dependencies = [
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
 ]
 
 [[package]]
@@ -1042,14 +1052,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.1",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+dependencies = [
+ "darling_core 0.20.1",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3081,7 +3116,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.1",
  "toml 0.7.3",
 ]
 
@@ -4872,6 +4907,7 @@ dependencies = [
  "mc-util-grpc",
  "mc-util-uri",
  "protobuf",
+ "rayon",
  "serde_json",
 ]
 
@@ -4892,6 +4928,7 @@ dependencies = [
  "mc-util-test-helper",
  "prost",
  "serde",
+ "serde_with 3.0.0",
 ]
 
 [[package]]
@@ -5843,7 +5880,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "serde_with",
+ "serde_with 2.3.1",
 ]
 
 [[package]]
@@ -7665,7 +7702,23 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.3.1",
+ "time 0.3.15",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64 0.21.0",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.0.0",
  "time 0.3.15",
 ]
 
@@ -7675,10 +7728,22 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
- "darling",
+ "darling 0.14.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
+dependencies = [
+ "darling 0.20.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,18 +1023,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
- "darling_core 0.14.1",
- "darling_macro 0.14.1",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
-dependencies = [
- "darling_core 0.20.1",
- "darling_macro 0.20.1",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1052,39 +1042,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
- "darling_core 0.14.1",
+ "darling_core",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
-dependencies = [
- "darling_core 0.20.1",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]
@@ -3116,7 +3081,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "serde_with 2.3.1",
+ "serde_with",
  "toml 0.7.3",
 ]
 
@@ -4928,7 +4893,7 @@ dependencies = [
  "mc-util-test-helper",
  "prost",
  "serde",
- "serde_with 3.0.0",
+ "serde_with",
 ]
 
 [[package]]
@@ -5880,7 +5845,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "serde_with 2.3.1",
+ "serde_with",
 ]
 
 [[package]]
@@ -7702,23 +7667,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros 2.3.1",
- "time 0.3.15",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
-dependencies = [
- "base64 0.21.0",
- "chrono",
- "hex",
- "indexmap",
- "serde",
- "serde_json",
- "serde_with_macros 3.0.0",
+ "serde_with_macros",
  "time 0.3.15",
 ]
 
@@ -7728,22 +7677,10 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
- "darling 0.14.1",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
-dependencies = [
- "darling 0.20.1",
- "proc-macro2",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]

--- a/blockchain/types/src/block_id.rs
+++ b/blockchain/types/src/block_id.rs
@@ -30,6 +30,14 @@ impl TryFrom<&[u8]> for BlockID {
     }
 }
 
+impl TryFrom<Vec<u8>> for BlockID {
+    type Error = ConvertError;
+
+    fn try_from(src: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(src.as_slice())
+    }
+}
+
 impl AsRef<[u8]> for BlockID {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -25,4 +25,5 @@ clap = { version = "4.1", features = ["derive", "env"] }
 clio = { version = "0.3.1", features = ["clap-parse"] }
 grpcio = "0.12.1"
 protobuf = "2.27.1"
+rayon = "1.7"
 serde_json = "1.0"

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -20,6 +20,7 @@ use mc_light_client_verifier::{
 use mc_util_grpc::ConnectionUriGrpcioChannel;
 use mc_util_uri::ConsensusClientUri;
 use protobuf::Message;
+use rayon::{iter::ParallelIterator, prelude::IntoParallelIterator};
 use std::{fs, io::Write, path::PathBuf, str::FromStr, sync::Arc};
 
 #[derive(Subcommand)]
@@ -172,7 +173,7 @@ fn cmd_fetch_archive_blocks(
     logger: Logger,
 ) {
     let block_data = tx_source_urls
-        .into_iter()
+        .into_par_iter()
         .map(|url| {
             log::info!(logger, "Fetching block data from {}", url);
             let rts = ReqwestTransactionsFetcher::new(vec![url], logger.clone())

--- a/light-client/verifier/Cargo.toml
+++ b/light-client/verifier/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.21"
 displaydoc = "0.2"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_with = { version = "3.0", features = ["hex"] }
+serde_with = { version = "2.3", features = ["hex"] }
 
 mc-api = { path = "../../api" }
 mc-blockchain-types = { path = "../../blockchain/types" }

--- a/light-client/verifier/Cargo.toml
+++ b/light-client/verifier/Cargo.toml
@@ -11,6 +11,7 @@ base64 = "0.21"
 displaydoc = "0.2"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_with = { version = "3.0", features = ["hex"] }
 
 mc-api = { path = "../../api" }
 mc-blockchain-types = { path = "../../blockchain/types" }

--- a/light-client/verifier/src/config.rs
+++ b/light-client/verifier/src/config.rs
@@ -10,6 +10,7 @@ use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::Ed25519Public;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use serde_with::{hex::Hex, serde_as};
 use std::{collections::BTreeSet, fmt, ops::Range};
 
 /// A version of `[TrustedValidatorSet]` that uses a quorum set that encodes
@@ -33,11 +34,14 @@ impl From<TrustedValidatorSetConfig> for TrustedValidatorSet {
 /// node keys as base64 strings. This makes it more pleasant to use in config
 /// files, as well as allowing the key format to match what consensus already
 /// uses.
+#[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LightClientVerifierConfig {
     pub trusted_validator_set: TrustedValidatorSetConfig,
     pub trusted_validator_set_start_block: BlockIndex,
     pub historical_validator_sets: Vec<(Range<BlockIndex>, TrustedValidatorSetConfig)>,
+
+    #[serde_as(as = "BTreeSet<Hex>")]
     pub known_valid_block_ids: BTreeSet<BlockID>,
 }
 


### PR DESCRIPTION
This changes the light client config JSON to use hex notation for block ids instead of a byte array. It also switches to using a parallel iterator when fetching blocks using the CLI tool, making it faster to run.