### PR TITLE
`From` instead of `TryFrom` for proto to prost

### DIFF
--- a/api/src/convert/collateral.rs
+++ b/api/src/convert/collateral.rs
@@ -2,7 +2,7 @@
 
 //! Convert to/from external::Collateral
 
-use crate::{convert::encode_to_protobuf_vec, external, ConversionError};
+use crate::{external, ConversionError};
 use mc_attest_verifier_types::prost;
 use mc_sgx_dcap_types::Collateral;
 use mc_util_serial::Message;
@@ -24,9 +24,22 @@ impl TryFrom<&Collateral> for external::Collateral {
 impl TryFrom<&external::Collateral> for Collateral {
     type Error = ConversionError;
     fn try_from(src: &external::Collateral) -> Result<Self, Self::Error> {
-        let bytes = encode_to_protobuf_vec(src)?;
-        let prost = prost::Collateral::decode(bytes.as_slice())?;
+        let prost = prost::Collateral::from(src);
         Ok((&prost).try_into()?)
+    }
+}
+
+impl From<&external::Collateral> for prost::Collateral {
+    fn from(src: &external::Collateral) -> Self {
+        Self {
+            pck_crl_issuer_chain: src.pck_crl_issuer_chain.clone().into_vec(),
+            root_ca_crl: src.root_ca_crl.clone(),
+            pck_crl: src.pck_crl.clone(),
+            tcb_info_issuer_chain: src.tcb_info_issuer_chain.clone().into_vec(),
+            tcb_info: src.tcb_info.clone(),
+            qe_identity_issuer_chain: src.qe_identity_issuer_chain.clone().into_vec(),
+            qe_identity: src.qe_identity.clone(),
+        }
     }
 }
 

--- a/api/src/convert/dcap_evidence.rs
+++ b/api/src/convert/dcap_evidence.rs
@@ -2,7 +2,7 @@
 
 //! Convert to/from external::DcapEvidence
 
-use crate::{convert::encode_to_protobuf_vec, external, ConversionError};
+use crate::{external, ConversionError};
 use mc_attest_verifier_types::{prost, DcapEvidence};
 use mc_util_serial::Message;
 use protobuf::Message as ProtoMessage;
@@ -34,11 +34,13 @@ impl From<&prost::DcapEvidence> for external::DcapEvidence {
     }
 }
 
-impl TryFrom<&external::DcapEvidence> for prost::DcapEvidence {
-    type Error = ConversionError;
-    fn try_from(src: &external::DcapEvidence) -> Result<Self, Self::Error> {
-        let bytes = encode_to_protobuf_vec(src)?;
-        Ok(prost::DcapEvidence::decode(bytes.as_slice())?)
+impl From<&external::DcapEvidence> for prost::DcapEvidence {
+    fn from(src: &external::DcapEvidence) -> Self {
+        Self {
+            quote: src.quote.as_ref().map(|q| q.into()),
+            collateral: src.collateral.as_ref().map(|c| c.into()),
+            report_data: src.report_data.as_ref().map(|r| r.into()),
+        }
     }
 }
 

--- a/api/src/convert/enclave_report_data_contents.rs
+++ b/api/src/convert/enclave_report_data_contents.rs
@@ -2,7 +2,7 @@
 
 //! Convert to/from external::EnclaveReportDataContents
 
-use crate::{convert::encode_to_protobuf_vec, external, ConversionError};
+use crate::{external, ConversionError};
 use mc_attest_verifier_types::{prost, EnclaveReportDataContents};
 use mc_util_serial::Message;
 use protobuf::Message as ProtoMessage;
@@ -22,9 +22,18 @@ impl From<&EnclaveReportDataContents> for external::EnclaveReportDataContents {
 impl TryFrom<&external::EnclaveReportDataContents> for EnclaveReportDataContents {
     type Error = ConversionError;
     fn try_from(src: &external::EnclaveReportDataContents) -> Result<Self, Self::Error> {
-        let bytes = encode_to_protobuf_vec(src)?;
-        let prost = prost::EnclaveReportDataContents::decode(bytes.as_slice())?;
+        let prost = prost::EnclaveReportDataContents::from(src);
         Ok((&prost).try_into()?)
+    }
+}
+
+impl From<&external::EnclaveReportDataContents> for prost::EnclaveReportDataContents {
+    fn from(value: &external::EnclaveReportDataContents) -> Self {
+        Self {
+            nonce: value.nonce.clone(),
+            key: value.key.clone(),
+            custom_identity: value.custom_identity.clone(),
+        }
     }
 }
 

--- a/api/src/convert/mod.rs
+++ b/api/src/convert/mod.rs
@@ -64,7 +64,6 @@ mod error;
 pub use error::ConversionError;
 
 use mc_blockchain_types::BlockIndex;
-use protobuf::Message as ProtoMessage;
 use std::path::PathBuf;
 
 /// Helper method for getting the suggested path/filename for a given block
@@ -92,25 +91,6 @@ pub fn merged_block_num_to_s3block_path(
     path.push(base_dir);
     path.push(block_num_to_s3block_path(first_block_index));
     path
-}
-
-/// Encode a protobuf type to the protobuf representation.
-///
-/// This makes it easy to convert from a protobuf to a rust type by way of a
-/// prost implementation. While this requires converting to a protobuf stream
-/// and back again, this allows for placing most of the complex logic in the
-/// `prost` implementation and keeping the local `try_from` implementations
-/// simple.
-///
-/// For example:
-/// ```ignore
-///     let bytes = encode_to_protobuf_vec(proto_type)?;
-///     let prost = prost::TYPENAME::decode(bytes.as_slice())?;
-///     let rust_type = TYPENAME::try_from(prost)?;
-/// ```
-pub(crate) fn encode_to_protobuf_vec<T: ProtoMessage>(msg: &T) -> Result<Vec<u8>, ConversionError> {
-    let bytes = msg.write_to_bytes().map_err(|_| ConversionError::Other)?;
-    Ok(bytes)
 }
 
 #[cfg(test)]

--- a/api/src/convert/quote3.rs
+++ b/api/src/convert/quote3.rs
@@ -3,6 +3,7 @@
 //! Convert to/from external::Quote3
 
 use crate::{external, ConversionError};
+use mc_attest_verifier_types::prost;
 use mc_sgx_dcap_types::Quote3;
 
 impl<T: AsRef<[u8]>> From<&Quote3<T>> for external::Quote3 {
@@ -14,10 +15,18 @@ impl<T: AsRef<[u8]>> From<&Quote3<T>> for external::Quote3 {
     }
 }
 
-impl TryFrom<external::Quote3> for Quote3<Vec<u8>> {
+impl TryFrom<&external::Quote3> for Quote3<Vec<u8>> {
     type Error = ConversionError;
-    fn try_from(src: external::Quote3) -> Result<Self, Self::Error> {
-        Ok(Quote3::try_from(src.data)?)
+    fn try_from(src: &external::Quote3) -> Result<Self, Self::Error> {
+        Ok(Quote3::try_from(&prost::Quote3::from(src))?)
+    }
+}
+
+impl From<&external::Quote3> for prost::Quote3 {
+    fn from(value: &external::Quote3) -> Self {
+        Self {
+            data: value.data.clone(),
+        }
     }
 }
 
@@ -33,18 +42,18 @@ mod test {
         let report = Report::default();
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
         let proto_quote = external::Quote3::from(&quote);
-        let new_quote = Quote3::try_from(proto_quote).expect("failed to decode proto quote");
+        let new_quote = Quote3::try_from(&proto_quote).expect("failed to decode proto quote");
         assert_eq!(quote, new_quote);
     }
 
     #[test]
-    fn try_from_prost_quote_fails_on_bad_bytes() {
+    fn try_from_proto_quote_fails_on_bad_bytes() {
         let report = Report::default();
         let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
         let mut proto_quote = external::Quote3::from(&quote);
         // Corrupting the quote type
         proto_quote.data[1] += 1;
-        let error = Quote3::try_from(proto_quote);
+        let error = Quote3::try_from(&proto_quote);
 
         assert_matches!(error, Err(ConversionError::InvalidContents));
     }


### PR DESCRIPTION
Previously some conversions in `mc-api` that were from protobuf types to
prost types were implemented as `TryFrom`. Now these conversions are
implemented as `From`. This allows for a more ergonomic API preventing
callers from having to check for errors that really shouldn't happen in
this conversion step.
