### PR TITLE
Remove use of `default()` for unit structs

### DIFF
--- a/api/src/convert/input_ring.rs
+++ b/api/src/convert/input_ring.rs
@@ -130,7 +130,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 

--- a/api/src/convert/signed_contingent_input.rs
+++ b/api/src/convert/signed_contingent_input.rs
@@ -95,7 +95,7 @@ mod tests {
             BlockVersion::MAX,
             input_credentials,
             fpr.clone(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
 

--- a/api/src/convert/signing_data.rs
+++ b/api/src/convert/signing_data.rs
@@ -84,7 +84,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 

--- a/api/src/convert/tx.rs
+++ b/api/src/convert/tx.rs
@@ -65,7 +65,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -152,7 +152,7 @@ mod tests {
                 block_version,
                 input_credentials,
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -175,7 +175,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -270,7 +270,7 @@ mod tests {
                 block_version,
                 input_credentials,
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -302,7 +302,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 

--- a/api/src/convert/unsigned_tx.rs
+++ b/api/src/convert/unsigned_tx.rs
@@ -133,7 +133,7 @@ mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fpr.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 

--- a/api/tests/prost.rs
+++ b/api/tests/prost.rs
@@ -68,7 +68,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
         block_version,
         input_credentials,
         fpr.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
     builder
@@ -87,7 +87,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
         block_version,
         input_credentials,
         fpr.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
     builder
@@ -109,7 +109,7 @@ fn signed_contingent_input_examples<T: RngCore + CryptoRng>(
         block_version,
         input_credentials,
         fpr.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
     builder

--- a/attest/untrusted/src/sim.rs
+++ b/attest/untrusted/src/sim.rs
@@ -30,7 +30,7 @@ impl SimQuotingEnclave {
         let sgx_quote = sgx_quote(report.body(), &cert_data);
         let mut quote_bytes = c_struct_as_bytes(&sgx_quote).to_vec();
 
-        let mut rng = McRng::default();
+        let mut rng = McRng;
         let signing_key = SigningKey::random(&mut rng);
         // Per <https://download.01.org/intel-sgx/latest/dcap-latest/linux/docs/Intel_SGX_ECDSA_QuoteLibReference_DCAP_API.pdf#%5B%7B%22num%22%3A75%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C687%2C0%5D>
         // the signature is only over the header and report body of the quote.

--- a/attest/verifier/src/dcap.rs
+++ b/attest/verifier/src/dcap.rs
@@ -285,7 +285,7 @@ mod test {
 
         // The certs, TCB info, and QE identity are generated at build time, so `now()`
         // should be alright to use in testing.
-        let now = SystemTimeProvider::default()
+        let now = SystemTimeProvider
             .since_epoch()
             .expect("Failed to get duration since epoch");
         let time =
@@ -342,7 +342,7 @@ mod test {
 
         // The certs, TCB info, and QE identity are generated at build time, so `now()`
         // should be alright to use in testing.
-        let now = SystemTimeProvider::default()
+        let now = SystemTimeProvider
             .since_epoch()
             .expect("Failed to get duration since epoch");
         let time =

--- a/common/src/time.rs
+++ b/common/src/time.rs
@@ -43,7 +43,7 @@ cfg_if::cfg_if! {
             fn default() -> Self {
                 Self {
                     cur_since_epoch: Arc::new(Mutex::new(
-                        SystemTimeProvider::default()
+                        SystemTimeProvider
                             .since_epoch()
                             .expect("failed getting initial value for cur_since_epoch"),
                     )),

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -309,7 +309,7 @@ impl<CP: CredentialsProvider> AttestedConnection for ThickClient<CP> {
         // If we have an existing attestation, nuke it.
         self.deattest();
 
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let initiator = Start::new(self.uri.responder_id()?.to_string());
 
@@ -324,7 +324,7 @@ impl<CP: CredentialsProvider> AttestedConnection for ThickClient<CP> {
                     .map_err(ThickClientAttestationError::from)
             })?;
 
-        let epoch_time = SystemTimeProvider::default()
+        let epoch_time = SystemTimeProvider
             .since_epoch()
             .map_err(|_| ThickClientAttestationError::Other("Time went backwards".to_owned()))?;
         let time = DateTime::from_unix_duration(epoch_time)

--- a/consensus/enclave/impl/src/identity.rs
+++ b/consensus/enclave/impl/src/identity.rs
@@ -14,7 +14,7 @@ pub struct Ed25519Identity {
 impl Default for Ed25519Identity {
     fn default() -> Self {
         Self {
-            signing_keypair: Mutex::new(Ed25519Pair::from_random(&mut McRng::default())),
+            signing_keypair: Mutex::new(Ed25519Pair::from_random(&mut McRng)),
         }
     }
 }

--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -149,10 +149,8 @@ impl SgxConsensusEnclave {
     pub fn new(logger: Logger) -> Self {
         Self {
             ake: Default::default(),
-            locally_encrypted_tx_cipher: Mutex::new(AesMessageCipher::new(&mut McRng::default())),
-            well_formed_encrypted_tx_cipher: Mutex::new(AesMessageCipher::new(
-                &mut McRng::default(),
-            )),
+            locally_encrypted_tx_cipher: Mutex::new(AesMessageCipher::new(&mut McRng)),
+            well_formed_encrypted_tx_cipher: Mutex::new(AesMessageCipher::new(&mut McRng)),
             logger,
             blockchain_config: Default::default(),
             ct_min_fee_map: Default::default(),
@@ -612,7 +610,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         // Convert to TxContext
         let maybe_locally_encrypted_tx: Result<LocallyEncryptedTx> = {
             let mut cipher = self.locally_encrypted_tx_cipher.lock()?;
-            let mut rng = McRng::default();
+            let mut rng = McRng;
 
             Ok(LocallyEncryptedTx(cipher.encrypt_bytes(&mut rng, tx_bytes)))
         };
@@ -641,7 +639,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let txs = mc_util_serial::decode::<TxList>(&data)?.txs;
 
         // Convert to TxContexts
-        let mut rng = McRng::default();
+        let mut rng = McRng;
         txs.into_iter()
             .map(|tx| {
                 let tx_bytes = mc_util_serial::encode(&tx);
@@ -703,7 +701,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         let fee_token_id = TokenId::from(tx.prefix.fee_token_id);
 
         // Validate.
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let minimum_fee = ct_min_fee_map
             .get(&fee_token_id)
             .ok_or(TransactionValidationError::TokenNotYetConfigured)?;
@@ -771,7 +769,7 @@ impl ConsensusEnclave for SgxConsensusEnclave {
         inputs: FormBlockInputs,
         root_element: &TxOutMembershipElement,
     ) -> Result<(Block, BlockContents, BlockSignature)> {
-        let mut rng = McRng::default();
+        let mut rng = McRng;
         let config = self
             .blockchain_config
             .get()

--- a/consensus/enclave/mock/src/lib.rs
+++ b/consensus/enclave/mock/src/lib.rs
@@ -277,7 +277,7 @@ impl ConsensusEnclave for ConsensusServiceMockEnclave {
         // root_elements contains the root hash of the Merkle tree of all TxOuts in the
         // ledger that were used to validate the tranasctions.
         let mut root_elements = Vec::new();
-        let mut rng = McRng::default();
+        let mut rng = McRng;
 
         for (tx, proofs) in transactions_with_proofs.iter() {
             mc_transaction_core::validation::validate(

--- a/consensus/enclave/tests/enclave_api_tests.rs
+++ b/consensus/enclave/tests/enclave_api_tests.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 /// as expected.
 #[test_with_logger]
 fn consensus_enclave_client_tx_propose(logger: Logger) {
-    let mut rng = McRng::default();
+    let mut rng = McRng;
 
     let responder_id = ResponderId::from_str("127.0.0.1:3000").unwrap();
     let block_version = BlockVersion::MAX;

--- a/consensus/mint-client/src/fog.rs
+++ b/consensus/mint-client/src/fog.rs
@@ -46,8 +46,7 @@ impl FogContext {
         let validated_fog_pubkey = self.resolve_one_fog_url(public_address)?;
 
         Ok((
-            FogHint::from(public_address)
-                .encrypt(&validated_fog_pubkey.pubkey, &mut McRng::default()),
+            FogHint::from(public_address).encrypt(&validated_fog_pubkey.pubkey, &mut McRng),
             validated_fog_pubkey.pubkey_expiry,
         ))
     }

--- a/consensus/service/src/api/attested_api_service.rs
+++ b/consensus/service/src/api/attested_api_service.rs
@@ -173,7 +173,7 @@ mod peer_tests {
         let authenticator = Arc::new(TokenAuthenticator::new(
             [1; 32],
             Duration::from_secs(60),
-            SystemTimeProvider::default(),
+            SystemTimeProvider,
         ));
         let enclave = Arc::new(MockConsensusEnclave::new());
 
@@ -239,7 +239,7 @@ mod client_tests {
         let authenticator = Arc::new(TokenAuthenticator::new(
             [1; 32],
             Duration::from_secs(60),
-            SystemTimeProvider::default(),
+            SystemTimeProvider,
         ));
         let enclave = Arc::new(MockConsensusEnclave::new());
 

--- a/consensus/service/src/api/blockchain_api_service.rs
+++ b/consensus/service/src/api/blockchain_api_service.rs
@@ -219,7 +219,7 @@ mod tests {
             FeeMap::try_from_iter([(Mob::ID, 4000000000), (TokenId::from(60), 128000)]).unwrap();
 
         let mut ledger_db = create_ledger();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let account_key = AccountKey::random(&mut rng);
         let blocks_data = initialize_ledger(
@@ -253,7 +253,7 @@ mod tests {
         let authenticator = Arc::new(TokenAuthenticator::new(
             [1; 32],
             Duration::from_secs(60),
-            SystemTimeProvider::default(),
+            SystemTimeProvider,
         ));
 
         let blockchain_api_service = BlockchainApiService::new(
@@ -283,7 +283,7 @@ mod tests {
     // `get_blocks` should returns the correct range of blocks.
     fn test_get_blocks_response_range(logger: Logger) {
         let mut ledger_db = create_ledger();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let account_key = AccountKey::random(&mut rng);
         let expected_blocks = initialize_ledger(
@@ -335,7 +335,7 @@ mod tests {
     // data if a client requests data that does not exist.
     fn test_get_blocks_request_out_of_bounds(logger: Logger) {
         let mut ledger_db = create_ledger();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let account_key = AccountKey::random(&mut rng);
         let _blocks = initialize_ledger(
@@ -367,7 +367,7 @@ mod tests {
     // requested range is larger.
     fn test_get_blocks_max_size(logger: Logger) {
         let mut ledger_db = create_ledger();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let account_key = AccountKey::random(&mut rng);
         let expected_blocks = initialize_ledger(
@@ -407,7 +407,7 @@ mod tests {
         let authenticator = Arc::new(TokenAuthenticator::new(
             [1; 32],
             Duration::from_secs(60),
-            SystemTimeProvider::default(),
+            SystemTimeProvider,
         ));
 
         let blockchain_api_service = BlockchainApiService::new(

--- a/consensus/service/src/api/client_api_service.rs
+++ b/consensus/service/src/api/client_api_service.rs
@@ -557,7 +557,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -629,7 +629,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -680,7 +680,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -762,7 +762,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -825,7 +825,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -896,7 +896,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -947,7 +947,7 @@ mod client_api_tests {
              _responder_id: Option<&ResponderId>| {},
         );
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1000,7 +1000,7 @@ mod client_api_tests {
              _responder_id: Option<&ResponderId>| {},
         );
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1053,11 +1053,8 @@ mod client_api_tests {
              _responder_id: Option<&ResponderId>| {},
         );
 
-        let authenticator = TokenAuthenticator::new(
-            [1; 32],
-            Duration::from_secs(60),
-            SystemTimeProvider::default(),
-        );
+        let authenticator =
+            TokenAuthenticator::new([1; 32], Duration::from_secs(60), SystemTimeProvider);
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1122,7 +1119,7 @@ mod client_api_tests {
             .return_const(Ok(()));
 
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1195,7 +1192,7 @@ mod client_api_tests {
             )));
 
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1249,7 +1246,7 @@ mod client_api_tests {
         let ledger = MockLedger::new();
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { false });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1305,7 +1302,7 @@ mod client_api_tests {
         let ledger = MockLedger::new();
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1366,11 +1363,8 @@ mod client_api_tests {
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = TokenAuthenticator::new(
-            [1; 32],
-            Duration::from_secs(60),
-            SystemTimeProvider::default(),
-        );
+        let authenticator =
+            TokenAuthenticator::new([1; 32], Duration::from_secs(60), SystemTimeProvider);
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1433,7 +1427,7 @@ mod client_api_tests {
             .return_const(Ok(()));
 
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1516,7 +1510,7 @@ mod client_api_tests {
             )));
 
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1575,7 +1569,7 @@ mod client_api_tests {
         let ledger = MockLedger::new();
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { false });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1636,7 +1630,7 @@ mod client_api_tests {
         let ledger = MockLedger::new();
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { true });
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1702,11 +1696,8 @@ mod client_api_tests {
         let mint_tx_manager = MockMintTxManager::new();
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = TokenAuthenticator::new(
-            [1; 32],
-            Duration::from_secs(60),
-            SystemTimeProvider::default(),
-        );
+        let authenticator =
+            TokenAuthenticator::new([1; 32], Duration::from_secs(60), SystemTimeProvider);
 
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(4096)));
 
@@ -1780,7 +1771,7 @@ mod client_api_tests {
 
         let is_serving_fn = Arc::new(|| -> bool { true });
 
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         const LRU_CAPACITY: usize = 4096;
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(LRU_CAPACITY)));

--- a/consensus/service/src/bin/main.rs
+++ b/consensus/service/src/bin/main.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), ConsensusServiceError> {
         local_ledger,
         Arc::new(tx_manager),
         Arc::new(mint_tx_manager),
-        Arc::new(SystemTimeProvider::default()),
+        Arc::new(SystemTimeProvider),
         logger.clone(),
     );
     consensus_service

--- a/consensus/service/src/consensus_service.rs
+++ b/consensus/service/src/consensus_service.rs
@@ -216,7 +216,7 @@ impl<
                     time_provider,
                 ))
             } else {
-                Arc::new(AnonymousAuthenticator::default())
+                Arc::new(AnonymousAuthenticator)
             };
         let tracked_sessions = Arc::new(Mutex::new(LruCache::new(config.client_tracking_capacity)));
         // Return
@@ -435,7 +435,7 @@ impl<
         );
 
         // Peers currently do not support request authentication.
-        let peer_authenticator = Arc::new(AnonymousAuthenticator::default());
+        let peer_authenticator = Arc::new(AnonymousAuthenticator);
 
         // Initialize services.
         let enclave = Arc::new(self.enclave.clone());

--- a/consensus/service/src/validators.rs
+++ b/consensus/service/src/validators.rs
@@ -584,7 +584,7 @@ mod combine_tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 MockFogResolver::default(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
             transaction_builder.add_input(input_credentials);
@@ -647,7 +647,7 @@ mod combine_tests {
                         block_version,
                         Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                         MockFogResolver::default(),
-                        EmptyMemoBuilder::default(),
+                        EmptyMemoBuilder,
                     )
                     .unwrap();
 
@@ -756,7 +756,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -800,7 +800,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -868,7 +868,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -964,7 +964,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -1009,7 +1009,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);
@@ -1078,7 +1078,7 @@ mod combine_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                     MockFogResolver::default(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
                 transaction_builder.add_input(input_credentials);

--- a/crypto/ake/enclave/src/lib.rs
+++ b/crypto/ake/enclave/src/lib.rs
@@ -122,7 +122,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         Self {
             peer_self_id: Mutex::new(None),
             client_self_id: Mutex::new(None),
-            kex_identity: X25519Private::from_random(&mut McRng::default()),
+            kex_identity: X25519Private::from_random(&mut McRng),
             custom_identity,
             quote_pending: Mutex::new(LruCache::new(MAX_PENDING_QUOTES)),
             current_attestation_evidence: Mutex::new(None),
@@ -260,7 +260,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         };
 
         // Advance the state machine
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let (responder, auth_response) = responder.try_next(&mut csprng, auth_request)?;
         // For the first message, nonce is a zero
         let session_id = NonceSession::new(responder.binding().to_owned(), 0);
@@ -286,7 +286,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
     /// connection to the enclave described by `backend_id`. Rather, this
     /// enclave serves as a client to this other backend enclave.
     pub fn backend_init(&self, backend_id: ResponderId) -> Result<NonceAuthRequest> {
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let initiator = Start::new(backend_id.to_string());
 
@@ -313,7 +313,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
             .pop(&backend_id)
             .ok_or(Error::NotFound)?;
 
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let auth_response_output_bytes: Vec<u8> = backend_auth_response.into();
         let auth_response_event = AuthResponseInput::new(
@@ -352,7 +352,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         };
 
         // Advance the state machine
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let (responder, auth_response) = responder.try_next(&mut csprng, auth_request)?;
         let session_id = ClientSession::from(responder.binding());
 
@@ -377,7 +377,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let dcap_evidence = self.get_attestation_evidence()?;
 
         // Fire up the state machine.
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let initiator = Start::new(peer_id.to_string());
 
         // Construct the initializer input.
@@ -417,7 +417,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         };
 
         // Advance the state machine
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let (responder, auth_response) = responder.try_next(&mut csprng, auth_request)?;
         let session_id = PeerSession::from(responder.binding());
 
@@ -449,7 +449,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let auth_response_input = AuthResponseInput::new(auth_response_output, identities, None);
 
         // Advance the state machine to ready (or failure)
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
         let (initiator, evidence) = initiator.try_next(&mut csprng, auth_response_input)?;
 
         let peer_session = PeerSession::from(initiator.binding());
@@ -633,7 +633,7 @@ impl<EI: EnclaveIdentity> AkeEnclaveState<EI> {
         let mut quote_pending = self.quote_pending.lock()?;
 
         let quote_nonce = loop {
-            let mut csprng = McRng::default();
+            let mut csprng = McRng;
             let quote_nonce = QuoteNonce::new(&mut csprng)?;
             if quote_pending.contains(&quote_nonce) {
                 continue;

--- a/crypto/noise/src/patterns.rs
+++ b/crypto/noise/src/patterns.rs
@@ -240,12 +240,12 @@ mod test {
     #[test]
     fn display() {
         assert_eq!(
-            format!("{}", HandshakeIX::default()),
+            format!("{HandshakeIX}"),
             String::from("IX:\n  -> e, s\n  <- e, ee, se, s, es\n")
         );
 
         assert_eq!(
-            format!("{}", HandshakeNX::default()),
+            format!("{HandshakeNX}"),
             String::from("NX:\n  -> e\n  <- e, ee, s, es\n")
         );
     }

--- a/enclave-boundary/src/trusted.rs
+++ b/enclave-boundary/src/trusted.rs
@@ -67,7 +67,7 @@ impl RetryBuffer {
         // the output and return a retry ID.
         let outdata_len = outdata.len();
         if outdata_len > outbuf.len() {
-            let mut csprng = McRng::default();
+            let mut csprng = McRng;
             let mut retry_guard = self
                 .retry_data
                 .lock()

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -711,13 +711,8 @@ fn build_tx(
     let fee_amount = Amount::new(MOB_FEE.load(Ordering::SeqCst), token_id);
 
     // Create tx_builder.
-    let mut tx_builder = TransactionBuilder::new(
-        block_version,
-        fee_amount,
-        fog_resolver,
-        EmptyMemoBuilder::default(),
-    )
-    .unwrap();
+    let mut tx_builder =
+        TransactionBuilder::new(block_version, fee_amount, fog_resolver, EmptyMemoBuilder).unwrap();
 
     // Unzip each vec of tuples into a tuple of vecs.
     let mut rings_and_proofs: Vec<(Vec<TxOut>, Vec<TxOutMembershipProof>)> = rings

--- a/fog/enclave_connection/src/lib.rs
+++ b/fog/enclave_connection/src/lib.rs
@@ -94,7 +94,7 @@ impl<U: ConnectionUri, G: EnclaveGrpcChannel> AttestedConnection for EnclaveConn
         // If we have an existing attestation, nuke it.
         self.deattest();
 
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let initiator = Start::new(self.uri.responder_id()?.to_string());
 
@@ -118,7 +118,7 @@ impl<U: ConnectionUri, G: EnclaveGrpcChannel> AttestedConnection for EnclaveConn
             )
         }
 
-        let epoch_time = SystemTimeProvider::default()
+        let epoch_time = SystemTimeProvider
             .since_epoch()
             .map_err(|_| Error::Other("Time went backwards".to_owned()))?;
         let time = DateTime::from_unix_duration(epoch_time)

--- a/fog/ingest/enclave/impl/src/identity.rs
+++ b/fog/ingest/enclave/impl/src/identity.rs
@@ -17,7 +17,7 @@ pub struct RistrettoIdentity {
 impl Default for RistrettoIdentity {
     fn default() -> Self {
         Self {
-            private_key: Mutex::new(RistrettoPrivate::from_random(&mut McRng::default())),
+            private_key: Mutex::new(RistrettoPrivate::from_random(&mut McRng)),
         }
     }
 }

--- a/fog/ingest/enclave/impl/src/lib.rs
+++ b/fog/ingest/enclave/impl/src/lib.rs
@@ -76,7 +76,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> SgxIngestEnclave
     pub fn new(logger: Logger) -> Self {
         Self {
             ake: Default::default(),
-            egress_key: Mutex::new(RistrettoPrivate::from_random(&mut McRng::default())),
+            egress_key: Mutex::new(RistrettoPrivate::from_random(&mut McRng)),
             rng_store: Mutex::new(None),
             logger,
         }
@@ -92,7 +92,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> SgxIngestEnclave
         egress_key: &RistrettoPrivate,
         rng_store: &mut RngStore<OSC>,
     ) -> Option<Vec<ETxOutRecord>> {
-        let mut rng = McRng::default();
+        let mut rng = McRng;
 
         let mut new_tx_rows = Vec::new();
 
@@ -326,7 +326,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> IngestEnclave
                 // Once we have done this, we can try to ingest again.
                 // If the capacity of the rng store is large enough to hold one block,
                 // then this will not be an infinite loop.
-                *egress_key = RistrettoPrivate::from_random(&mut McRng::default());
+                *egress_key = RistrettoPrivate::from_random(&mut McRng);
                 let public_key =
                     CompressedRistrettoPublic::from(&RistrettoPublic::from(&*egress_key));
                 new_kex_rng_pubkey = Some(KexRngPubkey {
@@ -344,8 +344,8 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> IngestEnclave
         let mut rng_store_lk = self.rng_store.lock()?;
         let rng_store = rng_store_lk.as_mut().expect("enclave was not initialized");
 
-        *ingress_key = RistrettoPrivate::from_random(&mut McRng::default());
-        *egress_key = RistrettoPrivate::from_random(&mut McRng::default());
+        *ingress_key = RistrettoPrivate::from_random(&mut McRng);
+        *egress_key = RistrettoPrivate::from_random(&mut McRng);
         rng_store.clear();
         Ok(())
     }
@@ -355,7 +355,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> IngestEnclave
         let mut rng_store_lk = self.rng_store.lock()?;
         let rng_store = rng_store_lk.as_mut().expect("enclave was not initialized");
 
-        *egress_key = RistrettoPrivate::from_random(&mut McRng::default());
+        *egress_key = RistrettoPrivate::from_random(&mut McRng);
         rng_store.clear();
         Ok(())
     }

--- a/fog/ingest/enclave/impl/src/rng_store.rs
+++ b/fog/ingest/enclave/impl/src/rng_store.rs
@@ -144,7 +144,7 @@ impl<OSC: ORAMStorageCreator<StorageDataSize, StorageMetaSize>> RngStore<OSC> {
         let result_code = self.omap.as_mut().unwrap().access_and_insert(
             &aligned_shared_secret,
             &Default::default(),
-            &mut McRng::default(),
+            &mut McRng,
             |_status_code, counter_buf| {
                 let mut counter_val = u64::from_ne_bytes(*counter_buf.as_ref());
                 // Compute the next rng output given shared secret and counter value

--- a/fog/ledger/connection/src/router_client.rs
+++ b/fog/ledger/connection/src/router_client.rs
@@ -96,7 +96,7 @@ impl LedgerGrpcClient {
         // If we have an existing attestation, nuke it.
         self.deattest();
 
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let initiator = Start::new(self.uri.responder_id()?.to_string());
 
@@ -117,7 +117,7 @@ impl LedgerGrpcClient {
             .ok_or(Error::ResponseNotReceived)?;
         let auth_response_msg = response.take_auth();
 
-        let epoch_time = SystemTimeProvider::default()
+        let epoch_time = SystemTimeProvider
             .since_epoch()
             .map_err(|_| Error::Other("Time went backwards".to_owned()))?;
         let time = DateTime::from_unix_duration(epoch_time)

--- a/fog/ledger/server/src/bin/key_image_store.rs
+++ b/fog/ledger/server/src/bin/key_image_store.rs
@@ -47,7 +47,7 @@ fn main() {
             db,
             watcher,
             sharding_strategy,
-            SystemTimeProvider::default(),
+            SystemTimeProvider,
             logger.clone(),
         ),
     };

--- a/fog/ledger/server/src/key_image_store_server.rs
+++ b/fog/ledger/server/src/key_image_store_server.rs
@@ -59,7 +59,7 @@ where
                     time_provider,
                 ))
             } else {
-                Arc::new(AnonymousAuthenticator::default())
+                Arc::new(AnonymousAuthenticator)
             };
 
         Self::new(

--- a/fog/ledger/server/src/merkle_proof_service.rs
+++ b/fog/ledger/server/src/merkle_proof_service.rs
@@ -296,7 +296,7 @@ mod test {
         }
 
         let enclave = MockEnclave::default();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut ledger_server_node = MerkleProofService::new(
             "local".to_string(),
             mock_ledger.clone(),
@@ -355,7 +355,7 @@ mod test {
         }
 
         let enclave = MockEnclave::default();
-        let authenticator = Arc::new(AnonymousAuthenticator::default());
+        let authenticator = Arc::new(AnonymousAuthenticator);
         let mut ledger_server_node = MerkleProofService::new(
             "local".to_string(),
             mock_ledger,

--- a/fog/ledger/server/src/router_server.rs
+++ b/fog/ledger/server/src/router_server.rs
@@ -75,10 +75,10 @@ where
                 Arc::new(TokenAuthenticator::new(
                     *shared_secret,
                     config.client_auth_token_max_lifetime,
-                    SystemTimeProvider::default(),
+                    SystemTimeProvider,
                 ))
             } else {
-                Arc::new(AnonymousAuthenticator::default())
+                Arc::new(AnonymousAuthenticator)
             };
 
         let env = Arc::new(

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -366,7 +366,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
                 ledger.clone(),
                 watcher.clone(),
                 EpochShardingStrategy::default(),
-                SystemTimeProvider::default(),
+                SystemTimeProvider,
                 logger.clone(),
             );
 
@@ -918,7 +918,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 ledger.clone(),
                 watcher.clone(),
                 EpochShardingStrategy::default(),
-                SystemTimeProvider::default(),
+                SystemTimeProvider,
                 logger.clone(),
             );
 

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -155,7 +155,7 @@ fn create_store(
         ledger,
         watcher,
         EpochShardingStrategy::new(block_range),
-        SystemTimeProvider::default(),
+        SystemTimeProvider,
         logger,
     );
     store.start();

--- a/fog/ledger/server/tests/store.rs
+++ b/fog/ledger/server/tests/store.rs
@@ -165,7 +165,7 @@ pub fn direct_key_image_store_check(logger: Logger) {
         watcher,
         enclave.clone(), //LedgerSgxEnclave is an Arc<SgxEnclave> internally
         shared_state.clone(),
-        Arc::new(AnonymousAuthenticator::default()),
+        Arc::new(AnonymousAuthenticator),
         logger.clone(),
     );
 

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -467,7 +467,7 @@ impl Client {
             block_version,
             input_credentials,
             fog_resolver,
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )?;
 
         let change_destination = ReservedSubaddresses::from(&self.account_key);
@@ -597,12 +597,8 @@ impl Client {
 
         // Make transaction builder
         // TODO: Use RTH memos
-        let mut tx_builder = TransactionBuilder::new(
-            block_version,
-            fee,
-            fog_resolver,
-            EmptyMemoBuilder::default(),
-        )?;
+        let mut tx_builder =
+            TransactionBuilder::new(block_version, fee, fog_resolver, EmptyMemoBuilder)?;
         tx_builder.set_tombstone_block(tombstone_block);
 
         tx_builder.set_fee_map(self.get_fee_map(true)?);

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -311,7 +311,7 @@ impl TestClient {
                 .map_err(TestClientError::CheckBalance)
         })?;
 
-        let mut rng = McRng::default();
+        let mut rng = McRng;
         assert!(target_address.fog_report_url().is_some());
 
         let fee = self.get_minimum_fee(token_id, source_client)?;
@@ -731,7 +731,7 @@ impl TestClient {
         self.tx_info.clear();
         let target_address = target_client.get_account_key().default_subaddress();
 
-        let mut rng = McRng::default();
+        let mut rng = McRng;
 
         // Note: McRng does not implement rand::Rng because rand historically
         // has not been no_std

--- a/fog/view/connection/src/fog_view_router_client.rs
+++ b/fog/view/connection/src/fog_view_router_client.rs
@@ -95,7 +95,7 @@ impl FogViewRouterGrpcClient {
         // If we have an existing attestation, nuke it.
         self.deattest();
 
-        let mut csprng = McRng::default();
+        let mut csprng = McRng;
 
         let initiator = Start::new(self.uri.responder_id()?.to_string());
 
@@ -116,7 +116,7 @@ impl FogViewRouterGrpcClient {
             .ok_or(Error::ResponseNotReceived)?;
         let auth_response_msg = response.take_auth();
 
-        let epoch_time = SystemTimeProvider::default()
+        let epoch_time = SystemTimeProvider
             .since_epoch()
             .map_err(|_| Error::Other("Time went backwards".to_owned()))?;
         let time = DateTime::from_unix_duration(epoch_time)

--- a/fog/view/server/src/bin/main.rs
+++ b/fog/view/server/src/bin/main.rs
@@ -56,7 +56,7 @@ fn main() {
         config.clone(),
         sgx_enclave,
         recovery_db,
-        SystemTimeProvider::default(),
+        SystemTimeProvider,
         sharding_strategy,
         logger.clone(),
     );

--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -70,13 +70,8 @@ fn main() {
     }
     let shards = Arc::new(RwLock::new(shards));
 
-    let mut router_server = FogViewRouterServer::new(
-        config,
-        sgx_enclave,
-        shards,
-        SystemTimeProvider::default(),
-        logger,
-    );
+    let mut router_server =
+        FogViewRouterServer::new(config, sgx_enclave, shards, SystemTimeProvider, logger);
     router_server.start();
 
     loop {

--- a/fog/view/server/src/fog_view_router_server.rs
+++ b/fog/view/server/src/fog_view_router_server.rs
@@ -95,7 +95,7 @@ where
                     time_provider,
                 ))
             } else {
-                Arc::new(AnonymousAuthenticator::default())
+                Arc::new(AnonymousAuthenticator)
             };
 
         let admin_service = FogViewRouterAdminService::new(shards.clone(), logger.clone());

--- a/fog/view/server/src/server.rs
+++ b/fog/view/server/src/server.rs
@@ -91,7 +91,7 @@ where
                     time_provider,
                 ))
             } else {
-                Arc::new(AnonymousAuthenticator::default())
+                Arc::new(AnonymousAuthenticator)
             };
 
         // Health check service

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -151,13 +151,8 @@ impl RouterTestEnvironment {
             config.omap_capacity,
             logger.clone(),
         );
-        let mut router_server = FogViewRouterServer::new(
-            config,
-            enclave,
-            shards,
-            SystemTimeProvider::default(),
-            logger.clone(),
-        );
+        let mut router_server =
+            FogViewRouterServer::new(config, enclave, shards, SystemTimeProvider, logger.clone());
         router_server.start();
         router_server
     }
@@ -248,7 +243,7 @@ impl RouterTestEnvironment {
                     config.clone(),
                     enclave,
                     db.clone(),
-                    SystemTimeProvider::default(),
+                    SystemTimeProvider,
                     sharding_strategy.clone(),
                     logger.clone(),
                 );

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -187,7 +187,7 @@ pub fn create_transaction_with_amount_and_comparer_and_recipients<
         block_version,
         Amount::new(fee, sender_amount.token_id),
         MockFogResolver::default(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
 

--- a/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
+++ b/mobilecoind-dev-faucet/src/slam/prepared_utxo.rs
@@ -163,13 +163,9 @@ impl PreparedUtxo {
         };
 
         // Create tx_builder.
-        let mut tx_builder = TransactionBuilder::new(
-            block_version,
-            fee_amount,
-            fog_resolver,
-            EmptyMemoBuilder::default(),
-        )
-        .map_err(|err| format!("Transaction builder new: {err}"))?;
+        let mut tx_builder =
+            TransactionBuilder::new(block_version, fee_amount, fog_resolver, EmptyMemoBuilder)
+                .map_err(|err| format!("Transaction builder new: {err}"))?;
 
         tx_builder.set_tombstone_block(tombstone_block);
         tx_builder.add_input(self.get_input_credentials(account_key)?);

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -3272,7 +3272,7 @@ mod test {
             BLOCK_VERSION,
             Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
         let TxOutContext {
@@ -6228,7 +6228,7 @@ mod test {
             BLOCK_VERSION,
             Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
         let TxOutContext { tx_out, .. } = transaction_builder
@@ -6341,7 +6341,7 @@ mod test {
             BLOCK_VERSION,
             Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
         let TxOutContext { tx_out, .. } = transaction_builder

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -780,7 +780,7 @@ mod test {
             BlockVersion::MAX,
             Amount::new(Mob::MINIMUM_FEE, Mob::ID),
             MockFogResolver::default(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
         let mut tx_outs = Vec::new();

--- a/transaction/builder/src/signed_contingent_input_builder.rs
+++ b/transaction/builder/src/signed_contingent_input_builder.rs
@@ -609,7 +609,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -732,7 +732,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -843,7 +843,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -873,7 +873,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1103,7 +1103,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1133,7 +1133,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1334,7 +1334,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1368,7 +1368,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1401,7 +1401,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1661,7 +1661,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1680,7 +1680,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1753,7 +1753,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1772,7 +1772,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1864,7 +1864,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1887,7 +1887,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1971,7 +1971,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1990,7 +1990,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2081,7 +2081,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2115,7 +2115,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2206,7 +2206,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2235,7 +2235,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2326,7 +2326,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2345,7 +2345,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2437,7 +2437,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2470,7 +2470,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2554,7 +2554,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2617,7 +2617,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2828,7 +2828,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -2891,7 +2891,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -3106,7 +3106,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -3170,7 +3170,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -3386,7 +3386,7 @@ pub mod tests {
                 block_version,
                 input_credentials,
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -3440,7 +3440,7 @@ pub mod tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, Mob::ID),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 

--- a/transaction/builder/src/test_utils.rs
+++ b/transaction/builder/src/test_utils.rs
@@ -177,7 +177,7 @@ pub fn get_unsigned_transaction<RNG: RngCore + CryptoRng, FPR: FogPubkeyResolver
         block_version,
         Amount::new(Mob::MINIMUM_FEE, token_id),
         fog_resolver.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
     let input_value = 1000;

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -982,7 +982,7 @@ pub mod transaction_builder_tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, token_id),
                 fpr,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1066,7 +1066,7 @@ pub mod transaction_builder_tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, token_id),
                 fog_resolver,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1159,7 +1159,7 @@ pub mod transaction_builder_tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, token_id),
                 fog_resolver.clone(),
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
 
@@ -1237,7 +1237,7 @@ pub mod transaction_builder_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, token_id),
                     fog_resolver.clone(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
 
@@ -1274,7 +1274,7 @@ pub mod transaction_builder_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, token_id),
                     fog_resolver.clone(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
 
@@ -1340,7 +1340,7 @@ pub mod transaction_builder_tests {
                     block_version,
                     Amount::new(Mob::MINIMUM_FEE, token_id),
                     fog_resolver.clone(),
-                    EmptyMemoBuilder::default(),
+                    EmptyMemoBuilder,
                 )
                 .unwrap();
 
@@ -2824,7 +2824,7 @@ pub mod transaction_builder_tests {
                 block_version,
                 Amount::new(Mob::MINIMUM_FEE, token_id),
                 fpr,
-                EmptyMemoBuilder::default(),
+                EmptyMemoBuilder,
             )
             .unwrap();
             transaction_builder.add_input(input_credentials);
@@ -3441,7 +3441,7 @@ pub mod transaction_builder_tests {
 
         for block_version in 3..=*BlockVersion::MAX {
             let block_version = BlockVersion::try_from(block_version).unwrap();
-            let memo_builder = EmptyMemoBuilder::default();
+            let memo_builder = EmptyMemoBuilder;
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,
@@ -3576,7 +3576,7 @@ pub mod transaction_builder_tests {
         // Builds a transaction using a particular amount in place of tx_out1, returning
         // result of `.build()`
         let mut test_fn = |block_version, tx_out1_amount| -> Result<_, _> {
-            let memo_builder = EmptyMemoBuilder::default();
+            let memo_builder = EmptyMemoBuilder;
 
             let mut transaction_builder = TransactionBuilder::new(
                 block_version,

--- a/transaction/extra/tests/verifier.rs
+++ b/transaction/extra/tests/verifier.rs
@@ -282,7 +282,7 @@ fn test_two_input_tx_with_change_tx_summary_verification() {
             block_version,
             Amount::new(Mob::MINIMUM_FEE, token_id),
             fog_resolver.clone(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
 
@@ -382,7 +382,7 @@ fn test_simple_tx_with_change_tx_summary_verification() {
             block_version,
             Amount::new(Mob::MINIMUM_FEE, token_id),
             fog_resolver.clone(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
 
@@ -477,7 +477,7 @@ fn test_two_output_tx_with_change_tx_summary_verification() {
             block_version,
             Amount::new(Mob::MINIMUM_FEE, token_id),
             fog_resolver.clone(),
-            EmptyMemoBuilder::default(),
+            EmptyMemoBuilder,
         )
         .unwrap();
 
@@ -584,7 +584,7 @@ fn test_sci_tx_summary_verification() {
         block_version,
         input_credentials,
         fog_resolver.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
 
@@ -611,7 +611,7 @@ fn test_sci_tx_summary_verification() {
         block_version,
         Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         fog_resolver,
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
 
@@ -707,7 +707,7 @@ fn test_sci_three_way_tx_summary_verification() {
         block_version,
         input_credentials,
         fog_resolver.clone(),
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
 
@@ -734,7 +734,7 @@ fn test_sci_three_way_tx_summary_verification() {
         block_version,
         Amount::new(Mob::MINIMUM_FEE, Mob::ID),
         fog_resolver,
-        EmptyMemoBuilder::default(),
+        EmptyMemoBuilder,
     )
     .unwrap();
 

--- a/util/grpc-token-generator/src/bin/main.rs
+++ b/util/grpc-token-generator/src/bin/main.rs
@@ -27,7 +27,7 @@ pub struct Config {
 fn main() {
     let config = Config::parse();
     let token_generator =
-        TokenBasicCredentialsGenerator::new(config.shared_secret, SystemTimeProvider::default());
+        TokenBasicCredentialsGenerator::new(config.shared_secret, SystemTimeProvider);
     let creds = token_generator
         .generate_for(&config.username)
         .expect("Failed generating token");

--- a/util/grpc/src/auth/mod.rs
+++ b/util/grpc/src/auth/mod.rs
@@ -200,7 +200,7 @@ mod test {
 
     #[test]
     fn authenticate_anonymous() {
-        let authenticator = AnonymousAuthenticator::default();
+        let authenticator = AnonymousAuthenticator;
 
         // Authorizing without any headers should work.
         let metadata = MetadataBuilder::new().build();
@@ -251,11 +251,8 @@ mod test {
     #[test]
     fn authenticate_token() {
         let shared_secret = [66; 32];
-        let authenticator = TokenAuthenticator::new(
-            shared_secret,
-            TOKEN_MAX_LIFETIME,
-            SystemTimeProvider::default(),
-        );
+        let authenticator =
+            TokenAuthenticator::new(shared_secret, TOKEN_MAX_LIFETIME, SystemTimeProvider);
         const TEST_USERNAME: &str = "user123";
 
         // Authorizing without any headers should fail.
@@ -283,8 +280,7 @@ mod test {
         }
 
         // Authorizing with a valid Authorization header should succeed.
-        let generator =
-            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider);
         let creds = generator
             .generate_for(TEST_USERNAME)
             .expect("failed generating token");

--- a/util/grpc/src/auth/token_authenticator.rs
+++ b/util/grpc/src/auth/token_authenticator.rs
@@ -190,13 +190,9 @@ mod tests {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator =
-            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
-        let authenticator = TokenAuthenticator::new(
-            shared_secret,
-            TOKEN_MAX_LIFETIME,
-            SystemTimeProvider::default(),
-        );
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider);
+        let authenticator =
+            TokenAuthenticator::new(shared_secret, TOKEN_MAX_LIFETIME, SystemTimeProvider);
 
         let creds = generator.generate_for(TEST_USERNAME).unwrap();
         let user = authenticator
@@ -208,11 +204,8 @@ mod tests {
     #[test]
     fn missing_creds_fails_authentication() {
         let shared_secret = [3; 32];
-        let authenticator = TokenAuthenticator::new(
-            shared_secret,
-            TOKEN_MAX_LIFETIME,
-            SystemTimeProvider::default(),
-        );
+        let authenticator =
+            TokenAuthenticator::new(shared_secret, TOKEN_MAX_LIFETIME, SystemTimeProvider);
 
         assert_eq!(
             authenticator.authenticate(None),
@@ -225,12 +218,11 @@ mod tests {
         let shared_secret = [3; 32];
         const TEST_USERNAME: &str = "test user";
 
-        let generator =
-            TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider::default());
+        let generator = TokenBasicCredentialsGenerator::new(shared_secret, SystemTimeProvider);
 
         // Signature will fail if authenticator uses a different shared secret.
         let authenticator =
-            TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME, SystemTimeProvider::default());
+            TokenAuthenticator::new([4; 32], TOKEN_MAX_LIFETIME, SystemTimeProvider);
 
         let creds = generator.generate_for(TEST_USERNAME).unwrap();
 

--- a/watcher/src/attestation_evidence_collector.rs
+++ b/watcher/src/attestation_evidence_collector.rs
@@ -68,17 +68,17 @@ impl NodeClient for ConsensusNodeClient {
             .ok_or_else(|| "No consensus client url".to_owned())?;
 
         // Construct a credentials_provider based on our configuration.
-        let credentials_provider =
-            if let Some(secret) = source_config.consensus_client_auth_token_secret() {
-                let username = node_url.username();
-                let token_generator =
-                    TokenBasicCredentialsGenerator::new(secret, SystemTimeProvider::default());
-                let token_credentials_provider =
-                    TokenBasicCredentialsProvider::new(username, token_generator);
-                AnyCredentialsProvider::Token(token_credentials_provider)
-            } else {
-                AnyCredentialsProvider::Hardcoded(HardcodedCredentialsProvider::from(&node_url))
-            };
+        let credentials_provider = if let Some(secret) =
+            source_config.consensus_client_auth_token_secret()
+        {
+            let username = node_url.username();
+            let token_generator = TokenBasicCredentialsGenerator::new(secret, SystemTimeProvider);
+            let token_credentials_provider =
+                TokenBasicCredentialsProvider::new(username, token_generator);
+            AnyCredentialsProvider::Token(token_credentials_provider)
+        } else {
+            AnyCredentialsProvider::Hardcoded(HardcodedCredentialsProvider::from(&node_url))
+        };
 
         attestation_evidence_from_node_url(env, logger, node_url, credentials_provider)
     }
@@ -143,7 +143,7 @@ fn attestation_evidence_from_node_url(
     credentials_provider: AnyCredentialsProvider,
 ) -> Result<EvidenceKind, String> {
     trace_time!(logger, "attestation_evidence_from_node_url");
-    let mut csprng = McRng::default();
+    let mut csprng = McRng;
 
     let initiator = Start::new(
         node_url


### PR DESCRIPTION
This fixes clippy lints which will be coming in
<https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs>