### PR TITLE
Use canonical `PartialOrd`

### DIFF
--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -296,8 +296,7 @@ impl PartialEq for AccountKey {
 
 impl PartialOrd for AccountKey {
     fn partial_cmp(&self, other: &AccountKey) -> Option<Ordering> {
-        self.default_subaddress()
-            .partial_cmp(&other.default_subaddress())
+        Some(self.cmp(other))
     }
 }
 

--- a/common/src/node_id.rs
+++ b/common/src/node_id.rs
@@ -70,7 +70,7 @@ impl Eq for NodeID {}
 
 impl PartialOrd for NodeID {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.public_key.partial_cmp(&other.public_key)
+        Some(self.cmp(other))
     }
 }
 

--- a/connection/src/sync.rs
+++ b/connection/src/sync.rs
@@ -111,9 +111,7 @@ impl<C: Connection> PartialEq for SyncConnection<C> {
 
 impl<C: Connection> PartialOrd for SyncConnection<C> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_g = self.read();
-        let other_g = other.read();
-        self_g.deref().partial_cmp(other_g.deref())
+        Some(self.cmp(other))
     }
 }
 

--- a/connection/src/thick.rs
+++ b/connection/src/thick.rs
@@ -476,6 +476,6 @@ impl<CP: CredentialsProvider> Ord for ThickClient<CP> {
 
 impl<CP: CredentialsProvider> PartialOrd for ThickClient<CP> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }

--- a/connection/test-utils/src/blockchain.rs
+++ b/connection/test-utils/src/blockchain.rs
@@ -77,7 +77,7 @@ impl<L: Ledger + Sync> PartialEq for MockBlockchainConnection<L> {
 
 impl<L: Ledger + Sync> PartialOrd for MockBlockchainConnection<L> {
     fn partial_cmp(&self, other: &MockBlockchainConnection<L>) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }
 

--- a/connection/test-utils/src/user_tx.rs
+++ b/connection/test-utils/src/user_tx.rs
@@ -55,7 +55,7 @@ impl PartialEq for MockUserTxConnection {
 
 impl PartialOrd for MockUserTxConnection {
     fn partial_cmp(&self, other: &MockUserTxConnection) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }
 

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -341,7 +341,7 @@ impl RistrettoPublic {
 
 impl PartialOrd for RistrettoPublic {
     fn partial_cmp(&self, other: &RistrettoPublic) -> Option<Ordering> {
-        self.to_bytes().partial_cmp(&other.to_bytes())
+        Some(self.cmp(other))
     }
 }
 

--- a/fog/enclave_connection/src/lib.rs
+++ b/fog/enclave_connection/src/lib.rs
@@ -316,6 +316,6 @@ impl<U: ConnectionUri, G: EnclaveGrpcChannel> Ord for EnclaveConnection<U, G> {
 
 impl<U: ConnectionUri, G: EnclaveGrpcChannel> PartialOrd for EnclaveConnection<U, G> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }

--- a/fog/ingest/server/src/connection.rs
+++ b/fog/ingest/server/src/connection.rs
@@ -128,7 +128,7 @@ impl<Enclave: IngestEnclaveProxy> PartialEq for PeerConnection<Enclave> {
 
 impl<Enclave: IngestEnclaveProxy> PartialOrd for PeerConnection<Enclave> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }
 

--- a/peers/src/connection.rs
+++ b/peers/src/connection.rs
@@ -160,7 +160,7 @@ impl<Enclave: ConsensusEnclave + Clone + Send + Sync> PartialEq for PeerConnecti
 
 impl<Enclave: ConsensusEnclave + Clone + Send + Sync> PartialOrd for PeerConnection<Enclave> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }
 

--- a/peers/test-utils/src/lib.rs
+++ b/peers/test-utils/src/lib.rs
@@ -135,7 +135,7 @@ impl<L: Ledger + Sync> PartialEq for MockPeerConnection<L> {
 
 impl<L: Ledger + Sync> PartialOrd for MockPeerConnection<L> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.uri.addr().partial_cmp(&other.uri.addr())
+        Some(self.cmp(other))
     }
 }
 

--- a/util/ffi/src/ffi_ref_ptr.rs
+++ b/util/ffi/src/ffi_ref_ptr.rs
@@ -55,7 +55,7 @@ impl<'a, T: 'a + ?Sized> Copy for FfiRefPtr<'a, T> {}
 impl<'a, T: 'a + ?Sized> Clone for FfiRefPtr<'a, T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self(self.0, Default::default())
+        *self
     }
 }
 
@@ -218,7 +218,7 @@ impl<'a, T: 'a + ?Sized> Copy for FfiOptRefPtr<'a, T> {}
 impl<'a, T: 'a + ?Sized> Clone for FfiOptRefPtr<'a, T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self(self.0, Default::default())
+        *self
     }
 }
 

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -388,8 +388,7 @@ macro_rules! derive_core_cmp_from_as_ref {
     ($mytype:ty, $asref:ty) => {
         impl PartialOrd for $mytype {
             fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
-                <Self as AsRef<$asref>>::as_ref(self)
-                    .partial_cmp(<Self as AsRef<$asref>>::as_ref(other))
+                Some(self.cmp(other))
             }
         }
 


### PR DESCRIPTION
For types that implement `Ord` the `PartialOrd` now redirects to the
`Ord` implementations to ensure they are consistent.

This addresses a clippy lint coming in a newer rust version,
https://rust-lang.github.io/rust-clippy/master/index.html#/non_canonical_partial_ord_impl

Also fixes some non canonical `Clone` implementation from https://rust-lang.github.io/rust-clippy/master/index.html#/non_canonical_clone_impl
