### PR TITLE
Remove uneeded use of `into_iter()`

### DIFF
--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -322,7 +322,7 @@ impl<V: Value, ValidationError: Display> ScpSlot<V> for Slot<V, ValidationError>
             return Ok(None);
         }
 
-        self.W.extend(valid_values.into_iter());
+        self.W.extend(valid_values);
         self.do_nominate_phase();
         self.do_ballot_protocol();
         Ok(self.out_msg())
@@ -633,8 +633,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
         // Invariant: X and Y are disjoint.
         assert!(self.X.is_disjoint(&self.Y));
 
-        self.Z
-            .extend(self.additional_values_confirmed_nominated().into_iter());
+        self.Z.extend(self.additional_values_confirmed_nominated());
         // let mut new_Z = self.additional_values_confirmed_nominated();
         // if !new_Z.is_empty() {
         //     new_Z.append(&mut self.Z);

--- a/consensus/service/src/byzantine_ledger/pending_values.rs
+++ b/consensus/service/src/byzantine_ledger/pending_values.rs
@@ -175,7 +175,7 @@ mod tests {
         let mint_tx_manager = MockMintTxManager::new();
 
         // A few test values.
-        let values = vec![TxHash([1u8; 32]), TxHash([2u8; 32]), TxHash([3u8; 32])];
+        let values = [TxHash([1u8; 32]), TxHash([2u8; 32]), TxHash([3u8; 32])];
 
         // `validate` should be called one for each pending value.
         tx_manager
@@ -254,7 +254,7 @@ mod tests {
         let mint_tx_manager = MockMintTxManager::new();
 
         // A few test values.
-        let tx_hashes = vec![TxHash([1u8; 32]), TxHash([2u8; 32]), TxHash([3u8; 32])];
+        let tx_hashes = [TxHash([1u8; 32]), TxHash([2u8; 32]), TxHash([3u8; 32])];
 
         let values: Vec<ConsensusValue> = tx_hashes
             .iter()

--- a/consensus/service/src/byzantine_ledger/worker.rs
+++ b/consensus/service/src/byzantine_ledger/worker.rs
@@ -739,7 +739,7 @@ impl<
                     let entry = self
                         .unavailable_tx_hashes
                         .entry(from_responder_id.clone())
-                        .or_insert_with(BTreeSet::default);
+                        .or_default();
                     entry.extend(tx_hashes);
                     return false;
                 }

--- a/fog/distribution/src/main.rs
+++ b/fog/distribution/src/main.rs
@@ -836,7 +836,7 @@ fn get_membership_proofs(
         .collect();
     let proofs = ledger_db.get_tx_out_proof_of_memberships(&indexes).unwrap();
 
-    utxos.iter().cloned().zip(proofs.into_iter()).collect()
+    utxos.iter().cloned().zip(proofs).collect()
 }
 
 /// Get ring mixins for a transaction from the ledger
@@ -864,7 +864,7 @@ fn get_rings(
         .unwrap();
 
     // Create an iterator that returns (index, proof) elements.
-    let mut indexes_and_proofs_iterator = sampled_indices_vec.into_iter().zip(proofs.into_iter());
+    let mut indexes_and_proofs_iterator = sampled_indices_vec.into_iter().zip(proofs);
 
     // Convert that into a Vec<Vec<TxOut, TxOutMembershipProof>>
     let mut rings_with_proofs = Vec::new();

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -612,7 +612,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         );
 
         // Try to get a block
-        let queries = [0..1];
+        let queries = [0..1; 1];
         let result = client.get_blocks(&queries).unwrap();
         // Check that we got 1 block, as expected
         assert_eq!(result.blocks.len(), 1);
@@ -627,7 +627,7 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
         assert_eq!(result.global_txo_count, ledger.num_txos().unwrap());
 
         // Try to get two blocks
-        let queries = [1..3];
+        let queries = [1..3; 1];
         let result = client.get_blocks(&queries).unwrap();
 
         // Check that we got 2 blocks, as expected

--- a/fog/ledger/test_infra/src/lib.rs
+++ b/fog/ledger/test_infra/src/lib.rs
@@ -366,7 +366,7 @@ impl ShardProxyServer {
         let server = Server::bind(address).serve(make_service);
         let graceful = server.with_graceful_shutdown(Self::shutdown(rx));
 
-        let server_handle = tokio::spawn(async move { graceful.await });
+        let server_handle = tokio::spawn(graceful);
 
         Self {
             server_handle: Some(server_handle),

--- a/fog/sample-paykit/src/cached_tx_data/mod.rs
+++ b/fog/sample-paykit/src/cached_tx_data/mod.rs
@@ -1474,7 +1474,7 @@ mod tests {
 
     #[test]
     fn calculate_updated_missed_block_ranges_multiple_indices_returns_block_range_with_indices() {
-        let indices = vec![(5, 11), (34, 40), (1, 3)];
+        let indices = [(5, 11), (34, 40), (1, 3)];
         let mut missed_block_ranges = Vec::new();
 
         for (start_block, end_block) in indices.iter() {

--- a/fog/test_infra/src/mock_users.rs
+++ b/fog/test_infra/src/mock_users.rs
@@ -73,9 +73,7 @@ pub fn test_block_to_inputs_and_expected_outputs(
     let mut result_delta: Delta = Default::default();
 
     for (ref upriv, ref txo) in pairs.iter() {
-        let user_result_set = result_delta
-            .entry(upriv.clone())
-            .or_insert_with(HashSet::default);
+        let user_result_set = result_delta.entry(upriv.clone()).or_default();
 
         let fog_tx_out = FogTxOut::try_from(txo).unwrap();
         let meta = FogTxOutMetadata {
@@ -204,7 +202,7 @@ impl UserPool {
             let user_id = &self.users[user_idx].0;
             result
                 .entry(user_id.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(make_random_tx(rng, acct_server_pubkey, &user_id.get_hint()));
         }
         result

--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -546,13 +546,10 @@ fn group_by_block(
     for (responder_id, blocks) in node_to_blocks {
         for block in blocks.iter() {
             let block_id_to_group: &mut HashMap<BlockID, HashSet<ResponderId>> =
-                block_index_to_grouping
-                    .entry(block.index)
-                    .or_insert_with(HashMap::default);
+                block_index_to_grouping.entry(block.index).or_default();
 
-            let group: &mut HashSet<ResponderId> = block_id_to_group
-                .entry(block.id.clone())
-                .or_insert_with(HashSet::default);
+            let group: &mut HashSet<ResponderId> =
+                block_id_to_group.entry(block.id.clone()).or_default();
 
             group.insert(responder_id.clone());
         }

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -425,10 +425,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .collect();
             let proofs = self.get_membership_proofs(&outputs)?;
 
-            all_selected_utxos
-                .into_iter()
-                .zip(proofs.into_iter())
-                .collect()
+            all_selected_utxos.into_iter().zip(proofs).collect()
         };
         log::trace!(logger, "Got membership proofs");
 
@@ -654,7 +651,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .collect();
             let proofs = self.get_membership_proofs(&outputs)?;
 
-            selected_utxos.into_iter().zip(proofs.into_iter()).collect()
+            selected_utxos.into_iter().zip(proofs).collect()
         };
         log::trace!(logger, "Got membership proofs");
 
@@ -764,7 +761,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let inputs_with_proofs: Vec<(UnspentTxOut, TxOutMembershipProof)> = {
             let tx_outs: Vec<TxOut> = inputs.iter().map(|utxo| utxo.tx_out.clone()).collect();
             let proofs = self.get_membership_proofs(&tx_outs)?;
-            inputs.iter().cloned().zip(proofs.into_iter()).collect()
+            inputs.iter().cloned().zip(proofs).collect()
         };
         log::trace!(logger, "Got membership proofs");
 
@@ -1060,10 +1057,8 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .ledger_db
             .get_tx_out_proof_of_memberships(&mixin_indices)?;
 
-        let mixins_with_proofs: Vec<(TxOut, TxOutMembershipProof)> = mixins
-            .into_iter()
-            .zip(membership_proofs.into_iter())
-            .collect();
+        let mixins_with_proofs: Vec<(TxOut, TxOutMembershipProof)> =
+            mixins.into_iter().zip(membership_proofs).collect();
 
         // Group mixins and proofs into individual rings.
         let result: Vec<Vec<(_, _)>> = mixins_with_proofs

--- a/sgx/sync/src/mutex.rs
+++ b/sgx/sync/src/mutex.rs
@@ -356,7 +356,7 @@ impl<T: ?Sized> SgxMutex<T> {
     /// the current thread.
     pub fn lock(&self) -> LockResult<SgxMutexGuard<T>> {
         unsafe {
-            drop(self.inner.lock());
+            let _ = self.inner.lock();
             SgxMutexGuard::new(self)
         }
     }
@@ -416,7 +416,7 @@ impl<T: ?Sized> SgxMutex<T> {
                 (ptr::read(inner), ptr::read(poison), ptr::read(data))
             };
             mem::forget(self);
-            drop(inner.destroy());
+            let _ = inner.destroy();
             drop(inner);
 
             poison::map_result(poison.borrow(), |_| data.into_inner())
@@ -442,7 +442,7 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for SgxMutex<T> {
     fn drop(&mut self) {
         // IMPORTANT: This code must be kept in sync with `Mutex::into_inner`.
         unsafe {
-            drop(self.inner.destroy());
+            let _ = self.inner.destroy();
         }
     }
 }

--- a/transaction/builder/src/input_credentials.rs
+++ b/transaction/builder/src/input_credentials.rs
@@ -66,10 +66,8 @@ impl InputCredentials {
         // Sort the ring and the corresponding proofs. This ensures that the ordering
         // of mixins in the transaction does not depend on the user's implementation for
         // obtaining mixins.
-        let mut ring_and_proofs: Vec<(TxOut, TxOutMembershipProof)> = ring
-            .into_iter()
-            .zip(membership_proofs.into_iter())
-            .collect();
+        let mut ring_and_proofs: Vec<(TxOut, TxOutMembershipProof)> =
+            ring.into_iter().zip(membership_proofs).collect();
 
         ring_and_proofs
             .sort_by(|(tx_out_a, _), (tx_out_b, _)| tx_out_a.public_key.cmp(&tx_out_b.public_key));


### PR DESCRIPTION
Some other minor clippy changes
- use slices for temporary locals instead of vec![].
- use `let _` instead of drop() on copy types.
- Be explicit when creating a slice of type Range
