### PR TITLE
Fog-Report - Helm chart improvements for consolidating fog instances.

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -35,7 +35,7 @@ jobs:
 # Generate environment information
 ############################################
   generate-metadata:
-    if: "! startsWith(github.head_ref, 'dependabot/')"
+    if: ${{ ! startsWith(github.head_ref, 'dependabot/') }}
     name: 👾 Environment Info 👾
     runs-on: [self-hosted, Linux, small]
     outputs:
@@ -80,11 +80,11 @@ jobs:
       MINTING_TRUST_ROOT_PUBLIC_KEY_PEM: ${{ github.workspace }}/.tmp/minting_trust_root.public.pem
     steps:
     - name: Checkout
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       uses: actions/checkout@v3
 
     - name: Write environment values
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       env:
         ENCLAVE_SIGNING_KEY: ${{ secrets.DEV_ENCLAVE_SIGNING_KEY }}
         MINTING_TRUST_ROOT_PUBLIC: ${{ secrets.DEV_MINTING_TRUST_ROOT_PUBLIC }}
@@ -94,7 +94,7 @@ jobs:
         echo "${MINTING_TRUST_ROOT_PUBLIC}" > "${MINTING_TRUST_ROOT_PUBLIC_KEY_PEM}"
 
     - name: Cache rust build binaries
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       id: rust_artifact_cache
       uses: ./.github/actions/mobilecoin-cache-rust-binaries
       with:
@@ -173,12 +173,12 @@ jobs:
         done
 
     - name: Check artifacts
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       run: |
         ls -alR rust_build_artifacts
 
     - name: Upload artifacts
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       uses: actions/upload-artifact@v3
       with:
         name: rust-binaries
@@ -192,17 +192,17 @@ jobs:
       image: golang:1.18.5
     steps:
     - name: Checkout
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       uses: actions/checkout@v3
 
     - name: Add protobuf-compiler
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       run: |
         apt update
         apt install -y protobuf-compiler zstd
 
     - name: Cache go build binaries
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       id: go_artifact_cache
       uses: ./.github/actions/mobilecoin-cache-go-binaries
       with:
@@ -220,12 +220,12 @@ jobs:
         cp go-grpc-gateway ../go_build_artifacts/
 
     - name: check artifacts
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       run: |
         ls -alR go_build_artifacts
 
     - name: Upload Artifacts
-      if: "! contains(github.event.head_commit.message, '[skip build]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip build]') }}
       uses: actions/upload-artifact@v3
       with:
         name: go-binaries
@@ -367,13 +367,14 @@ jobs:
         - mc-core-dev-env-setup
         - mobilecoind
         - watcher
+        - fog-report
     steps:
     - name: Checkout
-      if: "! contains(github.event.head_commit.message, '[skip charts]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip charts]') }}
       uses: actions/checkout@v3
 
     - name: Package and publish chart
-      if: "! contains(github.event.head_commit.message, '[skip charts]')"
+      if: ${{ ! contains(github.event.head_commit.message, '[skip charts]') }}
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: helm-publish

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -43,10 +43,17 @@ on:
       DEV_RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
+      DEV_FOG_REPORT_B_SIGNING_CERT:
+        description: "fog-report alternate instance"
+        required: true
+      DEV_FOG_REPORT_B_SIGNING_CERT_KEY:
+        description: "fog-report alternate instance"
+        required: true
 
 env:
   FLIPSIDE: ${{ inputs.ingest_color == 'blue' && 'green' || 'blue' }}
   VALUES_BASE_PATH: .tmp/values
+  CERTS_BASE_PATH: .tmp/certs
 
 jobs:
   setup-environment:
@@ -123,6 +130,118 @@ jobs:
           --set=image.org=${{ inputs.docker_image_org }}
         chart_wait_timeout: 5m
         release_name: mobilecoind
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
+  # run two copies of fog-report a/b
+  fog-report-deploy-a:
+    needs:
+    - consensus-deploy
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Generate fog-report values file
+      run: |
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/fog-report-values.yaml"
+        image:
+          org: ${{ inputs.docker_image_org }}
+
+        mobilecoin:
+          network: ${{ inputs.namespace }}
+          partner: dev
+
+        fogReport:
+          hosts:
+          - fog.${{ inputs.namespace }}.development.mobilecoin.com
+          ingress:
+            common:
+              blocklist:
+                enabled: false
+              tls:
+                clusterIssuer: google-public-ca
+          externalSecrets:
+            postgresReader:
+              name: fog-recovery-postgresql
+
+    - name: Deploy fog-report-a
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: fog-report
+        chart_version: ${{ inputs.version }}
+        chart_wait_timeout: 10m
+        chart_values: ${{ env.VALUES_BASE_PATH }}/fog-report-values.yaml
+        release_name: fog-report-a
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
+  fog-report-deploy-b:
+    needs:
+    - consensus-deploy
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Write fog-report signing certificate
+      run: |
+        # Create minting secrets dir
+        mkdir -p "${CERTS_BASE_PATH}/fog-report-b"
+
+        # Write values to be used as k8s secret values.
+        echo -n "${{ secrets.DEV_FOG_REPORT_B_SIGNING_CERT }}" > "${CERTS_BASE_PATH}/fog-report-b/tls.crt"
+        echo -n "${{ secrets.DEV_FOG_REPORT_B_SIGNING_CERT_KEY }}" > "${CERTS_BASE_PATH}/fog-report-b/tls.key"
+
+    - name: Create fog-report-signing-cert-b secret
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: secrets-create-from-file
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+        object_name: fog-report-signing-cert-b
+        src: ${{ env.CERTS_BASE_PATH }}/fog-report-b
+
+    - name: Generate fog-report values file
+      run: |
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/fog-report-values.yaml"
+        image:
+          org: ${{ inputs.docker_image_org }}
+
+        mobilecoin:
+          network: ${{ inputs.namespace }}
+          partner: dev
+
+        fogReport:
+          hosts:
+          - fog-b.${{ inputs.namespace }}.development.mobilecoin.com
+          - fog-report-b.${{ inputs.namespace }}.development.mobilecoin.com
+          ingress:
+            common:
+              blocklist:
+                enabled: false
+              tls:
+                clusterIssuer: google-public-ca
+          externalSecrets:
+            postgresReader:
+              name: fog-recovery-postgresql
+            signingCert:
+              name: fog-report-signing-cert-b
+
+    - name: Deploy fog-report-b
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: fog-report
+        chart_version: ${{ inputs.version }}
+        chart_wait_timeout: 10m
+        chart_values: ${{ env.VALUES_BASE_PATH }}/fog-report-values.yaml
+        release_name: fog-report-b
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.DEV_RANCHER_URL }}
@@ -271,6 +390,8 @@ jobs:
     needs:
     - fog-ingest-deploy
     - fog-services-deploy
+    - fog-report-deploy-a
+    - fog-report-deploy-b
     runs-on: [self-hosted, Linux, small]
     steps:
     - name: Check end points up.
@@ -285,6 +406,7 @@ jobs:
         command: |
           # Get fog report
           /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
+          /test/check-ingress-ready.sh --url "https://fog-b.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
 
           # Get fog ledger
           /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks"

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -25,6 +25,15 @@ on:
         type: string
         required: true
     secrets:
+      DEV_FOG_REPORT_B_SIGNING_CA_CERT:
+        description: "Fog Report signing CA cert"
+        required: true
+      DEV_FOG_REPORT_B_SIGNING_CERT:
+        description: "Fog Report signing cert pem"
+        required: true
+      DEV_FOG_REPORT_B_SIGNING_CERT_KEY:
+        description: "Fog Report signing cert key"
+        required: true
       DEV_FOG_REPORT_SIGNING_CA_CERT:
         description: "Fog Report signing CA cert"
         required: true
@@ -161,8 +170,11 @@ jobs:
         echo -n "${{ secrets.DEV_KEYS_SEED_MNEMONIC }}" > "${SEEDS_BASE_PATH}/MNEMONIC_KEYS_SEED"
         echo -n "${{ secrets.DEV_KEYS_SEED_MNEMONIC_FOG }}" > "${SEEDS_BASE_PATH}/MNEMONIC_FOG_KEYS_SEED"
         echo -n "${{ secrets.DEV_FOG_REPORT_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT"
+        echo -n "${{ secrets.DEV_FOG_REPORT_B_SIGNING_CA_CERT }}" > "${SEEDS_BASE_PATH}/FOG_REPORT_B_SIGNING_CA_CERT"
         echo -n "/wallet-seeds/FOG_REPORT_SIGNING_CA_CERT" > "${SEEDS_BASE_PATH}/FOG_REPORT_SIGNING_CA_CERT_PATH"
+        echo -n "/wallet-seeds/FOG_REPORT_B_SIGNING_CA_CERT" > "${SEEDS_BASE_PATH}/FOG_REPORT_B_SIGNING_CA_CERT_PATH"
         echo -n "fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_URL"
+        echo -n "fog://fog-b.${{ inputs.namespace }}.development.mobilecoin.com:443" > "${SEEDS_BASE_PATH}/FOG_REPORT_B_URL"
 
     - name: Create wallet key secrets
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -93,10 +93,12 @@ jobs:
     env:
       SRC_KEYS_DIR: /tmp/sample_data/keys
       SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys
+      SRC_FOG_B_KEYS_DIR: /tmp/sample_data/fog_keys_b
       V2_DST_KEYS_DIR: /tmp/2-testing/keys
       V2_DST_FOG_KEYS_DIR: /tmp/2-testing/fog_keys
       V3_DST_KEYS_DIR: /tmp/3-testing/keys
       V3_DST_FOG_KEYS_DIR: /tmp/3-testing/fog_keys
+      V3_DST_FOG_B_KEYS_DIR: /tmp/3-testing/fog_keys_b
       START_KEYS: '494'
       END_KEYS: '499'
     steps:
@@ -128,6 +130,7 @@ jobs:
         command: |
           INITIALIZE_LEDGER="true" \
           FOG_REPORT_URL="fog://fog.${{ inputs.namespace }}.development.mobilecoin.com:443" \
+          FOG_REPORT_B_URL="fog://fog-b.${{ inputs.namespace }}.development.mobilecoin.com:443" \
           /util/generate_origin_data.sh
 
     - name: Test - fog-distribution
@@ -196,7 +199,7 @@ jobs:
             --start ${{ env.START_KEYS }} \
             --end ${{ env.END_KEYS }}
 
-    - name: Setup - block-v3 - Copy subset of fog keys
+    - name: Setup - block-v3 - Copy subset of fog keys - fog-report-a
       if: inputs.testing_block_v3
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -210,6 +213,23 @@ jobs:
           /util/copy_account_keys.sh \
             --src ${{ env.SRC_FOG_KEYS_DIR }} \
             --dst ${{ env.V3_DST_FOG_KEYS_DIR }} \
+            --start ${{ env.START_KEYS }} \
+            --end ${{ env.END_KEYS }}
+
+    - name: Setup - block-v3 - Copy subset of fog keys - fog-report-b
+      if: inputs.testing_block_v3
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+        command: |
+          /util/copy_account_keys.sh \
+            --src ${{ env.SRC_FOG_B_KEYS_DIR }} \
+            --dst ${{ env.V3_DST_FOG_B_KEYS_DIR }} \
             --start ${{ env.START_KEYS }} \
             --end ${{ env.END_KEYS }}
 
@@ -278,7 +298,7 @@ jobs:
             --fee 1024 \
             --token-id 8192
 
-    - name: Test - block-v3 - fog-test-client token ids 0,8192
+    - name: Test - block-v3 - fog-test-client fog-report-a, token ids 0,8192
       if: inputs.testing_block_v3
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -291,4 +311,19 @@ jobs:
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V3_DST_FOG_KEYS_DIR }} \
+            --token-ids 0,8192
+
+    - name: Test - block-v3 - fog-test-client fog-report-b, token ids 0,8192
+      if: inputs.testing_block_v3
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: toolbox-exec
+        ingest_color: ${{ inputs.ingest_color }}
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+        command: |
+          /test/fog-test-client.sh \
+            --key-dir ${{ env.V3_DST_FOG_B_KEYS_DIR }} \
             --token-ids 0,8192

--- a/.internal-ci/helm/fog-report/.helmignore
+++ b/.internal-ci/helm/fog-report/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/.internal-ci/helm/fog-report/Chart.yaml
+++ b/.internal-ci/helm/fog-report/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fog-report
+description: MobileCoin Fog Report service
+type: application
+version: 0.0.0
+appVersion: "0.0.0"

--- a/.internal-ci/helm/fog-report/README.md
+++ b/.internal-ci/helm/fog-report/README.md
@@ -1,0 +1,156 @@
+# Fog-Report
+
+Run a MobileCoin fog-report instance.
+
+### Required Values
+
+You must set the fog report service hostnames and mobilecoin network and partner ids.
+
+```yaml
+mobilecoin:
+  network: main
+  partner: mc
+
+fogReport:
+  hosts:
+  - fog.prod.mobilecoinww.com
+```
+
+### Launching multiple fog-report instances
+
+Create 2 fog-report-signing-cert secrets Use the `fogReport.externalSecrets.signingCert.name` value to override the name for each instance that you launch.
+
+**Instance A**
+
+Create `fog-report-signing-cert-a` secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fog-report-signing-cert-a
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |-
+    <certificate pem>
+  tls.key: |-
+    <key pem>
+```
+
+`fog-report-signing-cert-a` values.yaml
+
+```yaml
+mobilecoin:
+  network: main
+  partner: mc
+
+fogReport:
+  hosts:
+  - fog.prod.example-a.com
+  externalSecrets:
+    signingCert:
+      name: fog-report-signing-cert-a
+```
+
+Install chart with name override:
+
+```bash
+helm upgrade fog-report-a mco-public/fog-report -i -f values.yaml
+```
+
+**Instance B**
+
+Create `fog-report-signing-cert-b` secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fog-report-signing-cert-b
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |-
+    <certificate pem>
+  tls.key: |-
+    <key pem>
+```
+
+`fog-report-signing-cert-b` values.yaml
+
+```yaml
+mobilecoin:
+  network: main
+  partner: mc
+
+fogReport:
+  hosts:
+  - fog.prod.example-b.com
+  externalSecrets:
+    signingCert:
+      name: fog-report-signing-cert-b
+```
+
+Install chart with name override:
+
+```bash
+helm upgrade fog-report-b mco-public/fog-report -i -f values.yaml
+```
+
+### Required ConfigMaps
+
+postgresReader example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fog-recovery-reader-0-postgresql
+data:
+  postgresql-database: recovery
+  postgresql-hostname: <hostname>
+  postgresql-port: "5432"
+  postgresql-ssl-options: "?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca-certificates.crt"
+  postgresql-username: <user>
+```
+
+### Required Secrets
+
+postgresReader example:
+
+```yaml
+apiVersion: v1
+metadata:
+  name: fog-recovery-reader-0-postgresql
+kind: Secret
+type: Opaque
+stringData:
+  postgresql-password: <password>
+```
+
+signingCert example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fog-report-signing-cert
+type: kubernetes.io/tls
+stringData:
+  tls.crt: |-
+    <certificate pem>
+  tls.key: |-
+    <key pem>
+```
+
+### Optional ConfigMaps
+
+sentry:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sentry
+data:
+  fog-report-sentry-dsn: <sentry dsn>
+```

--- a/.internal-ci/helm/fog-report/templates/_helpers.tpl
+++ b/.internal-ci/helm/fog-report/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fog-report.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fog-report.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fog-report.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fog-report.labels" -}}
+helm.sh/chart: {{ include "fog-report.chart" . }}
+{{ include "fog-report.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fog-report.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fog-report.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fog-report.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fog-report.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-report/templates/fog-report-configmap.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-configmap.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "fog-report.fullname" . }}
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.fogReport.configMap.data | nindent 2 }}

--- a/.internal-ci/helm/fog-report/templates/fog-report-deployment.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-deployment.yaml
@@ -1,25 +1,23 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
-{{- if .Values.fogReport.enabled }}
+# Copyright (c) 2018-2023 The MobileCoin Foundation
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "fogServices.fullname" . }}-fog-report
+  name: {{ include "fog-report.fullname" . }}
+  annotations:
+    sidecar.jaegertracing.io/inject: {{ .Values.jaegerTracing.enabled | quote }}
   labels:
-    app: fog-report
-    {{- include "fogServices.labels" . | nindent 4 }}
+    {{- include "fog-report.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.fogReport.replicaCount }}
   selector:
     matchLabels:
-      app: fog-report
-      {{- include "fogServices.selectorLabels" . | nindent 6 }}
+      {{- include "fog-report.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         {{- toYaml .Values.fogReport.podAnnotations | nindent 8 }}
       labels:
-        app: fog-report
-        {{- include "fogServices.labels" . | nindent 8 }}
+        {{- include "fog-report.labels" . | nindent 8 }}
     spec:
       # Try to balance pods across zones
       topologySpreadConstraints:
@@ -30,9 +28,8 @@ spec:
         labelSelector:
           matchLabels:
             # match on this helm chart install
-            app: fog-report
-            helm.sh/chart: {{ include "fogServices.chart" . }}
-            {{- include "fogServices.selectorLabels" . | nindent 12 }}
+            helm.sh/chart: {{ include "fog-report.chart" . }}
+            {{- include "fog-report.selectorLabels" . | nindent 12 }}
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       initContainers:
@@ -58,65 +55,59 @@ spec:
           containerPort: 8000
         envFrom:
         - configMapRef:
-            name: fog-report
+            name: {{ include "fog-report.fullname" . }}
         env:
-        - name: "RUST_BACKTRACE"
+        - name: MC_TELEMETRY
+          value: {{ .Values.jaegerTracing.enabled | quote }}
+        - name: RUST_BACKTRACE
           value: {{ .Values.fogReport.rust.backtrace | quote }}
-        - name: "RUST_LOG"
+        - name: RUST_LOG
           value: {{ .Values.fogReport.rust.log | quote }}
-        - name: "FOG_REPORT_SENTRY_DSN"
+        - name: MC_SENTRY_DSN
           valueFrom:
             configMapKeyRef:
-              name: sentry
+              name: {{ .Values.fogReport.externalConfigMaps.sentry.name }}
               key: fog-report-sentry-dsn
+              optional: true
         # Maps to Sentry Environment
         - name: MC_BRANCH
-          valueFrom:
-            configMapKeyRef:
-              name: mobilecoin-network
-              key: network
+          value: {{ .Values.mobilecoin.network }}
         - name: MC_CHAIN_ID
-          valueFrom:
-            configMapKeyRef:
-              name: mobilecoin-network
-              key: network
+          value: {{ .Values.mobilecoin.network }}
         - name: FOGDB_HOST
           valueFrom:
             configMapKeyRef:
-              name: fog-recovery-reader-0-postgresql
+              name: {{ .Values.fogReport.externalConfigMaps.postgresReader.name }}
               key: postgresql-hostname
         - name: FOGDB_USER
           valueFrom:
             configMapKeyRef:
-              name: fog-recovery-reader-0-postgresql
+              name: {{ .Values.fogReport.externalConfigMaps.postgresReader.name }}
               key: postgresql-username
         - name: FOGDB_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: fog-recovery-postgresql
+              name: {{ .Values.fogReport.externalSecrets.postgresReader.name }}
               key: postgresql-password
         - name: FOGDB_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: fog-recovery-reader-0-postgresql
+              name: {{ .Values.fogReport.externalConfigMaps.postgresReader.name }}
               key: postgresql-database
         - name: FOGDB_SSL_OPTIONS
           valueFrom:
             configMapKeyRef:
-              name: fog-recovery-reader-0-postgresql
+              name: {{ .Values.fogReport.externalConfigMaps.postgresReader.name }}
               key: postgresql-ssl-options
         - name: DATABASE_URL
           value: "postgres://$(FOGDB_USER):$(FOGDB_PASSWORD)@$(FOGDB_HOST)/$(FOGDB_DATABASE)$(FOGDB_SSL_OPTIONS)"
-                # Hold liveness and readiness until this probe passes.
         startupProbe:
           exec:
             command:
             - "/usr/local/bin/grpc_health_probe"
             - "-addr=:3222"
-          # Wait 5 min for startup
           failureThreshold: 30
           periodSeconds: 10
-        # Will wait for startup probe to succeed. When this passes k8s won't kill the service.
         livenessProbe:
           exec:
             command:
@@ -124,7 +115,6 @@ spec:
             - "-addr=:3222"
           failureThreshold: 5
           periodSeconds: 30
-        # Will wait for startup probe to succeed. When this passes services/ingress will pass traffic
         readinessProbe:
           exec:
             command:
@@ -155,42 +145,6 @@ spec:
           containerPort: 8222
         resources:
           {{- toYaml .Values.grpcGateway.resources | nindent 10 }}
-{{- if eq .Values.jaegerTracing.enabled true }}
-      - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:latest
-        imagePullPolicy: IfNotPresent
-        ports:
-          - containerPort: 5775
-            name: zk-compact-trft
-            protocol: UDP
-          - containerPort: 5778
-            name: config-rest
-            protocol: TCP
-          - containerPort: 6831
-            name: jg-compact-trft
-            protocol: UDP
-          - containerPort: 6832
-            name: jg-binary-trft
-            protocol: UDP
-          - containerPort: 14271
-            name: admin-http
-            protocol: TCP
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-        args:
-          - --reporter.grpc.host-port={{ .Values.jaegerTracing.collector }}
-          - --reporter.type=grpc
-          - --agent.tags=cluster=undefined,container.name=fog-report,deployment.name={{ include "fogServices.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
-{{- end }}
       nodeSelector:
         {{- toYaml .Values.fogReport.nodeSelector | nindent 8 }}
       tolerations:
@@ -200,14 +154,13 @@ spec:
       volumes:
       - name: signing-cert
         secret:
-          secretName: fog-report-signing-cert
+          secretName: {{ .Values.fogReport.externalSecrets.signingCert.name }}
       - name: supervisor-conf
         projected:
           sources:
           - configMap:
-              name: {{ include "fogServices.fullname" . }}-supervisord-daemon
+              name: {{ include "fog-report.fullname" . }}-supervisord-daemon
           - configMap:
-              name: {{ include "fogServices.fullname" . }}-supervisord-fog-report
+              name: {{ include "fog-report.fullname" . }}-supervisord-fog-report
           - configMap:
-              name: {{ include "fogServices.fullname" . }}-supervisord-admin
-{{- end }}
+              name: {{ include "fog-report.fullname" . }}-supervisord-admin

--- a/.internal-ci/helm/fog-report/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-grpc-ingress.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- if .Values.fogReport.ingress.enabled }}
+{{- $hosts := .Values.fogReport.hosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fog-report.fullname" . }}-grpc
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.fogReport.ingress.common.blocklist.enabled }}
+    haproxy.org/blacklist: {{ .Values.fogReport.ingress.common.blocklist.pattern }}
+    {{- end }}
+    {{- toYaml .Values.fogReport.ingress.common.annotations | nindent 4 }}
+    {{- toYaml .Values.fogReport.ingress.grpc.annotations | nindent 4 }}
+spec:
+  tls:
+  - hosts:
+    {{- range $hosts }}
+    - {{ . }}
+    {{- end }}
+    secretName: {{ include "fog-report.fullname" . }}-tls
+  rules:
+  {{- range $hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: /report.ReportAPI
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "fog-report.fullname" $ }}
+            port:
+              name: report-grpc
+  {{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-report/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-http-ingress.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- if .Values.fogReport.ingress.enabled }}
+{{- $hosts := .Values.fogReport.hosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fog-report.fullname" . }}-http
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.fogReport.ingress.common.blocklist.enabled }}
+    haproxy.org/blacklist: {{ .Values.fogReport.ingress.common.blocklist.pattern }}
+    {{- end }}
+    {{- toYaml .Values.fogReport.ingress.common.annotations | nindent 4 }}
+    {{- toYaml .Values.fogReport.ingress.http.annotations | nindent 4 }}
+spec:
+  tls:
+  - hosts:
+    {{- range $hosts }}
+    - {{ . }}
+    {{- end }}
+    secretName: {{ include "fog-report.fullname" . }}-tls
+  rules:
+  {{- range $hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+      - path: /gw/report.ReportAPI
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "fog-report.fullname" $ }}
+            port:
+              name: report-http
+  {{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-report/templates/fog-report-service.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-service.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fog-report.fullname" . }}
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "fog-report.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: report-grpc
+    port: 3222
+    targetPort: report-grpc
+  - name: mgmt-http
+    port: 8000
+    targetPort: mgmt-http
+  - name: report-http
+    port: 8222
+    targetPort: report-http

--- a/.internal-ci/helm/fog-report/templates/fog-report-servicmonitor.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-servicmonitor.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- $network := .Values.mobilecoin.network | required "mobilecoin.network is required." }}
+{{- $partner := .Values.mobilecoin.partner | required "mobilecoin.partner is required." }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fog-report.fullname" . }}
+  labels:
+    publish: grafana-cloud
+    {{- include "fog-report.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fog-report.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: mgmt-http
+    relabelings:
+    - targetLabel: network
+      replacement: {{ $network }}
+    - targetLabel: partner
+      replacement: {{ $partner }}

--- a/.internal-ci/helm/fog-report/templates/fog-report-tls-certificate.yaml
+++ b/.internal-ci/helm/fog-report/templates/fog-report-tls-certificate.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- $hosts := .Values.fogReport.hosts | required "fogReport.hosts is required." }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "fog-report.fullname" . }}-tls
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "fog-report.fullname" . }}-tls
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
+  dnsNames:
+  {{- range $hosts }}
+  - {{ . }}
+  {{- end }}
+  issuerRef:
+    name: {{ .Values.fogReport.ingress.common.tls.clusterIssuer }}
+    kind: ClusterIssuer

--- a/.internal-ci/helm/fog-report/templates/supervisord-admin-configmap.yaml
+++ b/.internal-ci/helm/fog-report/templates/supervisord-admin-configmap.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-report.fullname" . }}-supervisord-admin
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+data:
+  admin_http_gw.conf: |
+    [program:mc-admin-http-gateway]
+    priority=200
+    command=/usr/bin/mc-admin-http-gateway
+      --listen-host 0.0.0.0
+      --listen-port 8000
+      --admin-uri insecure-mca://127.0.0.1:8001/
+
+    stdout_logfile=/dev/fd/1
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/fd/2
+    stderr_logfile_maxbytes=0
+    autorestart=true

--- a/.internal-ci/helm/fog-report/templates/supervisord-daemon-configmap.yaml
+++ b/.internal-ci/helm/fog-report/templates/supervisord-daemon-configmap.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-report.fullname" . }}-supervisord-daemon
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+data:
+  supervisor.conf: |
+    [supervisord]
+    nodaemon=true

--- a/.internal-ci/helm/fog-report/templates/supervisord-fog-report-configmap.yaml
+++ b/.internal-ci/helm/fog-report/templates/supervisord-fog-report-configmap.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-report.fullname" . }}-supervisord-fog-report
+  labels:
+    {{- include "fog-report.labels" . | nindent 4 }}
+data:
+  fog_report.conf: |
+    [program:fog-report]
+    priority=100
+    command=/usr/bin/report_server
+      --client-listen-uri insecure-fog://0.0.0.0:3222/
+      --admin-listen-uri insecure-mca://127.0.0.1:8001/
+      --signing-chain /certs/tls.crt
+      --signing-key /certs/tls.key
+
+    stdout_logfile=/dev/fd/1
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/fd/2
+    stderr_logfile_maxbytes=0
+    autorestart=true

--- a/.internal-ci/helm/fog-report/values.yaml
+++ b/.internal-ci/helm/fog-report/values.yaml
@@ -1,0 +1,122 @@
+imagePullSecrets:
+- name: docker-credentials
+
+# Pods share the image tag.
+image:
+  org: mobilecoin
+  tag: '' # Overrides the image tag whose default is the chart appVersion.
+
+# Mobilecoin network instance
+mobilecoin:
+  network: ''
+  partner: ''
+
+fogReport:
+  ### list of fog-report hostnames for this instance.
+  hosts: []
+
+  replicaCount: 2
+
+  image:
+    org: ''
+    name: fogreport
+    pullPolicy: Always
+
+  rust:
+    backtrace: full
+    log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+  ingress:
+    enabled: true
+    common:
+      tls:
+        clusterIssuer: letsencrypt-production-http
+      blocklist:
+        enabled: true
+        pattern: patterns/blocked-countries
+      annotations:
+        haproxy.org/server-ssl: 'false'             # The backend (server) is http
+        haproxy.org/timeout-client: 239s            # 4 min timeout on azure
+        haproxy.org/timeout-server: 239s
+        haproxy.org/timeout-http-keep-alive: 120s
+        haproxy.org/abortonclose: 'true'
+        haproxy.org/backend-config-snippet: |-
+          http-reuse aggressive
+
+    grpc:
+      annotations:
+        haproxy.org/server-proto: 'h2'              # Force GRPC/H2 mode
+
+    http:
+      annotations:
+        haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
+
+  podAnnotations:
+    fluentbit.io/include: 'true' # collect logs with fluentbit
+    fluentbit.io/exclude-jaeger-agent: 'true'
+
+  nodeSelector:
+    builder-node: 'false'
+    sgx-enabled-node: 'false'
+
+  affinity: {}
+  tolerations: []
+  resources:
+    limits:
+      cpu: 1
+      memory: 512Mi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+  configMap:
+    data:
+      # https://docs.diesel.rs/diesel/r2d2/struct.Builder.html
+      POSTGRES_IDLE_TIMEOUT: '60'
+      POSTGRES_MAX_LIFETIME: '120'
+      POSTGRES_CONNECTION_TIMEOUT: '5'
+      POSTGRES_MAX_CONNECTIONS: '3'
+
+  ### These configmaps and secrets must be deployed by external process to the namespace.
+  # override the name of the required configmaps
+  externalConfigMaps:
+    sentry:
+      name: sentry
+      ### required keys:
+      #   fog-report-sentry-dsn
+    postgresReader:
+      name: fog-recovery-reader-0-postgresql
+      ### required keys:
+      #   postgresql-ssl-options
+      #   postgresql-database
+      #   postgresql-username
+      #   postgresql-hostname
+
+  # override the name of the required secrets
+  externalSecrets:
+    postgresReader:
+      name: fog-recovery-reader-0-postgresql
+      ### required keys:
+      #   postgresql-password
+    signingCert:
+      name: fog-report-signing-cert
+      ### required keys:
+      #   tls.crt
+      #   tls.key
+
+grpcGateway:
+  image:
+    org: ''
+    name: go-grpc-gateway
+    pullPolicy: Always
+
+  resources:
+    limits:
+      cpu: 1
+      memory: 256Mi
+    requests:
+      cpu: 256m
+      memory: 256Mi
+
+jaegerTracing:
+  enabled: false

--- a/.internal-ci/helm/fog-services-config/templates/fog-report-configmap.yaml
+++ b/.internal-ci/helm/fog-services-config/templates/fog-report-configmap.yaml
@@ -1,9 +1,0 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: fog-report
-  labels:
-    {{- include "fogServicesConfig.labels" . | nindent 4 }}
-data:
-  {{- toYaml .Values.fogReport.configMap | nindent 2 }}

--- a/.internal-ci/helm/fog-services-config/values.yaml
+++ b/.internal-ci/helm/fog-services-config/values.yaml
@@ -32,12 +32,6 @@ fogReport:
   signingCert:
     key: ''
     crt: ''
-  configMap:
-    # https://docs.diesel.rs/diesel/r2d2/struct.Builder.html
-    POSTGRES_IDLE_TIMEOUT: '60'
-    POSTGRES_MAX_LIFETIME: '120'
-    POSTGRES_CONNECTION_TIMEOUT: '5'
-    POSTGRES_MAX_CONNECTIONS: '3'
 
 fogView:
   ### Cookie salts will be generated if no values are provided

--- a/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-grpc-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogReport.enabled }}
 {{- if .Values.ingress.enabled }}
 {{- $hosts := split "\n" (include "fogServices.fogReportHosts" . | trim) }}
 apiVersion: networking.k8s.io/v1
@@ -34,4 +35,5 @@ spec:
             port:
               name: report-grpc
   {{- end }}
+{{- end }}
 {{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-http-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogReport.enabled }}
 {{- if .Values.ingress.enabled }}
 {{- $hosts := split "\n" (include "fogServices.fogReportHosts" . | trim) }}
 apiVersion: networking.k8s.io/v1
@@ -34,4 +35,5 @@ spec:
             port:
               name: report-http
   {{- end }}
+{{- end }}
 {{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-service.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-service.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogReport.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
   - name: report-http
     port: 8222
     targetPort: report-http
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-report-servicmonitor.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-report-servicmonitor.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogReport.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,3 +20,4 @@ spec:
       replacement: {{ include "fogServices.mobileCoinNetwork.network" . }}
     - targetLabel: partner
       replacement: {{ include "fogServices.mobileCoinNetwork.partner" . }}
+{{- end }}

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -301,6 +301,7 @@ fogLedger:
 
 ### Fog Report Service
 fogReport:
+  enabled: false
   replicaCount: 2
   image:
     org: ''

--- a/.internal-ci/util/generate_origin_data.sh
+++ b/.internal-ci/util/generate_origin_data.sh
@@ -23,6 +23,7 @@ is_set INITIAL_KEYS_SEED
 mkdir -p "${BASE_PATH}/sample_data/ledger"
 mkdir -p "${BASE_PATH}/sample_data/keys"
 mkdir -p "${BASE_PATH}/sample_data/fog_keys"
+mkdir -p "${BASE_PATH}/sample_data/fog_keys_b"
 mkdir -p "${BASE_PATH}/sample_data/mnemonic_keys"
 mkdir -p "${BASE_PATH}/sample_data/mnemonic_fog_keys"
 
@@ -68,6 +69,27 @@ then
         read-pubfile --pubfile "./fog_keys/account_keys_${i}.pub" \
             --out-b58 "./fog_keys/account_keys_${i}.b58pub" >/dev/null 2>&1
     done
+
+    if [[ -n "${FOG_REPORT_B_URL}" ]]
+    then
+        is_set FOG_REPORT_B_SIGNING_CA_CERT_PATH
+        is_set FOG_REPORT_B_URL
+        echo ""
+        echo "-- Generate keys for fog-report b server"
+
+        /util/sample-keys.1.1.3 --num 500 \
+        --seed "${FOG_KEYS_SEED}" \
+        --fog-report-url "${FOG_REPORT_B_URL}" \
+        --fog-authority-root "${FOG_REPORT_B_SIGNING_CA_CERT_PATH}" \
+        --output-dir ./fog_keys_b
+
+        echo "-- Generate b58pub files for fog_keys_b"
+        for i in {0..499}
+        do
+            read-pubfile --pubfile "./fog_keys_b/account_keys_${i}.pub" \
+                --out-b58 "./fog_keys_b/account_keys_${i}.b58pub" >/dev/null 2>&1
+        done
+    fi
 fi
 
 if [[ -n "${MNEMONIC_KEYS_SEED}" ]]


### PR DESCRIPTION
- Break out fog-report chart from fog-services monolith.
- Update GHA and integration tests to support multiple fog-report instances.

### Motivation

We need to be able to build fog instances that have multiple copies of fog-report, fog-view-router and fog-ledger-router with appropriate ingress and secret alignment.


