### PR TITLE
Panic on Enclave Fatal Error

### DIFF
--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -64,7 +64,7 @@ pub fn make_variable_length_ecall(
             },
             status if is_fatal_sgx_status(status) => {
                 panic!(
-                    "Enclave reported fatal error: ecall returned {:?}. Panicking to restart.",
+                    "Enclave reported fatal error: ecall returned {:?}",
                     result
                 );
             }

--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -56,7 +56,7 @@ pub fn make_variable_length_ecall(
                 }
                 other_retval if is_fatal_sgx_status(other_retval) => {
                     panic!(
-                        "Enclave reported fatal error: ecall retval: {:?}. Panicking to restart.",
+                        "Enclave reported fatal error: ecall retval: {:?}",
                         retval
                     );
                 }

--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -63,10 +63,7 @@ pub fn make_variable_length_ecall(
                 other_retval => break (Err(other_retval)),
             },
             status if is_fatal_sgx_status(status) => {
-                panic!(
-                    "Enclave reported fatal error: ecall returned {:?}",
-                    status
-                );
+                panic!("Enclave reported fatal error: ecall returned {:?}", status);
             }
             status => break Err(status),
         }

--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -35,8 +35,8 @@ pub fn make_variable_length_ecall(
         }
 
         let mut outbuf = vec![0u8; outbuf_used];
-        match unsafe {
-            ecall_fcn(
+        unsafe {
+            let result = ecall_fcn(
                 eid,
                 &mut retval,
                 inbuf.as_ptr(),
@@ -44,18 +44,36 @@ pub fn make_variable_length_ecall(
                 outbuf.as_mut_ptr(),
                 outbuf.len(),
                 &mut outbuf_used,
-                &mut outbuf_retry_id,
-            )
-        } {
-            sgx_status_t::SGX_SUCCESS => match retval {
-                sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => continue,
-                sgx_status_t::SGX_SUCCESS => {
-                    outbuf.truncate(outbuf_used);
-                    break Ok(outbuf);
+                &mut outbuf_retry_id
+            );
+            match result {
+                sgx_status_t::SGX_SUCCESS => match retval {
+                    sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => continue,
+                    sgx_status_t::SGX_SUCCESS => {
+                        outbuf.truncate(outbuf_used);
+                        break Ok(outbuf);
+                    },
+                    // Fatal runtime errors
+                    sgx_status_t::SGX_ERROR_INVALID_FUNCTION |
+                        sgx_status_t::SGX_ERROR_OUT_OF_TCS |
+                        sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED |
+                        sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED |
+                        sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED |
+                        sgx_status_t::SGX_ERROR_STACK_OVERRUN => {
+                        panic!("Enclave reported fatal error: ecall retval: {:?}. Panicking to restart.", retval);
+                    },
+                    other_retval => break (Err(other_retval)),
+                },
+                sgx_status_t::SGX_ERROR_INVALID_FUNCTION |
+                    sgx_status_t::SGX_ERROR_OUT_OF_TCS |
+                    sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED |
+                    sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED |
+                    sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED |
+                    sgx_status_t::SGX_ERROR_STACK_OVERRUN => {
+                    panic!("Enclave reported fatal error: ecall returned {:?}. Panicking to restart.", result);
                 }
-                other_retval => break (Err(other_retval)),
-            },
-            status => break Err(status),
+                status => break Err(status),
+            }
         }
     }
 }

--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -35,8 +35,8 @@ pub fn make_variable_length_ecall(
         }
 
         let mut outbuf = vec![0u8; outbuf_used];
-        unsafe {
-            let result = ecall_fcn(
+        let result = unsafe {
+            ecall_fcn(
                 eid,
                 &mut retval,
                 inbuf.as_ptr(),
@@ -44,36 +44,44 @@ pub fn make_variable_length_ecall(
                 outbuf.as_mut_ptr(),
                 outbuf.len(),
                 &mut outbuf_used,
-                &mut outbuf_retry_id
+                &mut outbuf_retry_id,
+            )
+        };
+        if is_fatal_sgx_status(retval) {
+            panic!(
+                "Enclave reported fatal error: ecall retval: {:?}. Panicking to restart.",
+                retval
             );
-            match result {
-                sgx_status_t::SGX_SUCCESS => match retval {
-                    sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => continue,
-                    sgx_status_t::SGX_SUCCESS => {
-                        outbuf.truncate(outbuf_used);
-                        break Ok(outbuf);
-                    },
-                    // Fatal runtime errors
-                    sgx_status_t::SGX_ERROR_INVALID_FUNCTION |
-                        sgx_status_t::SGX_ERROR_OUT_OF_TCS |
-                        sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED |
-                        sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED |
-                        sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED |
-                        sgx_status_t::SGX_ERROR_STACK_OVERRUN => {
-                        panic!("Enclave reported fatal error: ecall retval: {:?}. Panicking to restart.", retval);
-                    },
-                    other_retval => break (Err(other_retval)),
-                },
-                sgx_status_t::SGX_ERROR_INVALID_FUNCTION |
-                    sgx_status_t::SGX_ERROR_OUT_OF_TCS |
-                    sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED |
-                    sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED |
-                    sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED |
-                    sgx_status_t::SGX_ERROR_STACK_OVERRUN => {
-                    panic!("Enclave reported fatal error: ecall returned {:?}. Panicking to restart.", result);
-                }
-                status => break Err(status),
-            }
         }
+        if is_fatal_sgx_status(result) {
+            panic!(
+                "Enclave reported fatal error: ecall returned {:?}. Panicking to restart.",
+                result
+            );
+        }
+        match result {
+            sgx_status_t::SGX_SUCCESS => match retval {
+                sgx_status_t::SGX_ERROR_OUT_OF_MEMORY => continue,
+                sgx_status_t::SGX_SUCCESS => {
+                    outbuf.truncate(outbuf_used);
+                    break Ok(outbuf);
+                }
+                other_retval => break (Err(other_retval)),
+            },
+            status => break Err(status),
+        }
+    }
+}
+
+fn is_fatal_sgx_status(status: sgx_status_t) -> bool {
+    match status {
+        // SGX Fatal runtime errors
+        sgx_status_t::SGX_ERROR_INVALID_FUNCTION
+        | sgx_status_t::SGX_ERROR_OUT_OF_TCS
+        | sgx_status_t::SGX_ERROR_ENCLAVE_CRASHED
+        | sgx_status_t::SGX_ERROR_ECALL_NOT_ALLOWED
+        | sgx_status_t::SGX_ERROR_OCALL_NOT_ALLOWED
+        | sgx_status_t::SGX_ERROR_STACK_OVERRUN => true,
+        _ => false,
     }
 }

--- a/enclave-boundary/src/untrusted.rs
+++ b/enclave-boundary/src/untrusted.rs
@@ -57,7 +57,7 @@ pub fn make_variable_length_ecall(
                 other_retval if is_fatal_sgx_status(other_retval) => {
                     panic!(
                         "Enclave reported fatal error: ecall retval: {:?}",
-                        retval
+                        other_retval
                     );
                 }
                 other_retval => break (Err(other_retval)),
@@ -65,7 +65,7 @@ pub fn make_variable_length_ecall(
             status if is_fatal_sgx_status(status) => {
                 panic!(
                     "Enclave reported fatal error: ecall returned {:?}",
-                    result
+                    status
                 );
             }
             status => break Err(status),

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -53,14 +53,8 @@ fn main() {
         WatcherDB::open_ro(&config.watcher_db, logger.clone()).expect("Could not open watcher DB");
 
     let ias_client = Client::new(&config.ias_api_key).expect("Could not create IAS client");
-    let mut router_server = LedgerRouterServer::new(
-        config,
-        enclave.clone(),
-        ias_client,
-        ledger_db,
-        watcher_db,
-        logger.clone(),
-    );
+    let mut router_server =
+        LedgerRouterServer::new(config, enclave, ias_client, ledger_db, watcher_db, logger);
     router_server.start();
 
     loop {

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -5,7 +5,7 @@ use std::env;
 use clap::Parser;
 use mc_attest_net::{Client, RaClient};
 use mc_common::logger::log;
-use mc_fog_ledger_enclave::{LedgerEnclave, LedgerSgxEnclave, ENCLAVE_FILE};
+use mc_fog_ledger_enclave::{LedgerSgxEnclave, ENCLAVE_FILE};
 use mc_fog_ledger_server::{LedgerRouterConfig, LedgerRouterServer};
 use mc_ledger_db::LedgerDB;
 use mc_watcher::watcher_db::WatcherDB;
@@ -65,9 +65,5 @@ fn main() {
 
     loop {
         std::thread::sleep(std::time::Duration::from_millis(1000));
-        if enclave.get_identity().is_err() {
-            mc_common::logger::log::crit!(logger, "get_identity call to ledger enclave failed. Enclave may not be running or is not in a healthy state.");
-            panic!("Panicking to restart enclave");
-        }
     }
 }


### PR DESCRIPTION
* Removed ledger enclave check
* Added check for result of enclave calls to panic on all fatal errors

### Motivation

Any time an enclave encounters a non-recoverable error, panic the untrusted code to force a restart.
