### PR TITLE
Add OID extensions to simulated signing certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ dependencies = [
  "mc-sgx-dcap-types",
  "mc-sgx-types",
  "p256",
+ "x509-cert",
 ]
 
 [[package]]

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -25,5 +25,8 @@ mc-sgx-dcap-types = "0.7.4"
 mc-sgx-types = { path = "../../sgx/types" }
 p256 = { version = "0.13.0", default-features = false, features = ["ecdsa", "pem"] }
 
+[dev-dependencies]
+x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
+
 [build-dependencies]
 mc-sgx-build = { path = "../../sgx/build" }


### PR DESCRIPTION
The quote signing certificates from `mc-attest-verifier` that are
created for `sgx-sim` now provide the necessar DCAP SGX OID extensions
in the leaf certificate.