### PR TITLE
node_hw.sh

### DIFF
--- a/.internal-ci/docker/entrypoints/node_hw.sh
+++ b/.internal-ci/docker/entrypoints/node_hw.sh
@@ -143,7 +143,6 @@ then
     then
         echo "Existing database found at ${MC_LEDGER_PATH}/data.mdb"
         echo "Migrating ledger to latest version"
-        cp /ledger/data.mdb "/ledger/data.mdb.$(date +%y%m%d-%H%M%S)"
         /usr/bin/mc-ledger-migration --ledger-db "${MC_LEDGER_PATH}"
     else
         # Try to find origin block from s3 archive - preserve existing data, testnet/mainnet


### PR DESCRIPTION
### Motivation

The backup process of the `/ledger/data.mdb` file is well-intended (backup happens before running an `mc-ledger-migration`) but adds about 8 minutes to the node startup.  The ledger migration itself is very stable, and in a worst-case scenario (corruption, failure, etc), we can remove the `/ledger/data.mdb` file, restart the node, and the node will rebuild its own ledger (with its own signatures) from its own S3 bucket.

This PR removes the backup process of that file.

### Future Work

* Investigate if there IS a way to backup the `/ledger/data.mdb` file out-of-process and without blocking startup.