### PR TITLE
Minor improvements to light-client-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,6 +4884,7 @@ dependencies = [
  "clap 4.1.14",
  "clio",
  "grpcio",
+ "hex",
  "mc-api",
  "mc-blockchain-types",
  "mc-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4892,6 +4892,7 @@ dependencies = [
  "mc-ledger-sync",
  "mc-light-client-verifier",
  "mc-util-grpc",
+ "mc-util-serial",
  "mc-util-uri",
  "protobuf",
  "rayon",

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -25,6 +25,7 @@ mc-util-uri = { path = "../../util/uri" }
 clap = { version = "4.1", features = ["derive", "env"] }
 clio = { version = "0.3.1", features = ["clap-parse"] }
 grpcio = "0.12.1"
+hex = "0.4"
 protobuf = "2.27.1"
 rayon = "1.7"
 serde_json = "1.0"

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -19,6 +19,7 @@ mc-consensus-scp-types = { path = "../../consensus/scp/types" }
 mc-ledger-sync = { path = "../../ledger/sync" }
 mc-light-client-verifier = { path = "../verifier" }
 mc-util-grpc = { path = "../../util/grpc" }
+mc-util-serial = { path = "../../util/serial" }
 mc-util-uri = { path = "../../util/uri" }
 
 clap = { version = "4.1", features = ["derive", "env"] }

--- a/light-client/cli/src/bin/main.rs
+++ b/light-client/cli/src/bin/main.rs
@@ -241,7 +241,7 @@ fn cmd_fetch_blocks(
         FileFormat::JsonBlockDataBytesArray => {
             let block_data_bytes = block_data
                 .iter()
-                .map(|block_data| mc_util_serial::encode(block_data))
+                .map(mc_util_serial::encode)
                 .collect::<Vec<_>>();
             serde_json::to_vec(&block_data_bytes).expect("failed serializing block data bytes")
         }
@@ -257,8 +257,7 @@ fn cmd_fetch_blocks(
 }
 
 fn block_id_from_hex_str(src: &str) -> Result<BlockID, String> {
-    let bytes = hex::decode(src).map_err(|e| format!("failed decoding hex: {}", e))?;
-    let block_id =
-        BlockID::try_from(bytes).map_err(|e| format!("failed parsing BlockID: {}", e))?;
+    let bytes = hex::decode(src).map_err(|e| format!("failed decoding hex: {e}"))?;
+    let block_id = BlockID::try_from(bytes).map_err(|e| format!("failed parsing BlockID: {e}"))?;
     Ok(block_id)
 }


### PR DESCRIPTION
This PR implements two changes in the light client CLI utility that makes it more friendly when used in the context of the cosmwasm work I am doing outside of this repo.

The changes are:
1) We can now pass known trusted block ids to `GenerateConfig`. This is useful since I want to trust some old knopwn block(s) that contain burn transactions - I can easily find them on https://auditor.mobilecoin.foundation/ and then go to the block explorer to get their ids.
2) Allow specifying the file format outputted by `FetchBlocks`. Previously it was outputting a protobuf-encoded `ArchiveBlocks`. Unfortunately we do not currently have a `prost` version of this, so using it in the cosmwasm realm is impossible without adding that (and all the associated conversions to go between that and protobuf/`BlockData`). Instead of doing that, I added an option to output as a JSON-formatted array of individually encoded `BlockData` protos, which can easily be deserialized on the cosmwasm side. The specific format in which we hand data to the contract is likely going to change/evolve over time but for now this allows me to make progress.