### PR TITLE
Implement `Message` for  `EvidenceKind`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "mc-sgx-dcap-types",
  "mc-util-encodings",
  "mc-util-serial",
+ "mc-util-test-helper",
  "prost",
  "prost-build",
  "serde",

--- a/attest/core/src/lib.rs
+++ b/attest/core/src/lib.rs
@@ -40,7 +40,7 @@ pub use crate::{
 };
 
 pub use mc_attest_verifier_types::{
-    DcapEvidence, EnclaveReportDataContents, EvidenceMessage, VerificationReport,
+    DcapEvidence, EnclaveReportDataContents, EvidenceKind, VerificationReport,
     VerificationSignature,
 };
 

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -28,6 +28,7 @@ x509-cert = { version = "0.2.3", default-features = false, features = ["pem"] }
 [dev-dependencies]
 assert_matches = "1.5.0"
 mc-attest-untrusted = { path = "../../untrusted", default-features = false }
+mc-util-test-helper = { path = "../../../util/test-helper" }
 
 [build-dependencies]
 prost-build = "0.12"

--- a/attest/verifier/types/src/lib.rs
+++ b/attest/verifier/types/src/lib.rs
@@ -16,7 +16,7 @@ mod verification;
 pub use crate::{
     convert::ConversionError,
     verification::{
-        DcapEvidence, EnclaveReportDataContents, EvidenceMessage, VerificationReport,
+        DcapEvidence, EnclaveReportDataContents, EvidenceKind, VerificationReport,
         VerificationSignature,
     },
 };

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -6,7 +6,7 @@ use crate::prost;
 use ::prost::{
     bytes::{Buf, BufMut},
     encoding::{self, DecodeContext, WireType},
-    DecodeError, Message, Oneof,
+    DecodeError, Message,
 };
 use alloc::{string::String, vec::Vec};
 use base64::{engine::general_purpose::STANDARD as BASE64_ENGINE, Engine};
@@ -27,16 +27,108 @@ pub struct DcapEvidence {
     pub report_data: EnclaveReportDataContents,
 }
 
-#[derive(Clone, Oneof)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum EvidenceKind {
-    #[prost(message, tag = "4")]
+    Epid(VerificationReport),
     Dcap(prost::DcapEvidence),
 }
 
-#[derive(Clone, Message)]
-pub struct EvidenceMessage {
-    #[prost(oneof = "EvidenceKind", tags = "4")]
-    pub evidence: Option<EvidenceKind>,
+// We default to `EvidenceKind::Epid` as that was the original kind of
+// `VerificationReport`.
+impl Default for EvidenceKind {
+    fn default() -> Self {
+        EvidenceKind::Epid(Default::default())
+    }
+}
+
+impl From<VerificationReport> for EvidenceKind {
+    fn from(report: VerificationReport) -> Self {
+        EvidenceKind::Epid(report)
+    }
+}
+
+impl From<prost::DcapEvidence> for EvidenceKind {
+    fn from(evidence: prost::DcapEvidence) -> Self {
+        EvidenceKind::Dcap(evidence)
+    }
+}
+
+// The first tag for a `VerificationReport`, this needs to match that defined
+// in `VerificationReport`.
+const TAG_VERIFICATION_REPORT_FIRST: u32 = 1;
+
+// The last tag for a `VerificationReport`, this needs to match that defined
+// in `VerificationReport`.
+const TAG_VERIFICATION_REPORT_LAST: u32 = 3;
+
+// The tag to indicate a `DcapEvidence` variant. For backwards compatibility
+// this must be outside the range of tags used by `VerificationReport`.
+const TAG_DCAP_EVIDENCE: u32 = 4;
+
+/// In order to make `EvidenceKind` backwards compatible with the previous
+/// logic which would send `VerificationReport`'s, the protobuf tags that
+/// correspond to tags defined in `VerificationReport` will decode to the
+/// `EvidenceKind::Epid()` variant. Tags outside of a `VerificationReport`'s
+/// will be treated as other variants.
+impl Message for EvidenceKind {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+        Self: Sized,
+    {
+        match self {
+            EvidenceKind::Dcap(evidence) => {
+                encoding::message::encode(4, evidence, buf);
+            }
+            EvidenceKind::Epid(report) => {
+                report.encode_raw(buf);
+            }
+        }
+    }
+
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+        Self: Sized,
+    {
+        match tag {
+            TAG_VERIFICATION_REPORT_FIRST..=TAG_VERIFICATION_REPORT_LAST => {
+                let mut report = match self {
+                    EvidenceKind::Epid(report) => report.clone(),
+                    _ => Default::default(),
+                };
+                report.merge_field(tag, wire_type, buf, ctx)?;
+                *self = EvidenceKind::Epid(report);
+                Ok(())
+            }
+            TAG_DCAP_EVIDENCE => {
+                let mut evidence = prost::DcapEvidence::default();
+                encoding::message::merge(wire_type, &mut evidence, buf, ctx).map(|_| {
+                    *self = EvidenceKind::Dcap(evidence);
+                })
+            }
+            _ => encoding::skip_field(wire_type, tag, buf, ctx),
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        match self {
+            EvidenceKind::Dcap(evidence) => {
+                encoding::message::encoded_len(TAG_DCAP_EVIDENCE, evidence)
+            }
+            EvidenceKind::Epid(report) => report.encoded_len(),
+        }
+    }
+
+    fn clear(&mut self) {
+        *self = Default::default();
+    }
 }
 
 /// Container for holding the quote verification sent back from IAS.
@@ -242,6 +334,9 @@ impl EnclaveReportDataContents {
 mod tests {
     use super::*;
     use alloc::{format, vec};
+    use mc_attest_untrusted::DcapQuotingEnclave;
+    use mc_sgx_core_types::Report;
+    use mc_util_test_helper::Rng;
 
     #[test]
     fn test_signature_debug() {
@@ -278,5 +373,78 @@ mod tests {
             report_data_without_custom_id.sha256(),
             report_data_with_zeroed_custom_id.sha256()
         );
+    }
+
+    #[test]
+    fn empty_evidence_kind_decodes_to_verification_report() {
+        let empty_evidence_kind = EvidenceKind::default();
+        let bytes = empty_evidence_kind.encode_to_vec();
+        let decoded_evidence_kind =
+            EvidenceKind::decode(bytes.as_slice()).expect("Failed to decode empty evidence kind");
+        assert_eq!(
+            EvidenceKind::Epid(Default::default()),
+            decoded_evidence_kind
+        );
+    }
+
+    #[test]
+    fn evidence_kind_to_from_verification_report() {
+        mc_util_test_helper::run_with_several_seeds(|mut rng| {
+            let string_length = rng.gen_range(1..=100);
+            let chain_len = rng.gen_range(2..42);
+            let report = VerificationReport {
+                sig: mc_util_test_helper::random_bytes_vec(32, &mut rng).into(),
+                chain: (1..=chain_len)
+                    .map(|n| mc_util_test_helper::random_bytes_vec(n as usize, &mut rng))
+                    .collect(),
+                http_body: mc_util_test_helper::random_str(string_length, &mut rng),
+            };
+            let bytes = report.encode_to_vec();
+
+            // For backwards compatibility `EvidenceKind` should decode directly
+            // from a `VerificationReport` byte stream
+            let evidence =
+                EvidenceKind::decode(bytes.as_slice()).expect("Failed to decode to EvidenceKind");
+            assert_eq!(EvidenceKind::Epid(report.clone()), evidence);
+
+            // For backwards compatibility the encoding of `EvidenceKind` when
+            // it's a `VerificationReport` should be able to decode to a
+            // `VerificationReport`.
+            let evidence_bytes = evidence.encode_to_vec();
+            let decoded_report = VerificationReport::decode(evidence_bytes.as_slice())
+                .expect("Failed to decode to VerificationReport");
+            assert_eq!(report, decoded_report);
+        })
+    }
+
+    #[test]
+    fn evidence_kind_dcap_encode_and_decode() {
+        let report_data = EnclaveReportDataContents::new(
+            [0x20u8; 16].into(),
+            [0x63u8; 32].as_slice().try_into().expect("bad key"),
+            [0xAEu8; 32],
+        );
+        let mut report = Report::default();
+        report.as_mut().body.report_data.d[..32].copy_from_slice(&report_data.sha256());
+
+        let quote = DcapQuotingEnclave::quote_report(&report).expect("Failed to create quote");
+        let collateral = DcapQuotingEnclave::collateral(&quote).expect("Failed to get collateral");
+        let dcap_evidence = prost::DcapEvidence {
+            quote: Some((&quote).into()),
+            collateral: Some(
+                (&collateral)
+                    .try_into()
+                    .expect("Failed to convert collateral"),
+            ),
+            report_data: Some((&report_data).into()),
+        };
+
+        let evidence_kind = EvidenceKind::Dcap(dcap_evidence);
+
+        let bytes = evidence_kind.encode_to_vec();
+
+        let decoded_evidence_kind =
+            EvidenceKind::decode(bytes.as_slice()).expect("Failed to decode to EvidenceKind");
+        assert_eq!(evidence_kind, decoded_evidence_kind);
     }
 }

--- a/attest/verifier/types/src/verification.rs
+++ b/attest/verifier/types/src/verification.rs
@@ -78,7 +78,7 @@ impl Message for EvidenceKind {
     {
         match self {
             EvidenceKind::Dcap(evidence) => {
-                encoding::message::encode(4, evidence, buf);
+                encoding::message::encode(TAG_DCAP_EVIDENCE, evidence, buf);
             }
             EvidenceKind::Epid(report) => {
                 report.encode_raw(buf);


### PR DESCRIPTION
Previously `EvidenceMessage` was a proxy to decode the `EvidenceKind`
enum. This resulted in clients needing to first attempt to decode as
`EvidenceMessage` and then fall back to `VerificationReport`. Now the
logic of decoding `VerificationReport` versus `DcapEvidence` is wrapped
in the `Message` implementation of `EvidenceKind`.
