### PR TITLE
Use references in `From` impl for `DcapEvidence`

### DIFF
--- a/api/src/convert/collateral.rs
+++ b/api/src/convert/collateral.rs
@@ -26,7 +26,7 @@ impl TryFrom<&external::Collateral> for Collateral {
     fn try_from(src: &external::Collateral) -> Result<Self, Self::Error> {
         let bytes = encode_to_protobuf_vec(src)?;
         let prost = prost::Collateral::decode(bytes.as_slice())?;
-        Ok(prost.try_into()?)
+        Ok((&prost).try_into()?)
     }
 }
 

--- a/api/src/convert/dcap_evidence.rs
+++ b/api/src/convert/dcap_evidence.rs
@@ -19,7 +19,7 @@ impl TryFrom<&external::DcapEvidence> for DcapEvidence {
     type Error = ConversionError;
     fn try_from(src: &external::DcapEvidence) -> Result<Self, Self::Error> {
         let prost = prost::DcapEvidence::try_from(src)?;
-        Ok(prost.try_into()?)
+        Ok((&prost).try_into()?)
     }
 }
 

--- a/api/src/convert/enclave_report_data_contents.rs
+++ b/api/src/convert/enclave_report_data_contents.rs
@@ -24,7 +24,7 @@ impl TryFrom<&external::EnclaveReportDataContents> for EnclaveReportDataContents
     fn try_from(src: &external::EnclaveReportDataContents) -> Result<Self, Self::Error> {
         let bytes = encode_to_protobuf_vec(src)?;
         let prost = prost::EnclaveReportDataContents::decode(bytes.as_slice())?;
-        Ok(prost.try_into()?)
+        Ok((&prost).try_into()?)
     }
 }
 

--- a/attest/untrusted/src/sim.rs
+++ b/attest/untrusted/src/sim.rs
@@ -268,7 +268,7 @@ mod test {
         let time =
             DateTime::from_unix_duration(now).expect("Failed to convert duration to DateTime");
         let verifier = DcapVerifier::new(identities, time, report_data_contents);
-        let verification = verifier.verify(evidence);
+        let verification = verifier.verify(&evidence);
         assert_eq!(verification.is_success().unwrap_u8(), 1);
     }
 }

--- a/attest/verifier/src/dcap.rs
+++ b/attest/verifier/src/dcap.rs
@@ -57,9 +57,9 @@ impl DcapVerifier {
     /// Verify the `evidence`
     pub fn verify(
         &self,
-        evidence: Evidence<Vec<u8>>,
+        evidence: &Evidence<Vec<u8>>,
     ) -> VerificationOutput<AndOutput<EvidenceValue, AndOutput<ReportData, Attributes>>> {
-        self.verifier.verify(&evidence)
+        self.verifier.verify(evidence)
     }
 }
 

--- a/attest/verifier/types/src/convert/collateral.rs
+++ b/attest/verifier/types/src/convert/collateral.rs
@@ -14,10 +14,10 @@ use x509_cert::{
     Certificate,
 };
 
-impl TryFrom<prost::Collateral> for Collateral {
+impl TryFrom<&prost::Collateral> for Collateral {
     type Error = ConversionError;
 
-    fn try_from(value: prost::Collateral) -> Result<Self, Self::Error> {
+    fn try_from(value: &prost::Collateral) -> Result<Self, Self::Error> {
         // Note: sgx_collateral uses null bytes at the end of most arrays.
 
         let mut sgx_collateral = version_3_1_empty_collateral();
@@ -52,7 +52,7 @@ impl TryFrom<prost::Collateral> for Collateral {
         sgx_collateral.qe_identity_issuer_chain_size =
             qe_identity_issuer_chain.as_bytes().len() as u32;
 
-        let mut qe_identity = value.qe_identity;
+        let mut qe_identity = value.qe_identity.clone();
         sgx_collateral.qe_identity = qe_identity.as_mut_ptr() as *mut core::ffi::c_char;
         sgx_collateral.qe_identity_size = qe_identity.as_bytes().len() as u32;
 
@@ -161,7 +161,7 @@ mod test {
             .expect("Failed to convert collateral to prost");
         let bytes = prost_collateral.encode_to_vec();
         let new_collateral = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         )
         .expect("Failed to convert prost collateral to collateral");
 
@@ -176,7 +176,7 @@ mod test {
         prost_collateral.pck_crl_issuer_chain.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -190,7 +190,7 @@ mod test {
         prost_collateral.pck_crl.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -204,7 +204,7 @@ mod test {
         prost_collateral.root_ca_crl.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -218,7 +218,7 @@ mod test {
         prost_collateral.tcb_info_issuer_chain.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -232,7 +232,7 @@ mod test {
         prost_collateral.tcb_info.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -246,7 +246,7 @@ mod test {
         prost_collateral.qe_identity_issuer_chain.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -260,7 +260,7 @@ mod test {
         prost_collateral.qe_identity.clear();
         let bytes = prost_collateral.encode_to_vec();
         let error = Collateral::try_from(
-            prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Collateral::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));

--- a/attest/verifier/types/src/convert/dcap_evidence.rs
+++ b/attest/verifier/types/src/convert/dcap_evidence.rs
@@ -5,18 +5,21 @@
 use crate::{prost, ConversionError, DcapEvidence};
 use alloc::string::ToString;
 
-impl TryFrom<prost::DcapEvidence> for DcapEvidence {
+impl TryFrom<&prost::DcapEvidence> for DcapEvidence {
     type Error = ConversionError;
 
-    fn try_from(value: prost::DcapEvidence) -> Result<Self, Self::Error> {
+    fn try_from(value: &prost::DcapEvidence) -> Result<Self, Self::Error> {
         let quote = value
             .quote
+            .as_ref()
             .ok_or_else(|| ConversionError::MissingField("quote".to_string()))?;
         let collateral = value
             .collateral
+            .as_ref()
             .ok_or_else(|| ConversionError::MissingField("collateral".to_string()))?;
         let report_data = value
             .report_data
+            .as_ref()
             .ok_or_else(|| ConversionError::MissingField("report_data".to_string()))?;
         Ok(Self {
             quote: quote.try_into()?,
@@ -73,7 +76,7 @@ mod test {
             prost::DcapEvidence::try_from(&evidence).expect("Failed to convert evidence to prost");
         let bytes = prost_evidence.encode_to_vec();
         let new_evidence = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         )
         .expect("Failed to convert prost evidence to evidence");
 
@@ -88,7 +91,7 @@ mod test {
         prost_evidence.quote = None;
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::MissingField(message)) if message.contains("quote"));
@@ -102,7 +105,7 @@ mod test {
         prost_evidence.collateral = None;
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::MissingField(message)) if message.contains("collateral"));
@@ -116,7 +119,7 @@ mod test {
         prost_evidence.report_data = None;
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::MissingField(message)) if message.contains("report_data"));
@@ -131,7 +134,7 @@ mod test {
         prost_quote.data[1] += 1;
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -149,7 +152,7 @@ mod test {
         prost_collateral.root_ca_crl[0] += 1;
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));
@@ -167,7 +170,7 @@ mod test {
         let _ = prost_report_data.custom_identity.pop();
         let bytes = prost_evidence.encode_to_vec();
         let error = DcapEvidence::try_from(
-            prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::DcapEvidence::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::LengthMismatch { .. }));

--- a/attest/verifier/types/src/convert/enclave_report_data_contents.rs
+++ b/attest/verifier/types/src/convert/enclave_report_data_contents.rs
@@ -6,10 +6,10 @@ use alloc::string::ToString;
 use mc_crypto_keys::X25519Public;
 use mc_sgx_core_types::QuoteNonce;
 
-impl TryFrom<prost::EnclaveReportDataContents> for EnclaveReportDataContents {
+impl TryFrom<&prost::EnclaveReportDataContents> for EnclaveReportDataContents {
     type Error = ConversionError;
 
-    fn try_from(value: prost::EnclaveReportDataContents) -> Result<Self, Self::Error> {
+    fn try_from(value: &prost::EnclaveReportDataContents) -> Result<Self, Self::Error> {
         let nonce: QuoteNonce =
             value
                 .nonce
@@ -21,7 +21,7 @@ impl TryFrom<prost::EnclaveReportDataContents> for EnclaveReportDataContents {
                     required: QuoteNonce::SIZE,
                 })?;
         let key: X25519Public = value.key.as_slice().try_into()?;
-        let custom_identity_bytes = value.custom_identity;
+        let custom_identity_bytes = &value.custom_identity;
         let custom_identity = if custom_identity_bytes.is_empty() {
             None
         } else {
@@ -69,7 +69,7 @@ mod tests {
 
         let prost_report_data = prost::EnclaveReportDataContents::from(&report_data);
         let new_report_data =
-            EnclaveReportDataContents::try_from(prost_report_data).expect("failed to convert");
+            EnclaveReportDataContents::try_from(&prost_report_data).expect("failed to convert");
 
         assert_eq!(report_data, new_report_data);
     }
@@ -84,7 +84,7 @@ mod tests {
 
         let prost_report_data = prost::EnclaveReportDataContents::from(&report_data);
         let new_report_data =
-            EnclaveReportDataContents::try_from(prost_report_data).expect("failed to convert");
+            EnclaveReportDataContents::try_from(&prost_report_data).expect("failed to convert");
 
         assert_eq!(report_data, new_report_data);
     }
@@ -99,7 +99,7 @@ mod tests {
 
         let mut prost_report_data = prost::EnclaveReportDataContents::from(&report_data);
         let _ = prost_report_data.nonce.pop();
-        let error = EnclaveReportDataContents::try_from(prost_report_data);
+        let error = EnclaveReportDataContents::try_from(&prost_report_data);
 
         assert_matches!(error, Err(ConversionError::LengthMismatch { .. }));
     }
@@ -114,7 +114,7 @@ mod tests {
 
         let mut prost_report_data = prost::EnclaveReportDataContents::from(&report_data);
         let _ = prost_report_data.key.pop();
-        let error = EnclaveReportDataContents::try_from(prost_report_data);
+        let error = EnclaveReportDataContents::try_from(&prost_report_data);
 
         assert_matches!(error, Err(ConversionError::Key(_)));
     }
@@ -129,7 +129,7 @@ mod tests {
 
         let mut prost_report_data = prost::EnclaveReportDataContents::from(&report_data);
         prost_report_data.custom_identity.push(0x12);
-        let error = EnclaveReportDataContents::try_from(prost_report_data);
+        let error = EnclaveReportDataContents::try_from(&prost_report_data);
 
         assert_matches!(error, Err(ConversionError::LengthMismatch { .. }));
     }

--- a/attest/verifier/types/src/convert/quote3.rs
+++ b/attest/verifier/types/src/convert/quote3.rs
@@ -6,11 +6,11 @@ use crate::{prost, ConversionError};
 use alloc::vec::Vec;
 use mc_sgx_dcap_types::Quote3;
 
-impl TryFrom<prost::Quote3> for Quote3<Vec<u8>> {
+impl TryFrom<&prost::Quote3> for Quote3<Vec<u8>> {
     type Error = ConversionError;
 
-    fn try_from(value: prost::Quote3) -> Result<Self, Self::Error> {
-        Ok(Quote3::try_from(value.data)?)
+    fn try_from(value: &prost::Quote3) -> Result<Self, Self::Error> {
+        Ok(Quote3::try_from(value.data.clone())?)
     }
 }
 
@@ -39,7 +39,7 @@ mod test {
         let prost_quote = prost::Quote3::from(&quote);
         let bytes = prost_quote.encode_to_vec();
         let new_quote = Quote3::try_from(
-            prost::Quote3::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Quote3::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         )
         .expect("failed to decode prost quote");
 
@@ -55,7 +55,7 @@ mod test {
         prost_quote.data[1] += 1;
         let bytes = prost_quote.encode_to_vec();
         let error = Quote3::try_from(
-            prost::Quote3::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
+            &prost::Quote3::decode(bytes.as_slice()).expect("Failed to decode prost bytes"),
         );
 
         assert_matches!(error, Err(ConversionError::InvalidContents(_)));


### PR DESCRIPTION
Previously some of the `From` implementations for `DcapEvidence` and
its substructs converted from moved instances. This resulted in
unecessary clones by consumers of the API. Now the `From`
implementations for `DcapEvidence` and its substructs convert from
references.
