### PR TITLE
Add `EnclaveReportDataContents` to `DcapEvidence`

### DIFF
--- a/attest/untrusted/src/sim.rs
+++ b/attest/untrusted/src/sim.rs
@@ -286,9 +286,15 @@ mod test {
         let report = Report::default();
         let quote = SimQuotingEnclave::quote_report(&report).expect("Failed to create quote");
         let collateral = SimQuotingEnclave::collateral(&quote);
+        let report_data = EnclaveReportDataContents::new(
+            [0x42u8; 16].into(),
+            [0x11u8; 32].as_slice().try_into().expect("bad key"),
+            [0xAAu8; 32],
+        );
         let mut uut = DcapEvidence {
             quote: Some(quote),
             collateral: Some(collateral),
+            report_data: Some(report_data),
         };
         uut.encode(&mut buf).expect("Failed to encode DcapEvidence");
         let decoded = DcapEvidence::decode(buf.as_slice()).expect("Failed to decode DcapEvidence");

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -30,7 +30,12 @@ const TAG_DCAP_EVIDENCE_QUOTE3: u32 = 1;
 const TAG_DCAP_EVIDENCE_COLLATERAL: u32 = 2;
 const TAG_DCAP_EVIDENCE_REPORT_DATA: u32 = 3;
 
-// Quote3 and Collateral cannot trivially be made to implement prost::Message.
+// Quote3 and Collateral cannot trivially be made to implement prost::Message:
+//    - Quote3 is a already an opaque byte array which implements serde. Prost
+//      isn't brought in to mc-sgx-dcap-types to minimize dependencies.
+//    - Collateral is composed of X509-cert types which do not implement
+//      prost::Message.
+//
 // Since they implement serde Serialize and Deserialize though, we can manually
 // implement it for DcapEvidence. To do this, we use serde to serialize and
 // deserialize them to/from Vec<u8>

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -23,10 +23,12 @@ use sha2::{Digest, Sha256};
 pub struct DcapEvidence {
     pub quote: Option<Quote3<Vec<u8>>>,
     pub collateral: Option<Collateral>,
+    pub report_data: Option<EnclaveReportDataContents>,
 }
 
 const TAG_DCAP_EVIDENCE_QUOTE3: u32 = 1;
 const TAG_DCAP_EVIDENCE_COLLATERAL: u32 = 2;
+const TAG_DCAP_EVIDENCE_REPORT_DATA: u32 = 3;
 
 // Quote3 and Collateral cannot trivially be made to implement prost::Message.
 // Since they implement serde Serialize and Deserialize though, we can manually
@@ -44,6 +46,9 @@ impl Message for DcapEvidence {
         let collateral_bytes: Vec<u8> =
             mc_util_serial::serialize(&self.collateral).expect("Failed to serialize Collateral");
         encoding::bytes::encode(TAG_DCAP_EVIDENCE_COLLATERAL, &collateral_bytes, buf);
+        let report_data_bytes: Vec<u8> = mc_util_serial::serialize(&self.report_data)
+            .expect("Failed to serialize EnclaveReportDataContents");
+        encoding::bytes::encode(TAG_DCAP_EVIDENCE_REPORT_DATA, &report_data_bytes, buf);
     }
 
     fn merge_field<B>(
@@ -77,6 +82,18 @@ impl Message for DcapEvidence {
                 self.collateral = collateral;
                 Ok(())
             }
+            TAG_DCAP_EVIDENCE_REPORT_DATA => {
+                let mut vbuf = Vec::new();
+                encoding::bytes::merge(wire_type, &mut vbuf, buf, ctx)?;
+                let report_data: Option<EnclaveReportDataContents> =
+                    mc_util_serial::deserialize(vbuf.as_slice()).map_err(|_| {
+                        DecodeError::new(
+                            "Failed to deserialize EnclaveReportDataContents from bytes",
+                        )
+                    })?;
+                self.report_data = report_data;
+                Ok(())
+            }
             _ => encoding::skip_field(wire_type, tag, buf, ctx),
         }
     }
@@ -86,9 +103,12 @@ impl Message for DcapEvidence {
             mc_util_serial::serialize(&self.quote).expect("Failed serializing Quote3");
         let collateral_bytes: Vec<u8> =
             mc_util_serial::serialize(&self.collateral).expect("Failed serializing Collateral");
+        let report_data_bytes: Vec<u8> = mc_util_serial::serialize(&self.report_data)
+            .expect("Failed serializing EnclaveReportDataContents");
 
         encoding::bytes::encoded_len(TAG_DCAP_EVIDENCE_QUOTE3, &quote_bytes)
             + encoding::bytes::encoded_len(TAG_DCAP_EVIDENCE_COLLATERAL, &collateral_bytes)
+            + encoding::bytes::encoded_len(TAG_DCAP_EVIDENCE_REPORT_DATA, &report_data_bytes)
     }
 
     fn clear(&mut self) {


### PR DESCRIPTION
The `DcapEvidence` now contains a member `report_data`, which holds
`EnclaveReportDataContents`. This allows the `DcapEvidence` to provide
the report data used by clients for things like public key identities.
