### PR TITLE
Make time optional for dcap verification

### DIFF
--- a/attest/verifier/src/dcap.rs
+++ b/attest/verifier/src/dcap.rs
@@ -33,8 +33,9 @@ impl DcapVerifier {
     /// * `trusted_identities` - The allowed identities that can be used in an
     ///   enclave. Verification will succeed if any of these match.
     /// * `time` - The time to use to verify the validity of the certificates
-    ///   and collateral. Verification will fail if this time is before or after
-    ///   any of the validity periods.
+    ///   and collateral. If time is provided, verification will fail if this
+    ///   time is before or after any of the validity periods. Otherwise, time
+    ///   validation of certificates will be skipped.
     pub fn new<I, ID>(
         trusted_identities: I,
         time: impl Into<Option<DateTime>>,

--- a/attest/verifier/src/dcap.rs
+++ b/attest/verifier/src/dcap.rs
@@ -37,7 +37,7 @@ impl DcapVerifier {
     ///   any of the validity periods.
     pub fn new<I, ID>(
         trusted_identities: I,
-        time: DateTime,
+        time: impl Into<Option<DateTime>>,
         report_data: EnclaveReportDataContents,
     ) -> Self
     where


### PR DESCRIPTION
* Make time optional for dcap verification

### Motivation

Time is not available in no-std environments. If time is not available, time validation for certs cannot occur and will be skipped.
