### PR TITLE
Change sim signing certs to use ECDSA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -2707,6 +2709,7 @@ dependencies = [
  "mc-util-build-script",
  "mc-util-build-sgx",
  "mc-util-encodings",
+ "p256",
  "rand",
  "rand_hc",
  "serde",
@@ -6877,9 +6880,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -7821,6 +7824,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/attest/net/src/sim.rs
+++ b/attest/net/src/sim.rs
@@ -90,8 +90,10 @@ impl RaClient for SimClient {
         let entropy = OsEntropy::new();
         let mut csprng = CtrDrbg::new(Arc::new(entropy), None).expect("Could not create CtrDrbg");
 
-        let mut signer = Pk::from_private_key(IAS_SIM_SIGNING_KEY.as_bytes(), None)
-            .expect("Could not load signing key.");
+        let mut null_terminated_key = IAS_SIM_SIGNING_KEY.as_bytes().to_vec();
+        null_terminated_key.push(0);
+        let mut signer =
+            Pk::from_private_key(&null_terminated_key, None).expect("Could not load signing key.");
         let mut signature = vec![0u8; 1024];
         let bytes_signed = signer
             .sign(

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -51,6 +51,7 @@ cargo-emit = "0.2"
 chrono = "0.4"
 hex = "0.4"
 lazy_static = "1.4"
+p256 = { version = "0.13.0", default-features = false, features = ["ecdsa", "pem"] }
 rand = "0.8"
 rand_hc = "0.3"
 

--- a/attest/verifier/src/ias.rs
+++ b/attest/verifier/src/ias.rs
@@ -104,7 +104,7 @@ impl IasReportVerifier {
         // will support
         let profile = Profile::new(
             vec![HashType::Sha256, HashType::Sha384, HashType::Sha512],
-            vec![PkType::Rsa, PkType::Ecdsa],
+            vec![PkType::Rsa, PkType::Eckey, PkType::Ecdsa],
             vec![
                 EcGroupId::Curve25519,
                 EcGroupId::SecP256K1,

--- a/attest/verifier/src/lib.rs
+++ b/attest/verifier/src/lib.rs
@@ -29,7 +29,7 @@ cfg_if::cfg_if! {
         /// The build-time generated mock IAS signing certificate chain
         pub const IAS_SIM_SIGNING_CHAIN: &str = concat!(include_str!("../data/sim/chain.pem"), "\0");
         /// The build-time generated mock IAS signing private key
-        pub const IAS_SIM_SIGNING_KEY: &str = concat!(include_str!("../data/sim/signer.key"), "\0");
+        pub const IAS_SIM_SIGNING_KEY: &str = include_str!("../data/sim/signer.key");
 
         /// Whether or not enclaves should be run and validated in debug mode
         pub const DEBUG_ENCLAVE: bool = true;

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -515,6 +515,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -958,6 +960,7 @@ dependencies = [
  "mc-sgx-types",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "p256",
  "rand",
  "rand_hc",
  "serde",
@@ -1849,9 +1852,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2096,6 +2099,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -545,6 +545,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -988,6 +990,7 @@ dependencies = [
  "mc-sgx-types",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "p256",
  "rand",
  "rand_hc",
  "serde",
@@ -1971,9 +1974,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2218,6 +2221,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -539,6 +539,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -982,6 +984,7 @@ dependencies = [
  "mc-sgx-types",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "p256",
  "rand",
  "rand_hc",
  "serde",
@@ -1945,9 +1948,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2192,6 +2195,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -545,6 +545,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
  "sec1",
  "subtle",
@@ -988,6 +990,7 @@ dependencies = [
  "mc-sgx-types",
  "mc-util-build-script",
  "mc-util-build-sgx",
+ "p256",
  "rand",
  "rand_hc",
  "serde",
@@ -1983,9 +1986,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34154ec92c136238e7c210443538e64350962b8e2788cadcf5f781a6da70c36"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2230,6 +2233,7 @@ dependencies = [
  "base16ct",
  "der",
  "generic-array",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]


### PR DESCRIPTION
Previously the sim signing certificates used RSA keys. Now they use
ECDSA keys. Changing to ECDSA allows for re-use with DCAP quote signing
which happen to use ECDSA signatures
