### PR TITLE
change light client config to use a quorumset data type compatible with cosmwasm

### DIFF
--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -12,7 +12,7 @@ use mc_common::{
 use mc_consensus_api::{
     consensus_client_grpc::ConsensusClientApiClient, consensus_common_grpc::BlockchainApiClient,
 };
-use mc_consensus_scp_types::QuorumSet;
+use mc_light_client_verifier::QuorumSet;
 use mc_ledger_sync::ReqwestTransactionsFetcher;
 use mc_light_client_verifier::{
     HexKeyNodeID, LightClientVerifier, LightClientVerifierConfig, TrustedValidatorSetConfig,

--- a/light-client/verifier/src/config.rs
+++ b/light-client/verifier/src/config.rs
@@ -5,7 +5,6 @@
 use crate::{LightClientVerifier, TrustedValidatorSet};
 use mc_blockchain_types::{BlockID, BlockIndex};
 use mc_common::{NodeID, ResponderId};
-use mc_consensus_scp_types::{QuorumSet, QuorumSetMember, QuorumSetMemberWrapper};
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::Ed25519Public;
 use prost::Message;
@@ -13,19 +12,74 @@ use serde::{Deserialize, Serialize};
 use serde_with::{hex::Hex, serde_as};
 use std::{collections::BTreeSet, fmt, ops::Range};
 
+/// A version of `[QuorumSetMember]` that does not use an internally-tagged
+/// enum. The only reseaon this is needed is because we want to be able to use
+/// this configuration inside a cosmos wasm contract, and unfortunately the
+/// cosmwasm runtime does not suppoprt floating point operations. It turns out
+/// that serde generates some floating point code when using internally-tagged
+/// enums, so we have to use a non-tagged enum instead :/
+/// See https://medium.com/cosmwasm/debugging-floating-point-generation-in-rust-wasm-smart-contract-f47d833b5fba
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum QuorumSetMember {
+    Node(HexKeyNodeID),
+    InnerSet(QuorumSet),
+}
+
+impl From<HexKeyNodeID> for QuorumSetMember {
+    fn from(src: HexKeyNodeID) -> Self {
+        Self::Node(src)
+    }
+}
+
+impl From<QuorumSet> for QuorumSetMember {
+    fn from(src: QuorumSet) -> Self {
+        Self::InnerSet(src)
+    }
+}
+
+/// A version of `[QuorumSet]` that uses our non-internally-tagged-enum
+/// `[QuorumSetMember]`.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct QuorumSet {
+    pub threshold: u32,
+    pub members: Vec<QuorumSetMember>,
+}
+
+impl From<QuorumSet> for mc_consensus_scp_types::QuorumSet<NodeID> {
+    fn from(src: QuorumSet) -> mc_consensus_scp_types::QuorumSet<NodeID> {
+        Self {
+            threshold: src.threshold,
+            members: src
+                .members
+                .into_iter()
+                .map(|member| mc_consensus_scp_types::QuorumSetMemberWrapper {
+                    member: match member {
+                        QuorumSetMember::Node(node_id) => Some(
+                            mc_consensus_scp_types::QuorumSetMember::Node(node_id.into()),
+                        ),
+                        QuorumSetMember::InnerSet(set) => Some(
+                            mc_consensus_scp_types::QuorumSetMember::InnerSet(Self::from(set)),
+                        ),
+                    },
+                })
+                .collect(),
+        }
+    }
+}
+
 /// A version of `[TrustedValidatorSet]` that uses a quorum set that encodes
 /// node keys as base64 strings. This makes it more pleasant to use in config
 /// files, as well as allowing the key format to match what consensus already
 /// uses.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustedValidatorSetConfig {
-    pub quorum_set: QuorumSet<HexKeyNodeID>,
+    pub quorum_set: QuorumSet,
 }
 
 impl From<TrustedValidatorSetConfig> for TrustedValidatorSet {
     fn from(config: TrustedValidatorSetConfig) -> Self {
         Self {
-            quorum_set: hex_key_node_id_from_node_id_quorum_set(config.quorum_set),
+            quorum_set: config.quorum_set.into(),
         }
     }
 }
@@ -35,7 +89,7 @@ impl From<TrustedValidatorSetConfig> for TrustedValidatorSet {
 /// files, as well as allowing the key format to match what consensus already
 /// uses.
 #[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct LightClientVerifierConfig {
     pub trusted_validator_set: TrustedValidatorSetConfig,
     pub trusted_validator_set_start_block: BlockIndex,
@@ -91,27 +145,6 @@ impl From<HexKeyNodeID> for NodeID {
 impl fmt::Display for HexKeyNodeID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}:{}", self.responder_id, self.public_key)
-    }
-}
-
-fn hex_key_node_id_from_node_id_quorum_set(src: QuorumSet<HexKeyNodeID>) -> QuorumSet<NodeID> {
-    QuorumSet {
-        threshold: src.threshold,
-        members: src
-            .members
-            .into_iter()
-            .map(|member| QuorumSetMemberWrapper {
-                member: match member.member {
-                    Some(QuorumSetMember::Node(node_id)) => {
-                        Some(QuorumSetMember::Node(node_id.into()))
-                    }
-                    Some(QuorumSetMember::InnerSet(set)) => Some(QuorumSetMember::InnerSet(
-                        hex_key_node_id_from_node_id_quorum_set(set),
-                    )),
-                    None => None,
-                },
-            })
-            .collect(),
     }
 }
 

--- a/light-client/verifier/src/lib.rs
+++ b/light-client/verifier/src/lib.rs
@@ -7,7 +7,9 @@ mod error;
 mod trusted_validator_set;
 mod verifier;
 
-pub use config::{HexKeyNodeID, LightClientVerifierConfig, TrustedValidatorSetConfig};
+pub use config::{
+    HexKeyNodeID, LightClientVerifierConfig, QuorumSet, QuorumSetMember, TrustedValidatorSetConfig,
+};
 pub use error::Error;
 pub use trusted_validator_set::TrustedValidatorSet;
 pub use verifier::LightClientVerifier;


### PR DESCRIPTION
### Motivation

We want to use the `LightClientVerifier` inside a [`cosmwasm`](https://book.cosmwasm.com/) contract.
That requires being able to pass a `LightClientVerifierConfig` configuration to the contract. Part of this configuration is a quorum set. Unfortunately, the current quorum set definition uses a serde internally-tagged enum: https://github.com/mobilecoinfoundation/mobilecoin/blob/cosmwasm-compat/consensus/scp/types/src/quorum_set.rs#L22
This unfortunately is incompatible with `cosmwasm` contracts - see https://medium.com/cosmwasm/debugging-floating-point-generation-in-rust-wasm-smart-contract-f47d833b5fba and https://book.cosmwasm.com/basics/fp-types.html

So, we need a non-internally-tagged version. There are a few possible approaches:
1. The hack done in this PR. It is not great because it makes the quorum set JSON incompatible with other quorum set JSONs we have in other places (e.g. [`network.toml`](https://github.com/mobilecoinfoundation/mobilecoin/blob/cosmwasm-compat/consensus/service/config/src/network.rs#L16), but maybe this is Good Enough.
2. We could add a feature-flag to `mc-consensus-scp-types` to skip the `#[serde(tag = "type", content = "args")]` directive, but that feels much hackier/error-prone.
3. We could potentially have this config stuff live outside the main repo and be specific for the cosmwam stuff
4. We could omit the tagged, reverting to the default [externally tagged](https://serde.rs/enum-representations.html#externally-tagged) behavior, and any quorum set JSONs we have.

I opted to try and go with option no. 1 because it seems like the path of least resistance, since we are still in the early stages of playing with `cosmwasm` and this can be improved upon at a later point.
