### PR TITLE
Add `Digestible` impl to `EnclaveReportDataContents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,6 +2504,7 @@ dependencies = [
  "mc-crypto-ring-signature-signer",
  "mc-crypto-x509-test-vectors",
  "mc-fog-report-validation-test-utils",
+ "mc-sgx-core-types",
  "mc-test-vectors-b58-encodings",
  "mc-transaction-builder",
  "mc-transaction-core",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,6 +28,7 @@ mc-watcher-api = { path = "../watcher/api" }
 bs58 = "0.4.0"
 crc = "3.0.0"
 displaydoc = { version = "0.2", default-features = false }
+mc-sgx-core-types = "0.7.5"
 protobuf = "2.27.1"
 
 curve25519-dalek = { version = "4.0.0-rc.1", default-features = false }

--- a/api/proto/external.proto
+++ b/api/proto/external.proto
@@ -393,6 +393,23 @@ message Receipt {
     };
 }
 
+/// Structure for holding the contents of the Enclave's Report Data.
+/// The Enclave Quote's ReportData member contains a SHA256 hash of this
+/// structure's contents.
+message EnclaveReportDataContents {
+    /// The nonce used for generating the quote.
+    /// Must be exactly 16 bytes long (see mc-sgx-core-types::QuoteNonce).
+    bytes nonce = 1;
+
+    /// The public key of the enclave, it's an x25519 key.
+    /// Must be exactly 32 bytes long.
+    bytes key = 2;
+
+    /// An optional custom identity of the enclave.
+    /// Must be exactly 32 bytes long.
+    bytes custom_identity = 3;
+}
+
 /// The signature over an IAS JSON reponse, created by Intel
 message VerificationSignature {
     bytes contents = 1;

--- a/api/src/convert/enclave_report_data_contents.rs
+++ b/api/src/convert/enclave_report_data_contents.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2023 The MobileCoin Foundation
+
+//! Convert to/from external::EnclaveReportDataContents
+
+use crate::{external, ConversionError};
+use mc_attest_verifier_types::EnclaveReportDataContents;
+use mc_crypto_keys::X25519Public;
+use mc_sgx_core_types::QuoteNonce;
+
+impl From<&EnclaveReportDataContents> for external::EnclaveReportDataContents {
+    fn from(src: &EnclaveReportDataContents) -> Self {
+        let mut dst = Self::new();
+
+        dst.set_nonce(<QuoteNonce as AsRef<[u8]>>::as_ref(src.nonce()).to_vec());
+        dst.set_key(<X25519Public as AsRef<[u8]>>::as_ref(src.key()).to_vec());
+        if let Some(custom_identity) = src.custom_identity() {
+            dst.set_custom_identity(custom_identity.to_vec());
+        }
+        dst
+    }
+}
+
+impl TryFrom<&external::EnclaveReportDataContents> for EnclaveReportDataContents {
+    type Error = ConversionError;
+    fn try_from(src: &external::EnclaveReportDataContents) -> Result<Self, Self::Error> {
+        let nonce: QuoteNonce = src
+            .get_nonce()
+            .try_into()
+            .map_err(|_| ConversionError::InvalidContents)?;
+        let key: X25519Public = src.get_key().try_into()?;
+        let custom_identity_bytes = src.get_custom_identity().to_vec();
+        let custom_identity = if custom_identity_bytes.is_empty() {
+            None
+        } else {
+            Some(
+                custom_identity_bytes
+                    .try_into()
+                    .map_err(|_| ConversionError::InvalidContents)?,
+            )
+        };
+        Ok(EnclaveReportDataContents::new(nonce, key, custom_identity))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prost_to_proto_roundtrip() {
+        let report_data = EnclaveReportDataContents::new(
+            [0x32u8; 16].into(),
+            [0x77u8; 32].as_slice().try_into().expect("bad key"),
+            [0xCCu8; 32],
+        );
+
+        let proto_report_data = external::EnclaveReportDataContents::from(&report_data);
+        let prost_report_data =
+            EnclaveReportDataContents::try_from(&proto_report_data).expect("failed to convert");
+
+        assert_eq!(report_data, prost_report_data);
+    }
+
+    #[test]
+    fn prost_to_proto_roundtrip_no_custom_id() {
+        let report_data = EnclaveReportDataContents::new(
+            [0x32u8; 16].into(),
+            [0x77u8; 32].as_slice().try_into().expect("bad key"),
+            None,
+        );
+
+        let proto_report_data = external::EnclaveReportDataContents::from(&report_data);
+        let prost_report_data =
+            EnclaveReportDataContents::try_from(&proto_report_data).expect("failed to convert");
+
+        assert_eq!(report_data, prost_report_data);
+    }
+}

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -23,6 +23,7 @@ mod compressed_ristretto;
 mod curve_scalar;
 mod ed25519_multisig;
 mod ed25519_signature;
+mod enclave_report_data_contents;
 mod input_ring;
 mod input_secret;
 mod key_image;

--- a/attest/verifier/src/dcap.rs
+++ b/attest/verifier/src/dcap.rs
@@ -140,8 +140,14 @@ impl VerificationMessage<ReportData> for ReportDataHashVerifier {
             writeln!(f, "{:pad$}  {line}", "")?;
         }
 
-        let hex = HexFmt(self.report_data.custom_identity());
-        writeln!(f, "{:pad$}- Custom identity: {hex:X}", "")?;
+        write!(f, "{:pad$}- Custom identity: ", "")?;
+        match self.report_data.custom_identity() {
+            Some(value) => {
+                let hex = HexFmt(value);
+                writeln!(f, "{hex:X}")?
+            }
+            None => writeln!(f, "<None>")?,
+        }
 
         self.report_data_verifier.fmt_padded(f, pad, result)
     }

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -6,7 +6,7 @@ use alloc::{string::String, vec::Vec};
 use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
 use core::fmt::{Debug, Display};
 use hex_fmt::{HexFmt, HexList};
-use mc_crypto_digestible::Digestible;
+use mc_crypto_digestible::{DigestTranscript, Digestible};
 use mc_crypto_keys::X25519Public;
 use mc_sgx_core_types::QuoteNonce;
 use mc_sgx_dcap_types::{Collateral, Quote3};
@@ -39,6 +39,8 @@ const TAG_DCAP_EVIDENCE_REPORT_DATA: u32 = 3;
 // Since they implement serde Serialize and Deserialize though, we can manually
 // implement it for DcapEvidence. To do this, we use serde to serialize and
 // deserialize them to/from Vec<u8>
+// This is implementation is tested in `attest/untrusted/src/sim.rs` as the
+// quote and collateral are not trivial to construct.
 impl Message for DcapEvidence {
     fn encode_raw<B>(&self, buf: &mut B)
     where
@@ -270,13 +272,13 @@ impl Message for VerificationSignature {
 }
 
 /// Structure for holding the contents of the Enclave's Report Data.
-/// The Enclave's ReportData member contains a SHA256 hash of this structure's
-/// contents.
+/// The Enclave Quote's ReportData member contains a SHA256 hash of this
+/// structure's contents.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct EnclaveReportDataContents {
     nonce: QuoteNonce,
     key: X25519Public,
-    custom_identity: [u8; 32],
+    custom_identity: Option<[u8; 32]>,
 }
 
 impl EnclaveReportDataContents {
@@ -290,11 +292,15 @@ impl EnclaveReportDataContents {
     /// * `custom_identity` - The custom identity of the enclave. Previously
     ///   this was bytes 32..64 of the enclave's
     ///   [`ReportData`](mc-sgx-core-types::ReportData).
-    pub fn new(nonce: QuoteNonce, key: X25519Public, custom_identity: [u8; 32]) -> Self {
+    pub fn new(
+        nonce: QuoteNonce,
+        key: X25519Public,
+        custom_identity: impl Into<Option<[u8; 32]>>,
+    ) -> Self {
         Self {
             nonce,
             key,
-            custom_identity,
+            custom_identity: custom_identity.into(),
         }
     }
 
@@ -309,8 +315,8 @@ impl EnclaveReportDataContents {
     }
 
     ///  Get the custom identity
-    pub fn custom_identity(&self) -> &[u8; 32] {
-        &self.custom_identity
+    pub fn custom_identity(&self) -> Option<&[u8; 32]> {
+        self.custom_identity.as_ref()
     }
 
     /// Returns a SHA256 hash of the contents of this structure.
@@ -321,8 +327,31 @@ impl EnclaveReportDataContents {
         let mut hasher = Sha256::new();
         hasher.update(&self.nonce);
         hasher.update(&self.key);
-        hasher.update(self.custom_identity);
+        if let Some(custom_identity) = &self.custom_identity {
+            hasher.update(custom_identity);
+        }
         hasher.finalize().into()
+    }
+}
+
+impl Digestible for EnclaveReportDataContents {
+    fn append_to_transcript<DT: DigestTranscript>(
+        &self,
+        context: &'static [u8],
+        transcript: &mut DT,
+    ) {
+        let typename = b"EnclaveReportDataContents";
+        transcript.append_agg_header(context, typename);
+        transcript.append_primitive(
+            context,
+            b"nonce",
+            <QuoteNonce as AsRef<[u8]>>::as_ref(&self.nonce),
+        );
+        self.key.append_to_transcript(context, transcript);
+        if let Some(custom_identity) = &self.custom_identity {
+            custom_identity.append_to_transcript(context, transcript);
+        }
+        transcript.append_agg_closer(context, typename);
     }
 }
 
@@ -330,6 +359,7 @@ impl EnclaveReportDataContents {
 mod tests {
     use super::*;
     use alloc::{format, vec};
+    use mc_crypto_digestible::MerlinTranscript;
 
     #[test]
     fn test_signature_debug() {
@@ -347,6 +377,74 @@ mod tests {
         assert_eq!(
             format!("{}", &report),
             "VerificationReport { sig: deadbeefcafe, chain: [abcd, cdef, 1234], http_body: \"some_body\" }"
+        );
+    }
+
+    #[test]
+    fn enclave_report_data_contents_digest() {
+        let nonce: QuoteNonce = [0x1u8; 16].into();
+        let key_bytes = [0x22u8; 32];
+        let key: X25519Public = key_bytes.as_slice().try_into().expect("bad key");
+        let custom_identity = [0x33u8; 32];
+        let report_data_1 =
+            EnclaveReportDataContents::new(nonce.clone(), key.clone(), custom_identity);
+
+        let report_data_2 =
+            EnclaveReportDataContents::new(nonce.clone(), key.clone(), custom_identity);
+
+        let digest_1 = report_data_1.digest32::<MerlinTranscript>(b"");
+        let digest_2 = report_data_2.digest32::<MerlinTranscript>(b"");
+        assert_eq!(digest_1, digest_2);
+
+        let mut modified_nonce = nonce.clone();
+        let nonce_bytes: &mut [u8] = modified_nonce.as_mut();
+        nonce_bytes[0] += 1;
+        let modified_nonce_report_data =
+            EnclaveReportDataContents::new(modified_nonce, key.clone(), custom_identity);
+
+        let modified_nonce_digest = modified_nonce_report_data.digest32::<MerlinTranscript>(b"");
+        assert_ne!(digest_1, modified_nonce_digest);
+
+        let mut modified_key_bytes = key_bytes;
+        modified_key_bytes[0] += 1;
+        let modified_key_report_data = EnclaveReportDataContents::new(
+            nonce.clone(),
+            modified_key_bytes.as_slice().try_into().expect("bad key"),
+            custom_identity,
+        );
+
+        let modified_key_digest = modified_key_report_data.digest32::<MerlinTranscript>(b"");
+        assert_ne!(digest_1, modified_key_digest);
+
+        let mut modified_custom_identity = custom_identity;
+        modified_custom_identity[0] += 1;
+        let modified_custom_identity_report_data =
+            EnclaveReportDataContents::new(nonce, key, modified_custom_identity);
+
+        let modified_custom_identity_digest =
+            modified_custom_identity_report_data.digest32::<MerlinTranscript>(b"");
+        assert_ne!(digest_1, modified_custom_identity_digest);
+    }
+
+    #[test]
+    fn enclave_report_data_contents_digest_without_custom_id() {
+        let nonce: QuoteNonce = [0x2u8; 16].into();
+        let key_bytes = [0x33u8; 32];
+        let key: X25519Public = key_bytes.as_slice().try_into().expect("bad key");
+        let zeroed_custom_identity = [0x0u8; 32];
+        let report_data_without_custom_id =
+            EnclaveReportDataContents::new(nonce.clone(), key.clone(), None);
+
+        let report_data_with_zeroed_custom_id =
+            EnclaveReportDataContents::new(nonce, key, zeroed_custom_identity);
+
+        let no_custom_id_digest = report_data_without_custom_id.digest32::<MerlinTranscript>(b"");
+        let zeroed_custom_id_digest =
+            report_data_with_zeroed_custom_id.digest32::<MerlinTranscript>(b"");
+        assert_ne!(no_custom_id_digest, zeroed_custom_id_digest);
+        assert_ne!(
+            report_data_without_custom_id.sha256(),
+            report_data_with_zeroed_custom_id.sha256()
         );
     }
 }

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -99,7 +99,7 @@ impl ReportableEnclave for ConsensusServiceMockEnclave {
         let report_data = EnclaveReportDataContents::new(
             Default::default(),
             [0u8; 32].as_slice().try_into().expect("bad key"),
-            Default::default(),
+            None,
         );
         Ok((Report::default(), report_data))
     }

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -654,8 +654,10 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let report_data_bytes: &mut [u8] = report_data.as_mut();
         let identity_bytes: &[u8] = report_contents.key().as_ref();
         report_data_bytes[..identity_bytes.len()].copy_from_slice(identity_bytes);
-        report_data_bytes[identity_bytes.len()..]
-            .copy_from_slice(report_contents.custom_identity());
+        if let Some(id) = report_contents.custom_identity() {
+            report_data_bytes[identity_bytes.len()..identity_bytes.len() + id.len()]
+                .copy_from_slice(id);
+        }
 
         // Actually get the EREPORT
         let report = Report::new(Some(&qe_info), Some(&report_data))?;

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -47,7 +47,7 @@ impl ReportableEnclave for MockEnclave {
         let report_data = EnclaveReportDataContents::new(
             Default::default(),
             [0u8; 32].as_slice().try_into().expect("bad key"),
-            Default::default(),
+            None,
         );
         Ok((Report::default(), report_data))
     }


### PR DESCRIPTION
The `EnclaveReportDataContents` is a member of `DcapEvidence` which will
need to be part of `BlockMetadataContents` which derives `Digestible`.
In order to support this future need a `Digestible` implementation has
been added to the `EnclaveReportDataContents`.

Also add `EnclaveReportDataContents` to the external protobufs. To
accomodate the need of it being part of the `BlockMetadataContents` in
the protobufs.

