### PR TITLE
Add `AttestationEvidence` to `BlockchainMetadata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "mc-transaction-types",
  "mc-util-from-random",
  "mc-util-repr-bytes",
+ "mc-util-serial",
  "mc-util-test-helper",
  "prost",
  "rand",

--- a/api/proto/blockchain.proto
+++ b/api/proto/blockchain.proto
@@ -78,8 +78,11 @@ message BlockMetadataContents {
     // Quorum set configuration at the time of externalization.
     quorum_set.QuorumSet quorum_set = 2;
 
-    // IAS report for the enclave which generated the signature.
-    external.VerificationReport verification_report = 3;
+    // The attestation evidence for the enclave which generated the signature.
+    oneof attestation_evidence {
+        external.VerificationReport verification_report = 3;
+        external.DcapEvidence dcap_evidence = 5;
+    }
 
     // Responder ID of the consensus node that externalized this block.
     string responder_id = 4;

--- a/api/src/convert/block_metadata.rs
+++ b/api/src/convert/block_metadata.rs
@@ -2,8 +2,11 @@
 
 //! Convert to/from blockchain::BlockMetadataContents.
 
-use crate::{blockchain, ConversionError};
-use mc_blockchain_types::{BlockMetadata, BlockMetadataContents};
+use crate::{
+    blockchain::{self, BlockMetadataContents_oneof_attestation_evidence},
+    ConversionError,
+};
+use mc_blockchain_types::{AttestationEvidence, BlockMetadata, BlockMetadataContents};
 use mc_common::ResponderId;
 use std::str::FromStr;
 
@@ -12,7 +15,12 @@ impl From<&BlockMetadataContents> for blockchain::BlockMetadataContents {
         let mut proto = Self::new();
         proto.set_block_id(src.block_id().into());
         proto.set_quorum_set(src.quorum_set().into());
-        proto.set_verification_report(src.verification_report().into());
+        match src.attestation_evidence() {
+            AttestationEvidence::DcapEvidence(evidence) => proto.set_dcap_evidence(evidence.into()),
+            AttestationEvidence::VerificationReport(report) => {
+                proto.set_verification_report(report.into())
+            }
+        }
         proto.set_responder_id(src.responder_id().to_string());
         proto
     }
@@ -24,13 +32,27 @@ impl TryFrom<&blockchain::BlockMetadataContents> for BlockMetadataContents {
     fn try_from(src: &blockchain::BlockMetadataContents) -> Result<Self, Self::Error> {
         let block_id = src.get_block_id().try_into()?;
         let quorum_set = src.get_quorum_set().try_into()?;
-        let report = src.get_verification_report().try_into()?;
+        let attestation_evidence = match &src.attestation_evidence {
+            Some(BlockMetadataContents_oneof_attestation_evidence::dcap_evidence(evidence)) => {
+                let evidence = evidence.try_into()?;
+                AttestationEvidence::DcapEvidence(evidence)
+            }
+            Some(BlockMetadataContents_oneof_attestation_evidence::verification_report(report)) => {
+                let report = report.try_into()?;
+                AttestationEvidence::VerificationReport(report)
+            }
+            None => {
+                return Err(ConversionError::MissingField(
+                    "attestation_evidence".to_string(),
+                ))
+            }
+        };
         let responder_id = ResponderId::from_str(&src.responder_id)
             .map_err(|_| ConversionError::InvalidContents)?;
         Ok(BlockMetadataContents::new(
             block_id,
             quorum_set,
-            report,
+            attestation_evidence,
             responder_id,
         ))
     }

--- a/blockchain/test-utils/src/lib.rs
+++ b/blockchain/test-utils/src/lib.rs
@@ -171,7 +171,7 @@ pub fn make_block_metadata_contents(
     BlockMetadataContents::new(
         block_id,
         make_quorum_set(rng),
-        make_verification_report(rng),
+        make_verification_report(rng).into(),
         ResponderId::from_str("test.mobilecoin.com:443").unwrap(),
     )
 }

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -31,6 +31,7 @@ zeroize = { version = "1", default-features = false }
 [dev-dependencies]
 mc-blockchain-test-utils = { path = "../test-utils" }
 mc-crypto-digestible-test-utils = { path = "../../crypto/digestible/test-utils" }
+mc-util-serial = { path = "../../util/serial" }
 mc-util-test-helper = { path = "../../util/test-helper" }
 
 rand = "0.8"

--- a/blockchain/types/src/block_metadata.rs
+++ b/blockchain/types/src/block_metadata.rs
@@ -4,12 +4,37 @@ use crate::{
     crypto::metadata::{MetadataSigner, MetadataVerifier},
     BlockID, QuorumSet, VerificationReport,
 };
+use ::prost::Message;
 use displaydoc::Display;
+use mc_attest_verifier_types::prost;
 use mc_common::ResponderId;
 use mc_crypto_digestible::Digestible;
 use mc_crypto_keys::{Ed25519Pair, Ed25519Public, Ed25519Signature, SignatureError};
-use prost::Message;
 use serde::{Deserialize, Serialize};
+
+/// The attestation evidence variants for a block.
+#[derive(Clone, ::prost::Oneof, Deserialize, Display, Eq, PartialEq, Serialize, Digestible)]
+#[digestible(transparent)]
+pub enum AttestationEvidence {
+    /// The attestation evidence is a [VerificationReport].
+    #[prost(message, tag = 3)]
+    VerificationReport(VerificationReport),
+    /// DCAP evidence
+    #[prost(message, tag = 5)]
+    DcapEvidence(prost::DcapEvidence),
+}
+
+impl From<VerificationReport> for AttestationEvidence {
+    fn from(report: VerificationReport) -> Self {
+        Self::VerificationReport(report)
+    }
+}
+
+impl From<prost::DcapEvidence> for AttestationEvidence {
+    fn from(evidence: prost::DcapEvidence) -> Self {
+        Self::DcapEvidence(evidence)
+    }
+}
 
 /// Metadata for a block.
 #[derive(Clone, Deserialize, Digestible, Display, Eq, Message, PartialEq, Serialize)]
@@ -22,9 +47,10 @@ pub struct BlockMetadataContents {
     #[prost(message, required, tag = 2)]
     quorum_set: QuorumSet,
 
-    /// IAS report for the enclave which generated the signature.
-    #[prost(message, required, tag = 3)]
-    verification_report: VerificationReport,
+    /// Attestation evidence for the enclave which generated the signature.
+    #[prost(oneof = "AttestationEvidence", tags = "3, 5")]
+    #[digestible(name = "verification_report")]
+    attestation_evidence: Option<AttestationEvidence>,
 
     /// Responder ID of the consensus node that externalized this block.
     #[prost(message, required, tag = 4)]
@@ -36,13 +62,13 @@ impl BlockMetadataContents {
     pub fn new(
         block_id: BlockID,
         quorum_set: QuorumSet,
-        verification_report: VerificationReport,
+        attestation_evidence: AttestationEvidence,
         responder_id: ResponderId,
     ) -> Self {
         Self {
             block_id,
             quorum_set,
-            verification_report,
+            attestation_evidence: Some(attestation_evidence),
             responder_id,
         }
     }
@@ -57,9 +83,11 @@ impl BlockMetadataContents {
         &self.quorum_set
     }
 
-    /// Get the Attested [VerificationReport].
-    pub fn verification_report(&self) -> &VerificationReport {
-        &self.verification_report
+    /// Get the Attestation evidence.
+    pub fn attestation_evidence(&self) -> &AttestationEvidence {
+        self.attestation_evidence
+            .as_ref()
+            .expect("Attestation evidence is always set")
     }
 
     /// Get the [ResponderId].
@@ -127,5 +155,73 @@ impl BlockMetadata {
     /// Get the signature.
     pub fn signature(&self) -> &Ed25519Signature {
         &self.signature
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::QuorumSetMember;
+    use alloc::vec;
+    use mc_blockchain_test_utils::test_node_id;
+    use mc_crypto_digestible::MerlinTranscript;
+
+    /// Metadata contents used in block version 3
+    #[derive(Clone, Deserialize, Digestible, Display, Eq, Message, PartialEq, Serialize)]
+    #[digestible(name = "BlockMetadataContents")]
+    struct BlockMetadataContentsV3 {
+        /// The Block ID.
+        #[prost(message, required, tag = 1)]
+        block_id: BlockID,
+
+        /// Quorum set configuration at the time of externalization.
+        #[prost(message, required, tag = 2)]
+        quorum_set: QuorumSet,
+
+        /// IAS report for the enclave which generated the signature.
+        #[prost(message, required, tag = 3)]
+        verification_report: VerificationReport,
+
+        /// Responder ID of the consensus node that externalized this block.
+        #[prost(message, required, tag = 4)]
+        responder_id: ResponderId,
+    }
+
+    #[test]
+    fn metadata_contents_version_3_works_with_version_4() {
+        mc_util_test_helper::run_with_several_seeds(|mut rng| {
+            let report = mc_blockchain_test_utils::make_verification_report(&mut rng);
+            let quorum_set = QuorumSet::new(
+                2,
+                vec![
+                    QuorumSetMember::Node(test_node_id(9)),
+                    QuorumSetMember::Node(test_node_id(8)),
+                    QuorumSetMember::Node(test_node_id(7)),
+                ],
+            );
+
+            let block_v3 = BlockMetadataContentsV3 {
+                block_id: BlockID([1; 32]),
+                quorum_set: quorum_set.clone(),
+                verification_report: report.clone(),
+                responder_id: ResponderId("hello".into()),
+            };
+
+            let bytes = mc_util_serial::encode(&block_v3);
+
+            let block_v4: BlockMetadataContents = mc_util_serial::decode(&bytes).unwrap();
+
+            assert_eq!(block_v4.block_id(), &BlockID([1; 32]));
+            assert_eq!(block_v4.quorum_set(), &quorum_set);
+            assert_eq!(block_v4.responder_id(), &ResponderId("hello".into()));
+            assert_eq!(
+                block_v4.attestation_evidence,
+                Some(AttestationEvidence::VerificationReport(report))
+            );
+
+            let block_v3_digest = block_v3.digest32::<MerlinTranscript>(b"");
+            let block_v4_digest = block_v4.digest32::<MerlinTranscript>(b"");
+            assert_eq!(block_v3_digest, block_v4_digest);
+        })
     }
 }

--- a/blockchain/types/src/lib.rs
+++ b/blockchain/types/src/lib.rs
@@ -22,7 +22,7 @@ pub use crate::{
     block_contents::{BlockContents, BlockContentsHash},
     block_data::BlockData,
     block_id::BlockID,
-    block_metadata::{BlockMetadata, BlockMetadataContents},
+    block_metadata::{AttestationEvidence, BlockMetadata, BlockMetadataContents},
     block_signature::BlockSignature,
     error::ConvertError,
 };

--- a/consensus/service/src/byzantine_ledger/metadata_provider.rs
+++ b/consensus/service/src/byzantine_ledger/metadata_provider.rs
@@ -2,7 +2,9 @@
 
 use std::sync::Arc;
 
-use mc_blockchain_types::{BlockData, BlockMetadata, BlockMetadataContents, QuorumSet};
+use mc_blockchain_types::{
+    AttestationEvidence, BlockData, BlockMetadata, BlockMetadataContents, QuorumSet,
+};
 use mc_common::ResponderId;
 use mc_crypto_keys::Ed25519Pair;
 use mc_ledger_sync::BlockMetadataProvider;
@@ -42,7 +44,7 @@ impl<E: ReportableEnclave> BlockMetadataProvider for ConsensusMetadataProvider<E
         let contents = BlockMetadataContents::new(
             block_data.block().id.clone(),
             self.quorum_set.clone(),
-            verification_report,
+            AttestationEvidence::VerificationReport(verification_report),
             self.responder_id.clone(),
         );
         Some(

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -329,7 +329,7 @@ mod tests {
         validators::DefaultTxManagerUntrustedInterfaces,
     };
     use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
-    use mc_blockchain_types::{BlockContents, BlockVersion};
+    use mc_blockchain_types::{AttestationEvidence, BlockContents, BlockVersion};
     use mc_common::logger::test_with_logger;
     use mc_consensus_enclave_mock::ConsensusServiceMockEnclave;
     use mc_consensus_scp::{ballot::Ballot, msg::*, SlotIndex};
@@ -845,8 +845,8 @@ mod tests {
         assert_eq!(metadata.contents().block_id(), &block_data.block().id);
         assert_eq!(metadata.contents().quorum_set(), &local_quorum_set);
         assert_eq!(
-            metadata.contents().verification_report(),
-            &verification_report
+            metadata.contents().attestation_evidence(),
+            &AttestationEvidence::VerificationReport(verification_report)
         );
     }
 
@@ -1168,8 +1168,8 @@ mod tests {
         assert_eq!(metadata.contents().block_id(), &block_data.block().id);
         assert_eq!(metadata.contents().quorum_set(), &local_quorum_set);
         assert_eq!(
-            metadata.contents().verification_report(),
-            &verification_report
+            metadata.contents().attestation_evidence(),
+            &AttestationEvidence::VerificationReport(verification_report)
         );
     }
 }

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -9,7 +9,9 @@ use crate::{
     mint_tx_manager::MintTxManager,
     tx_manager::TxManager,
 };
-use mc_blockchain_types::{BlockData, BlockID, BlockMetadata, BlockMetadataContents};
+use mc_blockchain_types::{
+    AttestationEvidence, BlockData, BlockID, BlockMetadata, BlockMetadataContents,
+};
 use mc_common::{
     logger::{log, Logger},
     ResponderId,
@@ -891,7 +893,7 @@ impl<
         let contents = BlockMetadataContents::new(
             block_id.clone(),
             self.scp_node.quorum_set(),
-            verification_report,
+            AttestationEvidence::VerificationReport(verification_report),
             self.scp_node.node_id().responder_id,
         );
 
@@ -1736,7 +1738,10 @@ mod tests {
         let contents = metadata.contents();
         assert_eq!(&block.id, contents.block_id());
         assert_eq!(&quorum_set, contents.quorum_set());
-        assert_eq!(&report, contents.verification_report());
+        assert_eq!(
+            &AttestationEvidence::VerificationReport(report),
+            contents.attestation_evidence()
+        );
         assert_eq!(&local_node_id.responder_id, contents.responder_id());
     }
 

--- a/light-client/relayer/tests/block_processing.rs
+++ b/light-client/relayer/tests/block_processing.rs
@@ -1,7 +1,9 @@
 // Copyright (c) 2018-2023 The MobileCoin Foundation
 
 use mc_account_keys::{burn_address, AccountKey, PublicAddress};
-use mc_blockchain_types::{Block, BlockContents, BlockData, BlockMetadata, BlockMetadataContents};
+use mc_blockchain_types::{
+    AttestationEvidence, Block, BlockContents, BlockData, BlockMetadata, BlockMetadataContents,
+};
 use mc_common::{
     logger::{log, test_with_logger, Logger},
     ResponderId,
@@ -53,7 +55,7 @@ fn append_tx_outs_as_block(
             let bmc = BlockMetadataContents::new(
                 block.id.clone(),
                 Default::default(),
-                Default::default(),
+                AttestationEvidence::VerificationReport(Default::default()),
                 ResponderId::from_str(&format!("node{idx}.test.com:8433")).unwrap(),
             );
             BlockMetadata::from_contents_and_keypair(bmc, signer).unwrap()

--- a/light-client/verifier/src/trusted_validator_set.rs
+++ b/light-client/verifier/src/trusted_validator_set.rs
@@ -97,7 +97,7 @@ impl TrustedValidatorSet {
 pub mod tests {
     use super::*;
     use core::assert_matches::assert_matches;
-    use mc_blockchain_types::{BlockMetadata, BlockMetadataContents};
+    use mc_blockchain_types::{AttestationEvidence, BlockMetadata, BlockMetadataContents};
     use mc_consensus_scp_types::test_utils::{test_node_id, test_node_id_and_signer};
 
     #[test]
@@ -292,7 +292,7 @@ pub mod tests {
         let bmc = BlockMetadataContents::new(
             block_id.clone(),
             Default::default(),
-            Default::default(),
+            AttestationEvidence::VerificationReport(Default::default()),
             Default::default(),
         );
         BlockMetadata::from_contents_and_keypair(bmc, &keypair).unwrap()

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2609,7 +2609,7 @@ mod test {
         // Add a block with a non-MOB token ID.
         add_block_to_ledger(
             &mut ledger_db,
-            BlockVersion::THREE,
+            BLOCK_VERSION,
             &vec![
                 AccountKey::random(&mut rng).default_subaddress(),
                 AccountKey::random(&mut rng).default_subaddress(),
@@ -3514,7 +3514,7 @@ mod test {
         {
             add_block_to_ledger(
                 &mut ledger_db,
-                BlockVersion::THREE,
+                BLOCK_VERSION,
                 &[account_key.subaddress(5)],
                 Amount::new(102030, 2.into()),
                 &[KeyImage::from(101)],

--- a/transaction/types/src/block_version.rs
+++ b/transaction/types/src/block_version.rs
@@ -59,7 +59,7 @@ impl FromStr for BlockVersion {
 impl BlockVersion {
     /// The maximum value of block_version that this build of
     /// mc-transaction-core has support for
-    pub const MAX: Self = Self(3);
+    pub const MAX: Self = Self::FOUR;
 
     /// Refers to the block version number at network launch.
     pub const ZERO: Self = Self(0);
@@ -73,6 +73,9 @@ impl BlockVersion {
     /// Constant for block version three
     pub const THREE: Self = Self(3);
 
+    /// Constant for block version four
+    pub const FOUR: Self = Self(4);
+
     /// Iterator over block versions from one up to max, inclusive. For use in
     /// tests.
     pub fn iterator() -> BlockVersionIterator {
@@ -82,74 +85,74 @@ impl BlockVersion {
     /// The encrypted memos feature is introduced in v1.
     /// [MCIP #3](https://github.com/mobilecoinfoundation/mcips/pull/3)
     pub fn e_memo_feature_is_supported(&self) -> bool {
-        self.0 >= 1
+        self >= &Self::ONE
     }
 
     /// The confidential token ids feature is introduced in v2.
     /// [MCIP #25](https://github.com/mobilecoinfoundation/mcips/pull/25)
     pub fn masked_token_id_feature_is_supported(&self) -> bool {
-        self.0 >= 2
+        self >= &Self::TWO
     }
 
     /// Transactions must be sorted from v3 onward.
     /// [MCIP #34](https://github.com/mobilecoinfoundation/mcips/pull/34)
     pub fn validate_transaction_outputs_are_sorted(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// Mint transactions are introduced in v2.
     /// [MCIP #37](https://github.com/mobilecoinfoundation/mcips/pull/37)
     pub fn mint_transactions_are_supported(&self) -> bool {
-        self.0 >= 2
+        self >= &Self::TWO
     }
 
     /// Minting_to_fog_addresses is supported in v3
     /// [MCIP #53](https://github.com/mobilecoinfoundation/mcips/pull/53)
     pub fn minting_to_fog_addresses_is_supported(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// The extended message digest is used when signing MLSAGs
     /// in v2 and higher. This is described in
     /// [MCIP #25](https://github.com/mobilecoinfoundation/mcips/pull/25).
     pub fn mlsags_sign_extended_message_digest(&self) -> bool {
-        self.0 >= 2
+        self >= &Self::TWO
     }
 
     /// Mixed transactions are introduced in v3
     /// [MCIP #31](https://github.com/mobilecoinfoundation/mcips/pull/31)
     pub fn mixed_transactions_are_supported(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// Signed input rules are introduced in v3.
     /// [MCIP #31](https://github.com/mobilecoinfoundation/mcips/pull/31)
     pub fn signed_input_rules_are_supported(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// Masked amount V2 derivation introduced with block version 3.
     /// [MCIP #42](https://github.com/mobilecoinfoundation/mcips/pull/42)
     pub fn masked_amount_v2_is_supported(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// `BlockData.metadata` is required starting from v3.
     /// [MCIP #43](https://github.com/mobilecoinfoundation/mcips/pull/43)
     pub fn require_block_metadata(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// MLSAGs sign extended-message-and-tx-summary digest starting from v3.
     /// [MCIP #52](https://github.com/mobilecoinfoundation/mcips/pull/52)
     pub fn mlsags_sign_extended_message_and_tx_summary_digest(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 
     /// Nested multisigs are supporoted starting from v3.
     /// [MCIP #TODO]
     pub fn nested_multisigs_are_supported(&self) -> bool {
-        self.0 >= 3
+        self >= &Self::THREE
     }
 }
 


### PR DESCRIPTION
Previously the `BlockchainMetadata` contained a filed
`VerificationReport`. With DCAP there is a new type of attestation
evidence `DcapEvidence`. The `BlockchainMetadata` has been updated to
take an `AttestationEvidence` which is a oneof the older
`VerificationReport` or the newer `DcapEvidence`