### PR TITLE
fix (helm): Fog routers deployed in stacks.

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -141,6 +141,18 @@ jobs:
           org: ${{ inputs.docker_image_org }}
         global:
           certManagerClusterIssuer: google-public-ca
+        fogLedgerShardRangeGenerator:
+          count: 2
+        fogViewShardRangeGenerator:
+          count: 2
+        fogLedgerRouter:
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
+          persistence:
+            enabled: false
         fogLedger:
           resources:
             limits:
@@ -149,6 +161,12 @@ jobs:
               intel.com/sgx: 2000
           persistence:
             enabled: false
+        fogViewRouter:
+          resources:
+            limits:
+              intel.com/sgx: 2000
+            requests:
+              intel.com/sgx: 2000
         fogView:
           resources:
             limits:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
-{{- stacks := seq $.Values.fogLedgerShardRangeGenerator.count }}
+{{- $stacks := until (int .Values.fogLedgerShardRangeGenerator.count) }}
 {{- range $stacks }}
 apiVersion: mc.mobilecoin.com/v1
 kind: FogShardRangeGenerator
 metadata:
-  name: {{ include "fogServices.fullname" $ }}-fog-ledger
+  name: {{ include "fogServices.fullname" $ }}-fog-ledger-{{ . }}
   labels:
     {{- include "fogServices.labels" $ | nindent 4 }}
 spec:
@@ -274,12 +274,15 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpression:
-                  - key: stack
-                    operator: In
-                    values:
-                    - fog-ledger-{{ . }}
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpression:
+                    - key: stack
+                      operator: In
+                      values:
+                      - fog-ledger-{{ . }}
+                  topologyKey: "kubernetes.io/hostname"
+                weight: 1
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
@@ -290,6 +293,7 @@ spec:
                     {{- range (without $stacks .) }}
                     - fog-ledger-{{ . }}
                     {{- end }}
+                topologyKey: "kubernetes.io/hostname"
           {{- end }}
           imagePullSecrets:
           {{- toYaml $.Values.imagePullSecrets | nindent 10 }}

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
@@ -42,22 +42,27 @@ spec:
             readinessGates:
             - conditionType: mobilecoin.com/shards-ready
             # Try to balance pods across zones
-            {{- if $.Values.fogViewRouter.topologySpreadConstraintsEnabled }}
-            topologySpreadConstraints:
-            - topologyKey: topology.kubernetes.io/zone
-              maxSkew: 1
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app: fog-ledger-router
-                  {{- include "fogServices.selectorLabels" $ | nindent 16 }}
-            - topologyKey: kubernetes.io/hostname
-              maxSkew: 1
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app: fog-ledger-router
-                  {{- include "fogServices.selectorLabels" $ | nindent 16 }}
+            {{- if $.Values.fogLedgerRouter.affinityEnabled }}
+            affinity:
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                    - key: stack
+                      operator: In
+                      values:
+                      - fog-ledger-{{ . }}
+                  topologyKey: topology.kubernetes.io/zone
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: stack
+                        operator: In
+                        values:
+                        - fog-ledger-{{ . }}
+                    topologyKey: "kubernetes.io/hostname"
+                  weight: 1
             {{- end }}
             imagePullSecrets:
             {{- toYaml $.Values.imagePullSecrets | nindent 12 }}
@@ -216,8 +221,6 @@ spec:
               {{- toYaml $.Values.fogLedgerRouter.nodeSelector | nindent 14 }}
             tolerations:
               {{- toYaml $.Values.fogLedgerRouter.tolerations | nindent 14 }}
-            affinity:
-              {{- toYaml $.Values.fogLedgerRouter.affinity | nindent 14 }}
             volumes:
             {{- if eq $.Values.fogLedger.persistence.enabled false }}
             - name: fog-data
@@ -270,30 +273,36 @@ spec:
             stack: fog-ledger-{{ . }}
             {{- include "fogServices.labels" $ | nindent 12 }}
         spec:
+          {{- if $.Values.fogLedger.topologySpreadConstraintsEnabled }}
+          topologySpreadConstraints:
+          - topologyKey: topology.kubernetes.io/zone
+            maxSkew: 1
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app: fog-ledger-store
+          {{- end }}
           {{- if $.Values.fogLedger.affinityEnabled }}
           affinity:
             podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: stack
+                    operator: In
+                    values:
+                    - fog-ledger-{{ . }}
+                topologyKey: topology.kubernetes.io/zone
               preferredDuringSchedulingIgnoredDuringExecution:
               - podAffinityTerm:
                   labelSelector:
-                    matchExpression:
+                    matchExpressions:
                     - key: stack
                       operator: In
                       values:
                       - fog-ledger-{{ . }}
                   topologyKey: "kubernetes.io/hostname"
                 weight: 1
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpression:
-                  - key: stack
-                    operator: In
-                    values:
-                    {{- range (without $stacks .) }}
-                    - fog-ledger-{{ . }}
-                    {{- end }}
-                topologyKey: "kubernetes.io/hostname"
           {{- end }}
           imagePullSecrets:
           {{- toYaml $.Values.imagePullSecrets | nindent 10 }}

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
@@ -277,7 +277,7 @@ spec:
           topologySpreadConstraints:
           - topologyKey: topology.kubernetes.io/zone
             maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
+            whenUnsatisfiable: ScheduleAnyway
             labelSelector:
               matchLabels:
                 app: fog-ledger-store

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
@@ -222,7 +222,7 @@ spec:
             tolerations:
               {{- toYaml $.Values.fogLedgerRouter.tolerations | nindent 14 }}
             volumes:
-            {{- if eq $.Values.fogLedger.persistence.enabled false }}
+            {{- if eq $.Values.fogLedgerRouter.persistence.enabled false }}
             - name: fog-data
               emptyDir: {}
             {{- end }}
@@ -243,12 +243,12 @@ spec:
                     name: {{ include "fogServices.fullname" $ }}-supervisord-fog-ledger-router
                 - configMap:
                     name: {{ include "fogServices.fullname" $ }}-supervisord-admin
-        {{- if $.Values.fogLedger.persistence.enabled }}
+        {{- if $.Values.fogLedgerRouter.persistence.enabled }}
         volumeClaimTemplates:
         - metadata:
             name: fog-data
           spec:
-            {{- toYaml $.Values.fogLedger.persistence.spec | nindent 12 }}
+            {{- toYaml $.Values.fogLedgerRouter.persistence.spec | nindent 12 }}
         {{- end }}
 
   store:

--- a/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-ledger-fogshardrangegenerator.yaml
@@ -1,14 +1,16 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- stacks := seq $.Values.fogLedgerShardRangeGenerator.count }}
+{{- range $stacks }}
 apiVersion: mc.mobilecoin.com/v1
 kind: FogShardRangeGenerator
 metadata:
-  name: {{ include "fogServices.fullname" . }}-fog-ledger
+  name: {{ include "fogServices.fullname" $ }}-fog-ledger
   labels:
-    {{- include "fogServices.labels" . | nindent 4 }}
+    {{- include "fogServices.labels" $ | nindent 4 }}
 spec:
-  {{- include "fogServices.fogLedgerStores" . | nindent 2 }}
-  blockCountURL: {{ include "fogServices.blockHeightURL" . | quote }}
-  {{- with .Values.blockHeighRetrieval }}
+  {{- include "fogServices.fogLedgerStores" $ | nindent 2 }}
+  blockCountURL: {{ include "fogServices.blockHeightURL" $ | quote }}
+  {{- with $.Values.blockHeighRetrieval }}
   blockCountQueryInterval: {{ .queryInterval | quote }}
   blockCountResponseJQ: {{ .responseJQ | quote }}
   blockCountReqBody: {{ .requestBody | quote }}
@@ -19,25 +21,28 @@ spec:
     template:
       containerName: fog-ledger-router
       spec:
-        podManagementPolicy: {{ .Values.fogLedgerRouter.podManagementPolicy }}
-        replicas: {{ .Values.fogLedgerRouter.replicaCount }}
+        podManagementPolicy: {{ $.Values.fogLedgerRouter.podManagementPolicy }}
+        replicas: {{ $.Values.fogLedgerRouter.replicaCount }}
         selector:
           matchLabels:
             app: fog-ledger-router
-            {{- include "fogServices.selectorLabels" . | nindent 12 }}
-        serviceName: {{ include "fogServices.fullname" . }}-fog-ledger
+            stack: fog-ledger-{{ . }}
+            {{- include "fogServices.selectorLabels" $ | nindent 12 }}
+        serviceName: {{ include "fogServices.fullname" $ }}-fog-ledger
         template:
           metadata:
             annotations:
-              {{- toYaml .Values.fogLedgerRouter.podAnnotations | nindent 14 }}
+              {{- toYaml $.Values.fogLedgerRouter.podAnnotations | nindent 14 }}
             labels:
               app: fog-ledger-router
-              {{- include "fogServices.labels" . | nindent 14 }}
+              stack: fog-ledger-{{ . }}
+              {{- include "fogServices.labels" $ | nindent 14 }}
           spec:
             # Prevent endpoint creation until all shards for this router are ready
             readinessGates:
             - conditionType: mobilecoin.com/shards-ready
             # Try to balance pods across zones
+            {{- if $.Values.fogViewRouter.topologySpreadConstraintsEnabled }}
             topologySpreadConstraints:
             - topologyKey: topology.kubernetes.io/zone
               maxSkew: 1
@@ -45,16 +50,17 @@ spec:
               labelSelector:
                 matchLabels:
                   app: fog-ledger-router
-                  {{- include "fogServices.selectorLabels" . | nindent 16 }}
+                  {{- include "fogServices.selectorLabels" $ | nindent 16 }}
             - topologyKey: kubernetes.io/hostname
               maxSkew: 1
               whenUnsatisfiable: DoNotSchedule
               labelSelector:
                 matchLabels:
                   app: fog-ledger-router
-                  {{- include "fogServices.selectorLabels" . | nindent 16 }}
+                  {{- include "fogServices.selectorLabels" $ | nindent 16 }}
+            {{- end }}
             imagePullSecrets:
-            {{- toYaml .Values.imagePullSecrets | nindent 12 }}
+            {{- toYaml $.Values.imagePullSecrets | nindent 12 }}
             terminationGracePeriodSeconds: 30
             dnsConfig:
               options:
@@ -74,8 +80,8 @@ spec:
                 runAsNonRoot: False
             containers:
             - name: fog-ledger-router
-              image: "{{ .Values.fogLedgerRouter.image.org | default .Values.image.org }}/{{ .Values.fogLedgerRouter.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.fogLedger.image.pullPolicy }}
+              image: "{{ $.Values.fogLedgerRouter.image.org | default $.Values.image.org }}/{{ $.Values.fogLedgerRouter.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ $.Values.fogLedger.image.pullPolicy }}
               args: [ "/usr/bin/supervisord" ]
               ports:
               - name: ledger-grpc
@@ -95,9 +101,9 @@ spec:
               - name: MC_LEDGER_DB_MIGRATE
                 value: "true"
               - name: RUST_BACKTRACE
-                value: {{ .Values.fogLedgerRouter.rust.backtrace | quote }}
+                value: {{ $.Values.fogLedgerRouter.rust.backtrace | quote }}
               - name: RUST_LOG
-                value: {{ .Values.fogLedgerRouter.rust.log | quote }}
+                value: {{ $.Values.fogLedgerRouter.rust.log | quote }}
               - name: FOG_LEDGER_SENTRY_DSN
                 valueFrom:
                   configMapKeyRef:
@@ -121,7 +127,7 @@ spec:
                     key: token
                     optional: true
               - name: CLIENT_RESPONDER_ID
-                value: "{{ include "fogServices.fogPublicFQDN" . }}:443"
+                value: "{{ include "fogServices.fogPublicFQDN" $ }}:443"
               startupProbe:
                 grpc:
                   port: 3228
@@ -155,9 +161,9 @@ spec:
               - name: tmp
                 mountPath: /tmp
               resources:
-                {{- toYaml .Values.fogLedgerRouter.resources | nindent 16 }}
+                {{- toYaml $.Values.fogLedgerRouter.resources | nindent 16 }}
             - name: grpc-gateway
-              image: "{{ .Values.grpcGateway.image.org | default .Values.image.org }}/{{ .Values.grpcGateway.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              image: "{{ $.Values.grpcGateway.image.org | default $.Values.image.org }}/{{ $.Values.grpcGateway.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: Always
               command:
               - /usr/bin/go-grpc-gateway
@@ -169,8 +175,8 @@ spec:
                 - name: ledger-http
                   containerPort: 8228
               resources:
-                {{- toYaml .Values.grpcGateway.resources | nindent 16 }}
-            {{- if eq .Values.jaegerTracing.enabled true }}
+                {{- toYaml $.Values.grpcGateway.resources | nindent 16 }}
+            {{- if eq $.Values.jaegerTracing.enabled true }}
             - name: jaeger-agent
               image: jaegertracing/jaeger-agent:latest
               imagePullPolicy: IfNotPresent
@@ -202,18 +208,18 @@ spec:
                       apiVersion: v1
                       fieldPath: status.hostIP
               args:
-                - --reporter.grpc.host-port={{ .Values.jaegerTracing.collector }}
+                - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
                 - --reporter.type=grpc
-                - --agent.tags=cluster=undefined,container.name=fog-ledger,deployment.name={{ include "fogServices.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
+                - --agent.tags=cluster=undefined,container.name=fog-ledger,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
             {{- end }}
             nodeSelector:
-              {{- toYaml .Values.fogLedgerRouter.nodeSelector | nindent 14 }}
+              {{- toYaml $.Values.fogLedgerRouter.nodeSelector | nindent 14 }}
             tolerations:
-              {{- toYaml .Values.fogLedgerRouter.tolerations | nindent 14 }}
+              {{- toYaml $.Values.fogLedgerRouter.tolerations | nindent 14 }}
             affinity:
-              {{- toYaml .Values.fogLedgerRouter.affinity | nindent 14 }}
+              {{- toYaml $.Values.fogLedgerRouter.affinity | nindent 14 }}
             volumes:
-            {{- if eq .Values.fogLedger.persistence.enabled false }}
+            {{- if eq $.Values.fogLedger.persistence.enabled false }}
             - name: fog-data
               emptyDir: {}
             {{- end }}
@@ -225,21 +231,21 @@ spec:
               projected:
                 sources:
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-sgx
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-daemon
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
                 - configMap:
                     name: fog-supervisord-mobilecoind
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-fog-ledger-router
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-fog-ledger-router
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-admin
-        {{- if .Values.fogLedger.persistence.enabled }}
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-admin
+        {{- if $.Values.fogLedger.persistence.enabled }}
         volumeClaimTemplates:
         - metadata:
             name: fog-data
           spec:
-            {{- toYaml .Values.fogLedger.persistence.spec | nindent 12 }}
+            {{- toYaml $.Values.fogLedger.persistence.spec | nindent 12 }}
         {{- end }}
 
   store:
@@ -247,49 +253,46 @@ spec:
     servicePort: 80
     targetPort: ledger-grpc
     spec:
-      podManagementPolicy: {{ .Values.fogLedger.podManagementPolicy }}
-      replicas: {{ .Values.fogLedger.replicaCount }}
+      podManagementPolicy: {{ $.Values.fogLedger.podManagementPolicy }}
+      replicas: {{ $.Values.fogLedger.replicaCount }}
       selector:
         matchLabels:
           app: fog-ledger-store
-          {{- include "fogServices.selectorLabels" . | nindent 10 }}
-      serviceName: {{ include "fogServices.fullname" . }}-fog-ledger-store
+          stack: fog-ledger-{{ . }}
+          {{- include "fogServices.selectorLabels" $ | nindent 10 }}
+      serviceName: {{ include "fogServices.fullname" $ }}-fog-ledger-store
       template:
         metadata:
           annotations:
-            {{- toYaml .Values.fogLedger.podAnnotations | nindent 12 }}
+            {{- toYaml $.Values.fogLedger.podAnnotations | nindent 12 }}
           labels:
             app: fog-ledger-store
-            {{- include "fogServices.labels" . | nindent 12 }}
+            stack: fog-ledger-{{ . }}
+            {{- include "fogServices.labels" $ | nindent 12 }}
         spec:
-          topologySpreadConstraints:
-          - topologyKey: topology.kubernetes.io/zone
-            maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
-            labelSelector:
-              matchLabels:
-                app: fog-ledger-store
-                {{- include "fogServices.selectorLabels" . | nindent 14 }}
-            matchLabelKeys:
-            - statefulset
-          - topologyKey: kubernetes.io/hostname
-            maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
-            labelSelector:
-              matchLabels:
-                app: fog-ledger-store
-                {{- include "fogServices.selectorLabels" . | nindent 14 }}
-            matchLabelKeys:
-            - statefulset
+          {{- if $.Values.fogLedger.affinityEnabled }}
           affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpression:
+                  - key: stack
+                    operator: In
+                    values:
+                    - fog-ledger-{{ . }}
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
-              - topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  app: fog-ledger-store
-                  {{- include "fogServices.selectorLabels" . | nindent 16 }}
+              - labelSelector:
+                  matchExpression:
+                  - key: stack
+                    operator: In
+                    values:
+                    {{- range (without $stacks .) }}
+                    - fog-ledger-{{ . }}
+                    {{- end }}
+          {{- end }}
           imagePullSecrets:
-          {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+          {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
           terminationGracePeriodSeconds: 30
           dnsConfig:
             options:
@@ -309,8 +312,8 @@ spec:
               runAsNonRoot: False
           containers:
           - name: fog-ledger-store
-            image: "{{ .Values.fogLedger.image.org | default .Values.image.org }}/{{ .Values.fogLedger.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-            imagePullPolicy: {{ .Values.fogLedger.image.pullPolicy }}
+            image: "{{ $.Values.fogLedger.image.org | default $.Values.image.org }}/{{ $.Values.fogLedger.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+            imagePullPolicy: {{ $.Values.fogLedger.image.pullPolicy }}
             args: [ "/usr/bin/supervisord" ]
             ports:
             - name: ledger-grpc
@@ -330,9 +333,9 @@ spec:
             - name: MC_LEDGER_DB_MIGRATE
               value: "true"
             - name: RUST_BACKTRACE
-              value: {{ .Values.fogLedger.rust.backtrace | quote }}
+              value: {{ $.Values.fogLedger.rust.backtrace | quote }}
             - name: RUST_LOG
-              value: {{ .Values.fogLedger.rust.log | quote }}
+              value: {{ $.Values.fogLedger.rust.log | quote }}
             - name: FOG_LEDGER_SENTRY_DSN
               valueFrom:
                 configMapKeyRef:
@@ -384,8 +387,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             resources:
-              {{- toYaml .Values.fogLedger.resources | nindent 14 }}
-          {{- if eq .Values.jaegerTracing.enabled true }}
+              {{- toYaml $.Values.fogLedger.resources | nindent 14 }}
+          {{- if eq $.Values.jaegerTracing.enabled true }}
           - name: jaeger-agent
             image: jaegertracing/jaeger-agent:latest
             imagePullPolicy: IfNotPresent
@@ -417,18 +420,16 @@ spec:
                     apiVersion: v1
                     fieldPath: status.hostIP
             args:
-              - --reporter.grpc.host-port={{ .Values.jaegerTracing.collector }}
+              - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
               - --reporter.type=grpc
-              - --agent.tags=cluster=undefined,container.name=fog-ledger,deployment.name={{ include "fogServices.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
+              - --agent.tags=cluster=undefined,container.name=fog-ledger,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
           {{- end }}
           nodeSelector:
-            {{- toYaml .Values.fogLedger.nodeSelector | nindent 12 }}
+            {{- toYaml $.Values.fogLedger.nodeSelector | nindent 12 }}
           tolerations:
-            {{- toYaml .Values.fogLedger.tolerations | nindent 12 }}
-          affinity:
-            {{- toYaml .Values.fogLedger.affinity | nindent 12 }}
+            {{- toYaml $.Values.fogLedger.tolerations | nindent 12 }}
           volumes:
-          {{- if eq .Values.fogLedger.persistence.enabled false }}
+          {{- if eq $.Values.fogLedger.persistence.enabled false }}
           - name: fog-data
             emptyDir: {}
           {{- end }}
@@ -440,20 +441,21 @@ spec:
             projected:
               sources:
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-sgx
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-daemon
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
               - configMap:
                   name: fog-supervisord-mobilecoind
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-fog-ledger-store
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-fog-ledger-store
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-admin
-      {{- if .Values.fogLedger.persistence.enabled }}
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-admin
+      {{- if $.Values.fogLedger.persistence.enabled }}
       volumeClaimTemplates:
       - metadata:
           name: fog-data
         spec:
-          {{- toYaml .Values.fogLedger.persistence.spec | nindent 10 }}
+          {{- toYaml $.Values.fogLedger.persistence.spec | nindent 10 }}
       {{- end }}
-
+---
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
@@ -1,14 +1,16 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- stacks := seq .Values.fogViewShardRangeGenerator.count }}
+{{- range $stacks }}
 apiVersion: mc.mobilecoin.com/v1
 kind: FogShardRangeGenerator
 metadata:
-  name: {{ include "fogServices.fullname" . }}-fog-view
+  name: {{ include "fogServices.fullname" $ }}-fog-view
   labels:
-    {{- include "fogServices.labels" . | nindent 4 }}
+    {{- include "fogServices.labels" $ | nindent 4 }}
 spec:
-  {{- include "fogServices.fogViewStores" . | nindent 2 }}
-  blockCountURL: {{ include "fogServices.blockHeightURL" . | quote }}
-  {{- with .Values.blockHeighRetrieval }}
+  {{- include "fogServices.fogViewStores" $ | nindent 2 }}
+  blockCountURL: {{ include "fogServices.blockHeightURL" $ | quote }}
+  {{- with $.Values.blockHeighRetrieval }}
   blockCountQueryInterval: {{ .queryInterval | quote }}
   blockCountResponseJQ: {{ .responseJQ | quote }}
   blockCountReqBody: {{ .requestBody | quote }}
@@ -17,20 +19,22 @@ spec:
     template:
       containerName: fog-view-router
       spec:
-        podManagementPolicy: {{ .Values.fogViewRouter.podManagementPolicy }}
-        replicas: {{ .Values.fogViewRouter.replicaCount }}
+        podManagementPolicy: {{ $.Values.fogViewRouter.podManagementPolicy }}
+        replicas: {{ $.Values.fogViewRouter.replicaCount }}
         selector:
           matchLabels:
             app: fog-view-router
-            {{- include "fogServices.selectorLabels" . | nindent 12 }}
-        serviceName: {{ include "fogServices.fullname" . }}-fog-view-router
+            stack: fog-view-{{ . }}
+            {{- include "fogServices.selectorLabels"$| nindent 12 }}
+        serviceName: {{ include "fogServices.fullname"$}}-fog-view-router
         template:
           metadata:
             annotations:
-              {{- toYaml .Values.fogViewRouter.podAnnotations | nindent 14 }}
+              {{- toYaml $.Values.fogViewRouter.podAnnotations | nindent 14 }}
             labels:
               app: fog-view-router
-              {{- include "fogServices.labels" . | nindent 14 }}
+              stack: fog-view-{{ . }}
+              {{- include "fogServices.labels"$| nindent 14 }}
           spec:
             # Prevent endpoint creation until all shards for this router are ready
             readinessGates:
@@ -43,17 +47,18 @@ spec:
                 defaultMode: 420
                 sources:
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-fog-view-router
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-fog-view-router
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-sgx
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
                 - configMap:
-                    name: {{ include "fogServices.fullname" . }}-supervisord-daemon
+                    name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
             nodeSelector:
-              {{- toYaml .Values.fogViewRouter.nodeSelector | nindent 14 }}
+              {{- toYaml $.Values.fogViewRouter.nodeSelector | nindent 14 }}
             tolerations:
-              {{- toYaml .Values.fogViewRouter.tolerations | nindent 14 }}
+              {{- toYaml $.Values.fogViewRouter.tolerations | nindent 14 }}
             affinity:
-              {{- toYaml .Values.fogViewRouter.affinity | nindent 14 }}
+              {{- toYaml $.Values.fogViewRouter.affinity | nindent 14 }}
+            {{- if $.Values.fogViewRouter.topologySpreadConstraintsEnabled }}
             topologySpreadConstraints:
             - topologyKey: topology.kubernetes.io/zone
               maxSkew: 1
@@ -67,8 +72,9 @@ spec:
               labelSelector:
                 matchLabels:
                   app: fog-view-router
+            {{- end }}
             imagePullSecrets:
-            {{- toYaml .Values.imagePullSecrets | nindent 12 }}
+            {{- toYaml $.Values.imagePullSecrets | nindent 12 }}
             initContainers:
             - name: sysctl
               image: ubuntu:20.04
@@ -83,8 +89,8 @@ spec:
                 runAsNonRoot: False
             containers:
             - name: fog-view-router
-              image: "{{ .Values.fogViewRouter.image.org | default .Values.image.org }}/{{ .Values.fogViewRouter.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.fogViewRouter.image.pullPolicy }}
+              image: "{{ $.Values.fogViewRouter.image.org | default $.Values.image.org }}/{{ $.Values.fogViewRouter.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ $.Values.fogViewRouter.image.pullPolicy }}
               command: [ "/usr/bin/supervisord", "-n" ]
               ports:
               - name: view-grpc
@@ -120,9 +126,9 @@ spec:
                 timeoutSeconds: 1
               env:
               - name: RUST_BACKTRACE
-                value: {{ .Values.fogViewRouter.rust.backtrace | quote }}
+                value: {{ $.Values.fogViewRouter.rust.backtrace | quote }}
               - name: RUST_LOG
-                value: {{ .Values.fogViewRouter.rust.log | quote }}
+                value: {{ $.Values.fogViewRouter.rust.log | quote }}
               - name: CLIENT_AUTH_TOKEN_SECRET
                 valueFrom:
                   secretKeyRef:
@@ -130,7 +136,7 @@ spec:
                     key: token
                     optional: true
               - name: MC_CLIENT_RESPONDER_ID
-                value: {{ include "fogServices.fogPublicFQDN" . }}:443
+                value: {{ include "fogServices.fogPublicFQDN" $ }}:443
               - name: MC_CLIENT_LISTEN_URI
                 value: insecure-fog-view://0.0.0.0:3225/
               - name: FOG_VIEW_SENTRY_DSN
@@ -150,9 +156,9 @@ spec:
               - mountPath: /var/run/aesmd
                 name: aesm-socket-dir
               resources:
-                {{- toYaml .Values.fogViewRouter.resources | nindent 16 }}
+                {{- toYaml $.Values.fogViewRouter.resources | nindent 16 }}
             - name: grpc-gateway
-              image: "{{ .Values.grpcGateway.image.org | default .Values.image.org }}/{{ .Values.grpcGateway.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              image: "{{ $.Values.grpcGateway.image.org | default $.Values.image.org }}/{{ $.Values.grpcGateway.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: Always
               command:
               - /usr/bin/go-grpc-gateway
@@ -164,8 +170,8 @@ spec:
                 - name: view-http
                   containerPort: 8225
               resources:
-                {{- toYaml .Values.grpcGateway.resources | nindent 16 }}
-            {{- if eq .Values.jaegerTracing.enabled true }}
+                {{- toYaml $.Values.grpcGateway.resources | nindent 16 }}
+            {{- if eq $.Values.jaegerTracing.enabled true }}
             - name: jaeger-agent
               image: jaegertracing/jaeger-agent:latest
               imagePullPolicy: IfNotPresent
@@ -197,9 +203,9 @@ spec:
                       apiVersion: v1
                       fieldPath: status.hostIP
               args:
-                - --reporter.grpc.host-port={{ .Values.jaegerTracing.collector }}
+                - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
                 - --reporter.type=grpc
-                - --agent.tags=cluster=undefined,container.name=fog-view-router,deployment.name={{ include "fogServices.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
+                - --agent.tags=cluster=undefined,container.name=fog-view-router,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
             {{- end }}
 
   store:
@@ -207,41 +213,46 @@ spec:
     servicePort: 80
     targetPort: view-grpc
     spec:
-      podManagementPolicy: {{ .Values.fogViewRouter.podManagementPolicy }}
-      replicas: {{ .Values.fogView.replicaCount }}
+      podManagementPolicy: {{ $.Values.fogViewRouter.podManagementPolicy }}
+      replicas: {{ $.Values.fogView.replicaCount }}
       selector:
         matchLabels:
           app: fog-view-store
-          {{- include "fogServices.selectorLabels" . | nindent 10 }}
-      serviceName: {{ include "fogServices.fullname" . }}-fog-view-store
+          stack: fog-view-{{ . }}
+          {{- include "fogServices.selectorLabels" $ | nindent 10 }}
+      serviceName: {{ include "fogServices.fullname" $ }}-fog-view-store
       template:
         metadata:
           annotations:
-            {{- toYaml .Values.fogView.podAnnotations | nindent 12 }}
+            {{- toYaml $.Values.fogView.podAnnotations | nindent 12 }}
           labels:
             app: fog-view-store
-            {{- include "fogServices.labels" . | nindent 12 }}
+            stack: fog-view-{{ . }}
+            {{- include "fogServices.labels" $ | nindent 12 }}
         spec:
-          # TODO: constraints, affinity used fog-view; but selector used fog-view-store?
-          topologySpreadConstraints:
-          - topologyKey: topology.kubernetes.io/zone
-            maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
-            labelSelector:
-              matchLabels:
-                app: fog-view-store
-            matchLabelKeys:
-            - statefulset
-          - topologyKey: kubernetes.io/hostname
-            maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
-            labelSelector:
-              matchLabels:
-                app: fog-view-store
-            matchLabelKeys:
-            - statefulset
+          {{- if $.Values.fogView.affinityEnabled }}
+          affinity:
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpression:
+                  - key: stack
+                    operator: In
+                    values:
+                    - fog-view-{{ . }}
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpression:
+                  - key: stack
+                    operator: In
+                    values:
+                    {{- range (without $stacks .) }}
+                    - fog-view-{{ . }}
+                    {{- end }}
+          {{- end }}
           imagePullSecrets:
-          {{- toYaml .Values.imagePullSecrets | nindent 10 }}
+          {{- toYaml $.Values.imagePullSecrets | nindent 10 }}
           initContainers:
           - name: sysctl
             image: ubuntu:20.04
@@ -256,8 +267,8 @@ spec:
               runAsNonRoot: False
           containers:
           - name: fog-view-store
-            image: "{{ .Values.fogView.image.org | default .Values.image.org }}/{{ .Values.fogView.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-            imagePullPolicy: {{ .Values.fogView.image.pullPolicy }}
+            image: "{{ $.Values.fogView.image.org | default $.Values.image.org }}/{{ $.Values.fogView.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+            imagePullPolicy: {{ $.Values.fogView.image.pullPolicy }}
             command: [ "/usr/bin/supervisord" ]
             ports:
             - name: view-grpc
@@ -271,9 +282,9 @@ spec:
                 name: ias
             env:
             - name: RUST_BACKTRACE
-              value: {{ .Values.fogView.rust.backtrace | quote }}
+              value: {{ $.Values.fogView.rust.backtrace | quote }}
             - name: RUST_LOG
-              value: {{ .Values.fogView.rust.log | quote }}
+              value: {{ $.Values.fogView.rust.log | quote }}
             - name: FOG_VIEW_SENTRY_DSN
               valueFrom:
                 configMapKeyRef:
@@ -348,8 +359,8 @@ spec:
             - mountPath: /var/run/aesmd
               name: aesm-socket-dir
             resources:
-              {{- toYaml .Values.fogView.resources | nindent 14 }}
-          {{- if eq .Values.jaegerTracing.enabled true }}
+              {{- toYaml $.Values.fogView.resources | nindent 14 }}
+          {{- if eq $.Values.jaegerTracing.enabled true }}
           - name: jaeger-agent
             image: jaegertracing/jaeger-agent:latest
             imagePullPolicy: IfNotPresent
@@ -381,16 +392,14 @@ spec:
                     apiVersion: v1
                     fieldPath: status.hostIP
             args:
-              - --reporter.grpc.host-port={{ .Values.jaegerTracing.collector }}
+              - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
               - --reporter.type=grpc
-              - --agent.tags=cluster=undefined,container.name=fog-view,deployment.name={{ include "fogServices.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
+              - --agent.tags=cluster=undefined,container.name=fog-view,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
           {{- end }}
           nodeSelector:
-            {{- toYaml .Values.fogView.nodeSelector | nindent 12 }}
+            {{- toYaml $.Values.fogView.nodeSelector | nindent 12 }}
           tolerations:
-            {{- toYaml .Values.fogView.tolerations | nindent 12 }}
-          affinity:
-            {{- toYaml .Values.fogView.affinity | nindent 12 }}
+            {{- toYaml $.Values.fogView.tolerations | nindent 12 }}
           volumes:
           - emptyDir: {}
             name: aesm-socket-dir
@@ -398,10 +407,12 @@ spec:
             projected:
               sources:
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-sgx
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-daemon
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-fog-view-store
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-fog-view-store
               - configMap:
-                  name: {{ include "fogServices.fullname" . }}-supervisord-admin
+                  name: {{ include "fogServices.fullname" $ }}-supervisord-admin
+---
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
-{{- stacks := seq .Values.fogViewShardRangeGenerator.count }}
+{{- $stacks := until (int .Values.fogViewShardRangeGenerator.count) }}
 {{- range $stacks }}
 apiVersion: mc.mobilecoin.com/v1
 kind: FogShardRangeGenerator
 metadata:
-  name: {{ include "fogServices.fullname" $ }}-fog-view
+  name: {{ include "fogServices.fullname" $ }}-fog-view-{{ . }}
   labels:
     {{- include "fogServices.labels" $ | nindent 4 }}
 spec:
@@ -25,8 +25,8 @@ spec:
           matchLabels:
             app: fog-view-router
             stack: fog-view-{{ . }}
-            {{- include "fogServices.selectorLabels"$| nindent 12 }}
-        serviceName: {{ include "fogServices.fullname"$}}-fog-view-router
+            {{- include "fogServices.selectorLabels" $ | nindent 12 }}
+        serviceName: {{ include "fogServices.fullname" $ }}-fog-view-router
         template:
           metadata:
             annotations:
@@ -34,7 +34,7 @@ spec:
             labels:
               app: fog-view-router
               stack: fog-view-{{ . }}
-              {{- include "fogServices.labels"$| nindent 14 }}
+              {{- include "fogServices.labels" $ | nindent 14 }}
           spec:
             # Prevent endpoint creation until all shards for this router are ready
             readinessGates:
@@ -234,12 +234,15 @@ spec:
           affinity:
             podAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpression:
-                  - key: stack
-                    operator: In
-                    values:
-                    - fog-view-{{ . }}
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpression:
+                    - key: stack
+                      operator: In
+                      values:
+                      - fog-view-{{ . }}
+                  topologyKey: "kubernetes.io/hostname"
+                weight: 1
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
@@ -250,6 +253,7 @@ spec:
                     {{- range (without $stacks .) }}
                     - fog-view-{{ . }}
                     {{- end }}
+                topologyKey: "kubernetes.io/hostname"
           {{- end }}
           imagePullSecrets:
           {{- toYaml $.Values.imagePullSecrets | nindent 10 }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
@@ -239,7 +239,7 @@ spec:
           topologySpreadConstraints:
           - topologyKey: topology.kubernetes.io/zone
             maxSkew: 1
-            whenUnsatisfiable: DoNotSchedule
+            whenUnsatisfiable: ScheduleAnyway
             labelSelector:
               matchLabels:
                 app: fog-view-store

--- a/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-fogshardrangegenerator.yaml
@@ -56,22 +56,27 @@ spec:
               {{- toYaml $.Values.fogViewRouter.nodeSelector | nindent 14 }}
             tolerations:
               {{- toYaml $.Values.fogViewRouter.tolerations | nindent 14 }}
+            {{- if $.Values.fogViewRouter.affinityEnabled }}
             affinity:
-              {{- toYaml $.Values.fogViewRouter.affinity | nindent 14 }}
-            {{- if $.Values.fogViewRouter.topologySpreadConstraintsEnabled }}
-            topologySpreadConstraints:
-            - topologyKey: topology.kubernetes.io/zone
-              maxSkew: 1
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app: fog-view-router
-            - topologyKey: kubernetes.io/hostname
-              maxSkew: 1
-              whenUnsatisfiable: DoNotSchedule
-              labelSelector:
-                matchLabels:
-                  app: fog-view-router
+              podAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                    - key: stack
+                      operator: In
+                      values:
+                      - fog-view-{{ . }}
+                  topologyKey: topology.kubernetes.io/zone
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                      - key: stack
+                        operator: In
+                        values:
+                        - fog-view-{{ . }}
+                    topologyKey: "kubernetes.io/hostname"
+                  weight: 1
             {{- end }}
             imagePullSecrets:
             {{- toYaml $.Values.imagePullSecrets | nindent 12 }}
@@ -230,30 +235,36 @@ spec:
             stack: fog-view-{{ . }}
             {{- include "fogServices.labels" $ | nindent 12 }}
         spec:
+          {{- if $.Values.fogView.topologySpreadConstraintsEnabled }}
+          topologySpreadConstraints:
+          - topologyKey: topology.kubernetes.io/zone
+            maxSkew: 1
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app: fog-view-store
+          {{- end }}
           {{- if $.Values.fogView.affinityEnabled }}
           affinity:
             podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: stack
+                    operator: In
+                    values:
+                    - fog-view-{{ . }}
+                topologyKey: topology.kubernetes.io/zone
               preferredDuringSchedulingIgnoredDuringExecution:
               - podAffinityTerm:
                   labelSelector:
-                    matchExpression:
+                    matchExpressions:
                     - key: stack
                       operator: In
                       values:
                       - fog-view-{{ . }}
                   topologyKey: "kubernetes.io/hostname"
                 weight: 1
-            podAntiAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-              - labelSelector:
-                  matchExpression:
-                  - key: stack
-                    operator: In
-                    values:
-                    {{- range (without $stacks .) }}
-                    - fog-view-{{ . }}
-                    {{- end }}
-                topologyKey: "kubernetes.io/hostname"
           {{- end }}
           imagePullSecrets:
           {{- toYaml $.Values.imagePullSecrets | nindent 10 }}

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -52,7 +52,7 @@ fogViewStores:
     shardOverlap: 400_000
 
 fogViewShardRangeGenerator:
-  count: 2
+  count: 4
 
 fogViewRouter:
   podManagementPolicy: Parallel
@@ -76,8 +76,9 @@ fogViewRouter:
     value: 'true'
     effect: NoSchedule
 
+  # disable affinity rules for single node testing
+  affinityEnabled: true
   topologySpreadConstraintsEnabled: true
-  affinity: {}
 
   rust:
     backtrace: full
@@ -128,6 +129,7 @@ fogView:
 
   # disable affinity rules for single node testing
   affinityEnabled: true
+  topologySpreadConstraintsEnabled: true
 
   ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
   resources:
@@ -161,14 +163,14 @@ fogLedgerStores:
     shardOverlap: 400_000
 
 fogLedgerShardRangeGenerator:
-  count: 2
+  count: 4
 
 fogLedgerRouter:
   replicaCount: 1
   podManagementPolicy: Parallel
 
+  affinityEnabled: true
   topologySpreadConstraintsEnabled: true
-  affinity: {}
 
   podAnnotations:
     fluentbit.io/include: 'true' # collect logs with fluentbit
@@ -210,6 +212,7 @@ fogLedger:
 
   # disable affinity rules for single node testing
   affinityEnabled: true
+  topologySpreadConstraintsEnabled: true
 
   podManagementPolicy: Parallel
 

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -199,7 +199,7 @@ fogLedgerRouter:
     effect: NoSchedule
 
 fogLedger:
-  replicaCount: 2
+  replicaCount: 1
   image:
     org: ''
     name: fog-ledger

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -13,35 +13,6 @@ mcCoreCommonConfig:
 fogServicesConfig:
   enabled: false
 
-fogViewRouter:
-  podManagementPolicy: Parallel
-  replicaCount: 2
-  resources:
-    limits:
-      intel.com/sgx: 5000
-      memory: 3Gi
-    requests:
-      intel.com/sgx: 5000
-      memory: 3Gi
-  nodeSelector:
-    sgx-enabled-node: 'true'
-  tolerations:
-  - key: sgx
-    operator: Equal
-    value: 'true'
-    effect: NoSchedule
-  affinity: {}
-  rust:
-    backtrace: full
-    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
-  podAnnotations:
-    fluentbit.io/include: 'true' # collect logs with fluentbit
-    fluentbit.io/exclude-jaeger-agent: 'true'
-  image:
-    org: ''
-    name: fogview
-    pullPolicy: Always
-
 # Used to retrieve block height for fog view & ledger stores
 blockHeighRetrieval:
   # .Network is retreived from mobilecoin-network configmap
@@ -51,26 +22,6 @@ blockHeighRetrieval:
   queryInterval: 5m
   requestBody: '{"method": "get_network_status", "jsonrpc": "2.0", "id": 1}'
   responseJQ: .result.network_status.network_block_height
-
-fogViewStores:
-  main:
-    shardSize: 400_000
-    exceedBlockHeightBy: 200_000
-    shardOverlap: 200_000
-  test:
-    shardSize: 800_000
-    exceedBlockHeightBy: 200_000
-    shardOverlap: 400_000
-
-fogLedgerStores:
-  main:
-    shardSize: 400_000
-    exceedBlockHeightBy: 200_000
-    shardOverlap: 200_000
-  test:
-    shardSize: 800_000
-    exceedBlockHeightBy: 200_000
-    shardOverlap: 400_000
 
 imagePullSecrets:
 - name: docker-credentials
@@ -88,6 +39,233 @@ global:
 
 ingress:
   enabled: true
+
+#### Fog View
+fogViewStores:
+  main:
+    shardSize: 400_000
+    exceedBlockHeightBy: 200_000
+    shardOverlap: 200_000
+  test:
+    shardSize: 800_000
+    exceedBlockHeightBy: 200_000
+    shardOverlap: 400_000
+
+fogViewShardRangeGenerator:
+  count: 2
+
+fogViewRouter:
+  podManagementPolicy: Parallel
+  replicaCount: 1
+
+  resources:
+    limits:
+      intel.com/sgx: 5000
+      memory: 3Gi
+    requests:
+      intel.com/sgx: 5000
+      memory: 3Gi
+
+  nodeSelector:
+    sgx-enabled-node: 'true'
+
+  tolerations:
+  - key: sgx
+    operator: Equal
+    value: 'true'
+    effect: NoSchedule
+
+  topologySpreadConstraintsEnabled: true
+  affinity: {}
+
+  rust:
+    backtrace: full
+    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+  podAnnotations:
+    fluentbit.io/include: 'true' # collect logs with fluentbit
+    fluentbit.io/exclude-jaeger-agent: 'true'
+  image:
+    org: ''
+    name: fogview
+    pullPolicy: Always
+
+fogView:
+  replicaCount: 1
+  image:
+    org: ''
+    name: fogview
+    pullPolicy: Always
+
+  rust:
+    backtrace: full
+    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+  ingress:
+    common:
+      annotations: |-
+        haproxy.org/server-ssl: "false"             # The backend (server) is http
+        haproxy.org/timeout-client: 239s            # 4 min timeout on azure
+        haproxy.org/timeout-server: 239s
+        haproxy.org/timeout-http-keep-alive: 120s
+        haproxy.org/abortonclose: "true"
+        haproxy.org/backend-config-snippet: |-
+          http-reuse aggressive
+          dynamic-cookie-key {{ include "fogServices.fogViewGRPCCookieSalt" . }}
+          cookie VIEW insert indirect nocache dynamic
+
+    grpc:
+      annotations: |-
+        haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
+
+    http:
+      annotations: |-
+        haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
+
+  podAnnotations:
+    fluentbit.io/include: 'true' # collect logs with fluentbit
+    fluentbit.io/exclude-jaeger-agent: 'true'
+
+  # disable affinity rules for single node testing
+  affinityEnabled: true
+
+  ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
+  resources:
+    limits:
+      intel.com/sgx: 5000
+      memory: 3Gi
+    requests:
+      intel.com/sgx: 5000
+      memory: 3Gi
+
+  nodeSelector:
+    sgx-enabled-node: 'true'
+
+  tolerations:
+  - key: sgx
+    operator: Equal
+    value: 'true'
+    effect: NoSchedule
+
+
+#### Fog Ledger
+fogLedgerStores:
+  main:
+    shardSize: 400_000
+    exceedBlockHeightBy: 200_000
+    shardOverlap: 200_000
+  test:
+    shardSize: 800_000
+    exceedBlockHeightBy: 200_000
+    shardOverlap: 400_000
+
+fogLedgerShardRangeGenerator:
+  count: 2
+
+fogLedgerRouter:
+  replicaCount: 1
+  podManagementPolicy: Parallel
+
+  topologySpreadConstraintsEnabled: true
+  affinity: {}
+
+  podAnnotations:
+    fluentbit.io/include: 'true' # collect logs with fluentbit
+    fluentbit.io/exclude-jaeger-agent: 'true'
+
+  image:
+    org: ''
+    name: fog-ledger
+    pullPolicy: Always
+
+  rust:
+    backtrace: full
+    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+  resources:
+    limits:
+      intel.com/sgx: 5000
+      memory: 1Gi
+    requests:
+      intel.com/sgx: 5000
+      memory: 1Gi
+
+  nodeSelector:
+    sgx-enabled-node: 'true'
+
+  tolerations:
+  - key: sgx
+    operator: Equal
+    value: 'true'
+    effect: NoSchedule
+
+fogLedger:
+  replicaCount: 2
+  image:
+    org: ''
+    name: fog-ledger
+    pullPolicy: Always
+
+  # disable affinity rules for single node testing
+  affinityEnabled: true
+
+  podManagementPolicy: Parallel
+
+  rust:
+    backtrace: full
+    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+  persistence:
+    enabled: true
+    spec:
+      storageClassName: fast
+      accessModes:
+        - 'ReadWriteOnce'
+      resources:
+        requests:
+          storage: 512Gi
+
+  ingress:
+    common:
+      annotations: |-
+        haproxy.org/server-ssl: "false"             # The backend (server) is http
+        haproxy.org/timeout-client: 239s            # 4 min timeout on azure
+        haproxy.org/timeout-server: 239s
+        haproxy.org/timeout-http-keep-alive: 120s
+        haproxy.org/abortonclose: "true"
+        haproxy.org/backend-config-snippet: |-
+          http-reuse aggressive
+          dynamic-cookie-key {{ include "fogServices.fogLedgerGRPCCookieSalt" . }}
+          cookie "LEDGER" insert indirect nocache dynamic
+
+    grpc:
+      annotations: |-
+        haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
+
+    http:
+      annotations: |-
+        haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
+
+  podAnnotations:
+    fluentbit.io/include: 'true' # collect logs with fluentbit
+    fluentbit.io/exclude-jaeger-agent: 'true'
+
+  ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
+  resources:
+    limits:
+      intel.com/sgx: 5000
+      memory: 3Gi
+    requests:
+      intel.com/sgx: 5000
+      memory: 3Gi
+
+  nodeSelector:
+    sgx-enabled-node: 'true'
+
+  tolerations:
+  - key: sgx
+    operator: Equal
+    value: 'true'
+    effect: NoSchedule
 
 ### Fog Report Service
 fogReport:
@@ -148,159 +326,7 @@ fogReport:
       POSTGRES_CONNECTION_TIMEOUT: '5'
       POSTGRES_MAX_CONNECTIONS: '3'
 
-fogView:
-  replicaCount: 2
-  image:
-    org: ''
-    name: fogview
-    pullPolicy: Always
 
-  rust:
-    backtrace: full
-    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
-
-  ingress:
-    common:
-      annotations: |-
-        haproxy.org/server-ssl: "false"             # The backend (server) is http
-        haproxy.org/timeout-client: 239s            # 4 min timeout on azure
-        haproxy.org/timeout-server: 239s
-        haproxy.org/timeout-http-keep-alive: 120s
-        haproxy.org/abortonclose: "true"
-        haproxy.org/backend-config-snippet: |-
-          http-reuse aggressive
-          dynamic-cookie-key {{ include "fogServices.fogViewGRPCCookieSalt" . }}
-          cookie VIEW insert indirect nocache dynamic
-
-    grpc:
-      annotations: |-
-        haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
-
-    http:
-      annotations: |-
-        haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
-
-  podAnnotations:
-    fluentbit.io/include: 'true' # collect logs with fluentbit
-    fluentbit.io/exclude-jaeger-agent: 'true'
-
-  ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
-  resources:
-    limits:
-      intel.com/sgx: 5000
-      memory: 3Gi
-    requests:
-      intel.com/sgx: 5000
-      memory: 3Gi
-
-  nodeSelector:
-    sgx-enabled-node: 'true'
-
-  tolerations:
-  - key: sgx
-    operator: Equal
-    value: 'true'
-    effect: NoSchedule
-
-fogLedgerRouter:
-  replicaCount: 2
-  podManagementPolicy: Parallel
-
-  podAnnotations:
-    fluentbit.io/include: 'true' # collect logs with fluentbit
-    fluentbit.io/exclude-jaeger-agent: 'true'
-
-  image:
-    org: ''
-    name: fog-ledger
-    pullPolicy: Always
-
-  rust:
-    backtrace: full
-    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
-
-  resources:
-    limits:
-      intel.com/sgx: 5000
-      memory: 1Gi
-    requests:
-      intel.com/sgx: 5000
-      memory: 1Gi
-
-  nodeSelector:
-    sgx-enabled-node: 'true'
-
-  tolerations:
-  - key: sgx
-    operator: Equal
-    value: 'true'
-    effect: NoSchedule
-
-fogLedger:
-  replicaCount: 2
-  image:
-    org: ''
-    name: fog-ledger
-    pullPolicy: Always
-
-  podManagementPolicy: Parallel
-
-  rust:
-    backtrace: full
-    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
-
-  persistence:
-    enabled: true
-    spec:
-      storageClassName: fast
-      accessModes:
-        - 'ReadWriteOnce'
-      resources:
-        requests:
-          storage: 512Gi
-
-  ingress:
-    common:
-      annotations: |-
-        haproxy.org/server-ssl: "false"             # The backend (server) is http
-        haproxy.org/timeout-client: 239s            # 4 min timeout on azure
-        haproxy.org/timeout-server: 239s
-        haproxy.org/timeout-http-keep-alive: 120s
-        haproxy.org/abortonclose: "true"
-        haproxy.org/backend-config-snippet: |-
-          http-reuse aggressive
-          dynamic-cookie-key {{ include "fogServices.fogLedgerGRPCCookieSalt" . }}
-          cookie "LEDGER" insert indirect nocache dynamic
-
-    grpc:
-      annotations: |-
-        haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
-
-    http:
-      annotations: |-
-        haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
-
-  podAnnotations:
-    fluentbit.io/include: 'true' # collect logs with fluentbit
-    fluentbit.io/exclude-jaeger-agent: 'true'
-
-  ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
-  resources:
-    limits:
-      intel.com/sgx: 5000
-      memory: 3Gi
-    requests:
-      intel.com/sgx: 5000
-      memory: 3Gi
-
-  nodeSelector:
-    sgx-enabled-node: 'true'
-
-  tolerations:
-  - key: sgx
-    operator: Equal
-    value: 'true'
-    effect: NoSchedule
 
 grpcGateway:
   image:

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -65,6 +65,7 @@ fogViewRouter:
     requests:
       intel.com/sgx: 5000
       memory: 3Gi
+      cpu: 1100m
 
   nodeSelector:
     sgx-enabled-node: 'true'
@@ -136,7 +137,7 @@ fogView:
     requests:
       intel.com/sgx: 5000
       memory: 3Gi
-      cpu: 1.1
+      cpu: 1100m
 
   nodeSelector:
     sgx-enabled-node: 'true'
@@ -189,7 +190,7 @@ fogLedgerRouter:
     requests:
       intel.com/sgx: 5000
       memory: 1Gi
-      cpu: 1.1
+      cpu: 1100m
 
   nodeSelector:
     sgx-enabled-node: 'true'
@@ -259,7 +260,7 @@ fogLedger:
     requests:
       intel.com/sgx: 5000
       memory: 3Gi
-      cpu: 1.1
+      cpu: 1100m
 
   nodeSelector:
     sgx-enabled-node: 'true'

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -52,7 +52,7 @@ fogViewStores:
     shardOverlap: 400_000
 
 fogViewShardRangeGenerator:
-  count: 4
+  count: 3
 
 fogViewRouter:
   podManagementPolicy: Parallel
@@ -163,7 +163,7 @@ fogLedgerStores:
     shardOverlap: 400_000
 
 fogLedgerShardRangeGenerator:
-  count: 4
+  count: 3
 
 fogLedgerRouter:
   replicaCount: 1
@@ -185,13 +185,23 @@ fogLedgerRouter:
     backtrace: full
     log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
 
+  persistence:
+    enabled: true
+    spec:
+      storageClassName: fast
+      accessModes:
+        - 'ReadWriteOnce'
+      resources:
+        requests:
+          storage: 512Gi
+
   resources:
     limits:
       intel.com/sgx: 5000
-      memory: 1Gi
+      memory: 3Gi
     requests:
       intel.com/sgx: 5000
-      memory: 1Gi
+      memory: 3Gi
       cpu: 1100m
 
   nodeSelector:
@@ -229,6 +239,9 @@ fogLedger:
       resources:
         requests:
           storage: 512Gi
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Delete
+        whenScaled: Retain
 
   ingress:
     common:

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -136,6 +136,7 @@ fogView:
     requests:
       intel.com/sgx: 5000
       memory: 3Gi
+      cpu: 1.1
 
   nodeSelector:
     sgx-enabled-node: 'true'
@@ -188,6 +189,7 @@ fogLedgerRouter:
     requests:
       intel.com/sgx: 5000
       memory: 1Gi
+      cpu: 1.1
 
   nodeSelector:
     sgx-enabled-node: 'true'
@@ -257,6 +259,7 @@ fogLedger:
     requests:
       intel.com/sgx: 5000
       memory: 3Gi
+      cpu: 1.1
 
   nodeSelector:
     sgx-enabled-node: 'true'

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -43,7 +43,6 @@ fn main() {
         transfer_amount: config.transfer_amount,
         token_ids: config.token_ids.clone(),
         polling_wait: config.balance_polling_wait,
-        ..Default::default()
     };
 
     let account_keys = config.load_accounts(&logger);

--- a/fog/test-client/src/bin/main.rs
+++ b/fog/test-client/src/bin/main.rs
@@ -42,6 +42,7 @@ fn main() {
         double_spend_wait: config.ledger_sync_wait,
         transfer_amount: config.transfer_amount,
         token_ids: config.token_ids.clone(),
+        polling_wait: config.balance_polling_wait,
         ..Default::default()
     };
 

--- a/fog/test-client/src/config.rs
+++ b/fog/test-client/src/config.rs
@@ -8,7 +8,7 @@ use mc_common::logger::{log, Logger};
 use mc_fog_sample_paykit::{AccountKey, TokenId};
 use mc_fog_uri::{FogLedgerUri, FogViewUri};
 use mc_util_grpc::GrpcRetryConfig;
-use mc_util_parse::parse_duration_in_seconds;
+use mc_util_parse::{parse_duration_in_millis, parse_duration_in_seconds};
 use mc_util_uri::{AdminUri, ConsensusClientUri};
 use serde::Serialize;
 use std::{path::PathBuf, time::Duration};
@@ -84,6 +84,12 @@ pub struct TestClientConfig {
     /// deadline.
     #[clap(long, default_value = "5", value_parser = parse_duration_in_seconds, env = "MC_CONSENSUS_WAIT")]
     pub consensus_wait: Duration,
+
+    /// ms to wait between balance polling intervals
+    /// Note that the Prometheus buckets for confirm time start at 1s
+    /// and increase at 1s intervals.
+    #[clap(long, default_value = "990", value_parser = parse_duration_in_millis, env = "MC_BALANCE_POLLING_WAIT")]
+    pub balance_polling_wait: Duration,
 
     /// Seconds to wait for ledger sync on fog
     /// This affects the double-spend test but not the continuous mode of

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -101,7 +101,7 @@ impl Default for TestClientPolicy {
             tx_submit_deadline: Duration::from_secs(10),
             tx_receive_deadline: Duration::from_secs(10),
             double_spend_wait: Duration::from_secs(10),
-            polling_wait: Duration::from_millis(50),
+            polling_wait: Duration::from_millis(200),
             transfer_amount: Mob::MINIMUM_FEE,
             token_ids: vec![Mob::ID],
             test_rth_memos: false,

--- a/util/parse/src/lib.rs
+++ b/util/parse/src/lib.rs
@@ -19,6 +19,13 @@ pub fn parse_duration_in_seconds(src: &str) -> Result<Duration, std::num::ParseI
     Ok(Duration::from_secs(u64::from_str(src)?))
 }
 
+/// Parse a number of milliseconds into a duration
+///
+/// This can be used with Clap
+pub fn parse_duration_in_millis(src: &str) -> Result<Duration, std::num::ParseIntError> {
+    Ok(Duration::from_millis(u64::from_str(src)?))
+}
+
 /// Load a CSS file from disk. This represents a signature over an enclave,
 /// and contains attestation parameters like MRENCLAVE and MRSIGNER as well
 /// as other stuff.


### PR DESCRIPTION
### Motivation

Since we found out that we can't scale fog-stores by adding more replicas (routers don't load-balance), This redesigns the fog-router/stores into "stacks". Each router has a dedicated set of stores with 1 replica. We run multiple stacks to provide availability and more capacity.

Also included is a change to fog-test-client to make the polling interval configurable.  The previous default of 50ms was a bit aggressive, considering we were measuring the result in 1s buckets.
