### PR TITLE
Limit `cargo sort` to only modify incorrect files.

### DIFF
--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -7,17 +7,17 @@ license = "GPL-3.0"
 rust-version = { workspace = true }
 
 [dependencies]
-mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-attest-ake = { path = "../../../attest/ake", default-features = false }
+mc-attest-core = { path = "../../../attest/core", default-features = false }
 mc-attest-enclave-api = { path = "../../../attest/enclave-api", default-features = false }
 mc-attest-trusted = { path = "../../../attest/trusted", default-features = false }
 mc-attest-verifier = { path = "../../../attest/verifier", default-features = false }
 mc-common = { path = "../../../common", default-features = false }
 mc-crypto-keys = { path = "../../../crypto/keys", default-features = false }
 mc-rand = "1.0"
+mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 mc-util-from-random = { path = "../../../util/from-random" }
 mc-util-serial = { path = "../../../util/serial" }
-mc-sgx-compat = { path = "../../../sgx/compat", default-features = false }
 
 aes-gcm = "0.10.1"
 digest = "0.10"

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 rust-version = { workspace = true }
 
 [features]
-default = [ "mc-crypto-digestible/default" ]
+default = ["mc-crypto-digestible/default"]
 
 [dependencies]
 mc-crypto-digestible = { path = "../digestible", default_features = false }

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -9,8 +9,8 @@ rust-version = { workspace = true }
 [dependencies]
 # MC/root
 mc-attest-net = { path = "../../../../attest/net" }
-mc-blockchain-types = { path = "../../../../blockchain/types" }
 mc-blockchain-test-utils = { path = "../../../../blockchain/test-utils" }
+mc-blockchain-types = { path = "../../../../blockchain/types" }
 mc-common = { path = "../../../../common", features = ["loggers"] }
 mc-crypto-keys = { path = "../../../../crypto/keys", default-features = false }
 mc-ledger-db = { path = "../../../../ledger/db" }

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -16,10 +16,10 @@ mc-common = { path = "../../../common" }
 mc-crypto-keys = { path = "../../../crypto/keys" }
 mc-ledger-db = { path = "../../../ledger/db" }
 mc-sgx-report-cache-api = { path = "../../../sgx/report-cache/api" }
-mc-transaction-core = {  path = "../../../transaction/core" }
+mc-transaction-core = { path = "../../../transaction/core" }
 
 # fog
-mc-fog-ledger-enclave = {  path = "../enclave" }
+mc-fog-ledger-enclave = { path = "../enclave" }
 mc-fog-ledger-enclave-api = { path = "../enclave/api" }
 mc-fog-types = { path = "../../types" }
 

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -12,10 +12,10 @@ rust-version = "1.68.0"
 [dependencies]
 cfg-if = "1.0"
 mc-sgx-alloc = { path = "../alloc", optional = true }
-mc-sgx-panic = { path = "../panic", optional = true }
-mc-sgx-sync = { path = "../sync", optional = true }
 mc-sgx-debug = { path = "../debug", optional = true }
+mc-sgx-panic = { path = "../panic", optional = true }
 mc-sgx-service = { path = "../service", optional = true }
+mc-sgx-sync = { path = "../sync", optional = true }
 mc-sgx-types = { path = "../types" }
 
 [features]

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 rust-version = "1.68.0"
 
 [dependencies]
-mc-sgx-types = { path = "../types" }
 mc-sgx-panic = { path = "../panic", optional = true }
+mc-sgx-types = { path = "../types" }
 
 [features]
 default = ["mc-sgx-panic"]

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -20,7 +20,7 @@ prost = { version = "0.12", default-features = false, features = ["prost-derive"
 protobuf = { version = "2.27", optional = true }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc"] }
-serde_with = { version = "3.1", default-features = false, features = ["macros"], optional = true}
+serde_with = { version = "3.1", default-features = false, features = ["macros"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
By default `cargo sort` will *always* re-write every `Cargo.toml` file
it processes. This causes the build system to see the files changed and
results in re-compiling unnecessarily. Now `cargo sort` will only update
a file if it deviates from the desired sorting order.

On my machine this took a no-op lint from 45 seconds down to 25 seconds
