### PR TITLE
Refactor logic for generating sim files in `mc-attest-verifier`

### DIFF
--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -111,11 +111,8 @@ fn generate_sim_files(data_path: impl AsRef<Path>) {
     let mut serial: [u8; 1] = [1u8];
 
     let now = Utc::now();
-    let end_now = now;
-    // Starting 1 hour ago
     let start_time = now - Duration::hours(1);
-    // Good for 30 days
-    let end_time = end_now + Duration::weeks(1);
+    let end_time = now + Duration::days(30);
 
     let mut csprng = RngForMbedTls {};
 

--- a/attest/verifier/build.rs
+++ b/attest/verifier/build.rs
@@ -1,18 +1,12 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-use chrono::{
-    offset::{TimeZone, Utc},
-    Datelike, Duration, Timelike,
-};
+use chrono::{offset::Utc, Datelike, Duration, Timelike};
 use core::{ptr::null_mut, slice::from_raw_parts_mut};
 use mbedtls::{
     hash::Type as HashType,
     pk::Pk,
     rng::RngCallback,
-    x509::{
-        certificate::{Builder, Certificate},
-        KeyUsage, Time,
-    },
+    x509::{certificate::Builder, KeyUsage, Time},
 };
 use mbedtls_sys::types::{
     raw_types::{c_int, c_uchar, c_void},
@@ -28,7 +22,7 @@ use rand::{RngCore, SeedableRng};
 use rand_hc::Hc128Rng;
 use std::{
     env,
-    fs::{read, remove_file, write},
+    fs::write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -72,213 +66,10 @@ impl RngCallback for RngForMbedTls {
         null_mut()
     }
 }
-fn purge_expired_cert(path: &Path) {
-    let mut bytes = match read(path) {
-        Ok(bytes) => bytes,
-        Err(_) => {
-            return;
-        }
-    };
-
-    // mbedtls says "Input must be NULL-terminated".
-    bytes.push(0);
-
-    match Certificate::from_pem_multiple(&bytes).map(|certs| {
-        let ts = certs
-            .iter()
-            .last()
-            .expect("no certs")
-            .not_after()
-            .unwrap_or_else(|e| panic!("invalid certificate expiration time: {e:?}"));
-        Utc.with_ymd_and_hms(
-            ts.year as i32,
-            ts.month as u32,
-            ts.day as u32,
-            ts.hour as u32,
-            ts.minute as u32,
-            ts.second as u32,
-        )
-        .single()
-        .unwrap_or_else(|| panic!("Invalid expiration time: {ts:?}."))
-    }) {
-        Ok(not_after) => {
-            let utc_now = Utc::now();
-
-            // If certificate expired or expires in the next 24 hours, delete it so it gets
-            // regenerated.
-            if utc_now + Duration::hours(24) > not_after {
-                remove_file(path)
-                    .unwrap_or_else(|e| panic!("failed deleting expired cert {path:?}: {e:?}"));
-            }
-        }
-        Err(_) => {
-            // Failed getting expiration date from certificate, delete it so it gets
-            // regenerated.
-            remove_file(path)
-                .unwrap_or_else(|e| panic!("failed deleting non-parseable cert {path:?}: {e:?}"));
-        }
-    }
-}
 
 fn main() {
-    // Generate simulation IAS certificates
     let base_dir = env::var("CARGO_MANIFEST_DIR").expect("Could not read manifest dir");
-    let mut data_path = PathBuf::from(base_dir);
-    data_path.push("data");
-    data_path.push("sim");
-
-    let mut root_anchor_path = data_path.clone();
-    root_anchor_path.push("root_anchor.pem");
-
-    let mut signer_key_path = data_path.clone();
-    signer_key_path.push("signer.key");
-
-    let mut chain_path = data_path;
-    chain_path.push("chain.pem");
-
-    cargo_emit::rerun_if_env_changed!("MC_SEED");
-    cargo_emit::rerun_if_changed!(root_anchor_path
-        .to_str()
-        .expect("Could not stringify root anchor path"));
-    cargo_emit::rerun_if_changed!(signer_key_path
-        .to_str()
-        .expect("Could not stringify signer key path"));
-    cargo_emit::rerun_if_changed!(chain_path
-        .to_str()
-        .expect("Could not stringify signer chain path"));
-
-    purge_expired_cert(&root_anchor_path);
-    purge_expired_cert(&chain_path);
-
-    if !(root_anchor_path.exists() && signer_key_path.exists() && chain_path.exists())
-        || env::var("MC_SEED").is_ok()
-    {
-        const ROOT_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signing CA\0";
-        const SIGNER_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signer\0";
-
-        let mut serial: [u8; 1] = [1u8];
-
-        let now = Utc::now();
-        let end_now = now;
-        // Starting 1 hour ago
-        let start_time = now - Duration::hours(1);
-        // Good for 30 days
-        let end_time = end_now + Duration::weeks(1);
-
-        let mut csprng = RngForMbedTls {};
-
-        // ROOT CERTIFICATE
-        let private_key = SigningKey::random(&mut *RNG.lock().expect("mutex poisoned"));
-        let der_private_key = private_key
-            .to_pkcs8_der()
-            .expect("Could not export privkey to DER");
-        let mut root_subject_key = Pk::from_private_key(der_private_key.as_bytes(), None)
-            .expect("Could not parse privkey from DER");
-        let mut root_issuer_key = Pk::from_private_key(der_private_key.as_bytes(), None)
-            .expect("Could not parse privkey from DER");
-        // Intermediate authority will be signed by this key.
-        let mut signer_issuer_key = Pk::from_private_key(der_private_key.as_bytes(), None)
-            .expect("Could not parse privkey from DER");
-
-        let root_not_before = Time::new(
-            u16::try_from(start_time.year()).expect("Year not a u16"),
-            u8::try_from(start_time.month()).expect("Month not a u8"),
-            u8::try_from(start_time.day()).expect("Day not a u8"),
-            u8::try_from(start_time.hour()).expect("Hour not a u8"),
-            u8::try_from(start_time.minute()).expect("Minute not a u8"),
-            u8::try_from(start_time.second()).expect("Second not a u8"),
-        )
-        .expect("Could not create a not_before time");
-        let root_not_after = Time::new(
-            u16::try_from(end_time.year()).expect("Year not a u16"),
-            u8::try_from(end_time.month()).expect("Month not a u8"),
-            u8::try_from(end_time.day()).expect("Day not a u8"),
-            u8::try_from(end_time.hour()).expect("Hour not a u8"),
-            u8::try_from(end_time.minute()).expect("Minute not a u8"),
-            u8::try_from(end_time.second()).expect("Second not a u8"),
-        )
-        .expect("Could not create a not_after time");
-
-        let mut root_builder = Builder::new();
-        let root_cert_pem = root_builder
-            .subject_with_nul(ROOT_SUBJECT)
-            .expect("Could not set subject")
-            .issuer_with_nul(ROOT_SUBJECT)
-            .expect("Could not set issuer")
-            .basic_constraints(true, Some(0))
-            .expect("Could not set basic constraints")
-            .key_usage(KeyUsage::CRL_SIGN | KeyUsage::KEY_CERT_SIGN)
-            .expect("Could not set key usage")
-            .validity(root_not_before, root_not_after)
-            .expect("Could not set time validity range")
-            .serial(&serial[..])
-            .expect("Could not set serial number")
-            .subject_key(&mut root_subject_key)
-            .issuer_key(&mut root_issuer_key)
-            .signature_hash(HashType::Sha256)
-            .write_pem_string(&mut csprng)
-            .expect("Could not create PEM string of certificate");
-        write(root_anchor_path, &root_cert_pem).expect("Unable to write root anchor");
-
-        // IAS SIGNER CERT
-        let signer_key = SigningKey::random(&mut *RNG.lock().expect("mutex poisoned"));
-        let der_signer_key = signer_key
-            .to_pkcs8_der()
-            .expect("Could not export privkey to DER");
-        write(
-            signer_key_path,
-            der_signer_key
-                .to_pem("PRIVATE KEY", LineEnding::LF)
-                .expect("Could not encode signer key to PEM"),
-        )
-        .expect("Could not write signer key PEM to file");
-
-        let mut signer_subject_key = Pk::from_private_key(der_signer_key.as_bytes(), None)
-            .expect("Could not parse privkey from DER");
-
-        let signer_not_before = Time::new(
-            u16::try_from(start_time.year()).expect("Year not a u16"),
-            u8::try_from(start_time.month()).expect("Month not a u8"),
-            u8::try_from(start_time.day()).expect("Day not a u8"),
-            u8::try_from(start_time.hour()).expect("Hour not a u8"),
-            u8::try_from(start_time.minute()).expect("Minute not a u8"),
-            u8::try_from(start_time.second()).expect("Second not a u8"),
-        )
-        .expect("Could not create a not_before time");
-        let signer_not_after = Time::new(
-            u16::try_from(end_time.year()).expect("Year not a u16"),
-            u8::try_from(end_time.month()).expect("Month not a u8"),
-            u8::try_from(end_time.day()).expect("Day not a u8"),
-            u8::try_from(end_time.hour()).expect("Hour not a u8"),
-            u8::try_from(end_time.minute()).expect("Minute not a u8"),
-            u8::try_from(end_time.second()).expect("Second not a u8"),
-        )
-        .expect("Could not create a not_after time");
-
-        serial[0] += 1;
-
-        let mut builder = Builder::new();
-        let signer_cert_pem = builder
-            .subject_with_nul(SIGNER_SUBJECT)
-            .expect("Could not set subject")
-            .issuer_with_nul(ROOT_SUBJECT)
-            .expect("Could not set issuer")
-            .basic_constraints(false, None)
-            .expect("Could not set basic constraints")
-            .key_usage(KeyUsage::DIGITAL_SIGNATURE | KeyUsage::NON_REPUDIATION)
-            .expect("Could not set key usage")
-            .validity(signer_not_before, signer_not_after)
-            .expect("Could not set time validity range")
-            .serial(&serial[..])
-            .expect("Could not set serial number")
-            .subject_key(&mut signer_subject_key)
-            .issuer_key(&mut signer_issuer_key)
-            .signature_hash(HashType::Sha256)
-            .write_pem_string(&mut csprng)
-            .expect("Could not create PEM string of certificate");
-
-        write(chain_path, root_cert_pem + &signer_cert_pem).expect("Unable to write cert chain");
-    }
+    let data_path = PathBuf::from(base_dir).join("data").join("sim");
 
     let env = Environment::default();
     let sgx = SgxEnvironment::new(&env).expect("Could not parse SGX environment");
@@ -290,4 +81,170 @@ fn main() {
     if sgx.ias_mode() == IasMode::Development {
         cargo_emit::rustc_cfg!("feature=\"ias-dev\"");
     }
+
+    if should_generating_sim_files(&data_path) {
+        generate_sim_files(&data_path);
+    }
+}
+fn generate_sim_files(data_path: impl AsRef<Path>) {
+    let data_path = data_path.as_ref();
+
+    let root_anchor_path = data_path.join("root_anchor.pem");
+    let signer_key_path = data_path.join("signer.key");
+    let chain_path = data_path.join("chain.pem");
+
+    const ROOT_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signing CA\0";
+    const SIGNER_SUBJECT: &str = "C=US,ST=CA,L=Santa Clara,O=Intel Corporation,CN=Simulation Intel SGX Attestation Report Signer\0";
+
+    let mut serial: [u8; 1] = [1u8];
+
+    let now = Utc::now();
+    let end_now = now;
+    // Starting 1 hour ago
+    let start_time = now - Duration::hours(1);
+    // Good for 30 days
+    let end_time = end_now + Duration::weeks(1);
+
+    let mut csprng = RngForMbedTls {};
+
+    // ROOT CERTIFICATE
+    let private_key = SigningKey::random(&mut *RNG.lock().expect("mutex poisoned"));
+    let der_private_key = private_key
+        .to_pkcs8_der()
+        .expect("Could not export privkey to DER");
+    let mut root_subject_key = Pk::from_private_key(der_private_key.as_bytes(), None)
+        .expect("Could not parse privkey from DER");
+    let mut root_issuer_key = Pk::from_private_key(der_private_key.as_bytes(), None)
+        .expect("Could not parse privkey from DER");
+    // Intermediate authority will be signed by this key.
+    let mut signer_issuer_key = Pk::from_private_key(der_private_key.as_bytes(), None)
+        .expect("Could not parse privkey from DER");
+
+    let root_not_before = Time::new(
+        u16::try_from(start_time.year()).expect("Year not a u16"),
+        u8::try_from(start_time.month()).expect("Month not a u8"),
+        u8::try_from(start_time.day()).expect("Day not a u8"),
+        u8::try_from(start_time.hour()).expect("Hour not a u8"),
+        u8::try_from(start_time.minute()).expect("Minute not a u8"),
+        u8::try_from(start_time.second()).expect("Second not a u8"),
+    )
+    .expect("Could not create a not_before time");
+    let root_not_after = Time::new(
+        u16::try_from(end_time.year()).expect("Year not a u16"),
+        u8::try_from(end_time.month()).expect("Month not a u8"),
+        u8::try_from(end_time.day()).expect("Day not a u8"),
+        u8::try_from(end_time.hour()).expect("Hour not a u8"),
+        u8::try_from(end_time.minute()).expect("Minute not a u8"),
+        u8::try_from(end_time.second()).expect("Second not a u8"),
+    )
+    .expect("Could not create a not_after time");
+
+    let mut root_builder = Builder::new();
+    let root_cert_pem = root_builder
+        .subject_with_nul(ROOT_SUBJECT)
+        .expect("Could not set subject")
+        .issuer_with_nul(ROOT_SUBJECT)
+        .expect("Could not set issuer")
+        .basic_constraints(true, Some(0))
+        .expect("Could not set basic constraints")
+        .key_usage(KeyUsage::CRL_SIGN | KeyUsage::KEY_CERT_SIGN)
+        .expect("Could not set key usage")
+        .validity(root_not_before, root_not_after)
+        .expect("Could not set time validity range")
+        .serial(&serial[..])
+        .expect("Could not set serial number")
+        .subject_key(&mut root_subject_key)
+        .issuer_key(&mut root_issuer_key)
+        .signature_hash(HashType::Sha256)
+        .write_pem_string(&mut csprng)
+        .expect("Could not create PEM string of certificate");
+    write(root_anchor_path, &root_cert_pem).expect("Unable to write root anchor");
+
+    // IAS SIGNER CERT
+    let signer_key = SigningKey::random(&mut *RNG.lock().expect("mutex poisoned"));
+    let der_signer_key = signer_key
+        .to_pkcs8_der()
+        .expect("Could not export privkey to DER");
+    write(
+        signer_key_path,
+        der_signer_key
+            .to_pem("PRIVATE KEY", LineEnding::LF)
+            .expect("Could not encode signer key to PEM"),
+    )
+    .expect("Could not write signer key PEM to file");
+
+    let mut signer_subject_key = Pk::from_private_key(der_signer_key.as_bytes(), None)
+        .expect("Could not parse privkey from DER");
+
+    let signer_not_before = Time::new(
+        u16::try_from(start_time.year()).expect("Year not a u16"),
+        u8::try_from(start_time.month()).expect("Month not a u8"),
+        u8::try_from(start_time.day()).expect("Day not a u8"),
+        u8::try_from(start_time.hour()).expect("Hour not a u8"),
+        u8::try_from(start_time.minute()).expect("Minute not a u8"),
+        u8::try_from(start_time.second()).expect("Second not a u8"),
+    )
+    .expect("Could not create a not_before time");
+    let signer_not_after = Time::new(
+        u16::try_from(end_time.year()).expect("Year not a u16"),
+        u8::try_from(end_time.month()).expect("Month not a u8"),
+        u8::try_from(end_time.day()).expect("Day not a u8"),
+        u8::try_from(end_time.hour()).expect("Hour not a u8"),
+        u8::try_from(end_time.minute()).expect("Minute not a u8"),
+        u8::try_from(end_time.second()).expect("Second not a u8"),
+    )
+    .expect("Could not create a not_after time");
+
+    serial[0] += 1;
+
+    let mut builder = Builder::new();
+    let signer_cert_pem = builder
+        .subject_with_nul(SIGNER_SUBJECT)
+        .expect("Could not set subject")
+        .issuer_with_nul(ROOT_SUBJECT)
+        .expect("Could not set issuer")
+        .basic_constraints(false, None)
+        .expect("Could not set basic constraints")
+        .key_usage(KeyUsage::DIGITAL_SIGNATURE | KeyUsage::NON_REPUDIATION)
+        .expect("Could not set key usage")
+        .validity(signer_not_before, signer_not_after)
+        .expect("Could not set time validity range")
+        .serial(&serial[..])
+        .expect("Could not set serial number")
+        .subject_key(&mut signer_subject_key)
+        .issuer_key(&mut signer_issuer_key)
+        .signature_hash(HashType::Sha256)
+        .write_pem_string(&mut csprng)
+        .expect("Could not create PEM string of certificate");
+
+    write(chain_path, root_cert_pem + &signer_cert_pem).expect("Unable to write cert chain");
+}
+
+/// Returns true of the build script should generate the sim files
+fn should_generating_sim_files(data_path: impl AsRef<Path>) -> bool {
+    let data_path = data_path.as_ref();
+    let signal_file = data_path.join("delete_me_to_regenerate_sim_files.empty");
+    cargo_emit::rerun_if_env_changed!("MC_SEED");
+    cargo_emit::rerun_if_changed!(signal_file.to_str().expect("Could not stringify path"));
+
+    // We use a signal file to know if this build script needs to be run again
+    // Using `rerun_if_changed` will ensure this build script runs when the
+    // signal file doesn't exist.
+    // However, the creation/updating of the signal file by this build script is
+    // itself a modification. So we only concern ourselves with the existence of
+    // the signal file.
+    if !signal_file.exists() {
+        write(&signal_file, "").expect("Could not write signal file");
+        return true;
+    }
+
+    // If we got this far we assume that the MC_SEED environment variable was
+    // changed The downside to this approach is that if the MC_SEED is set
+    // initially there will always be one incremental build:
+    // - first build the `signal_file` is created, which tells cargo to re-run this
+    //   build script
+    // - The second build will get down to here, see the MC_SEED env variable is set
+    //   and regenerate the files.
+    // - The third build cargo should skip this build script.
+    env::var("MC_SEED").is_ok()
 }

--- a/attest/verifier/data/sim/.gitignore
+++ b/attest/verifier/data/sim/.gitignore
@@ -1,3 +1,4 @@
 *.pem
 *.crt
 *.key
+*.empty

--- a/attest/verifier/data/sim/.gitignore
+++ b/attest/verifier/data/sim/.gitignore
@@ -1,4 +1,3 @@
 *.pem
 *.crt
 *.key
-*.empty


### PR DESCRIPTION
The logic for (re)generating sim files has been re-worked to make it
easier to add the generation of more sim files.

This is _smaller_ refactor to prepare for the need to generate more sim files.