### PR TITLE
Fix an error code returned by mobilecoind

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -705,7 +705,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let wrapper =
             api::printable::PrintableWrapper::b58_decode(request.get_b58_code().to_string())
                 .map_err(|err| {
-                    rpc_internal_error("PrintableWrapper_b58_decode", err, &self.logger)
+                    rpc_invalid_arg_error("PrintableWrapper_b58_decode", err, &self.logger)
                 })?;
 
         // An address code could be a public address or a payment request


### PR DESCRIPTION
When checking that a b58 address is valid, if the code cannot be parsed, that should be considered an invalid argument error rather than an internal error.

Improving this to return the right error code helps users of this API handle errors correctly themselves, since internal errors are often considered retriable but an invalid argument is not.