### PR TITLE
Chant type of `mc-attest-verifier::Error::Verification`

### DIFF
--- a/attest/verifier/src/ias.rs
+++ b/attest/verifier/src/ias.rs
@@ -5,7 +5,7 @@
 //! structure.
 
 use crate::{avr::Kind as AvrKind, Error, StatusVerifier, Verify};
-use alloc::{vec, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 use mbedtls::{
     alloc::{Box as MbedtlsBox, List as MbedtlsList},
     hash::Type as HashType,
@@ -237,7 +237,7 @@ impl IasReportVerifier {
         {
             Ok(report_data)
         } else {
-            Err(Error::Verification(report_data))
+            Err(Error::Verification(format!("{report_data:?}")))
         }
     }
 }

--- a/attest/verifier/src/lib.rs
+++ b/attest/verifier/src/lib.rs
@@ -141,9 +141,9 @@ pub enum Error {
     Parse(VerifyError),
     /**
      * The report was properly constructed, but did not meet security
-     * requirements, report contents: {0:?}
+     * requirements, verification output: {0}
      */
-    Verification(VerificationReportData),
+    Verification(String),
 }
 
 impl From<VerifyError> for Error {

--- a/sgx/report-cache/untrusted/src/lib.rs
+++ b/sgx/report-cache/untrusted/src/lib.rs
@@ -8,10 +8,8 @@ use mc_attest_core::{
     PibError, ProviderId, QuoteError, QuoteSignType, VerificationReport, VerificationReportData,
     VerifyError,
 };
-use mc_attest_enclave_api::Error as AttestEnclaveError;
 use mc_attest_net::{Error as RaError, RaClient};
 use mc_attest_untrusted::{QuotingEnclave, TargetInfoError};
-use mc_attest_verifier::Error as VerifierError;
 use mc_common::logger::{log, o, Logger};
 use mc_sgx_report_cache_api::{Error as ReportableEnclaveError, ReportableEnclave};
 use mc_util_metrics::IntGauge;
@@ -194,7 +192,7 @@ impl<E: ReportableEnclave, R: RaClient> ReportCache<E, R> {
             self.logger,
             "Starting enclave report cache update process..."
         );
-        let mut attestation_evidence = self.start_report_cache()?;
+        let attestation_evidence = self.start_report_cache()?;
 
         log::debug!(
             self.logger,
@@ -208,39 +206,7 @@ impl<E: ReportableEnclave, R: RaClient> ReportCache<E, R> {
                 log::debug!(self.logger, "Enclave accepted report as valid...");
                 Ok(())
             }
-            Err(ReportableEnclaveError::AttestEnclave(AttestEnclaveError::Verify(
-                VerifierError::Verification(report_data),
-            ))) => {
-                // A verifier failed...
-                if let Some(platform_info_blob) = report_data.platform_info_blob.as_ref() {
-                    // IAS gave us a PIB
-                    log::debug!(
-                        self.logger,
-                        "IAS requested TCB update, attempting to update..."
-                    );
-                    QuotingEnclave::update_tcb(platform_info_blob)?;
-                    log::debug!(
-                        self.logger,
-                        "TCB update complete, restarting reporting process"
-                    );
-                    attestation_evidence = self.start_report_cache()?;
-                    log::debug!(
-                        self.logger,
-                        "Verifying attestation evidence with enclave (again)..."
-                    );
-                    self.enclave
-                        .verify_attestation_evidence(attestation_evidence.clone())?;
-                    log::debug!(self.logger, "Enclave accepted new report as valid...");
-                    Ok(())
-                } else {
-                    Err(Error::ReportableEnclave(
-                        ReportableEnclaveError::AttestEnclave(AttestEnclaveError::Verify(
-                            VerifierError::Verification(report_data),
-                        )),
-                    ))
-                }
-            }
-            Err(other) => Err(other.into()),
+            Err(e) => Err(e.into()),
         };
 
         if retval.is_ok() {


### PR DESCRIPTION
Previously the `mc-attest-verifier::Error::Verification` type wrapped a
`VerificationReportData`. Now it wraps a `String` type. This allows for
a more generic interface to provide back the error from attempting to
verify the legacy `VerificationReportData` or the newer `DcapEvidence`.

Verification of the newer `DcapEvidence` provides a string output that
more clearly states where verification failed and as such passing back
the evidence itself isn't very beneficial.
