### PR TITLE
Change `FogResolver` to keep `Vec<TrustedIdentity>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,6 +3862,7 @@ dependencies = [
  "displaydoc",
  "mc-attest-core",
  "mc-attest-verifier",
+ "mc-attestation-verifier",
  "mc-crypto-keys",
  "mc-util-encodings",
  "serde",

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = { workspace = true }
 [dependencies]
 mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-attest-verifier = { path = "../../../attest/verifier", default-features = false }
+mc-attestation-verifier = "0.4.0"
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-util-encodings = { path = "../../../util/encodings" }
 

--- a/fog/report/resolver/src/lib.rs
+++ b/fog/report/resolver/src/lib.rs
@@ -14,15 +14,14 @@ use mc_fog_ingest_report::IngestAttestationEvidenceVerifier;
 use alloc::string::{String, ToString};
 use core::str::FromStr;
 use mc_account_keys::PublicAddress;
-use mc_attest_verifier::{Verifier, DEBUG_ENCLAVE};
 use mc_attestation_verifier::TrustedIdentity;
 use mc_fog_report_types::{FogReportResponses, ReportResponse};
 use mc_fog_sig::Verifier as FogSigVerifier;
 use mc_util_uri::{FogUri, UriParseError};
 
-/// A collection of unvalidated fog reports, together with an attestation
-/// evidence verifier. This object is passed to the TransactionBuilder object.
-/// When fog is not involved, it can simply be defaulted.
+/// A collection of unvalidated fog reports, together with trusted identities.
+/// This object is passed to the TransactionBuilder object. When fog is not
+/// involved, it can simply be defaulted.
 ///
 /// Once constructed, this object can get validated fog pubkeys to build fog
 /// hints for transactions, without talking to the internet, and so is
@@ -31,7 +30,7 @@ use mc_util_uri::{FogUri, UriParseError};
 #[derive(Default, Clone, Debug)]
 pub struct FogResolver {
     responses: FogReportResponses,
-    verifier: IngestAttestationEvidenceVerifier,
+    identities: Vec<TrustedIdentity>,
 }
 
 impl FogResolver {
@@ -52,11 +51,9 @@ impl FogResolver {
                 },
             )
             .collect::<Result<_, UriParseError>>()?;
-        let mut verifier = Verifier::default();
-        verifier.identities(identities).debug(DEBUG_ENCLAVE);
         Ok(Self {
             responses,
-            verifier: IngestAttestationEvidenceVerifier::from(&verifier),
+            identities: Vec::from_iter(identities.into_iter().cloned()),
         })
     }
 }
@@ -78,9 +75,10 @@ impl FogPubkeyResolver for FogResolver {
             let report_id = recipient.fog_report_id().unwrap_or("").to_string();
             for report in result.reports.iter() {
                 if report_id == report.fog_report_id {
-                    let pubkey = self
-                        .verifier
-                        .validate_ingest_attestation_evidence(report.report.clone())
+                    let verifier =
+                        IngestAttestationEvidenceVerifier::from(self.identities.as_slice());
+                    let pubkey = verifier
+                        .validate_ingest_attestation_evidence(&report.report)
                         .map_err(|e| FogPubkeyError::IngestReport(e.to_string()))?;
                     return Ok(FullyValidatedFogPubkey {
                         pubkey,


### PR DESCRIPTION
Previously the `FogResolver` created a `Verifier` and kept that around.
Now the `FogResolver` keeps a `Vec<TrustedIdentity>` and creates a
verifier as needed. This is to allow the `FogResolver` to better handle
EPID vs DCAP attestation.