### PR TITLE
fix (chart): watcher backups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 .git/
 cargo/
-target/
+

--- a/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
@@ -50,11 +50,9 @@ data:
     # Set sha256 signing
     ${AWS} configure set default payload_signing_enabled=true
 
-    # use the /watcher fs to do the backup since it has more space than
-    # the container root.
     mkdir -p /backups/watcher
 
-    # Do a lmbd tools copy on the db so we get a clean copy.
+    # Do a lmdb tools copy on the db so we get a clean copy.
     echo "mdb_copy /watcher /backups/watcher - this will take a while"
     mdb_copy /watcher /backups/watcher
 

--- a/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
@@ -11,14 +11,15 @@ data:
     #!/bin/bash
     set -e
 
+    # Year, Month and Day are probably safe, but we could get inconsistent values
+    # if we hit a hour/min/sec boundary
     YEAR=$(date '+%Y')
     MONTH=$(date '+%m')
     DAY=$(date '+%d')
-    HOUR=$(date '+%H')
-    MINUTE=$(date '+%M')
-    SECOND=$(date '+%S')
 
-    BACKUP_FILEPATH="watcher/db-backup/${WATCHER_NETWORK}/${WATCHER_REGION_ID}/${WATCHER_INSTANCE_NAME}/${YEAR}/${MONTH}/${DAY}/backup-${YEAR}${MONTH}${DAY}${HOUR}${MINUTE}${SECOND}-data.mdb"
+    TIMESTAMP=$(date '+%Y%m%d%H%M%S')
+
+    BACKUP_FILEPATH="watcher/db-backup/${WATCHER_NETWORK}/${WATCHER_REGION_ID}/${WATCHER_INSTANCE_NAME}/${YEAR}/${MONTH}/${DAY}/backup-${TIMESTAMP}-data.mdb"
     LATEST_FILEPATH="watcher/db-backup/${WATCHER_NETWORK}/${WATCHER_REGION_ID}/${WATCHER_INSTANCE_NAME}/latest-backup-data.mdb"
 
     AWS="aws"
@@ -26,7 +27,7 @@ data:
       AWS="aws --endpoint-url ${AWS_ENDPOINT_URL}"
     fi
 
-    # Don't compete with an alredy-running backup
+    # Don't compete with an already running backup
     PIDFILE="/var/run/watcherdb-backup.pid"
     if [ -f ${PIDFILE} ]; then
       echo "Current backup already running. Exiting."
@@ -42,15 +43,15 @@ data:
     trap "rm -f ${PIDFILE}" EXIT
 
     # Create pidfile for lock
-    echo $$ > ${PIDFILE}    
+    echo $$ > ${PIDFILE}
     echo "$(date) S3 backup storage path: s3://${AWS_BUCKET}/${BACKUP_FILEPATH}"
     echo "$(date) S3 latest storage path: s3://${AWS_BUCKET}/${LATEST_FILEPATH}"
 
     # Set sha256 signing
     ${AWS} configure set default payload_signing_enabled=true
 
-    # Copy the db file for stable upload
-    cp /watcher/data.mdb /tmp/data.mdb
+    # Do a lmbd tools copy on the db so we get a clean copy.
+    mdb_copy -n /watcher/data.mdb /tmp/data.mdb
 
     # Copy to S3
     ${AWS} s3 cp /tmp/data.mdb s3://${AWS_BUCKET}/${BACKUP_FILEPATH}

--- a/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-backup-scripts.yaml
@@ -50,12 +50,32 @@ data:
     # Set sha256 signing
     ${AWS} configure set default payload_signing_enabled=true
 
+    # use the /watcher fs to do the backup since it has more space than
+    # the container root.
+    mkdir -p /backups/watcher
+
     # Do a lmbd tools copy on the db so we get a clean copy.
-    mdb_copy -n /watcher/data.mdb /tmp/data.mdb
+    echo "mdb_copy /watcher /backups/watcher - this will take a while"
+    mdb_copy /watcher /backups/watcher
+
+    # ehh just in case, this really uses system memory for caching :)
+    sync
+
+    # test did we get a clean backup?
+    ls -al /backups/watcher
+    echo "Can we list the DB contents?"
+    mdb_dump -l /backups/watcher
 
     # Copy to S3
-    ${AWS} s3 cp /tmp/data.mdb s3://${AWS_BUCKET}/${BACKUP_FILEPATH}
-    ${AWS} s3 cp /tmp/data.mdb s3://${AWS_BUCKET}/${LATEST_FILEPATH}
+    echo "copy data to s3"
+    ${AWS} s3 cp /backups/watcher/data.mdb s3://${AWS_BUCKET}/${BACKUP_FILEPATH}
+
+    # Do an s3 -> s3 copy on the uploaded file to "latest" path.
+    echo "s3 -> s3 copy to create latest"
+    ${AWS} s3 cp s3://${AWS_BUCKET}/${BACKUP_FILEPATH} s3://${AWS_BUCKET}/${LATEST_FILEPATH}
+
+    # clean up backup
+    rm -rf /backups/watcher
 
   restore.sh: |
     #!/bin/bash

--- a/.internal-ci/helm/watcher/templates/watcher-backup-volume.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-backup-volume.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if eq .Values.watcher.backupEnabled true }}
+{{- range .Values.watcher.instances }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .watchername }}-{{ include "chart.fullname" $ }}-backup
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+spec:
+  storageClassName: fast
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 512Gi
+---
+{{- end }}
+{{- end }}

--- a/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         - name: watcherdb-restore
           image: "mobilecoin/infra-replication-sidecar:latest"
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
           command: [ "/bin/bash" ]
           env:
 {{- if .s3EndpointUrl }}
@@ -94,8 +97,11 @@ spec:
               mountPath: /config
 {{- if eq $.Values.watcher.backupEnabled true }}
         - name: watcherdb-backup
-          image: "amazon/aws-cli:2.0.19"
+          image: "mobilecoin/infra-replication-sidecar:latest"
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
           command: [ "/bin/bash" ]
           env:
 {{- if .s3EndpointUrl }}
@@ -136,6 +142,8 @@ spec:
               mountPath: /watcher
             - name: watcher-backup-scripts
               mountPath: /scripts
+            - name: watcher-backup-data
+              mountPath: /backups
 {{- end }}
       volumes:
         - name: watcher-db-dir
@@ -145,6 +153,7 @@ spec:
 {{- else }}
           emptyDir: {}
 {{- end }}
+
         - name: config
           configMap:
             name: {{ include "chart.fullname" $ }}-config-watcher
@@ -153,6 +162,9 @@ spec:
           configMap:
             name: {{ include "chart.fullname" $ }}-watcher-backup-scripts
             defaultMode: 0755
+        - name: watcher-backup-data
+          persistentVolumeClaim:
+            claimName: {{ .watchername }}-{{ include "chart.fullname" $ }}-backup
 {{- end }}
 ---
 {{- end }}

--- a/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
+++ b/.internal-ci/helm/watcher/templates/watcher-deployment.yaml
@@ -33,7 +33,7 @@ spec:
 {{- if eq $.Values.watcher.backupEnabled true }}
       initContainers:
         - name: watcherdb-restore
-          image: "amazon/aws-cli:2.0.19"
+          image: "mobilecoin/infra-replication-sidecar:latest"
           imagePullPolicy: Always
           command: [ "/bin/bash" ]
           env:
@@ -126,7 +126,7 @@ spec:
             - -c
             - |
               set -e
-              while true; do /scripts/backup.sh ; sleep 3600; done
+              while true; do /scripts/backup.sh ; sleep 86400; done
           lifecycle:
             preStop:
               exec:


### PR DESCRIPTION
- Update watcher backup process to only fire off once per day.
- Backup sidecar to use infra image so we have aws and mdb tools available.
- Fix backup script to use mdb tools to gracefully copy lmdb files.
- remove /target from .dockerignore (can't build docker containers/find binaries if we're just ignoring the default build dir)

### Motivation

AVR Watcher backup storage is a large infra expense.  This will continue to grow while we work on integrating AVRs into the chain.  In the mean time, we discussed and we're going to scale back the granularity and duplication of data. Complete backups will still continue to be available, we're just moving the timing from hourly to daily.

Note: since we're not changing binaries, I don't believe another 5.0.x release is necessary.  We will out-of-band build and publish updated charts for this change with 4.x and 5.x binaries.  This should be added to the 5.0 release branch and rolled up to master just in case we do need to make later 5.x releases.
 

### Future Work
- Clean up redundant historical copies.
- Complete AVRs on chain and retire the Watcher services.
