### PR TITLE
Add health check for ledger enclave

### DIFF
--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -5,7 +5,7 @@ use std::env;
 use clap::Parser;
 use mc_attest_net::{Client, RaClient};
 use mc_common::logger::log;
-use mc_fog_ledger_enclave::{LedgerSgxEnclave, ENCLAVE_FILE};
+use mc_fog_ledger_enclave::{LedgerEnclave, LedgerSgxEnclave, ENCLAVE_FILE};
 use mc_fog_ledger_server::{LedgerRouterConfig, LedgerRouterServer};
 use mc_ledger_db::LedgerDB;
 use mc_watcher::watcher_db::WatcherDB;
@@ -53,11 +53,21 @@ fn main() {
         WatcherDB::open_ro(&config.watcher_db, logger.clone()).expect("Could not open watcher DB");
 
     let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
-    let mut router_server =
-        LedgerRouterServer::new(config, enclave, ias_client, ledger_db, watcher_db, logger);
+    let mut router_server = LedgerRouterServer::new(
+        config,
+        enclave.clone(),
+        ias_client,
+        ledger_db,
+        watcher_db,
+        logger.clone(),
+    );
     router_server.start();
 
     loop {
         std::thread::sleep(std::time::Duration::from_millis(1000));
+        if enclave.get_identity().is_err() {
+            mc_common::logger::log::crit!(logger, "get_identity call to ledger enclave failed. Enclave may not be running or is not in a healthy state.");
+            panic!("Panicking to restart enclave");
+        }
     }
 }


### PR DESCRIPTION
* Use regular `get_identity` calls to monitor health of Fog Ledger enclave

### Motivation

There is an issue that is likely in the enclave code that is causing the enclave to crash in rare cases. This should be fixed, but when this crash happens, the enclave never recovers. This PR adds a simple check to ensure the enclave is running and makes sure it gets restarted if it isn't. While the root cause of the issue is also important, it is very rare and difficult to re-create. The fact that there is no recovery from this is also a problem. This PR fixes the fact that there is no recovery from the enclave either crashing completely or not being in a healthy state.

### Future Work

Monitor network logs for this error. Figure out what the cause of this particular crash is and fix it.
