### PR TITLE
Remove "-D warnings" for development builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,3 @@
-[build]
-rustflags = ["-D", "warnings"]
-
 # Using 'cfg` is broken, see https://github.com/rust-lang/cargo/issues/6858
 # [target.'cfg(target_arch = "x86_64")']
 # rustflags = ["-D", "warnings", "-C", "target-cpu=skylake"]
@@ -8,16 +5,16 @@ rustflags = ["-D", "warnings"]
 # ...so instead we list all target triples (Tier 1 64-bit platforms)
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-pc-windows-gnu]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-apple-darwin]
-rustflags = ["-D", "warnings", "-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
 
 [cargo-new]
 name = "MobileCoin"

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -35,14 +35,14 @@ cargo install --version 1.0.9 --locked cargo-sort
 
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
-cargo clippy --all --all-features --all-targets
+cargo clippy --all --all-features --all-targets -- -D warnings
 
 for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
   cargo sort --workspace --grouped $CHECK
   cargo fmt -- --unstable-features $CHECK
-  cargo clippy --all --all-features
+  cargo clippy --all --all-features -- -D warnings
   echo "Linting in $PWD complete."
   popd >/dev/null
 done

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -246,8 +246,6 @@ impl Builder {
         cargo_builder
             .target(ENCLAVE_TARGET_TRIPLE)
             .add_rust_flags(&[
-                "-D",
-                "warnings",
                 "-C",
                 &feature_buf,
                 "--cfg",


### PR DESCRIPTION
The "-D warnings" is only enforced during clippy or lint runs. If one
pushes to CI or runs `tools/lint.sh` the warnings will show up as
errors.
