### PR TITLE
Standalone view server

### DIFF
--- a/fog/view/server/src/fog_view_service.rs
+++ b/fog/view/server/src/fog_view_service.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
+//! Shard (store) fog view service
+
 use crate::{server::DbPollSharedState, sharding_strategy::ShardingStrategy, SVC_COUNTERS};
 use grpcio::{RpcContext, RpcStatus, RpcStatusCode, UnarySink};
 use mc_attest_api::attest;

--- a/fog/view/server/src/lib.rs
+++ b/fog/view/server/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod fog_view_router_server;
 pub mod fog_view_router_service;
 pub mod fog_view_service;
+pub mod fog_view_service_standalone;
 pub mod server;
 pub mod sharding_strategy;
 


### PR DESCRIPTION
We'd like to debug some latency issues with the new fog router, and one of the things that we want to try is to run a standalone view server and see how it performs (e.g. to skip the router stuff).

I believe the change in this PR allows a view store server/shard to directly serve view queries, so in theory we should be able to run a single instance of it and direct clients to that instead of the router.
