### PR TITLE
Rename instances of `ias_report` to `attestation_evidence`

### DIFF
--- a/attest/ake/src/error.rs
+++ b/attest/ake/src/error.rs
@@ -20,12 +20,12 @@ pub enum Error {
     EarlyHandshakeComplete,
     /// Handshake should have been completed
     HandshakeNotComplete,
-    /// The IAS report could not be serialized
-    ReportSerialization,
-    /// The IAS report could not be deserialized
-    ReportDeserialization,
-    /// The IAS report could not be verified: {0}
-    ReportVerification(VerifierError),
+    /// The attestation evidence could not be serialized
+    AttestationEvidenceSerialization,
+    /// The attestation evidence could not be deserialized
+    AttestationEvidenceDeserialization,
+    /// The attestation evidence could not be verified: {0}
+    AttestationEvidenceVerification(VerifierError),
     /// The remote identity was not in a format that fit within report data
     BadRemoteIdentity,
     /// Invariant problem: we completed a handshake without a remote identity
@@ -40,6 +40,6 @@ pub enum Error {
 
 impl From<VerifierError> for Error {
     fn from(src: VerifierError) -> Error {
-        Error::ReportVerification(src)
+        Error::AttestationEvidenceVerification(src)
     }
 }

--- a/attest/ake/src/initiator.rs
+++ b/attest/ake/src/initiator.rs
@@ -161,7 +161,7 @@ where
             HandshakeStatus::InProgress(_state) => Err(Error::HandshakeNotComplete),
             HandshakeStatus::Complete(result) => {
                 let remote_report = VerificationReport::decode(output.payload.as_slice())
-                    .map_err(|_e| Error::ReportDeserialization)?;
+                    .map_err(|_e| Error::AttestationEvidenceDeserialization)?;
 
                 let identities = input.identities;
                 let mut verifier = Verifier::default();
@@ -220,7 +220,7 @@ where
             HandshakeStatus::InProgress(_state) => Err(Error::HandshakeNotComplete),
             HandshakeStatus::Complete(_) => {
                 let remote_report = VerificationReport::decode(output.payload.as_slice())
-                    .map_err(|_e| Error::ReportDeserialization)?;
+                    .map_err(|_e| Error::AttestationEvidenceDeserialization)?;
 
                 Ok((Terminated, remote_report))
             }

--- a/attest/ake/src/lib.rs
+++ b/attest/ake/src/lib.rs
@@ -71,7 +71,7 @@ mod test {
 
         // Sign the forged quote with the sim client
         let ra_client = Client::new("").expect("Could not create sim client");
-        let ias_report = ra_client
+        let attestation_evidence = ra_client
             .verify_quote(&quote, None)
             .expect("Could not sign our bogus report");
 
@@ -91,8 +91,10 @@ mod test {
         let initiator = Start::new(RESPONDER_ID_STR.into());
         let responder = Start::new(RESPONDER_ID_STR.into());
 
-        let node_init =
-            NodeInitiate::<X25519, Aes256Gcm, Sha512>::new(identity.clone(), ias_report.clone());
+        let node_init = NodeInitiate::<X25519, Aes256Gcm, Sha512>::new(
+            identity.clone(),
+            attestation_evidence.clone(),
+        );
         let (initiator, auth_request_output) = initiator
             .try_next(&mut csprng, node_init)
             .expect("Initiator could not be initiated");
@@ -102,7 +104,7 @@ mod test {
         let auth_request_input = NodeAuthRequestInput::new(
             auth_request_output,
             identity,
-            ias_report,
+            attestation_evidence,
             identities.clone(),
         );
         let (responder, auth_response_output) = responder

--- a/attest/ake/src/responder.rs
+++ b/attest/ake/src/responder.rs
@@ -146,7 +146,7 @@ where
 
         // Parse the received IAS report
         let remote_report = VerificationReport::decode(payload.as_slice())
-            .map_err(|_| Error::ReportDeserialization)?;
+            .map_err(|_| Error::AttestationEvidenceDeserialization)?;
         // Verify using given verifier, and ensure the first 32B of the report data are
         // the identity pubkey.
         verifier

--- a/attest/api/README.md
+++ b/attest/api/README.md
@@ -6,11 +6,11 @@ This crate provides two API methods, `Auth`, and `Call`, which are more extensiv
 
 ## Auth
 
-This method takes an `AuthRequest` structure, which contains the DER serialized ephemeral public key of the initiator and the algorithm selection, and a transcript hash. It returns an `AuthResponse` structure, which contains the DER-serialized ephemeral public key of the responder, the next step of the transcript hash, and an encrypted blob containing the server's DER-encoded static, public-identity key, an updated transcript hash (including the identity key), and a second, inner cipher text containing the server's cached IAS verification report.
+This method takes an `AuthRequest` structure, which contains the DER serialized ephemeral public key of the initiator and the algorithm selection, and a transcript hash. It returns an `AuthResponse` structure, which contains the DER-serialized ephemeral public key of the responder, the next step of the transcript hash, and an encrypted blob containing the server's DER-encoded static, public-identity key, an updated transcript hash (including the identity key), and a second, inner cipher text containing the server's cached attestation evidence.
 
 ## Call
 
-This method has different behavior depending on the context. In all cases it will use the outer, plaintext transcript from `AuthResponse` as the session_id, and an encrypted payload. The first encrypted message after an `Auth` call will contain the client's DER-encoded, static, public-identity key, an updated transcript, and an inner ciphertext containing either a cryptonote transaction (when called from a client), or a cached IAS verification report and forwarded transaction (when called from another node)
+This method has different behavior depending on the context. In all cases it will use the outer, plaintext transcript from `AuthResponse` as the session_id, and an encrypted payload. The first encrypted message after an `Auth` call will contain the client's DER-encoded, static, public-identity key, an updated transcript, and an inner ciphertext containing either a cryptonote transaction (when called from a client), or a cached attestation evidence and forwarded transaction (when called from another node)
 
 The next request to the Call method should contain only the encrypted transaction.
 

--- a/attest/core/README.md
+++ b/attest/core/README.md
@@ -13,7 +13,7 @@ This crate exists to support remote attestation via Intel SGX, albeit on a lower
 There are several compile-time features which change the behavior of this crate, as well as the API compatibility:
 
  * `std` - Enables the Rust standard library (this should not be used when built for an enclave).
- * `sgx-sim` - Selects the fake IAS signing certificates generated at build time as the default verification certificates, and link against the `_sim.so` variants provided by Intel. Because this is dangerous, and should only be used during testing, a warning will be printed indicated what libraries are being linked.
+ * `sgx-sim` - Selects the fake signing certificates generated at build time as the default verification certificates, and link against the `_sim.so` variants provided by Intel. Because this is dangerous, and should only be used during testing, a warning will be printed indicated what libraries are being linked.
 
 ## Usage
 

--- a/attest/enclave-api/src/error.rs
+++ b/attest/enclave-api/src/error.rs
@@ -38,14 +38,15 @@ pub enum Error {
      * There was an error while handling a nonce: {0}
      *
      * This can represent a significant programming bug in the nonce
-     * generation or report parsing code, or a simple mismatch.
+     * generation or attestation evidence parsing code, or a simple
+     * mismatch.
      */
     Nonce(NonceError),
 
     /// The local quote could not be verified: {0}
     Quote(QuoteError),
 
-    /// The local report could not be verified: {0}
+    /// The local attestation evidence could not be verified: {0}
     Verify(VerifierError),
 
     /// Another thread crashed while holding a lock
@@ -61,15 +62,15 @@ pub enum Error {
      * Invalid state for call
      *
      * This indicates a bug in the calling code, typically attempting to
-     * re-submit an already-verified quote or IAS report.
+     * re-submit an already-verified quote or attestation evidence.
      */
     InvalidState,
 
-    /// No IAS report has been verified yet
-    NoReportAvailable,
+    /// No attestation evidence has been verified yet
+    NoAttestationEvidenceAvailable,
 
-    /// Too many IAS reports are already in-flight
-    TooManyPendingReports,
+    /// Too many attestation evidence instances are already in-flight
+    TooManyPendingAttestationEvidences,
 
     /// Encoding error
     Encode(String),

--- a/attest/enclave-api/src/error.rs
+++ b/attest/enclave-api/src/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     NoAttestationEvidenceAvailable,
 
     /// Too many attestation evidence instances are already in-flight
-    TooManyPendingAttestationEvidences,
+    TooManyPendingAttestationEvidenceInstances,
 
     /// Encoding error
     Encode(String),

--- a/attest/untrusted/README.md
+++ b/attest/untrusted/README.md
@@ -23,4 +23,4 @@ In particular, `Frobnication` will be stuffed into a `Call::Frobnicate(Frobnicat
 
 ## Traits
 
-At the moment, we have two traits: `ReportableEnclave`, which provides a way for the untrusted code to seed the IAS `VerificationReport` cache using the structures in `attest`, and `PeerableEnclave`, which is intended to support the node-to-node attestation via the gRPC API defined in `attest_api`. We anticipate adding a `BlockEnclave` to support the APIs needed by the SCP externalization phase, and an additional `ClientEnclave` to support client connectivity using the same gRPC API defined in `attest_api` (albeit on a different port).
+At the moment, we have two traits: `ReportableEnclave`, which provides a way for the untrusted code to seed the attestation evidence cache using the structures in `attest`, and `PeerableEnclave`, which is intended to support the node-to-node attestation via the gRPC API defined in `attest_api`. We anticipate adding a `BlockEnclave` to support the APIs needed by the SCP externalization phase, and an additional `ClientEnclave` to support client connectivity using the same gRPC API defined in `attest_api` (albeit on a different port).

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -123,7 +123,7 @@ impl AttestationError for ThickClientAttestationError {
     fn should_retry(&self) -> bool {
         match self {
             Self::Grpc(_) | Self::Cipher(_) | Self::CredentialsProvider(_) => true,
-            Self::Ake(AkeError::ReportVerification(_)) => false,
+            Self::Ake(AkeError::AttestationEvidenceVerification(_)) => false,
             Self::Ake(_) => true,
             Self::InvalidResponderID(_, _) | Self::UriConversionError(_) => false,
         }

--- a/connection/src/traits.rs
+++ b/connection/src/traits.rs
@@ -33,9 +33,10 @@ pub trait AttestationError: Debug + Display + Send + Sync {
     fn should_reattest(&self) -> bool;
 
     /// Should the error be retried?
-    /// Some errors like, failing to verify IAS report, are not retriable, since
-    /// report verification is deterministic and the report will probably not be
-    /// different the next time.
+    /// Some errors like, failing to verify attestation evidence, are not
+    /// retriable, since attestation evidence verification is deterministic
+    /// and the attestation evidence will probably not be different the next
+    /// time.
     fn should_retry(&self) -> bool;
 }
 

--- a/consensus/enclave/api/README.md
+++ b/consensus/enclave/api/README.md
@@ -23,4 +23,4 @@ In particular, `Frobnication` will be stuffed into a `Call::Frobnicate(Frobnicat
 
 ## Traits
 
-At the moment, we have two traits: `ReportableEnclave`, which provides a way for the untrusted code to seed the IAS `VerificationReport` cache using the structures in `attest`, and `PeerableEnclave`, which is intended to support the node-to-node attestation via the gRPC API defined in `attest_api`. We anticipate adding a `BlockEnclave` to support the APIs needed by the SCP externalization phase, and an additional `ClientEnclave` to support client connectivity using the same gRPC API defined in `attest_api` (albeit on a different port).
+At the moment, we have two traits: `ReportableEnclave`, which provides a way for the untrusted code to seed the attestation evidence cache using the structures in `attest`, and `PeerableEnclave`, which is intended to support the node-to-node attestation via the gRPC API defined in `attest_api`. We anticipate adding a `BlockEnclave` to support the APIs needed by the SCP externalization phase, and an additional `ClientEnclave` to support client connectivity using the same gRPC API defined in `attest_api` (albeit on a different port).

--- a/consensus/enclave/api/src/messages.rs
+++ b/consensus/enclave/api/src/messages.rs
@@ -93,18 +93,18 @@ pub enum EnclaveCall {
     /// * Caches the quote.
     VerifyQuote(Quote, Report, EnclaveReportDataContents),
 
-    /// The [ConsensusEnclave::verify_ias_report()] method.
+    /// The [ConsensusEnclave::verify_attestation_evidence()] method.
     ///
-    /// * Verifies the signed report from IAS matches the previously received
+    /// * Verifies the attestation evidence matches the previously received
     ///   quote,
-    /// * Caches the signed report. This cached report may be overwritten by
-    ///   later calls.
-    VerifyReport(VerificationReport),
+    /// * Caches the attestation evidence. This cached report may be overwritten
+    ///   by later calls.
+    VerifyAttestationEvidence(VerificationReport),
 
-    /// The [ConsensusEnclave::get_ias_report()] method.
+    /// The [ConsensusEnclave::get_attestation_evidence()] method.
     ///
     /// Retrieves a previously cached report, if any.
-    GetReport,
+    GetAttestationEvidence,
 
     /// The [ConsensusEnclave::client_tx_propose()] method.
     ///

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -122,7 +122,7 @@ pub struct TxList {
 pub struct SgxConsensusEnclave {
     /// All AKE and attestation related state including responder ids,
     /// established channels for peers and clients, and any pending quotes
-    /// or ias reports.
+    /// or attestation evidence.
     ake: AkeEnclaveState<Ed25519Identity>,
 
     /// Cipher used to encrypt locally-cached transactions.
@@ -445,13 +445,16 @@ impl ReportableEnclave for SgxConsensusEnclave {
         Ok(self.ake.verify_quote(quote, qe_report, &report_data)?)
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        self.ake.verify_ias_report(ias_report)?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        self.ake.verify_attestation_evidence(attestation_evidence)?;
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        Ok(self.ake.get_ias_report()?)
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        Ok(self.ake.get_attestation_evidence()?)
     }
 }
 

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -113,11 +113,14 @@ impl ReportableEnclave for ConsensusServiceMockEnclave {
         Ok(IasNonce::default())
     }
 
-    fn verify_ias_report(&self, _ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
+    fn verify_attestation_evidence(
+        &self,
+        _attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
         Ok(self.verification_report.clone())
     }
 }

--- a/consensus/enclave/mock/src/mock_consensus_enclave.rs
+++ b/consensus/enclave/mock/src/mock_consensus_enclave.rs
@@ -94,9 +94,9 @@ mock! {
 
         fn verify_quote(&self, quote: Quote, qe_report: Report, report_data: EnclaveReportDataContents) -> SgxReportResult<IasNonce>;
 
-        fn verify_ias_report(&self, ias_report: VerificationReport) -> SgxReportResult<()>;
+        fn verify_attestation_evidence(&self, attestation_evidence: VerificationReport) -> SgxReportResult<()>;
 
-        fn get_ias_report(&self) -> SgxReportResult<VerificationReport>;
+        fn get_attestation_evidence(&self) -> SgxReportResult<VerificationReport>;
     }
 }
 

--- a/consensus/enclave/src/lib.rs
+++ b/consensus/enclave/src/lib.rs
@@ -114,14 +114,19 @@ impl ReportableEnclave for ConsensusServiceSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyReport(ias_report))?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyAttestationEvidence(
+            attestation_evidence,
+        ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetReport)?;
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetAttestationEvidence)?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -64,8 +64,10 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::VerifyQuote(quote, qe_report, report_data) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report, report_data))
         }
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
-        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
+        EnclaveCall::VerifyAttestationEvidence(attestation_evidence) => {
+            serialize(&ENCLAVE.verify_attestation_evidence(attestation_evidence))
+        }
+        EnclaveCall::GetAttestationEvidence => serialize(&ENCLAVE.get_attestation_evidence()),
         // Transactions
         EnclaveCall::ClientTxPropose(msg) => serialize(&ENCLAVE.client_tx_propose(msg)),
         EnclaveCall::PeerTxPropose(msg) => serialize(&ENCLAVE.peer_tx_propose(msg)),

--- a/consensus/service/src/byzantine_ledger/metadata_provider.rs
+++ b/consensus/service/src/byzantine_ledger/metadata_provider.rs
@@ -35,7 +35,10 @@ impl<E: ReportableEnclave> ConsensusMetadataProvider<E> {
 
 impl<E: ReportableEnclave> BlockMetadataProvider for ConsensusMetadataProvider<E> {
     fn get_metadata(&self, block_data: &BlockData) -> Option<BlockMetadata> {
-        let verification_report = self.enclave.get_ias_report().expect("failed to get AVR");
+        let verification_report = self
+            .enclave
+            .get_attestation_evidence()
+            .expect("failed to get AVR");
         let contents = BlockMetadataContents::new(
             block_data.block().id.clone(),
             self.quorum_set.clone(),

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -880,9 +880,14 @@ impl<
     }
 
     fn get_block_metadata(&self, block_id: &BlockID) -> BlockMetadata {
-        let verification_report = self.enclave.get_ias_report().unwrap_or_else(|err| {
-            panic!("Failed to fetch verification report after forming block {block_id:?}: {err}")
-        });
+        let verification_report = self
+            .enclave
+            .get_attestation_evidence()
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Failed to fetch attestation evidence after forming block {block_id:?}: {err}"
+                )
+            });
         let contents = BlockMetadataContents::new(
             block_id.clone(),
             self.scp_node.quorum_set(),
@@ -1607,7 +1612,7 @@ mod tests {
             broadcast,
         ) = get_mocks(&local_node_id, &quorum_set, n_blocks);
         let enclave = ConsensusServiceMockEnclave::default();
-        let report = enclave.get_ias_report().unwrap();
+        let report = enclave.get_attestation_evidence().unwrap();
 
         let tx_manager = TxManagerImpl::new(
             enclave.clone(),

--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -31,7 +31,7 @@ impl AttestationError for Error {
     fn should_retry(&self) -> bool {
         match self {
             Error::Rpc(_) | Error::Cipher(_) | Error::ProtoDecode(_) => true,
-            Error::Ake(AkeError::ReportVerification(_)) => false,
+            Error::Ake(AkeError::AttestationEvidenceVerification(_)) => false,
             Error::Ake(_) => true,
             Error::InvalidUri(_) => false,
         }

--- a/fog/enclave_connection/src/lib.rs
+++ b/fog/enclave_connection/src/lib.rs
@@ -60,7 +60,7 @@ pub struct EnclaveConnection<U: ConnectionUri, G: EnclaveGrpcChannel> {
     grpc: G,
     /// The AKE state machine object, if one is available.
     attest_cipher: Option<Ready<Aes256Gcm>>,
-    /// The identities that a fog node's IAS report must match, one of
+    /// The identities that a fog node's attestation evidence must match, one of
     identities: Vec<TrustedIdentity>,
     /// Credentials to use for all GRPC calls (this allows authentication
     /// username/password to go through, if provided).

--- a/fog/ingest/enclave/api/src/error.rs
+++ b/fog/ingest/enclave/api/src/error.rs
@@ -78,7 +78,7 @@ pub enum Error {
     NoAttestationEvidenceAvailable,
 
     /// Too many attestation evidence instances are already in-flight
-    TooManyAttestationEvidences,
+    TooManyPendingAttestationEvidenceInstances,
 
     /// Error parsing key: {0}
     Key(KeyError),

--- a/fog/ingest/enclave/api/src/error.rs
+++ b/fog/ingest/enclave/api/src/error.rs
@@ -71,14 +71,14 @@ pub enum Error {
     /// The method call was not valid for the state machine for the data.
     //
     // This indicates a bug in the calling code, typically attempting to
-    // re-submit an already-verified quote or IAS report.
+    // re-submit an already-verified quote or attestation evidence.
     InvalidState,
 
-    /// No IAS report has been verified yet
-    NoReportAvailable,
+    /// No attestation evidence has been verified yet
+    NoAttestationEvidenceAvailable,
 
-    /// Too many IAS reports are already in-flight
-    TooManyPendingReports,
+    /// Too many attestation evidence instances are already in-flight
+    TooManyAttestationEvidences,
 
     /// Error parsing key: {0}
     Key(KeyError),

--- a/fog/ingest/enclave/api/src/messages.rs
+++ b/fog/ingest/enclave/api/src/messages.rs
@@ -85,18 +85,18 @@ pub enum EnclaveCall {
     /// * Caches the quote.
     VerifyQuote(Quote, Report, EnclaveReportDataContents),
 
-    /// The [IngestEnclave::verify_ias_report()] method.
+    /// The [IngestEnclave::verify_attestation_evidence()] method.
     ///
-    /// * Verifies the signed report from IAS matches the previously received
+    /// * Verifies the attestation evidence matches the previously received
     ///   quote,
-    /// * Caches the signed report. This cached report may be overwritten by
-    ///   later calls.
-    VerifyReport(VerificationReport),
+    /// * Caches the attestation evidence. This cached attestation evidence may
+    ///   be overwritten by later calls.
+    VerifyAttestationEvidence(VerificationReport),
 
-    /// The [IngestEnclave::get_ias_report()] method.
+    /// The [IngestEnclave::get_attestation_evidence()] method.
     ///
-    /// Retrieves a previously cached report, if any.
-    GetReport,
+    /// Retrieves a previously cached attestation evidence, if any.
+    GetAttestationEvidence,
 
     /// The [IngestEnclave::peer_init()] method.
     PeerInit(ResponderId),

--- a/fog/ingest/enclave/impl/src/identity.rs
+++ b/fog/ingest/enclave/impl/src/identity.rs
@@ -31,7 +31,7 @@ impl RistrettoIdentity {
 }
 
 impl EnclaveIdentity for RistrettoIdentity {
-    /// Get the bytes for the IAS report
+    /// Get the bytes for the attestation evidence
     fn get_bytes_for_report(&self) -> [u8; 32] {
         self.get_public_key().to_bytes()
     }

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -192,13 +192,16 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> ReportableEnclav
         Ok(self.ake.verify_quote(quote, qe_report, &report_data)?)
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        self.ake.verify_ias_report(ias_report)?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        self.ake.verify_attestation_evidence(attestation_evidence)?;
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        Ok(self.ake.get_ias_report()?)
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        Ok(self.ake.get_attestation_evidence()?)
     }
 }
 

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -161,14 +161,19 @@ impl ReportableEnclave for IngestSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyReport(ias_report))?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyAttestationEvidence(
+            attestation_evidence,
+        ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetReport)?;
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetAttestationEvidence)?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/ingest/enclave/trusted/src/lib.rs
+++ b/fog/ingest/enclave/trusted/src/lib.rs
@@ -57,8 +57,10 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::VerifyQuote(quote, qe_report, report_data) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report, report_data))
         }
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
-        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
+        EnclaveCall::VerifyAttestationEvidence(attestation_evidence) => {
+            serialize(&ENCLAVE.verify_attestation_evidence(attestation_evidence))
+        }
+        EnclaveCall::GetAttestationEvidence => serialize(&ENCLAVE.get_attestation_evidence()),
         EnclaveCall::PeerInit(peer_id) => serialize(&ENCLAVE.peer_init(&peer_id)),
         EnclaveCall::PeerAccept(req) => serialize(&ENCLAVE.peer_accept(req)),
         EnclaveCall::PeerConnect(peer_id, msg) => serialize(&ENCLAVE.peer_connect(&peer_id, msg)),

--- a/fog/ingest/report/src/lib.rs
+++ b/fog/ingest/report/src/lib.rs
@@ -7,21 +7,21 @@ use mc_attest_verifier::{Error as VerifierError, Verifier};
 use mc_crypto_keys::{KeyError, RistrettoPublic};
 use mc_util_encodings::Error as EncodingError;
 
-/// A structure that can validate ingest enclave reports and measurements at
+/// A structure that can validate ingest enclave evidence and measurements at
 /// runtime.
 ///
-/// This is expected to take the verification report and produce the
-/// ias-validated and decompressed RistrettoPublic key.
+/// This is expected to take the attestation evidence and produce the
+/// validated and decompressed RistrettoPublic key.
 #[derive(Default, Clone, Debug)]
-pub struct IngestReportVerifier {
+pub struct IngestAttestationEvidenceVerifier {
     verifier: Verifier,
 }
 
-impl IngestReportVerifier {
-    /// Validate a remote ingest ias report, and extract the pubkey from the
-    /// report data bytes. The details of this are tied to the layout of the
-    /// "identity" object in the ingest enclave impl.
-    pub fn validate_ingest_ias_report(
+impl IngestAttestationEvidenceVerifier {
+    /// Validate remote ingest attestation evidence, and extract the pubkey from
+    /// the report data bytes. The details of this are tied to the layout of
+    /// the "identity" object in the ingest enclave impl.
+    pub fn validate_ingest_attestation_evidence(
         &self,
         remote_report: VerificationReport,
     ) -> Result<RistrettoPublic, Error> {
@@ -32,7 +32,7 @@ impl IngestReportVerifier {
     }
 }
 
-impl From<&Verifier> for IngestReportVerifier {
+impl From<&Verifier> for IngestAttestationEvidenceVerifier {
     fn from(src: &Verifier) -> Self {
         Self {
             verifier: src.clone(),

--- a/fog/ingest/server/src/controller.rs
+++ b/fog/ingest/server/src/controller.rs
@@ -1199,7 +1199,7 @@ where
     ) -> Result<IngressPublicKeyStatus, Error> {
         // Get a report and check that it makes sense with what we think is happening
         let report = {
-            let report = self.enclave.get_ias_report()?;
+            let report = self.enclave.get_attestation_evidence()?;
             // Check that key in report data matches ingress_public_key.
             // If not, then there is some kind of race.
             let found_key = try_extract_unvalidated_ingress_pubkey_from_fog_report(&report)?;
@@ -1213,7 +1213,7 @@ where
                 );
                 self.update_enclave_report_cache()?;
 
-                let report = self.enclave.get_ias_report()?;
+                let report = self.enclave.get_attestation_evidence()?;
                 let found_key = try_extract_unvalidated_ingress_pubkey_from_fog_report(&report)?;
                 if &found_key == ingress_public_key {
                     report

--- a/fog/ledger/connection/src/router_client.rs
+++ b/fog/ledger/connection/src/router_client.rs
@@ -34,7 +34,7 @@ pub struct LedgerGrpcClient {
     /// The URI of the router to communicate with
     uri: FogLedgerUri,
 
-    /// The identities that a fog node's IAS report must match one of
+    /// The identities that a fog node's attestation evidence must match, one of
     identities: Vec<TrustedIdentity>,
 
     /// The AKE state machine object, if one is available.

--- a/fog/ledger/enclave/api/src/messages.rs
+++ b/fog/ledger/enclave/api/src/messages.rs
@@ -69,18 +69,18 @@ pub enum EnclaveCall {
     /// * Caches the quote.
     VerifyQuote(Quote, Report, EnclaveReportDataContents),
 
-    /// The [LedgerEnclave::verify_ias_report()] method.
+    /// The [LedgerEnclave::verify_attestation_evidence()] method.
     ///
-    /// * Verifies the signed report from IAS matches the previously received
+    /// * Verifies the attestation evidence matches the previously received
     ///   quote,
-    /// * Caches the signed report. This cached report may be overwritten by
-    ///   later calls.
-    VerifyReport(VerificationReport),
+    /// * Caches the attestation evidence. This cached attestation evidence may
+    ///   be overwritten by later calls.
+    VerifyAttestationEvidence(VerificationReport),
 
-    /// The [LedgerEnclave::get_ias_report()] method.
+    /// The [LedgerEnclave::get_attestation_evidence()] method.
     ///
-    /// Retrieves a previously cached report, if any.
-    GetReport,
+    /// Retrieves a previously cached attestation evidence, if any.
+    GetAttestationEvidence,
 
     /// The [LedgerEnclave::get_outputs()] method.
     ///

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -94,13 +94,16 @@ where
         Ok(self.ake.verify_quote(quote, qe_report, &report_data)?)
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        self.ake.verify_ias_report(ias_report)?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        self.ake.verify_attestation_evidence(attestation_evidence)?;
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        Ok(self.ake.get_ias_report()?)
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        Ok(self.ake.get_attestation_evidence()?)
     }
 }
 

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -63,14 +63,19 @@ impl ReportableEnclave for LedgerSgxEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyReport(ias_report))?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::VerifyAttestationEvidence(
+            attestation_evidence,
+        ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetReport)?;
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        let inbuf = mc_util_serial::serialize(&EnclaveCall::GetAttestationEvidence)?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -48,8 +48,10 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         EnclaveCall::VerifyQuote(quote, qe_report, report_data) => {
             serialize(&ENCLAVE.verify_quote(quote, qe_report, report_data))
         }
-        EnclaveCall::VerifyReport(ias_report) => serialize(&ENCLAVE.verify_ias_report(ias_report)),
-        EnclaveCall::GetReport => serialize(&ENCLAVE.get_ias_report()),
+        EnclaveCall::VerifyAttestationEvidence(attestation_evidence) => {
+            serialize(&ENCLAVE.verify_attestation_evidence(attestation_evidence))
+        }
+        EnclaveCall::GetAttestationEvidence => serialize(&ENCLAVE.get_attestation_evidence()),
         // Outputs
         EnclaveCall::GetOutputs(msg) => serialize(&ENCLAVE.get_outputs(msg)),
         EnclaveCall::GetOutputsData(resp, client) => {

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -61,11 +61,14 @@ impl ReportableEnclave for MockEnclave {
         Ok(IasNonce::default())
     }
 
-    fn verify_ias_report(&self, _ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
+    fn verify_attestation_evidence(
+        &self,
+        _attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
         Ok(VerificationReport::default())
     }
 }

--- a/fog/recovery_db_iface/src/lib.rs
+++ b/fog/recovery_db_iface/src/lib.rs
@@ -358,9 +358,9 @@ pub trait ReportDb {
     ///
     /// Arguments:
     /// * ingress_public_key - the public key signed by this report
-    /// * report_id - the report_id associated to the report. this should almost
+    /// * report_id - the report_id associated to the report. This should almost
     ///   always be the empty string.
-    /// * data - The IAS verification report and cert chain.
+    /// * data - The attestation evidence and cert chain.
     ///
     /// Returns:
     /// * The status of this ingress public key in the database. If the status

--- a/fog/report/resolver/src/lib.rs
+++ b/fog/report/resolver/src/lib.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 
 use mc_fog_report_validation::{FogPubkeyError, FogPubkeyResolver, FullyValidatedFogPubkey};
 
-use mc_fog_ingest_report::IngestReportVerifier;
+use mc_fog_ingest_report::IngestAttestationEvidenceVerifier;
 
 use alloc::string::{String, ToString};
 use core::str::FromStr;
@@ -20,8 +20,8 @@ use mc_fog_report_types::{FogReportResponses, ReportResponse};
 use mc_fog_sig::Verifier as FogSigVerifier;
 use mc_util_uri::{FogUri, UriParseError};
 
-/// A collection of unvalidated fog reports, together with an IAS verifier.
-/// This object is passed to the TransactionBuilder object.
+/// A collection of unvalidated fog reports, together with an attestation
+/// evidence verifier. This object is passed to the TransactionBuilder object.
 /// When fog is not involved, it can simply be defaulted.
 ///
 /// Once constructed, this object can get validated fog pubkeys to build fog
@@ -31,7 +31,7 @@ use mc_util_uri::{FogUri, UriParseError};
 #[derive(Default, Clone, Debug)]
 pub struct FogResolver {
     responses: FogReportResponses,
-    verifier: IngestReportVerifier,
+    verifier: IngestAttestationEvidenceVerifier,
 }
 
 impl FogResolver {
@@ -56,7 +56,7 @@ impl FogResolver {
         verifier.identities(identities).debug(DEBUG_ENCLAVE);
         Ok(Self {
             responses,
-            verifier: IngestReportVerifier::from(&verifier),
+            verifier: IngestAttestationEvidenceVerifier::from(&verifier),
         })
     }
 }
@@ -80,7 +80,7 @@ impl FogPubkeyResolver for FogResolver {
                 if report_id == report.fog_report_id {
                     let pubkey = self
                         .verifier
-                        .validate_ingest_ias_report(report.report.clone())
+                        .validate_ingest_attestation_evidence(report.report.clone())
                         .map_err(|e| FogPubkeyError::IngestReport(e.to_string()))?;
                     return Ok(FullyValidatedFogPubkey {
                         pubkey,

--- a/fog/report/validation/src/lib.rs
+++ b/fog/report/validation/src/lib.rs
@@ -36,14 +36,14 @@ pub trait FogPubkeyResolver {
 }
 
 /// Represents a fog public key validated to use for creating encrypted fog
-/// hints. This object should be constructed only when the IAS report has been
-/// validated, and the chain of trust from the connection has been validated,
-/// and the the fog user's fog_authority_sig over the root subjectPublicKeyInfo
-/// in the signature chain has been validated.
+/// hints. This object should be constructed only when the attestation evidence
+/// has been validated, and the chain of trust from the connection has been
+/// validated, and the the fog user's fog_authority_sig over the root
+/// subjectPublicKeyInfo in the signature chain has been validated.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct FullyValidatedFogPubkey {
-    /// The ristretto curve point which was extracted from the IAS report
-    /// additional data after validation. This is the encryption key used to
+    /// The ristretto curve point which was extracted from the attestation
+    /// evidence after validation. This is the encryption key used to
     /// create encrypted fog hints. The corresponding private key lives only
     /// in SGX ingest nodes.
     pub pubkey: RistrettoPublic,

--- a/fog/sig/src/lib.rs
+++ b/fog/sig/src/lib.rs
@@ -21,10 +21,11 @@
 //! # Fog Report Signatures
 //!
 //! A fog report server uses the signing key and certificate provided by the fog
-//! operator in order to cryptographically sign a list of IAS verification
-//! report structures created by ingest nodes. This resulting data (chain,
-//! signature, and reports) is then returned from the fog report server to a
-//! senders when they want to send coins to the destination account owner.
+//! operator in order to cryptographically sign a list of attestation evidence
+//! structures created by ingest nodes. This resulting data (chain,
+//! signature, and attestation evidence) is then returned from the fog report
+//! server to a sender when they want to send coins to the destination account
+//! owner.
 //!
 //! # Sender Verification
 //!

--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -45,7 +45,7 @@ pub struct FogViewRouterGrpcClient {
 
     uri: FogViewRouterUri,
 
-    /// The identities that a fog node's IAS report must match one of
+    /// The identities that a fog node's attestation evidence must match, one of
     identities: Vec<TrustedIdentity>,
 }
 

--- a/fog/view/enclave/api/src/lib.rs
+++ b/fog/view/enclave/api/src/lib.rs
@@ -72,11 +72,11 @@ pub enum ViewEnclaveRequest {
     /// The report part should be a quoting enclave report
     VerifyQuote(Quote, Report, EnclaveReportDataContents),
 
-    /// Verify an IAS report, and cache it if it is accepted
-    VerifyIasReport(VerificationReport),
+    /// Verify attestation evidence, and cache it if it is accepted
+    VerifyAttestationEvidence(VerificationReport),
 
-    /// Get the cached verification report if any
-    GetIasReport,
+    /// Get the cached attestation evidence if any
+    GetAttestationEvidence,
 
     // View-enclave specific
     /// Accept a client connection

--- a/fog/view/enclave/impl/src/lib.rs
+++ b/fog/view/enclave/impl/src/lib.rs
@@ -148,13 +148,16 @@ where
         Ok(self.ake.verify_quote(quote, qe_report, &report_data)?)
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        self.ake.verify_ias_report(ias_report)?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        self.ake.verify_attestation_evidence(attestation_evidence)?;
         Ok(())
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        Ok(self.ake.get_ias_report()?)
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        Ok(self.ake.get_attestation_evidence()?)
     }
 }
 

--- a/fog/view/enclave/src/lib.rs
+++ b/fog/view/enclave/src/lib.rs
@@ -138,14 +138,19 @@ impl ReportableEnclave for SgxViewEnclave {
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> ReportableEnclaveResult<()> {
-        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::VerifyIasReport(ias_report))?;
+    fn verify_attestation_evidence(
+        &self,
+        attestation_evidence: VerificationReport,
+    ) -> ReportableEnclaveResult<()> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::VerifyAttestationEvidence(
+            attestation_evidence,
+        ))?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }
 
-    fn get_ias_report(&self) -> ReportableEnclaveResult<VerificationReport> {
-        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::GetIasReport)?;
+    fn get_attestation_evidence(&self) -> ReportableEnclaveResult<VerificationReport> {
+        let inbuf = mc_util_serial::serialize(&ViewEnclaveRequest::GetAttestationEvidence)?;
         let outbuf = self.enclave_call(&inbuf)?;
         mc_util_serial::deserialize(&outbuf[..])?
     }

--- a/fog/view/enclave/trusted/src/lib.rs
+++ b/fog/view/enclave/trusted/src/lib.rs
@@ -112,10 +112,12 @@ pub fn ecall_dispatcher(inbuf: &[u8]) -> Result<Vec<u8>, sgx_status_t> {
         ViewEnclaveRequest::VerifyQuote(quote, report, report_data) => {
             serialize(&ENCLAVE.verify_quote(quote, report, report_data))
         }
-        ViewEnclaveRequest::VerifyIasReport(verification_report) => {
-            serialize(&ENCLAVE.verify_ias_report(verification_report))
+        ViewEnclaveRequest::VerifyAttestationEvidence(attestation_evidence) => {
+            serialize(&ENCLAVE.verify_attestation_evidence(attestation_evidence))
         }
-        ViewEnclaveRequest::GetIasReport => serialize(&ENCLAVE.get_ias_report()),
+        ViewEnclaveRequest::GetAttestationEvidence => {
+            serialize(&ENCLAVE.get_attestation_evidence())
+        }
         ViewEnclaveRequest::ClientAccept(msg) => serialize(&ENCLAVE.client_accept(msg)),
         ViewEnclaveRequest::ViewStoreInit(view_store_id) => {
             serialize(&ENCLAVE.view_store_init(view_store_id))

--- a/sgx/report-cache/api/src/lib.rs
+++ b/sgx/report-cache/api/src/lib.rs
@@ -79,20 +79,20 @@ pub trait ReportableEnclave {
         report_data: EnclaveReportDataContents,
     ) -> Result<IasNonce>;
 
-    /// Cache the verification report for this enclave.
+    /// Cache the attestation evidence for this enclave.
     ///
     /// Untrusted code should transmit the quote previously checked by
-    /// `check_quote()` to IAS, and construct the verification report structure
+    /// `check_quote()` to IAS, and construct the attestation evidence
     /// from the results. That result should be given back to the enclave
     /// for future use.
     ///
-    /// The enclave will verify the IAS report was signed by a trusted IAS
+    /// The enclave will verify the attestation evidence was signed by a trusted
     /// certifcate, and the contents match the previously checked quote.
     /// After that check has been performed, the enclave will use the
-    /// verification report for all requests until another verfication report
+    /// attestation evidence for all requests until another attestation evidence
     /// has been successfully loaded in it's place.
-    fn verify_ias_report(&self, ias_report: VerificationReport) -> Result<()>;
+    fn verify_attestation_evidence(&self, attestation_evidence: VerificationReport) -> Result<()>;
 
-    /// Retrieve a copy of the cached verification report.
-    fn get_ias_report(&self) -> Result<VerificationReport>;
+    /// Retrieve a copy of the cached attestation evidence.
+    fn get_attestation_evidence(&self) -> Result<VerificationReport>;
 }


### PR DESCRIPTION
The naming of `ias_report` conflicts with the upcoming transition to
using the DCAP protocol for attesting enclaves. The more generic name of
`attestation_evidence` is used in its place.
