### PR TITLE
fix: (docker) download lmdb bootstrap files to same volume as destination

### DIFF
--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -112,7 +112,7 @@ jobs:
     - consensus-deploy
     runs-on: [self-hosted, Linux, small]
     steps:
-    - name: Deploy Consensus nodes
+    - name: Mobilecoind nodes
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: helm-deploy

--- a/.internal-ci/docker/Dockerfile.fog-ledger
+++ b/.internal-ci/docker/Dockerfile.fog-ledger
@@ -19,8 +19,9 @@ COPY ${RUST_BIN_PATH}/mc-ledger-migration /usr/bin/
 COPY ${RUST_BIN_PATH}/mc-util-grpc-admin-tool /usr/bin/
 
 # Entrypoint
-COPY .internal-ci/docker/entrypoints/fog-ledger.sh /usr/bin/entrypoint.sh
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+COPY .internal-ci/docker/support/ledger-download.sh /usr/local/bin/ledger-download.sh
+COPY .internal-ci/docker/entrypoints/fog-ledger.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Rust defaults
 ENV RUST_BACKTRACE="1"

--- a/.internal-ci/docker/Dockerfile.fogingest
+++ b/.internal-ci/docker/Dockerfile.fogingest
@@ -18,8 +18,9 @@ COPY ${RUST_BIN_PATH}/mc-ledger-migration /usr/bin/
 COPY ${RUST_BIN_PATH}/mc-util-grpc-admin-tool /usr/bin/
 
 # Entrypoint
-COPY .internal-ci/docker/entrypoints/fogingest.sh /usr/bin/entrypoint.sh
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+COPY .internal-ci/docker/support/ledger-download.sh /usr/local/bin/ledger-download.sh
+COPY .internal-ci/docker/entrypoints/fogingest.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Rust defaults
 ENV RUST_BACKTRACE="1"

--- a/.internal-ci/docker/Dockerfile.mobilecoind
+++ b/.internal-ci/docker/Dockerfile.mobilecoind
@@ -26,7 +26,11 @@ COPY attest/test_certs/ /var/lib/mobilecoin/attest/test_certs
 
 COPY .internal-ci/util/sample-keys.1.1.3 /util/
 COPY .internal-ci/util/generate_origin_data.sh /usr/bin/
-COPY .internal-ci/docker/entrypoints/mobilecoind.sh /usr/bin/entrypoint.sh
+
+# Entrypoint
+COPY .internal-ci/docker/support/ledger-download.sh /usr/local/bin/ledger-download.sh
+COPY .internal-ci/docker/entrypoints/mobilecoind.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/bin/local/entrypoint.sh"]
 
 # Rust defaults
 ENV RUST_BACKTRACE="1"
@@ -46,7 +50,6 @@ EXPOSE 3229
 # JSON Client
 EXPOSE 9090
 
-# Entrypoint
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
+
 
 CMD ["/usr/bin/supervisord"]

--- a/.internal-ci/docker/Dockerfile.mobilecoind
+++ b/.internal-ci/docker/Dockerfile.mobilecoind
@@ -30,7 +30,7 @@ COPY .internal-ci/util/generate_origin_data.sh /usr/bin/
 # Entrypoint
 COPY .internal-ci/docker/support/ledger-download.sh /usr/local/bin/ledger-download.sh
 COPY .internal-ci/docker/entrypoints/mobilecoind.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/bin/local/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Rust defaults
 ENV RUST_BACKTRACE="1"
@@ -43,13 +43,12 @@ ARG MOBILECOIND_DB_DIR="/var/lib/mobilecoin/mobilecoind_db"
 ENV NODE_LEDGER_DIR=${NODE_LEDGER_DIR}
 ENV MOBILECOIND_DB_DIR=${MOBILECOIND_DB_DIR}
 ENV MC_FOG_INGEST_ENCLAVE_CSS="/enclaves/libingest-enclave.css"
+ENV MC_LEDGER_DB_MIGRATE="true"
 
 # Default Ports
 # GRPC Client
 EXPOSE 3229
 # JSON Client
 EXPOSE 9090
-
-
 
 CMD ["/usr/bin/supervisord"]

--- a/.internal-ci/docker/entrypoints/fog-ledger.sh
+++ b/.internal-ci/docker/entrypoints/fog-ledger.sh
@@ -4,39 +4,6 @@
 
 set -eo pipefail
 
-data="/fog-data"
-
-if [[ -n "${MC_LEDGER_DB_URL}" ]]
-then
-    ### CBB: these should use ENV vars for configuration.
-    #   Need to fix .internal-ci/helm/mc-core-common-config/templates/mobilecoind-supervisord-mobilecoind-configmap.yaml
-
-    echo "MC_LEDGER_DB_URL set, restoring ${data}/ledger/data.mdb from backup"
-    if [[ -f "${data}/ledger/data.mdb" ]]
-    then
-        echo "Found existing ledger database, skipping download"
-    else
-        echo "Downloading ledger data.mdb"
-        mkdir -p /tmp/ledger
-        curl -L "${MC_LEDGER_DB_URL}" -o "/tmp/ledger/data.mdb"
-        mkdir -p "${data}/ledger"
-        mv /tmp/ledger/data.mdb ${data}/ledger/data.mdb
-    fi
-fi
-
-if [[ -n "${MC_WATCHER_DB_URL}" ]]
-then
-    echo "MC_WATCHER_DB_URL set, restoring ${data}/watcher/data.mdb from backup"
-    if [[ -f "${data}/watcher/data.mdb" ]]
-    then
-        echo "Found existing watcher database, skipping download"
-    else
-        echo "Downloading watcher data.mdb"
-        mkdir -p /tmp/watcher
-        curl -L "${MC_WATCHER_DB_URL}" -o "/tmp/watcher/data.mdb"
-        mkdir -p "${data}/watcher"
-        mv /tmp/watcher/data.mdb ${data}/watcher/data.mdb
-    fi
-fi
+/usr/local/bin/ledger-download.sh /fog-data
 
 exec "$@"

--- a/.internal-ci/docker/entrypoints/fogingest.sh
+++ b/.internal-ci/docker/entrypoints/fogingest.sh
@@ -4,39 +4,6 @@
 
 set -eo pipefail
 
-data="/fog-data"
-
-if [[ -n "${MC_LEDGER_DB_URL}" ]]
-then
-    ### CBB: these should use ENV vars for configuration.
-    #   Need to fix .internal-ci/helm/mc-core-common-config/templates/mobilecoind-supervisord-mobilecoind-configmap.yaml
-
-    echo "MC_LEDGER_DB_URL set, restoring ${data}/ledger/data.mdb from backup"
-    if [[ -f "${data}/ledger/data.mdb" ]]
-    then
-        echo "Found existing ledger database, skipping download"
-    else
-        echo "Downloading ledger data.mdb"
-        mkdir -p /tmp/ledger
-        curl -L "${MC_LEDGER_DB_URL}" -o "/tmp/ledger/data.mdb"
-        mkdir -p "${data}/ledger"
-        mv /tmp/ledger/data.mdb ${data}/ledger/data.mdb
-    fi
-fi
-
-if [[ -n "${MC_WATCHER_DB_URL}" ]]
-then
-    echo "MC_WATCHER_DB_URL set, restoring ${data}/watcher/data.mdb from backup"
-    if [[ -f "${data}/watcher/data.mdb" ]]
-    then
-        echo "Found existing watcher database, skipping download"
-    else
-        echo "Downloading watcher data.mdb"
-        mkdir -p /tmp/watcher
-        curl -L "${MC_WATCHER_DB_URL}" -o "/tmp/watcher/data.mdb"
-        mkdir -p "${data}/watcher"
-        mv /tmp/watcher/data.mdb ${data}/watcher/data.mdb
-    fi
-fi
+/usr/local/bin/ledger-download.sh /fog-data
 
 exec "$@"

--- a/.internal-ci/docker/entrypoints/mobilecoind.sh
+++ b/.internal-ci/docker/entrypoints/mobilecoind.sh
@@ -9,40 +9,6 @@ then
     generate_origin_data.sh
 fi
 
-data="/data"
-
-if [[ -n "${MC_LEDGER_DB_URL}" ]]
-then
-    ### CBB: these should use ENV vars for configuration.
-    #   Need to fix .internal-ci/helm/mc-core-common-config/templates/mobilecoind-supervisord-mobilecoind-configmap.yaml
-
-    echo "MC_LEDGER_DB_URL set, restoring ${data}/ledger/data.mdb from backup"
-    if [[ -f "${data}/ledger/data.mdb" ]]
-    then
-        echo "Found existing ledger database, skipping download"
-    else
-        echo "Downloading ledger data.mdb"
-        mkdir -p /tmp/ledger
-        curl -L "${MC_LEDGER_DB_URL}" -o "/tmp/ledger/data.mdb"
-        mkdir -p "${data}/ledger"
-        mv /tmp/ledger/data.mdb ${data}/ledger/data.mdb
-    fi
-fi
-
-if [[ -n "${MC_WATCHER_DB_URL}" ]]
-then
-    echo "MC_WATCHER_DB_URL set, restoring ${data}/watcher/data.mdb from backup"
-    if [[ -f "${data}/watcher/data.mdb" ]]
-    then
-        echo "Found existing watcher database, skipping download"
-    else
-        echo "Downloading watcher data.mdb"
-        mkdir -p /tmp/watcher
-
-        curl -L "${MC_WATCHER_DB_URL}" -o "/tmp/watcher/data.mdb"
-        mkdir -p "${data}/watcher"
-        mv /tmp/watcher/data.mdb ${data}/watcher/data.mdb
-    fi
-fi
+/usr/local/bin/ledger-download.sh /data
 
 exec "$@"

--- a/.internal-ci/docker/support/ledger-download.sh
+++ b/.internal-ci/docker/support/ledger-download.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+data="${1}"
+
+if [[ -n "${MC_LEDGER_DB_URL}" ]]
+then
+    echo "MC_LEDGER_DB_URL set, restoring ${data}/ledger/data.mdb from backup"
+    if [[ -f "${data}/ledger/data.mdb" ]]
+    then
+        echo "Found existing ledger database, skipping download"
+    else
+        echo "Downloading ledger data.mdb"
+        mkdir -p "${data}/tmp-ledger"
+        curl -L "${MC_LEDGER_DB_URL}" -o "${data}/tmp-ledger/data.mdb"
+        mkdir -p "${data}/ledger"
+        mv "${data}/tmp-ledger/data.mdb" "${data}/ledger/data.mdb"
+    fi
+fi
+
+if [[ -n "${MC_WATCHER_DB_URL}" ]]
+then
+    echo "MC_WATCHER_DB_URL set, restoring ${data}/watcher/data.mdb from backup"
+    if [[ -f "${data}/watcher/data.mdb" ]]
+    then
+        echo "Found existing watcher database, skipping download"
+    else
+        echo "Downloading watcher data.mdb"
+        mkdir -p "${data}/tmp-watcher"
+        curl -L "${MC_WATCHER_DB_URL}" -o "${data}/tmp-watcher/data.mdb"
+        mkdir -p "${data}/watcher"
+        mv "${data}/tmp-watcher/data.mdb" "${data}/watcher/data.mdb"
+    fi
+fi

--- a/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
+++ b/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:
-      {{- tpl (toYaml .Values.mobilecoind.initContainers) . | nindent 6 }}
+      {{- toYaml .Values.mobilecoind.initContainers | nindent 6 }}
       containers:
       - name: mobilecoind
         image: '{{ .Values.mobilecoind.image.org | default .Values.image.org }}/{{ .Values.mobilecoind.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}'

--- a/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
+++ b/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- include "mobilecoind.labels" . | nindent 8 }}
     spec:
       nodeSelector:
-        {{- toYaml .Values.mobilecoindNodeSelector | nindent 8 }}
+        {{- toYaml .Values.mobilecoind.nodeSelector | nindent 8 }}
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:

--- a/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
+++ b/.internal-ci/helm/mobilecoind/templates/mobilecoind-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
       {{- toYaml .Values.imagePullSecrets | nindent 6 }}
       initContainers:
-      {{- toYaml .Values.mobilecoind.initContainers | nindent 6 }}
+        {{- toYaml .Values.mobilecoind.initContainers | nindent 8 }}
       containers:
       - name: mobilecoind
         image: '{{ .Values.mobilecoind.image.org | default .Values.image.org }}/{{ .Values.mobilecoind.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}'

--- a/.internal-ci/helm/mobilecoind/values.yaml
+++ b/.internal-ci/helm/mobilecoind/values.yaml
@@ -43,7 +43,7 @@ mobilecoind:
     # MC_LEDGER_DB_URL: ''
     # MC_WATCHER_DB_URL: ''
 
-  initContainers: {}
+  initContainers: []
 
   nodeSelector: {}
 

--- a/.internal-ci/helm/mobilecoind/values.yaml
+++ b/.internal-ci/helm/mobilecoind/values.yaml
@@ -38,37 +38,12 @@ mobilecoind:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 
-  # TODO: enable persistence, need a pvc
-  # persistence:
-  #   enabled: false
-  #   spec:
-  #     storageClassName: fast
-  #     accessModes:
-  #     - ReadWriteOnce
-  #     resources:
-  #       requests:
-  #         storage: 128Gi
-
   configMap: {}
     # Bootstrap ledger/watcher db from public bucket
     # MC_LEDGER_DB_URL: ''
     # MC_WATCHER_DB_URL: ''
 
-  initContainers:
-  - name: migrate-ledger
-    image: '{{ .Values.mobilecoind.image.org | default .Values.image.org }}/{{ .Values.mobilecoind.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
-    imagePullPolicy: IfNotPresent
-    command: [ "/bin/bash" ]
-    args:
-    - -c
-    - |
-      set -x
-      if [ -f /mobilecoin/ledger/data.mdb ]; then
-        /usr/bin/mc-ledger-migration --ledger-db /data/ledger
-      fi
-    volumeMounts:
-    - name: data
-      mountPath: /data
+  initContainers: {}
 
   nodeSelector: {}
 


### PR DESCRIPTION
### Motivation

We download the lmdb database from block storage to a temporary location so we don't end up with a corrupted database in case the start up process is interrupted.  The problem is moving the files from /tmp to the data volume was taking longer than the original curl. 

Download to the same volume/filesystem, then the `mv` is just changing pointers rather than transferring GBs of data.

Bonus:
- consolidate logic into 1 script used by the 3 containers. 
- clean up paths for external installed binaries. 

