### PR TITLE
Use a MRSIGNER identity for watcher.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6293,6 +6293,7 @@ dependencies = [
  "mc-blockchain-types",
  "mc-common",
  "mc-connection",
+ "mc-consensus-enclave-measurement",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-ledger-db",

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -21,6 +21,7 @@ mc-attest-core = { path = "../attest/core" }
 mc-blockchain-types = { path = "../blockchain/types" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }
+mc-consensus-enclave-measurement = { path = "../consensus/enclave/measurement" }
 mc-crypto-digestible = { path = "../crypto/digestible" }
 mc-crypto-keys = { path = "../crypto/keys" }
 mc-ledger-db = { path = "../ledger/db" }

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -71,12 +71,16 @@ impl NodeClient for ConsensusNodeClient {
                 AnyCredentialsProvider::Hardcoded(HardcodedCredentialsProvider::from(&node_url))
             };
 
+        // We allow any svn as we don't need to attest with the node, just store it's
+        // report.
+        let mr_signer = mc_consensus_enclave_measurement::mr_signer_identity(Some(0.into()));
+
         // Contact node and get a VerificationReport.
         let mut client = ThickClient::new(
             // TODO: Supply a chain-id to watcher?
             String::default(),
             node_url.clone(),
-            [],
+            [mr_signer],
             env,
             credentials_provider,
             logger,


### PR DESCRIPTION
Previously watcher didn't verify VerificationReports against a known
identity. This was because watcher isn't trying to securely communicate
with an enclave, it's leveraging the common attestation API to get
access to the VerificationReports. The VerificationReports are stored
for historical proof of the enclaves. The new DCAP verifier requires an
identity in order to succeed. Now the watcher will provide a MRSIGNER
identity with a 0 SVN so that any signed consensus node will succeed in
verifying, providing watcher with the verification report.
