### PR TITLE
fix (view-router): shardng strategy should not assume 50% overlap

### DIFF
--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -164,7 +164,11 @@ pub fn process_shard_responses(
             }
             // This call will be retried as part of the larger retry logic
             MultiKeyImageStoreResponseStatus::NOT_READY => {
-                log::debug!(logger, "Shard {} status NotReady", shard_client);
+                log::debug!(
+                    logger,
+                    "Shard {} status NotReady",
+                    KeyImageStoreUri::from_str(&response.store_uri)?
+                );
             }
             // This is a Protobuf decode error - we should never see this
             MultiKeyImageStoreResponseStatus::INVALID_ARGUMENT => {

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -163,7 +163,9 @@ pub fn process_shard_responses(
                 store_uris_for_authentication.push(store_uri);
             }
             // This call will be retried as part of the larger retry logic
-            MultiKeyImageStoreResponseStatus::NOT_READY => (),
+            MultiKeyImageStoreResponseStatus::NOT_READY => {
+                log::debug!(logger, "Shard {} status NotReady", shard_client);
+            }
             // This is a Protobuf decode error - we should never see this
             MultiKeyImageStoreResponseStatus::INVALID_ARGUMENT => {
                 log::error!(

--- a/fog/ledger/server/src/sharding_strategy.rs
+++ b/fog/ledger/server/src/sharding_strategy.rs
@@ -211,8 +211,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_not_first_shard_prevents_less_than_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
@@ -225,8 +224,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_not_first_shard_allows_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
@@ -239,8 +237,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_not_first_shard_allows_over_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 110;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 

--- a/fog/ledger/server/src/sharding_strategy.rs
+++ b/fog/ledger/server/src/sharding_strategy.rs
@@ -72,11 +72,17 @@ impl EpochShardingStrategy {
             return true;
         }
 
-        let epoch_block_range_length =
-            self.epoch_block_range.end_block - self.epoch_block_range.start_block;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        // Original logic requires/assumes a 50% overlap.
+        // This doesn't really work if the we try a minimal overlap to optimize
+        // for cost. We should revisit at some point and create
+        // alternative strategies. This logic should drive the health
+        // check endpoint that k8s can consume more than a response to
+        // the router.
+        // let epoch_block_range_length =
+        //     self.epoch_block_range.end_block - self.epoch_block_range.start_block;
+        // let minimum_processed_block_count = epoch_block_range_length / 2;
 
-        u64::from(processed_block_count) >= minimum_processed_block_count
+        u64::from(processed_block_count) >= 1
     }
 
     fn is_first_epoch(&self) -> bool {

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -176,6 +176,15 @@ impl CachedTxData {
             .map(|block_range| BlockCount::from(block_range.start_block + 1))
             .min()
             .unwrap_or(BlockCount::MAX);
+
+        log::debug!(
+            self.logger,
+            "get_num_blocks {} {} {}",
+            self.rng_set.get_highest_processed_block_count(),
+            self.key_image_data_completeness,
+            missing_block_limit
+        );
+
         *[
             self.rng_set.get_highest_processed_block_count(),
             self.key_image_data_completeness,

--- a/fog/view/server/src/router_request_handler.rs
+++ b/fog/view/server/src/router_request_handler.rs
@@ -9,7 +9,7 @@ use futures::{future::try_join_all, SinkExt, TryStreamExt};
 use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
 use mc_attest_api::attest;
 use mc_attest_enclave_api::SealedClientMessage;
-use mc_common::logger::Logger;
+use mc_common::logger::{log, Logger};
 use mc_fog_api::{
     view::{FogViewRouterRequest, FogViewRouterResponse, MultiViewStoreQueryRequest},
     view_grpc::FogViewStoreApiClient,
@@ -160,6 +160,12 @@ async fn get_query_responses<E>(
 where
     E: ViewEnclaveProxy,
 {
+    log::debug!(
+        logger,
+        "get_query_responses called with {} shards",
+        shards.len()
+    );
+
     let mut query_responses: Vec<MultiViewStoreQueryResponse> = Vec::with_capacity(shards.len());
     let mut remaining_tries = RETRY_COUNT;
     while remaining_tries > 0 {
@@ -220,6 +226,12 @@ where
             remaining_tries -= 1;
         }
     }
+
+    log::debug!(
+        logger,
+        "get_query_responses returning {} responses",
+        query_responses.len()
+    );
 
     if remaining_tries == 0 {
         return Err(router_server_err_to_rpc_status(

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -45,10 +45,18 @@ pub fn process_shard_responses(
     let mut view_store_uris_for_authentication = Vec::new();
     let mut new_query_responses = Vec::new();
 
-    for (shard, response) in shards_and_responses {
+    log::debug!(
+        logger,
+        "process_shard_responses called on {} shards_and_responses",
+        shards_and_responses.len()
+    );
+
+    for (i, (shard, response)) in shards_and_responses.into_iter().enumerate() {
         if response.block_range != shard.block_range {
             return Err(RouterServerError::ViewStoreError(format!("The shard response's block range {} does not match the shard's configured block range {}.", response.block_range, shard.block_range)));
         }
+        log::debug!(logger, "Shard {} status: {:?}", i, response.status);
+
         match response.status {
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::Unknown => {
                 log::error!(

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -55,7 +55,6 @@ pub fn process_shard_responses(
         if response.block_range != shard.block_range {
             return Err(RouterServerError::ViewStoreError(format!("The shard response's block range {} does not match the shard's configured block range {}.", response.block_range, shard.block_range)));
         }
-        log::debug!(logger, "Shard {} status: {:?}", i, response.status);
 
         match response.status {
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::Unknown => {
@@ -80,7 +79,9 @@ pub fn process_shard_responses(
             }
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,
             // hasn't returned a new query response, and shouldn't be retried yet.
-            mc_fog_types::view::MultiViewStoreQueryResponseStatus::NotReady => (),
+            mc_fog_types::view::MultiViewStoreQueryResponseStatus::NotReady => {
+                log::debug!(logger, "Shard {} status NotReady", i);
+            }
         }
     }
 

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -51,7 +51,7 @@ pub fn process_shard_responses(
         shards_and_responses.len()
     );
 
-    for (_i, (shard, response)) in shards_and_responses.into_iter().enumerate() {
+    for (shard, response) in shards_and_responses {
         if response.block_range != shard.block_range {
             return Err(RouterServerError::ViewStoreError(format!("The shard response's block range {} does not match the shard's configured block range {}.", response.block_range, shard.block_range)));
         }

--- a/fog/view/server/src/shard_responses_processor.rs
+++ b/fog/view/server/src/shard_responses_processor.rs
@@ -51,7 +51,7 @@ pub fn process_shard_responses(
         shards_and_responses.len()
     );
 
-    for (i, (shard, response)) in shards_and_responses.into_iter().enumerate() {
+    for (_i, (shard, response)) in shards_and_responses.into_iter().enumerate() {
         if response.block_range != shard.block_range {
             return Err(RouterServerError::ViewStoreError(format!("The shard response's block range {} does not match the shard's configured block range {}.", response.block_range, shard.block_range)));
         }
@@ -80,7 +80,7 @@ pub fn process_shard_responses(
             // Don't do anything if the Fog View Store isn't ready. It's already authenticated,
             // hasn't returned a new query response, and shouldn't be retried yet.
             mc_fog_types::view::MultiViewStoreQueryResponseStatus::NotReady => {
-                log::debug!(logger, "Shard {} status NotReady", i);
+                log::debug!(logger, "Shard {} status NotReady", response.store_uri);
             }
         }
     }

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -237,8 +237,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_to_serve_tx_outs_not_first_shard_prevents_less_than_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
@@ -252,8 +251,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_to_serve_tx_outs_not_first_shard_allows_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 111;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 
@@ -267,8 +265,7 @@ mod epoch_sharding_strategy_tests {
     fn is_ready_to_serve_tx_outs_not_first_shard_allows_over_minimum() {
         const START_BLOCK: BlockIndex = 100;
         const END_BLOCK_EXCLUSIVE: BlockIndex = 110;
-        let epoch_block_range_length = END_BLOCK_EXCLUSIVE - START_BLOCK;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        let minimum_processed_block_count = 1;
         let epoch_block_range = BlockRange::new(START_BLOCK, END_BLOCK_EXCLUSIVE);
         let epoch_sharding_strategy = EpochShardingStrategy::new(epoch_block_range);
 

--- a/fog/view/server/src/sharding_strategy.rs
+++ b/fog/view/server/src/sharding_strategy.rs
@@ -95,11 +95,18 @@ impl EpochShardingStrategy {
             return true;
         }
 
-        let epoch_block_range_length =
-            self.epoch_block_range.end_block - self.epoch_block_range.start_block;
-        let minimum_processed_block_count = epoch_block_range_length / 2;
+        // Original logic requires/assumes a 50% overlap.
+        // This doesn't really work if the we try a minimal overlap to optimize
+        // for cost. We should revisit at some point and create
+        // alternative strategies. This logic should drive the health
+        // check endpoint that k8s can consume more than a response to
+        // the router.
+        // let epoch_block_range_length =
+        //     self.epoch_block_range.end_block -
+        // self.epoch_block_range.start_block;
+        // let minimum_processed_block_count = epoch_block_range_length / 2;
 
-        u64::from(processed_block_count) >= minimum_processed_block_count
+        u64::from(processed_block_count) >= 1
     }
 
     fn is_first_epoch(&self) -> bool {


### PR DESCRIPTION
### Motivation

View stores assumed a 50% overlap on shards and required half the shard total range to be loaded before returning data to routers. Having a full 50% overlap is resource heavy. This change will makes sure at least 1 block is loaded but will allow for smaller or no overlap configurations. 

- Add some debug logging for view router/store behavior troubleshooting.
- Change logic for returning NOT_READY or SUCCESS to router.

### Future Work

- Revisit logic for when to start serving responses to router.
- This NOT_READY/SERVING behavior should set the gRPC Health Check endpoint, which will enable/disable routing to stores on the k8s/system level. 

