### PR TITLE
Update the rust version in the enclave crates

### DIFF
--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."
 license = "GPL-3.0"
 readme = "README.md"
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [workspace]
 

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -4,7 +4,7 @@ version = "5.0.8"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 # Declare as an empty workspace to not confuse cargo.
 [workspace]

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -4,7 +4,7 @@ version = "5.0.8"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 # Declare as an empty workspace to not confuse cargo.
 [workspace]

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -6,7 +6,7 @@ description = "The MobileCoin Fog user-facing server's enclave entry point."
 edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [workspace]
 

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [features]
 default = ["oom_panic"]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 cc = "1.0"

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-sgx-debug-edl = { path = "../debug-edl" }

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 # All dependencies are optional
 [dependencies]

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-sgx-css = { path = "../css" }

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 links = "sgx_debug_edl"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-sgx-types = { path = "../types" }

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 links = "sgx_panic_edl"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [features]
 default = ["alloc", "panic_abort"]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-sgx-types = { path = "../types" }

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 links = "sgx_slog_edl"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [features]
 default = []

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-sgx-panic = { path = "../panic", optional = true }

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"
 description = "Rust SGX SDK provides the ability to write Intel SGX applications in Rust Programming Language."
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 include = [
     "LICENSE",

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.68.0"
+rust-version = "1.74.0"
 
 [dependencies]
 mc-common = { path = "../../common", features = ["log"] }


### PR DESCRIPTION
Previously the rust version was bumped in the root workspace, but it was
missed for the enclave crates.
