### PR TITLE
Place test modules at end of files

### DIFF
--- a/attest/verifier/src/ias.rs
+++ b/attest/verifier/src/ias.rs
@@ -50,13 +50,12 @@ impl IasReportVerifier {
         // Here's the background information for this code:
         //
         //  1. An X509 certificate can be signed by only one issuer.
-        //  2. mbedtls' certificates-list API demands certs in the RFC5246
-        //     order (endpoint cert first, every other cert signed the
-        //     cert preceeding it in the list).
-        //  3. I don't recall Intel's specification mentioning certificate
-        //     ordering at all (meaning they can change it w/o warning).
-        //  4. mbedtls' certificates-list API isn't actually exposed to us,
-        //     anyways.
+        //  2. mbedtls' certificates-list API demands certs in the RFC5246 order
+        //     (endpoint cert first, every other cert signed the cert preceeding it in
+        //     the list).
+        //  3. I don't recall Intel's specification mentioning certificate ordering at
+        //     all (meaning they can change it w/o warning).
+        //  4. mbedtls' certificates-list API isn't actually exposed to us, anyways.
         //
         // As a result, we need to find the cert which signed the data (this
         // doubles as the signature check), then find a way back up the

--- a/attest/verifier/src/status.rs
+++ b/attest/verifier/src/status.rs
@@ -1171,10 +1171,9 @@ mod test {
             AdvisoryStatus::ConfigurationNeeded,
         ));
 
-        let Kind::Enclave(mr_enclave_verifier) = verifier
-            else {
-                panic!("Should be a mr enclave verifier");
-            };
+        let Kind::Enclave(mr_enclave_verifier) = verifier else {
+            panic!("Should be a mr enclave verifier");
+        };
         assert_eq!(
             mr_enclave_verifier.advisories,
             Advisories::new(["one", "two", "three"], AdvisoryStatus::ConfigurationNeeded)
@@ -1194,8 +1193,7 @@ mod test {
             AdvisoryStatus::SWHardeningNeeded,
         ));
 
-        let Kind::Enclave(mr_enclave_verifier) = verifier
-        else {
+        let Kind::Enclave(mr_enclave_verifier) = verifier else {
             panic!("Should be a mr enclave verifier");
         };
         assert_eq!(
@@ -1219,10 +1217,9 @@ mod test {
             AdvisoryStatus::ConfigurationNeeded,
         ));
 
-        let Kind::Signer(mr_signer_verifier) = verifier
-            else {
-                panic!("Should be a mr signer verifier");
-            };
+        let Kind::Signer(mr_signer_verifier) = verifier else {
+            panic!("Should be a mr signer verifier");
+        };
         assert_eq!(
             mr_signer_verifier.advisories,
             Advisories::new(["who", "what", "when"], AdvisoryStatus::ConfigurationNeeded)
@@ -1244,10 +1241,9 @@ mod test {
             AdvisoryStatus::SWHardeningNeeded,
         ));
 
-        let Kind::Signer(mr_signer_verifier) = verifier
-            else {
-                panic!("Should be a mr signer verifier");
-            };
+        let Kind::Signer(mr_signer_verifier) = verifier else {
+            panic!("Should be a mr signer verifier");
+        };
         assert_eq!(
             mr_signer_verifier.advisories,
             Advisories::new(

--- a/consensus/enclave/api/src/lib.rs
+++ b/consensus/enclave/api/src/lib.rs
@@ -177,27 +177,6 @@ impl PartialOrd for WellFormedTxContext {
     }
 }
 
-#[cfg(test)]
-mod well_formed_tx_context_tests {
-    use crate::WellFormedTxContext;
-    use alloc::{vec, vec::Vec};
-
-    #[test]
-    /// WellFormedTxContext should be sorted by priority, descending.
-    fn test_ordering() {
-        let a = WellFormedTxContext::new(100, Default::default(), 0, vec![], vec![], vec![]);
-        let b = WellFormedTxContext::new(557, Default::default(), 0, vec![], vec![], vec![]);
-        let c = WellFormedTxContext::new(88, Default::default(), 0, vec![], vec![], vec![]);
-
-        let mut contexts = vec![a, b, c];
-        contexts.sort();
-
-        let priorities: Vec<_> = contexts.iter().map(|context| context.priority).collect();
-        let expected = vec![557, 100, 88];
-        assert_eq!(priorities, expected);
-    }
-}
-
 /// An intermediate struct for holding data required to perform the two-step
 /// is-well-formed test. This is returned by `txs_propose` and allows untrusted
 /// to gather data required for the in-enclave well-formedness test that takes
@@ -356,3 +335,24 @@ pub trait ConsensusEnclave: ReportableEnclave {
 /// This marker trait can be implemented for the untrusted-side representation
 /// of the enclave.
 pub trait ConsensusEnclaveProxy: ConsensusEnclave + Clone + Send + Sync + 'static {}
+
+#[cfg(test)]
+mod well_formed_tx_context_tests {
+    use crate::WellFormedTxContext;
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    /// WellFormedTxContext should be sorted by priority, descending.
+    fn test_ordering() {
+        let a = WellFormedTxContext::new(100, Default::default(), 0, vec![], vec![], vec![]);
+        let b = WellFormedTxContext::new(557, Default::default(), 0, vec![], vec![], vec![]);
+        let c = WellFormedTxContext::new(88, Default::default(), 0, vec![], vec![], vec![]);
+
+        let mut contexts = vec![a, b, c];
+        contexts.sort();
+
+        let priorities: Vec<_> = contexts.iter().map(|context| context.priority).collect();
+        let expected = vec![557, 100, 88];
+        assert_eq!(priorities, expected);
+    }
+}

--- a/crypto/box/src/versioned.rs
+++ b/crypto/box/src/versioned.rs
@@ -38,9 +38,9 @@ use mc_crypto_keys::{Kex, Ristretto};
 use mc_oblivious_aes_gcm::{Aes256Gcm, CtDecryptResult};
 use rand_core::{CryptoRng, RngCore};
 
-////
+//
 // CONFIGURATION
-////
+//
 
 pub type RistrettoHkdfBlake2bAes256Gcm = HkdfBox<Ristretto, Blake2b512, Aes256Gcm>;
 
@@ -61,9 +61,9 @@ const ACCEPTABLE_MINOR_VERSIONS: &[u8] = &[0];
 /// statements in the implementation below.
 type ImplTuple = (RistrettoHkdfBlake2bAes256Gcm,);
 
-////
+//
 // Implementation
-////
+//
 
 /// An object implementing CryptoBox trait that calls out to one of several
 /// other implementations, then attaches versioning tags. When decrypting, it

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -579,9 +579,7 @@ mod ed25519_tests {
         );
     }
 
-    ////
     // Validate ED25519_*_PREFIX against openssl implementation
-    ////
     //
     // In review, Isis suggested that the 12 byte pattern ED25519_SIG_DER_PREFIX
     // should be validated by

--- a/crypto/message-cipher/src/aes_impl.rs
+++ b/crypto/message-cipher/src/aes_impl.rs
@@ -111,9 +111,9 @@ impl<C: AeadInPlace + KeyInit> MessageCipher for AeadMessageCipher<C> {
     }
 }
 
-////
+//
 // Details
-////
+//
 
 /// A representation of a nonce suitable for e.g. AES, supporting inc(),
 /// copy_to_slice(), and other functions
@@ -150,10 +150,6 @@ impl<L: ArrayLength<u8>> Nonce<L> {
         &self.bytes
     }
 }
-
-////
-// Tests
-////
 
 #[cfg(test)]
 mod tests {

--- a/crypto/message-cipher/src/traits.rs
+++ b/crypto/message-cipher/src/traits.rs
@@ -7,18 +7,15 @@ use prost::Message;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
-////
-// A message cipher is a symmetric cipher meant to be used by the enclave as an
-// alternative to intel's "Sealing" when persistence across power cycles is not
-// needed.
-//
-// The trait also provides convenient wrappers over prost serialization.
-//
-// The payloads are encrypted in a way that includes the nonce
-// and the key number in a ciphertext header. Rekeying happens under the hood
-// when the counter is exhausted.
-////
-
+/// A message cipher is a symmetric cipher meant to be used by the enclave as an
+/// alternative to intel's "Sealing" when persistence across power cycles is not
+/// needed.
+///
+/// The trait also provides convenient wrappers over prost serialization.
+///
+/// The payloads are encrypted in a way that includes the nonce
+/// and the key number in a ciphertext header. Rekeying happens under the hood
+/// when the counter is exhausted.
 pub trait MessageCipher {
     fn new<R: CryptoRng + RngCore>(rng: &mut R) -> Self;
 

--- a/fog/ingest/enclave/src/lib.rs
+++ b/fog/ingest/enclave/src/lib.rs
@@ -301,8 +301,7 @@ extern "C" {
     ///  1. Application Code
     ///  2. Untrusted generated_enclave_api(eid, retval, inbuf, ...) function
     ///  3. Trusted, generated_enclave_api(inbuf, ...) ECALL
-    ///  4. Target enclave_api(inbuf, ...) method inside rust in the
-    ///     enclave.
+    ///  4. Target enclave_api(inbuf, ...) method inside rust in the enclave.
     pub fn ingest_enclave_call(
         eid: sgx_enclave_id_t,
         retval: *mut sgx_status_t,

--- a/fog/kex_rng/src/versioned/buffered.rs
+++ b/fog/kex_rng/src/versioned/buffered.rs
@@ -24,9 +24,9 @@ where
     buffer: GenericArray<u8, <Core as KexRngCore<KexAlgo>>::OutputSize>,
 }
 
-////
+//
 // Implement high-level traits
-////
+//
 
 impl<Core, KexAlgo> BufferedRng for BufferedKexRng<Core, KexAlgo>
 where
@@ -113,9 +113,9 @@ where
     }
 }
 
-////
+//
 // Implement underlying required traits
-////
+//
 
 // Clone
 impl<Core, KexAlgo> Clone for BufferedKexRng<Core, KexAlgo>

--- a/fog/ledger/enclave/src/lib.rs
+++ b/fog/ledger/enclave/src/lib.rs
@@ -295,8 +295,7 @@ extern "C" {
     ///  1. Application Code
     ///  2. Untrusted generated_enclave_api(eid, retval, inbuf, ...) function
     ///  3. Trusted, generated_enclave_api(inbuf, ...) ECALL
-    ///  4. Target enclave_api(inbuf, ...) method inside rust in the
-    ///     enclave.
+    ///  4. Target enclave_api(inbuf, ...) method inside rust in the enclave.
     pub fn ledger_enclave_call(
         eid: sgx_enclave_id_t,
         retval: *mut sgx_status_t,

--- a/fog/overseer/server/src/worker.rs
+++ b/fog/overseer/server/src/worker.rs
@@ -296,21 +296,21 @@ where
     ///      but Fog Ingest isn't currently doing that because all nodes are
     ///      idle.
     ///   2. If there are:
-    ///         a) 0 outstanding keys:
-    ///              No node will be activated. We now have to:
-    ///                 (i)  Set new keys on an idle node.
-    ///                 (ii) Activate that node.
-    ///         b) 1 outsanding key:
-    ///              Try to find an idle node that contains that key.
-    ///                 (i)  If you find one, great! Just activate that node. If
-    ///                      activation is unsuccessful, then return an error
-    ///                      and return to the overseer polling logic.
-    ///                 (ii) If you don't find an idle node with that key,
-    ///                      then you have to report that key as lost, set
-    ///                      new keys on an idle node, and activate that node.
-    ///        c) > 1 outstanding key:
-    ///             (i) Disable
-    ///             (ii) TODO: Send an alert.
+    ///     a. 0 outstanding keys:
+    ///        No node will be activated. We now have to:
+    ///        i. Set new keys on an idle node.
+    ///        ii. Activate that node.
+    ///     b. 1 outsanding key:
+    ///        Try to find an idle node that contains that key.
+    ///        i. If you find one, great! Just activate that node. If
+    ///           activation is unsuccessful, then return an error
+    ///           and return to the overseer polling logic.
+    ///        ii. If you don't find an idle node with that key,
+    ///            then you have to report that key as lost, set
+    ///            new keys on an idle node, and activate that node.
+    ///     c. > 1 outstanding key:
+    ///        i. Disable
+    ///        ii. TODO: Send an alert.
     fn perform_automatic_failover(
         &self,
         ingest_summary_node_mappings: Vec<IngestSummaryNodeMapping>,
@@ -381,12 +381,12 @@ where
     }
 
     /// Performs the following logic when one inactive outstanding key is found:
-    ///   1) Tries to find an idle node that contains that key.
-    ///      (i)  If it's found, it activates the node that contains it. If
-    ///           activation is unsuccessful, then it returns an error.
-    ///      (ii) If no idle node is found that contains the key, then it
-    ///           reports that key as lost, sets new keys on an idle node, and
-    ///           activates that node.
+    ///   1. Tries to find an idle node that contains that key.
+    ///     a. If it's found, it activates the node that contains it. If
+    ///        activation is unsuccessful, then it returns an error.
+    ///     b. If no idle node is found that contains the key, then it
+    ///        reports that key as lost, sets new keys on an idle node, and
+    ///        activates that node.
     fn handle_one_inactive_outstanding_key(
         &self,
         inactive_outstanding_key: CompressedRistrettoPublic,

--- a/fog/view/enclave/src/ecall.rs
+++ b/fog/view/enclave/src/ecall.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
-///! Forward declarations for ECALL-able methods which live inside an enclave
+/// Forward declarations for ECALL-able methods which live inside an enclave
 use mc_sgx_types::{sgx_enclave_id_t, sgx_status_t};
 
 extern "C" {

--- a/ledger/db/src/mint_config_store.rs
+++ b/ledger/db/src/mint_config_store.rs
@@ -3,8 +3,8 @@
 //! Data access abstraction for minting configuration stored in the ledger.
 //!
 //! This store maintains three LMDB databases:
-//! 1) A mapping of token id -> currently active mint configurations.
-//!    This database is used for two things:
+//! 1) A mapping of token id -> currently active mint configurations. This
+//!    database is used for two things:
 //!      1) It allows transaction validation code to figure out if a mint
 //! transaction is allowed to mint.
 //!      2) It enables keeping track of how much was minted using a given

--- a/mobilecoind/src/db_crypto.rs
+++ b/mobilecoind/src/db_crypto.rs
@@ -266,9 +266,9 @@ impl DbCryptoProvider {
         //    ciphertext back to the caller.
         // 2) When the db is encrypted but has not yet been unlocked by calling
         //    check_and_store_password. In order to provide a better user experience, we
-        //    test if that is the case before assuming no password is required.
-        //    This allows callers to get a meaningful error (PasswordNeeded) instead of
-        //    prost decode errors.
+        //    test if that is the case before assuming no password is required. This
+        //    allows callers to get a meaningful error (PasswordNeeded) instead of prost
+        //    decode errors.
         match (state.is_db_encrypted, state.encryption_key.is_empty()) {
             // Db is not encrypted and password is empty
             (false, true) => Ok(ciphertext.to_vec()),

--- a/test-vectors/memos/build.rs
+++ b/test-vectors/memos/build.rs
@@ -103,15 +103,15 @@ fn write_incorrect_encrypted_sender_memos() {
             let sender_memo_bytes: [u8; 64] = encrypted_sender_memo.clone().into();
 
             let encrypted_sender_memo_data = IncorrectEncryptedSenderMemoData {
-                /// Report the recipient_public_address as the
-                /// sender_public_address. This results in a memo that won't be
-                /// correct.
+                // Report the recipient_public_address as the
+                // sender_public_address. This results in a memo that won't be
+                // correct.
                 incorrect_sender_public_address_hex_proto_bytes: hex::encode(
                     mc_util_serial::encode(&recipient_public_address.clone()),
                 ),
-                /// Report the sender's view_public_key as the
-                /// recipient_view_public_key.  This results in a memo that
-                /// won't be correct.
+                // Report the sender's view_public_key as the
+                // recipient_view_public_key.  This results in a memo that
+                // won't be correct.
                 incorrect_recipient_view_public_key_hex_raw_bytes: hex::encode(
                     sender_public_address.view_public_key().to_bytes(),
                 ),

--- a/util/repr-bytes/src/lib.rs
+++ b/util/repr-bytes/src/lib.rs
@@ -102,7 +102,6 @@ impl Display for LengthMismatch {
     }
 }
 
-////
 // Suggested Implementations:
 // These macros provide instances of what can be thought of as "blanket
 // implementations" on a per-type basis.
@@ -112,7 +111,6 @@ impl Display for LengthMismatch {
 // There are two types of suggested impls:
 // - Impls of other traits in terms of ReprBytes
 // - Impls of ReprBytes in terms of other traits
-////
 
 /// Derive [ReprBytes] from [AsRef<[u8]>], [TryFrom<&[u8]>], and Size as a
 /// typenum. This is expected to be the right implementation for almost all


### PR DESCRIPTION
Newer clippy versions will warn if the test module is not the last one
in the file,
https://rust-lang.github.io/rust-clippy/master/index.html#/items_after_test_module

Also update some comment formatting for newer `cargo fmt` behavior.
