### PR TITLE
Use `TrustedIdentity::Any` for watcher report verification

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -19,3 +19,6 @@ rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"'
 [cargo-new]
 name = "MobileCoin"
 email = ""
+
+[patch.crates-io]
+mc-attestation-verifier = { git = "https://github.com/mobilecoinfoundation/attestation.git", rev = "31e6ff41a436a365e2030e8f36e6d4695b05a4c8" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,8 +2745,7 @@ dependencies = [
 [[package]]
 name = "mc-attestation-verifier"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdeca0948f17208a69b0bccd33f28c7f75c0053c5b13e22389d04fcbb662aaf"
+source = "git+https://github.com/mobilecoinfoundation/attestation.git?rev=31e6ff41a436a365e2030e8f36e6d4695b05a4c8#31e6ff41a436a365e2030e8f36e6d4695b05a4c8"
 dependencies = [
  "der",
  "displaydoc",
@@ -6292,6 +6291,7 @@ dependencies = [
  "mc-account-keys",
  "mc-api",
  "mc-attest-core",
+ "mc-attestation-verifier",
  "mc-blockchain-test-utils",
  "mc-blockchain-types",
  "mc-common",

--- a/attest/verifier/src/status.rs
+++ b/attest/verifier/src/status.rs
@@ -68,6 +68,8 @@ pub enum Kind {
     /// MRSIGNER/product-id/enclave-version tuple, allow select non-OK
     /// quote-status results from IAS.
     Signer(MrSignerVerifier),
+    /// Any enclave identity is allowed.
+    Any,
 }
 
 impl Kind {
@@ -82,6 +84,7 @@ impl Kind {
             Kind::Signer(v) => {
                 v.set_advisories(advisories);
             }
+            Kind::Any => {}
         }
         self
     }
@@ -92,6 +95,7 @@ impl From<&TrustedIdentity> for Kind {
         match trusted_identity {
             TrustedIdentity::MrEnclave(mr_enclave) => MrEnclaveVerifier::from(mr_enclave).into(),
             TrustedIdentity::MrSigner(mr_signer) => MrSignerVerifier::from(mr_signer).into(),
+            TrustedIdentity::Any => Kind::Any,
         }
     }
 }
@@ -113,6 +117,7 @@ impl Verify<VerificationReportData> for Kind {
         match self {
             Kind::Enclave(v) => v.verify(data),
             Kind::Signer(v) => v.verify(data),
+            Kind::Any => true,
         }
     }
 }

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -993,8 +993,7 @@ dependencies = [
 [[package]]
 name = "mc-attestation-verifier"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdeca0948f17208a69b0bccd33f28c7f75c0053c5b13e22389d04fcbb662aaf"
+source = "git+https://github.com/mobilecoinfoundation/attestation.git?rev=31e6ff41a436a365e2030e8f36e6d4695b05a4c8#31e6ff41a436a365e2030e8f36e6d4695b05a4c8"
 dependencies = [
  "der",
  "displaydoc",

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -1023,8 +1023,7 @@ dependencies = [
 [[package]]
 name = "mc-attestation-verifier"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdeca0948f17208a69b0bccd33f28c7f75c0053c5b13e22389d04fcbb662aaf"
+source = "git+https://github.com/mobilecoinfoundation/attestation.git?rev=31e6ff41a436a365e2030e8f36e6d4695b05a4c8#31e6ff41a436a365e2030e8f36e6d4695b05a4c8"
 dependencies = [
  "der",
  "displaydoc",

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -1017,8 +1017,7 @@ dependencies = [
 [[package]]
 name = "mc-attestation-verifier"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdeca0948f17208a69b0bccd33f28c7f75c0053c5b13e22389d04fcbb662aaf"
+source = "git+https://github.com/mobilecoinfoundation/attestation.git?rev=31e6ff41a436a365e2030e8f36e6d4695b05a4c8#31e6ff41a436a365e2030e8f36e6d4695b05a4c8"
 dependencies = [
  "der",
  "displaydoc",

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -1023,8 +1023,7 @@ dependencies = [
 [[package]]
 name = "mc-attestation-verifier"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdeca0948f17208a69b0bccd33f28c7f75c0053c5b13e22389d04fcbb662aaf"
+source = "git+https://github.com/mobilecoinfoundation/attestation.git?rev=31e6ff41a436a365e2030e8f36e6d4695b05a4c8#31e6ff41a436a365e2030e8f36e6d4695b05a4c8"
 dependencies = [
  "der",
  "displaydoc",

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/bin/db-dump.rs"
 [dependencies]
 mc-api = { path = "../api" }
 mc-attest-core = { path = "../attest/core" }
+mc-attestation-verifier = "0.3.1"
 mc-blockchain-types = { path = "../blockchain/types" }
 mc-common = { path = "../common", features = ["log"] }
 mc-connection = { path = "../connection" }

--- a/watcher/src/verification_reports_collector.rs
+++ b/watcher/src/verification_reports_collector.rs
@@ -5,6 +5,7 @@
 use crate::{config::SourceConfig, watcher_db::WatcherDB};
 use grpcio::Environment;
 use mc_attest_core::{VerificationReport, VerificationReportData};
+use mc_attestation_verifier::TrustedIdentity;
 use mc_common::{
     logger::{log, Logger},
     time::SystemTimeProvider,
@@ -76,7 +77,7 @@ impl NodeClient for ConsensusNodeClient {
             // TODO: Supply a chain-id to watcher?
             String::default(),
             node_url.clone(),
-            [],
+            [TrustedIdentity::Any],
             env,
             credentials_provider,
             logger,


### PR DESCRIPTION
Previously watcher used an empty trusted identities list. Now it uses a
`TrustedIdentity::Any` identity. The new DCAP verifier will fail if no
identities are provided. The `Any` identity allows one to be specific
to not verify against the enclave's identity.
