### PR TITLE
Remove use of `&mut` that didn't mutate

### DIFF
--- a/consensus/enclave/impl/src/lib.rs
+++ b/consensus/enclave/impl/src/lib.rs
@@ -1167,7 +1167,7 @@ mod tests {
 
             let tx = create_transaction(
                 block_version,
-                &mut ledger,
+                &ledger,
                 &tx_out,
                 &sender,
                 &recipient.default_subaddress(),
@@ -1254,7 +1254,7 @@ mod tests {
 
             let tx = create_transaction(
                 block_version,
-                &mut ledger,
+                &ledger,
                 &tx_out,
                 &sender,
                 &recipient.default_subaddress(),
@@ -1396,7 +1396,7 @@ mod tests {
 
                     create_transaction(
                         block_version,
-                        &mut ledger,
+                        &ledger,
                         &tx_out,
                         &sender,
                         &recipient.default_subaddress(),
@@ -1535,7 +1535,7 @@ mod tests {
 
                     create_transaction(
                         block_version,
-                        &mut ledger,
+                        &ledger,
                         &tx_out,
                         &sender,
                         &recipient.default_subaddress(),
@@ -1567,7 +1567,7 @@ mod tests {
 
                     let tx = create_transaction(
                         block_version,
-                        &mut ledger,
+                        &ledger,
                         &spendable_output,
                         &sender,
                         &recipient.default_subaddress(),
@@ -1735,7 +1735,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -1751,7 +1751,7 @@ mod tests {
 
                 create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -1846,7 +1846,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -1863,7 +1863,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -1960,7 +1960,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -2066,7 +2066,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -2154,7 +2154,7 @@ mod tests {
 
                 let tx = create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     tx_out,
                     &sender,
                     &recipient.default_subaddress(),
@@ -3192,7 +3192,7 @@ mod tests {
 
                     create_transaction(
                         block_version,
-                        &mut ledger,
+                        &ledger,
                         &tx_out,
                         &sender,
                         &recipient.default_subaddress(),

--- a/consensus/enclave/tests/enclave_api_tests.rs
+++ b/consensus/enclave/tests/enclave_api_tests.rs
@@ -86,7 +86,7 @@ fn consensus_enclave_client_tx_propose(logger: Logger) {
 
     let tx = create_transaction(
         block_version,
-        &mut ledger,
+        &ledger,
         &tx_out,
         &sender,
         &recipient.default_subaddress(),

--- a/consensus/service/src/byzantine_ledger/mod.rs
+++ b/consensus/service/src/byzantine_ledger/mod.rs
@@ -597,7 +597,7 @@ mod tests {
             let recipient = AccountKey::random(&mut rng);
             let tx1 = create_transaction(
                 BLOCK_VERSION,
-                &mut ledger,
+                &ledger,
                 &block_contents.outputs[0],
                 &sender,
                 &recipient.default_subaddress(),
@@ -608,7 +608,7 @@ mod tests {
             let recipient = AccountKey::random(&mut rng);
             let tx2 = create_transaction(
                 BLOCK_VERSION,
-                &mut ledger,
+                &ledger,
                 &block_contents.outputs[1],
                 &sender,
                 &recipient.default_subaddress(),
@@ -619,7 +619,7 @@ mod tests {
             let recipient = AccountKey::random(&mut rng);
             let tx3 = create_transaction(
                 BLOCK_VERSION,
-                &mut ledger,
+                &ledger,
                 &block_contents.outputs[2],
                 &sender,
                 &recipient.default_subaddress(),

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -1591,7 +1591,7 @@ mod tests {
 
                 create_transaction(
                     block_version,
-                    &mut ledger,
+                    &ledger,
                     &tx_out,
                     &sender,
                     &recipient.default_subaddress(),

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -79,7 +79,7 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
         let db_full_path = ledger_dir.path();
         let mut ledger = recreate_ledger_db(db_full_path);
 
-        let (mut watcher, watcher_dir) = setup_watcher_db(logger.clone());
+        let (watcher, watcher_dir) = setup_watcher_db(logger.clone());
 
         // Populate ledger with some data
         add_block_to_ledger(
@@ -88,7 +88,7 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
             &recipients,
             &[],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         add_block_to_ledger(
             block_version,
@@ -96,7 +96,7 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
             &recipients,
             &[KeyImage::from(1)],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         let num_blocks = add_block_to_ledger(
             block_version,
@@ -104,7 +104,7 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
             &recipients,
             &[KeyImage::from(2)],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
 
         {
@@ -275,7 +275,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
         let mut ledger = recreate_ledger_db(db_full_path);
 
         // Make WatcherDB
-        let (mut watcher, watcher_dir) = setup_watcher_db(logger.clone());
+        let (watcher, watcher_dir) = setup_watcher_db(logger.clone());
 
         // Populate ledger with some data
         // Origin block cannot have key images
@@ -285,7 +285,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
             &recipients,
             &[],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         add_block_to_ledger(
             block_version,
@@ -293,7 +293,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
             &recipients,
             &keys[0..2],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         add_block_to_ledger(
             block_version,
@@ -301,7 +301,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
             &recipients,
             &keys[3..6],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         let num_blocks = add_block_to_ledger(
             block_version,
@@ -309,7 +309,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
             &recipients,
             &keys[6..9],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
 
         // Populate watcher with Signature and Timestamp for block 1
@@ -515,7 +515,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
     let db_full_path = ledger_dir.path();
     let mut ledger = recreate_ledger_db(db_full_path);
 
-    let (mut watcher, watcher_dir) = setup_watcher_db(logger.clone());
+    let (watcher, watcher_dir) = setup_watcher_db(logger.clone());
 
     // Populate ledger with some data
     // Origin block cannot have key images
@@ -525,7 +525,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         &[alice.default_subaddress()],
         &[],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     add_block_to_ledger(
         BlockVersion::MAX,
@@ -533,7 +533,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         &[alice.default_subaddress(), bob.default_subaddress()],
         &[KeyImage::from(1)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     add_block_to_ledger(
         BlockVersion::MAX,
@@ -545,7 +545,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         ],
         &[KeyImage::from(2)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     let num_blocks = add_block_to_ledger(
         BlockVersion::MAX,
@@ -553,7 +553,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         &recipients,
         &[KeyImage::from(3)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
 
     {
@@ -675,7 +675,7 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
     let db_full_path = ledger_dir.path();
     let mut ledger = recreate_ledger_db(db_full_path);
 
-    let (mut watcher, watcher_dir) = setup_watcher_db(logger.clone());
+    let (watcher, watcher_dir) = setup_watcher_db(logger.clone());
 
     // Populate ledger with some data
     // Origin block cannot have key images
@@ -685,7 +685,7 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
         &[alice.default_subaddress()],
         &[],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     add_block_to_ledger(
         BlockVersion::MAX,
@@ -693,7 +693,7 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
         &[alice.default_subaddress(), bob.default_subaddress()],
         &[KeyImage::from(1)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     add_block_to_ledger(
         BlockVersion::MAX,
@@ -705,7 +705,7 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
         ],
         &[KeyImage::from(2)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
     add_block_to_ledger(
         BlockVersion::MAX,
@@ -713,7 +713,7 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
         &recipients,
         &[KeyImage::from(3)],
         &mut rng,
-        &mut watcher,
+        &watcher,
     );
 
     {
@@ -827,7 +827,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
         let mut ledger = recreate_ledger_db(db_full_path);
 
         // Make WatcherDB
-        let (mut watcher, watcher_dir) = setup_watcher_db(logger.clone());
+        let (watcher, watcher_dir) = setup_watcher_db(logger.clone());
 
         // Populate ledger with some data
         // Origin block cannot have key images
@@ -837,7 +837,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             &recipients,
             &[],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         add_block_to_ledger(
             block_version,
@@ -845,7 +845,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             &recipients,
             &keys[0..2],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         add_block_to_ledger(
             block_version,
@@ -853,7 +853,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             &recipients,
             &keys[3..6],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
         let num_blocks = add_block_to_ledger(
             block_version,
@@ -861,7 +861,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             &recipients,
             &keys[6..9],
             &mut rng,
-            &mut watcher,
+            &watcher,
         );
 
         // Populate watcher with Signature and Timestamp for block 1
@@ -1071,7 +1071,7 @@ fn add_block_to_ledger(
     recipients: &[PublicAddress],
     key_images: &[KeyImage],
     rng: &mut (impl CryptoRng + RngCore),
-    watcher: &mut WatcherDB,
+    watcher: &WatcherDB,
 ) -> u64 {
     let amount = Amount::new(10, Mob::ID);
     let block_data = mc_ledger_db::test_utils::add_block_to_ledger(

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -73,7 +73,7 @@ fn add_block_to_ledger(
     recipients: &[PublicAddress],
     key_images: &[KeyImage],
     rng: &mut (impl CryptoRng + RngCore),
-    watcher: &mut WatcherDB,
+    watcher: &WatcherDB,
 ) -> u64 {
     let amount = Amount::new(10, Mob::ID);
     let block_data = mc_ledger_db::test_utils::add_block_to_ledger(
@@ -102,7 +102,7 @@ fn add_block_to_ledger(
     block_index + 1
 }
 
-fn populate_ledger(blocks_config: &BlockConfig, ledger: &mut LedgerDB, watcher: &mut WatcherDB) {
+fn populate_ledger(blocks_config: &BlockConfig, ledger: &mut LedgerDB, watcher: &WatcherDB) {
     let mut rng = thread_rng();
 
     let alice = AccountKey::random_with_fog(&mut rng);
@@ -145,9 +145,9 @@ fn create_store(
     );
 
     let mut ledger = recreate_ledger_db(ledger_db_path);
-    let mut watcher = setup_watcher_db(watcher_db_path.to_path_buf(), logger.clone());
+    let watcher = setup_watcher_db(watcher_db_path.to_path_buf(), logger.clone());
 
-    populate_ledger(blocks_config, &mut ledger, &mut watcher);
+    populate_ledger(blocks_config, &mut ledger, &watcher);
 
     let mut store = KeyImageStoreServer::new_from_config(
         config,
@@ -193,9 +193,9 @@ fn create_router(
     .unwrap();
 
     let mut ledger = recreate_ledger_db(ledger_db_path);
-    let mut watcher = setup_watcher_db(watcher_db_path.to_path_buf(), logger.clone());
+    let watcher = setup_watcher_db(watcher_db_path.to_path_buf(), logger.clone());
 
-    populate_ledger(blocks_config, &mut ledger, &mut watcher);
+    populate_ledger(blocks_config, &mut ledger, &watcher);
 
     let config = LedgerRouterConfig {
         chain_id: "local".to_string(),

--- a/fog/test-client/src/test_client.rs
+++ b/fog/test-client/src/test_client.rs
@@ -291,7 +291,7 @@ impl TestClient {
     fn transfer(
         &self,
         source_client: &mut Client,
-        target_client: &mut Client,
+        target_client: &Client,
         token_id: TokenId,
     ) -> Result<TransferData, TestClientError> {
         self.tx_info.clear();
@@ -586,8 +586,7 @@ impl TestClient {
         )?;
 
         let transfer_start = std::time::SystemTime::now();
-        let transfer_data =
-            self.transfer(&mut source_client_lk, &mut target_client_lk, token_id)?;
+        let transfer_data = self.transfer(&mut source_client_lk, &target_client_lk, token_id)?;
 
         let mut span = block_span_builder(&tracer, "test_iteration", transfer_data.block_count)
             .with_start_time(transfer_start)

--- a/ledger/db/src/test_utils/mod.rs
+++ b/ledger/db/src/test_utils/mod.rs
@@ -50,7 +50,7 @@ impl TxOutputsOrdering for InverseTxOutputsOrdering {
 /// * `rng` - The randomness used by this function
 pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
     block_version: BlockVersion,
-    ledger: &mut L,
+    ledger: &L,
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
@@ -93,7 +93,7 @@ pub fn create_transaction<L: Ledger, R: RngCore + CryptoRng>(
 /// * `rng` - The randomness used by this function
 pub fn create_transaction_with_amount<L: Ledger, R: RngCore + CryptoRng>(
     block_version: BlockVersion,
-    ledger: &mut L,
+    ledger: &L,
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
@@ -132,7 +132,7 @@ pub fn create_transaction_with_amount_and_comparer<
     O: TxOutputsOrdering,
 >(
     block_version: BlockVersion,
-    ledger: &mut L,
+    ledger: &L,
     tx_out: &TxOut,
     sender: &AccountKey,
     recipient: &PublicAddress,
@@ -172,7 +172,7 @@ pub fn create_transaction_with_amount_and_comparer_and_recipients<
     O: TxOutputsOrdering,
 >(
     block_version: BlockVersion,
-    ledger: &mut L,
+    ledger: &L,
     tx_out: &TxOut,
     sender: &AccountKey,
     recipients: &[&PublicAddress],

--- a/mobilecoind-json/src/data_types.rs
+++ b/mobilecoind-json/src/data_types.rs
@@ -1468,7 +1468,7 @@ mod test {
 
             create_transaction(
                 BlockVersion::MAX,
-                &mut ledger,
+                &ledger,
                 &tx_out,
                 &sender,
                 &recipient.default_subaddress(),

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -326,7 +326,7 @@ mod test {
 
             create_transaction(
                 BlockVersion::MAX,
-                &mut ledger,
+                &ledger,
                 &tx_out,
                 &sender,
                 &recipient.default_subaddress(),

--- a/transaction/core/tests/util/mod.rs
+++ b/transaction/core/tests/util/mod.rs
@@ -33,7 +33,7 @@ pub fn create_test_tx(block_version: BlockVersion) -> (Tx, LedgerDB) {
     let recipient = AccountKey::random(&mut rng);
     let tx = create_transaction(
         block_version,
-        &mut ledger,
+        &ledger,
         &tx_out,
         &sender,
         &recipient.default_subaddress(),
@@ -70,7 +70,7 @@ pub fn create_test_tx_with_amount_and_comparer<O: TxOutputsOrdering>(
     let recipient = AccountKey::random(&mut rng);
     let tx = create_transaction_with_amount_and_comparer::<_, _, O>(
         block_version,
-        &mut ledger,
+        &ledger,
         &tx_out,
         &sender,
         &recipient.default_subaddress(),
@@ -101,7 +101,7 @@ pub fn create_test_tx_with_amount_and_comparer_and_recipients<O: TxOutputsOrderi
 
     let tx = create_transaction_with_amount_and_comparer_and_recipients::<_, _, O>(
         block_version,
-        &mut ledger,
+        &ledger,
         &tx_out,
         &sender,
         recipients,

--- a/transaction/core/tests/validation.rs
+++ b/transaction/core/tests/validation.rs
@@ -362,7 +362,7 @@ fn test_validate_ring_elements_are_unique() {
             let mut tx_prefix = tx.prefix.clone();
             tx_prefix.inputs.push(tx.prefix.inputs[0].clone());
 
-            for mut tx_out in tx_prefix.inputs[1].ring.iter_mut() {
+            for tx_out in tx_prefix.inputs[1].ring.iter_mut() {
                 let mut bytes = tx_out.target_key.to_bytes();
                 bytes[0] = !bytes[0];
                 tx_out.target_key = CompressedRistrettoPublic::from_bytes(&bytes).unwrap();


### PR DESCRIPTION
The removal of mutable references that don't need to be mutable is to
address the coming clippy lint of
https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_ref_mut

