### PR TITLE
feat: add placeholder for manual mainnet on dev cluster deploy

### DIFF
--- a/.github/workflows/mobilecoin-dispatch-dev-mainnet-fog.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-mainnet-fog.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+#
+# MobileCoin Core projects - Deploy a MainNet Fog to Development cluster - placeholder
+
+name: (Manual) Deploy MainNet Fog to Dev Namespace
+
+run-name: Deploy ${{ inputs.version }} to ${{ inputs.namespace }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: "Target Namespace"
+        type: string
+        required: true
+      version:
+        description: "Chart Version"
+        type: string
+        required: true
+
+jobs:
+  placeholder:
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: dummy job
+      shell: bash
+      run: |
+        true


### PR DESCRIPTION
### Motivation 

Working on a manual (dispatch) action to deploy a fog instance that uses mainnet consensus. This is a placeholder action in the default branch so we can develop in a feature branch.

