### PR TITLE
Update `DcapQuotingEnclave::collateral()` to be fallible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "mc-sgx-build",
  "mc-sgx-core-types",
  "mc-sgx-dcap-ql",
+ "mc-sgx-dcap-quoteverify",
  "mc-sgx-dcap-sys-types",
  "mc-sgx-dcap-types",
  "mc-sgx-types",
@@ -5521,6 +5522,57 @@ checksum = "28eef0f91798251435ab99d89220815d1da36e5e439bbe4451d237fce2278c22"
 dependencies = [
  "mc-sgx-core-types",
  "mc-sgx-dcap-ql-sys-types",
+]
+
+[[package]]
+name = "mc-sgx-dcap-quoteverify"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67020b15c4b3efa8d7596cdb815f7a2a4fe0b5c31bdafb4a1de5c34a0783e742"
+dependencies = [
+ "displaydoc",
+ "mc-sgx-dcap-quoteverify-sys",
+ "mc-sgx-dcap-quoteverify-sys-types",
+ "mc-sgx-dcap-quoteverify-types",
+ "mc-sgx-dcap-sys-types",
+ "mc-sgx-dcap-types",
+ "mc-sgx-util",
+ "once_cell",
+]
+
+[[package]]
+name = "mc-sgx-dcap-quoteverify-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f3871d5f95a74145adb97db245bfa806ad0d32f57fbee2aad7974aeaa83d36"
+dependencies = [
+ "bindgen 0.66.1",
+ "cargo-emit",
+ "mc-sgx-core-build",
+ "mc-sgx-dcap-quoteverify-sys-types",
+ "mc-sgx-dcap-sys-types",
+]
+
+[[package]]
+name = "mc-sgx-dcap-quoteverify-sys-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6350c1827ec3e99efcfda84bfca9c1bb1b5e65a7d3d4e94a177019d33b33fe0"
+dependencies = [
+ "bindgen 0.66.1",
+ "cargo-emit",
+ "mc-sgx-core-build",
+ "mc-sgx-dcap-sys-types",
+]
+
+[[package]]
+name = "mc-sgx-dcap-quoteverify-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f0421d209683104439e07cd44fdfc5962b0b4bb79bbc772d8df594ecbdc16a"
+dependencies = [
+ "mc-sgx-core-types",
+ "mc-sgx-dcap-quoteverify-sys-types",
 ]
 
 [[package]]

--- a/attest/api/src/convert/collateral.rs
+++ b/attest/api/src/convert/collateral.rs
@@ -41,7 +41,7 @@ mod test {
     fn collateral_back_and_forth() {
         let report = Report::default();
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
-        let collateral = DcapQuotingEnclave::collateral(&quote);
+        let collateral = DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral");
         let proto_collateral = attest::Collateral::try_from(&collateral)
             .expect("Failed to convert collateral to proto");
         let new_collateral = Collateral::try_from(&proto_collateral)
@@ -54,7 +54,7 @@ mod test {
     fn bad_collateral_fails_to_decode() {
         let report = Report::default();
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
-        let collateral = DcapQuotingEnclave::collateral(&quote);
+        let collateral = DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral");
         let mut proto_collateral = attest::Collateral::try_from(&collateral)
             .expect("Failed to convert collateral to proto");
         proto_collateral.root_ca_crl[0] += 1;

--- a/attest/api/src/convert/dcap_evidence.rs
+++ b/attest/api/src/convert/dcap_evidence.rs
@@ -47,7 +47,7 @@ mod test {
         report.as_mut().body.report_data.d[..32].copy_from_slice(&report_data.sha256());
 
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
-        let collateral = DcapQuotingEnclave::collateral(&quote);
+        let collateral = DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral");
         DcapEvidence {
             quote,
             collateral,

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -22,6 +22,7 @@ mc-attestation-verifier = "0.4.0"
 mc-rand = "1.1.0"
 mc-sgx-core-types = "0.8.0"
 mc-sgx-dcap-ql = "0.8.0"
+mc-sgx-dcap-quoteverify = "0.8.0"
 mc-sgx-dcap-sys-types = "0.8.0"
 mc-sgx-dcap-types = "0.8.0"
 mc-sgx-types = { path = "../../sgx/types" }

--- a/attest/untrusted/src/hw.rs
+++ b/attest/untrusted/src/hw.rs
@@ -6,7 +6,8 @@ use crate::TargetInfoError;
 use mc_attest_core::QuoteError;
 use mc_sgx_core_types::{Report, TargetInfo};
 use mc_sgx_dcap_ql::{Error, QeTargetInfo, TryFromReport};
-use mc_sgx_dcap_types::{QlError, Quote3};
+use mc_sgx_dcap_quoteverify::{Collateral as CollateralTrait, Error as QuoteVerifyError};
+use mc_sgx_dcap_types::{Collateral, QlError, Quote3};
 
 pub struct HwQuotingEnclave;
 
@@ -24,5 +25,10 @@ impl HwQuotingEnclave {
     /// Get the target info for the quoting enclave.
     pub fn target_info() -> Result<TargetInfo, TargetInfoError> {
         Ok(TargetInfo::for_quoting_enclave()?)
+    }
+
+    /// Get the `Collateral` for the quote.
+    pub fn collateral<Q: AsRef<[u8]>>(quote: &Quote3<Q>) -> Result<Collateral, QuoteVerifyError> {
+        quote.collateral()
     }
 }

--- a/attest/verifier/types/src/convert/collateral.rs
+++ b/attest/verifier/types/src/convert/collateral.rs
@@ -151,7 +151,7 @@ mod test {
     fn collateral() -> Collateral {
         let report = Report::default();
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
-        DcapQuotingEnclave::collateral(&quote)
+        DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral")
     }
 
     #[test]

--- a/attest/verifier/types/src/convert/dcap_evidence.rs
+++ b/attest/verifier/types/src/convert/dcap_evidence.rs
@@ -58,7 +58,7 @@ mod test {
         report.as_mut().body.report_data.d[..32].copy_from_slice(&report_data.sha256());
 
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
-        let collateral = DcapQuotingEnclave::collateral(&quote);
+        let collateral = DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral");
         DcapEvidence {
             quote,
             collateral,


### PR DESCRIPTION
The previous implementation of `DcapQuotingEnclave::collateral()` only
supported `sgx-sim` builds. Adding in the logic for hw builds requires
that the `DcapQuotingEnclave::collateral()` be fallible since it could
be fallible on a real system.
