### PR TITLE
Update lint script to lint root workspace once

### DIFF
--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -35,14 +35,18 @@ cargo install --version 1.0.9 --locked cargo-sort
 
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
+cargo sort --workspace --grouped $CHECK
 cargo clippy --all --all-features --all-targets -- -D warnings
+cargo fmt -- --unstable-features $CHECK
 
-for toml in $(grep --exclude-dir cargo --exclude-dir rust-mbedtls --include=Cargo.toml -r . -e '\[workspace\]' | cut -d: -f1); do
+# Run on all the nested workspaces.
+# We exclude `cargo` paths as these are crates from `[patch.crates-io]`
+for toml in $(find . -mindepth 2 -type f -not -path '*/cargo/*' -name Cargo.toml -exec grep -l -e '\[workspace\]' {} +); do
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
   cargo sort --workspace --grouped $CHECK
-  cargo fmt -- --unstable-features $CHECK
   cargo clippy --all --all-features -- -D warnings
+  cargo fmt -- --unstable-features $CHECK
   echo "Linting in $PWD complete."
   popd >/dev/null
 done

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -36,8 +36,8 @@ cargo install --version 1.0.9 --locked cargo-sort
 # We want to check with --all-targets since it checks test code, but that flag
 # leads to build errors in enclave workspaces, so check it here.
 cargo sort --workspace --grouped $CHECK
-cargo clippy --all --all-features --all-targets -- -D warnings
 cargo fmt -- --unstable-features $CHECK
+cargo clippy --all --all-features --all-targets -- -D warnings
 
 # Run on all the nested workspaces.
 # We exclude `cargo` paths as these are crates from `[patch.crates-io]`
@@ -45,8 +45,8 @@ for toml in $(find . -mindepth 2 -type f -not -path '*/cargo/*' -name Cargo.toml
   pushd $(dirname $toml) >/dev/null
   echo "Linting in $PWD"
   cargo sort --workspace --grouped $CHECK
-  cargo clippy --all --all-features -- -D warnings
   cargo fmt -- --unstable-features $CHECK
+  cargo clippy --all --all-features -- -D warnings
   echo "Linting in $PWD complete."
   popd >/dev/null
 done


### PR DESCRIPTION
Previously clippy would run twice on the root workspace.
Now the root workspace is only linted once.

