### PR TITLE
Add UnverifiedReport state for attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,6 +6282,7 @@ dependencies = [
 name = "mc-watcher"
 version = "5.0.5"
 dependencies = [
+ "aes-gcm",
  "clap 4.3.19",
  "displaydoc",
  "futures",
@@ -6291,6 +6292,8 @@ dependencies = [
  "lmdb-rkv",
  "mc-account-keys",
  "mc-api",
+ "mc-attest-ake",
+ "mc-attest-api",
  "mc-attest-core",
  "mc-blockchain-test-utils",
  "mc-blockchain-types",
@@ -6298,8 +6301,10 @@ dependencies = [
  "mc-connection",
  "mc-crypto-digestible",
  "mc-crypto-keys",
+ "mc-crypto-noise",
  "mc-ledger-db",
  "mc-ledger-sync",
+ "mc-rand",
  "mc-util-from-random",
  "mc-util-grpc",
  "mc-util-lmdb",
@@ -6316,6 +6321,7 @@ dependencies = [
  "rayon",
  "serde",
  "serial_test",
+ "sha2 0.10.7",
  "tempfile",
  "toml 0.7.6",
  "url",

--- a/attest/ake/src/event.rs
+++ b/attest/ake/src/event.rs
@@ -284,7 +284,7 @@ impl From<AuthResponseOutput> for Vec<u8> {
 /// An authentication response is output from a responder
 impl MealyOutput for AuthResponseOutput {}
 
-/// The authentication response is combined with a verifier for the initiator.
+/// The authentication response is combined with identities for the initiator.
 pub struct AuthResponseInput {
     pub(crate) data: Vec<u8>,
     pub(crate) identities: Vec<TrustedIdentity>,
@@ -313,6 +313,27 @@ impl From<AuthResponseInput> for Vec<u8> {
 
 /// An authentication response input to a responder
 impl MealyInput for AuthResponseInput {}
+
+/// An unverified report is used when the initiator may not know the identity of
+/// the enclave.
+pub struct UnverifiedReport {
+    pub(crate) data: Vec<u8>,
+}
+
+impl UnverifiedReport {
+    pub fn new(data: AuthResponseOutput) -> Self {
+        Self { data: data.0 }
+    }
+}
+
+impl AsRef<[u8]> for UnverifiedReport {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+}
+
+/// An authentication response from a responder
+impl MealyInput for UnverifiedReport {}
 
 /// The IAS report is the final output when authentication succeeds.
 impl MealyOutput for VerificationReport {}

--- a/attest/ake/src/lib.rs
+++ b/attest/ake/src/lib.rs
@@ -24,6 +24,7 @@ pub use crate::{
     event::{
         AuthRequestOutput, AuthResponseInput, AuthResponseOutput, Ciphertext,
         ClientAuthRequestInput, ClientInitiate, NodeAuthRequestInput, NodeInitiate, Plaintext,
+        UnverifiedReport,
     },
     mealy::Transition,
     state::{AuthPending, Ready, Start},

--- a/attest/ake/src/lib.rs
+++ b/attest/ake/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::{
         UnverifiedReport,
     },
     mealy::Transition,
-    state::{AuthPending, Ready, Start},
+    state::{AuthPending, Ready, Start, Terminated},
 };
 
 #[cfg(test)]

--- a/attest/ake/src/state.rs
+++ b/attest/ake/src/state.rs
@@ -110,3 +110,10 @@ where
 }
 
 impl<Cipher> State for Ready<Cipher> where Cipher: NoiseCipher {}
+
+/// The state after an auth response has been sent by a responder/received by
+/// an initiator, but no further communication can occur. A new handshake must
+/// be created in order to continue communication.
+pub struct Terminated;
+
+impl State for Terminated {}

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -17,12 +17,15 @@ path = "src/bin/db-dump.rs"
 
 [dependencies]
 mc-api = { path = "../api" }
+mc-attest-ake = { path = "../attest/ake" }
+mc-attest-api = { path = "../attest/api" }
 mc-attest-core = { path = "../attest/core" }
 mc-blockchain-types = { path = "../blockchain/types" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }
 mc-crypto-digestible = { path = "../crypto/digestible" }
 mc-crypto-keys = { path = "../crypto/keys" }
+mc-crypto-noise = { path = "../crypto/noise" }
 mc-ledger-db = { path = "../ledger/db" }
 mc-ledger-sync = { path = "../ledger/sync" }
 mc-util-from-random = { path = "../util/from-random" }
@@ -35,6 +38,7 @@ mc-util-serial = { path = "../util/serial" }
 mc-util-uri = { path = "../util/uri" }
 mc-watcher-api = { path = "api" }
 
+aes-gcm = "0.10.2"
 clap = { version = "4.3", features = ["derive", "env"] }
 displaydoc = { version = "0.2", default-features = false }
 futures = "0.3"
@@ -42,9 +46,11 @@ grpcio = "0.12.1"
 hex = "0.4"
 lazy_static = "1.4"
 lmdb-rkv = "0.14.0"
+mc-rand = "1"
 prost = { version = "0.11", default-features = false, features = ["prost-derive"] }
 rayon = "1.7"
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+sha2 = "0.10"
 toml = "0.7"
 url = "2.4"
 


### PR DESCRIPTION
A new state `UnverifiedReport` as been added to the attest key exchange
state machine. The `UnverifiedReport` allows clients like watcher to
get the attestation report from the key exchange handshake without
requiring the report to pass verification. This is useful when the
client doesn't know or need to know the identity of the enclave.

