### PR TITLE
fog-view - Helm chart improvements for consolidating fog instances

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -368,6 +368,7 @@ jobs:
         - mobilecoind
         - watcher
         - fog-report
+        - fog-view
     steps:
     - name: Checkout
       if: ${{ ! contains(github.event.head_commit.message, '[skip charts]') }}

--- a/.github/workflows/mobilecoin-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dev-delete.yaml
@@ -4,8 +4,7 @@
 
 name: Mobilecoin Dev Clean Up
 
-on:
-  delete: {}
+on: delete
 
 jobs:
   metadata:

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -205,7 +205,7 @@ jobs:
         object_name: fog-report-signing-cert-b
         src: ${{ env.CERTS_BASE_PATH }}/fog-report-b
 
-    - name: Generate fog-report values file
+    - name: Generate fog-report-b values file
       run: |
         mkdir -p "${VALUES_BASE_PATH}"
         cat <<EOF > "${VALUES_BASE_PATH}/fog-report-values.yaml"
@@ -242,6 +242,54 @@ jobs:
         chart_wait_timeout: 10m
         chart_values: ${{ env.VALUES_BASE_PATH }}/fog-report-values.yaml
         release_name: fog-report-b
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.DEV_RANCHER_URL }}
+        rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
+
+  fog-view-deploy:
+    needs:
+    - consensus-deploy
+    runs-on: [self-hosted, Linux, small]
+    steps:
+    - name: Generate fog-view values file
+      run: |
+        mkdir -p "${VALUES_BASE_PATH}"
+        cat <<EOF > "${VALUES_BASE_PATH}/fog-view-values.yaml"
+        image:
+          org: ${{ inputs.docker_image_org }}
+
+        mobilecoin:
+          network: ${{ inputs.namespace }}
+          partner: dev
+
+        fogView:
+          router:
+            hosts:
+            - partner: a
+              responderID: fog.${{ inputs.namespace }}.development.mobilecoin.com
+            - partner: b
+              responderID: fog-b.${{ inputs.namespace }}.development.mobilecoin.com
+          ingress:
+            common:
+              blocklist:
+                enabled: false
+              tls:
+                clusterIssuer: google-public-ca
+          externalSecrets:
+            postgresReader:
+              name: fog-recovery-postgresql
+
+    - name: Deploy fog-view
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: helm-deploy
+        chart_repo: ${{ inputs.chart_repo }}
+        chart_name: fog-view
+        chart_version: ${{ inputs.version }}
+        chart_wait_timeout: 10m
+        chart_values: ${{ env.VALUES_BASE_PATH }}/fog-view-values.yaml
+        release_name: fog-view
         namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.DEV_RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.DEV_RANCHER_URL }}

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -298,7 +298,7 @@ jobs:
             --fee 1024 \
             --token-id 8192
 
-    - name: Test - block-v3 - fog-test-client fog-report-a, token ids 0,8192
+    - name: Test - block-v3 - fog-test-client fog-a token ids 0,8192
       if: inputs.testing_block_v3
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -311,9 +311,10 @@ jobs:
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V3_DST_FOG_KEYS_DIR }} \
-            --token-ids 0,8192
+            --token-ids 0,8192 \
+            --fog-hostname fog.${{ inputs.namespace }}.development.mobilecoin.com
 
-    - name: Test - block-v3 - fog-test-client fog-report-b, token ids 0,8192
+    - name: Test - block-v3 - fog-test-client fog-b, token ids 0,8192
       if: inputs.testing_block_v3
       uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
@@ -326,4 +327,5 @@ jobs:
         command: |
           /test/fog-test-client.sh \
             --key-dir ${{ env.V3_DST_FOG_B_KEYS_DIR }} \
-            --token-ids 0,8192
+            --token-ids 0,8192 \
+            --fog-hostname fog-b.${{ inputs.namespace }}.development.mobilecoin.com

--- a/.internal-ci/helm/fog-report/README.md
+++ b/.internal-ci/helm/fog-report/README.md
@@ -55,7 +55,7 @@ fogReport:
 Install chart with name override:
 
 ```bash
-helm upgrade fog-report-a mco-public/fog-report -i -f values.yaml
+helm upgrade fog-report-a mcf-public/fog-report -i -f values.yaml
 ```
 
 **Instance B**
@@ -93,7 +93,7 @@ fogReport:
 Install chart with name override:
 
 ```bash
-helm upgrade fog-report-b mco-public/fog-report -i -f values.yaml
+helm upgrade fog-report-b mcf-public/fog-report -i -f values.yaml
 ```
 
 ### Required ConfigMaps

--- a/.internal-ci/helm/fog-report/values.yaml
+++ b/.internal-ci/helm/fog-report/values.yaml
@@ -55,9 +55,7 @@ fogReport:
     fluentbit.io/include: 'true' # collect logs with fluentbit
     fluentbit.io/exclude-jaeger-agent: 'true'
 
-  nodeSelector:
-    builder-node: 'false'
-    sgx-enabled-node: 'false'
+  nodeSelector: {}
 
   affinity: {}
   tolerations: []

--- a/.internal-ci/helm/fog-services-config/templates/fog-view-configmap.yaml
+++ b/.internal-ci/helm/fog-services-config/templates/fog-view-configmap.yaml
@@ -1,9 +1,0 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: fog-view
-  labels:
-    {{- include "fogServicesConfig.labels" . | nindent 4 }}
-data:
-  {{- toYaml .Values.fogView.configMap | nindent 2 }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-grpc-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,4 +30,5 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-view-router
             port:
               name: view-grpc
+{{- end }}
 {{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-http-ingress.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,4 +30,5 @@ spec:
             name: {{ include "fogServices.fullname" . }}-fog-view-router
             port:
               name: view-http
+{{- end }}
 {{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-router-service.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-router-service.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
   - name: view-http
     port: 8225
     targetPort: view-http
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-router-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-router-servicemonitor.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,3 +20,4 @@ spec:
       replacement: {{ include "fogServices.mobileCoinNetwork.network" . }}
     - targetLabel: partner
       replacement: {{ include "fogServices.mobileCoinNetwork.partner" . }}
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/fog-view-store-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-services/templates/fog-view-store-servicemonitor.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,4 +20,4 @@ spec:
       replacement: {{ include "fogServices.mobileCoinNetwork.network" . }}
     - targetLabel: partner
       replacement: {{ include "fogServices.mobileCoinNetwork.partner" . }}
-
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/supervisord-fog-report-configmap.yaml
+++ b/.internal-ci/helm/fog-services/templates/supervisord-fog-report-configmap.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogReport.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,3 +22,4 @@ data:
     stderr_logfile=/dev/fd/2
     stderr_logfile_maxbytes=0
     autorestart=true
+{{- end }}

--- a/.internal-ci/helm/fog-services/templates/supervisord-fog-view-store-configmap.yaml
+++ b/.internal-ci/helm/fog-services/templates/supervisord-fog-view-store-configmap.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2022 The MobileCoin Foundation
+{{- if .Values.fogView.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,3 +23,4 @@ data:
     stderr_logfile=/dev/fd/2
     stderr_logfile_maxbytes=0
     autorestart=true
+{{- end }}

--- a/.internal-ci/helm/fog-services/values.yaml
+++ b/.internal-ci/helm/fog-services/values.yaml
@@ -61,6 +61,7 @@ fogViewShardRangeGenerator:
     count: 2
 
 fogViewRouter:
+  enabled: false
   podManagementPolicy: Parallel
   replicaCount: 1
 
@@ -98,6 +99,7 @@ fogViewRouter:
     pullPolicy: Always
 
 fogView:
+  enabled: false
   replicaCount: 1
   image:
     org: ''

--- a/.internal-ci/helm/fog-view/.helmignore
+++ b/.internal-ci/helm/fog-view/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/.internal-ci/helm/fog-view/Chart.yaml
+++ b/.internal-ci/helm/fog-view/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fog-view
+description: MobileCoin Fog View service stack.
+type: application
+version: 0.0.0
+appVersion: "0.0.0"

--- a/.internal-ci/helm/fog-view/README.md
+++ b/.internal-ci/helm/fog-view/README.md
@@ -1,0 +1,83 @@
+# Fog-View
+
+Run a MobileCoin fog-view instance.
+
+### Required Values
+
+You must set the fog view service hostnames and mobilecoin network and partner ids.
+
+```yaml
+mobilecoin:
+  network: main
+  partner: mc
+
+fogView:
+  router:
+    hosts:
+    # add more instances here to generate additional routers
+    - partner: mc
+      responderID: fog.prod.mobilecoinww.com
+```
+
+Install chart:
+
+```bash
+helm upgrade fog-view mcf-public/fog-view -i -f values.yaml
+```
+
+### Required ConfigMaps
+
+postgresReader example:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fog-recovery-reader-0-postgresql
+data:
+  postgresql-database: recovery
+  postgresql-hostname: <hostname>
+  postgresql-port: "5432"
+  postgresql-ssl-options: "?sslmode=verify-full&sslrootcert=/etc/ssl/certs/ca-certificates.crt"
+  postgresql-username: <user>
+```
+
+### Required Secrets
+
+postgresReader example:
+
+```yaml
+apiVersion: v1
+metadata:
+  name: fog-recovery-reader-0-postgresql
+kind: Secret
+type: Opaque
+stringData:
+  postgresql-password: <password>
+```
+
+IAS example
+
+```yaml
+apiVersion: v1
+metadata:
+  name: ias
+kind: Secret
+type: Opaque
+stringData:
+  MC_IAS_API_KEY
+  MC_IAS_SPID
+```
+
+### Optional ConfigMaps
+
+sentry:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sentry
+data:
+  fog-report-sentry-dsn: <sentry dsn>
+```

--- a/.internal-ci/helm/fog-view/templates/_helpers.tpl
+++ b/.internal-ci/helm/fog-view/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- randAlphaNum 8 }}
 {{- end }}
 
-{{/* shardRangeGenerator - get "network" name of fall back to default */}}
+{{/* stackConfig - get "network" name of fall back to default */}}
 {{- define "fog-view.stackConfig" }}
 {{- $networkName := .Values.mobilecoin.network }}
 {{- get .Values.fogView.stackConfig.network $networkName | default (get .Values.fogView.stackConfig.network "default") | toYaml }}

--- a/.internal-ci/helm/fog-view/templates/_helpers.tpl
+++ b/.internal-ci/helm/fog-view/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fog-view.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fog-view.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fog-view.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | trimSuffix "." }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fog-view.labels" -}}
+helm.sh/chart: {{ include "fog-view.chart" . }}
+{{ include "fog-view.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "fog-view.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fog-view.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* grpcCookieSalt */}}
+{{- define "fog-view.grpcCookieSalt" -}}
+{{- randAlphaNum 8 }}
+{{- end }}
+
+{{/* shardRangeGenerator - get "network" name of fall back to default */}}
+{{- define "fog-view.stackConfig" }}
+{{- $networkName := .Values.mobilecoin.network }}
+{{- get .Values.fogView.stackConfig.network $networkName | default (get .Values.fogView.stackConfig.network "default") | toYaml }}
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-fogshardrangegenerator.yaml
@@ -1,88 +1,80 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
-{{- if .Values.fogView.enabled }}
-{{- $count := (include "fogServices.fogViewShardRangeGenerator" . | fromYaml).count }}
-{{- $stacks := until (int $count) }}
-{{- range $stacks }}
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- $stackConfig := (include "fog-view.stackConfig" . | fromYaml) }}
+{{- range $stack := until (int $stackConfig.count) }}
 apiVersion: mc.mobilecoin.com/v1
 kind: FogShardRangeGenerator
 metadata:
-  name: {{ include "fogServices.fullname" $ }}-fog-view-{{ . }}
+  name: {{ include "fog-view.fullname" $ }}-{{ $stack }}
   labels:
-    {{- include "fogServices.labels" $ | nindent 4 }}
+    {{- include "fog-view.labels" $ | nindent 4 }}
 spec:
-  blockCountURL: {{ include "fogServices.blockHeightURL" $ | quote }}
-  {{- with (include "fogServices.fogViewShardRangeGenerator" $ | fromYaml) }}
+  {{- with $stackConfig }}
   shardSize: {{ .shardSize }}
   exceedBlockHeightBy: {{ .exceedBlockHeightBy }}
   shardOverlap: {{ .shardOverlap }}
-  {{- end }}
-  {{- with $.Values.blockHeighRetrieval }}
+  {{- with .blockHeightRetrieval }}
+  blockCountURL: {{ tpl .blockCountURL $ | quote }}
   blockCountQueryInterval: {{ .queryInterval | quote }}
   blockCountResponseJQ: {{ .responseJQ | quote }}
   blockCountReqBody: {{ .requestBody | quote }}
   {{- end }}
+  {{- end }}
+
   router:
-    template:
+    templates:
+    {{- range $routerHosts := $.Values.fogView.router.hosts }}
+    {{- with $.Values.fogView.router }}
+    - templateID: {{ $routerHosts.partner }}
       containerName: fog-view-router
       spec:
-        podManagementPolicy: {{ $.Values.fogViewRouter.podManagementPolicy }}
-        replicas: {{ $.Values.fogViewRouter.replicaCount }}
+        podManagementPolicy: {{ .podManagementPolicy }}
+        replicas: {{ .replicaCount }}
         selector:
           matchLabels:
             app: fog-view-router
-            stack: fog-view-{{ . }}
-            {{- include "fogServices.selectorLabels" $ | nindent 12 }}
-        serviceName: {{ include "fogServices.fullname" $ }}-fog-view-router
+            stack: fog-view-{{ $stack }}
+            partner: {{ $routerHosts.partner }}
+            client-responder-id: {{ $routerHosts.responderID }}
+            {{- include "fog-view.selectorLabels" $ | nindent 12 }}
+        serviceName: {{ include "fog-view.fullname" $ }}-router-{{ $routerHosts.partner }}
         template:
           metadata:
             annotations:
-              {{- toYaml $.Values.fogViewRouter.podAnnotations | nindent 14 }}
+              {{- toYaml .podAnnotations | nindent 14 }}
             labels:
               app: fog-view-router
-              stack: fog-view-{{ . }}
-              {{- include "fogServices.labels" $ | nindent 14 }}
+              stack: fog-view-{{ $stack }}
+              partner: {{ $routerHosts.partner }}
+              client-responder-id: {{ $routerHosts.responderID }}
+              {{- include "fog-view.labels" $ | nindent 14 }}
           spec:
-            # Prevent endpoint creation until all shards for this router are ready
-            readinessGates:
-            - conditionType: mobilecoin.com/shards-ready
-            volumes:
-            - emptyDir: {}
-              name: aesm-socket-dir
-            - name: supervisor-conf
-              projected:
-                defaultMode: 420
-                sources:
-                - configMap:
-                    name: {{ include "fogServices.fullname" $ }}-supervisord-fog-view-router
-                - configMap:
-                    name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
-                - configMap:
-                    name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
-                - configMap:
-                    name: {{ include "fogServices.fullname" $ }}-supervisord-admin
-            nodeSelector:
-              {{- toYaml $.Values.fogViewRouter.nodeSelector | nindent 14 }}
-            tolerations:
-              {{- toYaml $.Values.fogViewRouter.tolerations | nindent 14 }}
-            {{- if $.Values.fogViewRouter.affinityEnabled }}
+            {{- if .affinityEnabled }}
             affinity:
               podAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:
                 - labelSelector:
                     matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - fog-view-router
                     - key: stack
                       operator: In
                       values:
-                      - fog-view-{{ . }}
+                      - fog-view-{{ $stack }}
                   topologyKey: topology.kubernetes.io/zone
                 preferredDuringSchedulingIgnoredDuringExecution:
                 - podAffinityTerm:
                     labelSelector:
                       matchExpressions:
+                      - key: app
+                        operator: In
+                        values:
+                        - fog-view-router
                       - key: stack
                         operator: In
                         values:
-                        - fog-view-{{ . }}
+                        - fog-view-{{ $stack }}
                     topologyKey: "kubernetes.io/hostname"
                   weight: 1
             {{- end }}
@@ -102,8 +94,8 @@ spec:
                 runAsNonRoot: False
             containers:
             - name: fog-view-router
-              image: "{{ $.Values.fogViewRouter.image.org | default $.Values.image.org }}/{{ $.Values.fogViewRouter.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
-              imagePullPolicy: {{ $.Values.fogViewRouter.image.pullPolicy }}
+              image: "{{ .image.org | default $.Values.image.org }}/{{ .image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ .image.pullPolicy }}
               command: [ "/usr/bin/supervisord", "-n" ]
               ports:
               - name: view-grpc
@@ -112,8 +104,7 @@ spec:
                 containerPort: 8000
               envFrom:
               - configMapRef:
-                  # This is pre-installed from the fog-services-config chart or Terraform
-                  name: fog-view
+                  name: {{ include "fog-view.fullname" $ }}-router
               - secretRef:
                   name: ias
               startupProbe:
@@ -139,33 +130,30 @@ spec:
                 timeoutSeconds: 1
               env:
               - name: RUST_BACKTRACE
-                value: {{ $.Values.fogViewRouter.rust.backtrace | quote }}
+                value: {{ .rust.backtrace | quote }}
               {{- if eq $.Values.jaegerTracing.enabled true }}
               - name: MC_TELEMETRY
                 value: "true"
               {{- end }}
               - name: RUST_LOG
-                value: {{ $.Values.fogViewRouter.rust.log | quote }}
-              - name: CLIENT_AUTH_TOKEN_SECRET
-                valueFrom:
-                  secretKeyRef:
-                    name: client-auth-token
-                    key: token
-                    optional: true
+                value: {{ .rust.log | quote }}
               - name: MC_CLIENT_RESPONDER_ID
-                value: {{ include "fogServices.fogPublicFQDN" $ }}:443
+                value: {{ $routerHosts.responderID }}:443
               - name: MC_CLIENT_LISTEN_URI
                 value: insecure-fog-view://0.0.0.0:3225/
+              - name: MC_ADMIN_LISTEN_URI
+                value: insecure-mca://127.0.0.1:8001/
               - name: FOG_VIEW_SENTRY_DSN
                 valueFrom:
                   configMapKeyRef:
                     name: sentry
                     key: fog-view-sentry-dsn
+                    optional: true
+              # Maps to Sentry Environment
+              - name: MC_BRANCH
+                value: {{ $.Values.mobilecoin.network }}
               - name: MC_CHAIN_ID
-                valueFrom:
-                  configMapKeyRef:
-                    name: mobilecoin-network
-                    key: network
+                value: {{ $.Values.mobilecoin.network }}
               volumeMounts:
               - name: supervisor-conf
                 mountPath: /etc/supervisor/conf.d
@@ -173,7 +161,7 @@ spec:
               - mountPath: /var/run/aesmd
                 name: aesm-socket-dir
               resources:
-                {{- toYaml $.Values.fogViewRouter.resources | nindent 16 }}
+                {{- toYaml .resources | nindent 16 }}
             - name: grpc-gateway
               image: "{{ $.Values.grpcGateway.image.org | default $.Values.image.org }}/{{ $.Values.grpcGateway.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: Always
@@ -184,8 +172,8 @@ spec:
               - -http-server-listen=:8225
               - -logtostderr
               ports:
-                - name: view-http
-                  containerPort: 8225
+              - name: view-http
+                containerPort: 8225
               resources:
                 {{- toYaml $.Values.grpcGateway.resources | nindent 16 }}
             {{- if eq $.Values.jaegerTracing.enabled true }}
@@ -193,61 +181,85 @@ spec:
               image: jaegertracing/jaeger-agent:latest
               imagePullPolicy: IfNotPresent
               ports:
-                - containerPort: 5775
-                  name: zk-compact-trft
-                  protocol: UDP
-                - containerPort: 5778
-                  name: config-rest
-                  protocol: TCP
-                - containerPort: 6831
-                  name: jg-compact-trft
-                  protocol: UDP
-                - containerPort: 6832
-                  name: jg-binary-trft
-                  protocol: UDP
-                - containerPort: 14271
-                  name: admin-http
-                  protocol: TCP
+              - containerPort: 5775
+                name: zk-compact-trft
+                protocol: UDP
+              - containerPort: 5778
+                name: config-rest
+                protocol: TCP
+              - containerPort: 6831
+                name: jg-compact-trft
+                protocol: UDP
+              - containerPort: 6832
+                name: jg-binary-trft
+                protocol: UDP
+              - containerPort: 14271
+                name: admin-http
+                protocol: TCP
               env:
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      apiVersion: v1
-                      fieldPath: metadata.name
-                - name: HOST_IP
-                  valueFrom:
-                    fieldRef:
-                      apiVersion: v1
-                      fieldPath: status.hostIP
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: HOST_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.hostIP
               args:
-                - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
-                - --reporter.type=grpc
-                - --agent.tags=cluster=undefined,container.name=fog-view-router,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
+              - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
+              - --reporter.type=grpc
+              - --agent.tags=cluster=undefined,container.name=fog-view-router,deployment.name={{ include "fog-view.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
             {{- end }}
+            nodeSelector:
+              {{- toYaml .nodeSelector | nindent 14 }}
+            tolerations:
+            {{- toYaml .tolerations | nindent 12 }}
+            readinessGates:
+            - conditionType: mobilecoin.com/shards-ready
+            volumes:
+            - emptyDir: {}
+              name: aesm-socket-dir
+            - name: supervisor-conf
+              projected:
+                defaultMode: 420
+                sources:
+                - configMap:
+                    name: {{ include "fog-view.fullname" $ }}-supervisord-fog-view-router
+                - configMap:
+                    name: {{ include "fog-view.fullname" $ }}-supervisord-sgx
+                - configMap:
+                    name: {{ include "fog-view.fullname" $ }}-supervisord-daemon
+                - configMap:
+                    name: {{ include "fog-view.fullname" $ }}-supervisord-admin
+    {{- end }}
+    {{- end }}
 
+  {{- with $.Values.fogView.store }}
   store:
     containerName: fog-view-store
     servicePort: 80
     targetPort: view-grpc
     spec:
-      podManagementPolicy: {{ $.Values.fogViewRouter.podManagementPolicy }}
-      replicas: {{ $.Values.fogView.replicaCount }}
+      podManagementPolicy: {{ .podManagementPolicy }}
+      replicas: {{ .replicaCount }}
       selector:
         matchLabels:
           app: fog-view-store
-          stack: fog-view-{{ . }}
-          {{- include "fogServices.selectorLabels" $ | nindent 10 }}
-      serviceName: {{ include "fogServices.fullname" $ }}-fog-view-store
+          stack: fog-view-{{ $stack }}
+          {{- include "fog-view.selectorLabels" $ | nindent 10 }}
+      serviceName: {{ include "fog-view.fullname" $ }}-store
       template:
         metadata:
           annotations:
-            {{- toYaml $.Values.fogView.podAnnotations | nindent 12 }}
+            {{- toYaml .podAnnotations | nindent 12 }}
           labels:
             app: fog-view-store
-            stack: fog-view-{{ . }}
-            {{- include "fogServices.labels" $ | nindent 12 }}
+            stack: fog-view-{{ $stack }}
+            {{- include "fog-view.labels" $ | nindent 12 }}
         spec:
-          {{- if $.Values.fogView.topologySpreadConstraintsEnabled }}
+          {{- if .topologySpreadConstraintsEnabled }}
           topologySpreadConstraints:
           - topologyKey: topology.kubernetes.io/zone
             maxSkew: 1
@@ -255,26 +267,35 @@ spec:
             labelSelector:
               matchLabels:
                 app: fog-view-store
+                stack: fog-view-{{ $stack }}
           {{- end }}
-          {{- if $.Values.fogView.affinityEnabled }}
+          {{- if .affinityEnabled }}
           affinity:
             podAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
                   matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - fog-view-store
                   - key: stack
                     operator: In
                     values:
-                    - fog-view-{{ . }}
+                    - fog-view-{{ $stack }}
                 topologyKey: topology.kubernetes.io/zone
               preferredDuringSchedulingIgnoredDuringExecution:
               - podAffinityTerm:
                   labelSelector:
                     matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - fog-view-store
                     - key: stack
                       operator: In
                       values:
-                      - fog-view-{{ . }}
+                      - fog-view-{{ $stack }}
                   topologyKey: "kubernetes.io/hostname"
                 weight: 1
           {{- end }}
@@ -294,8 +315,8 @@ spec:
               runAsNonRoot: False
           containers:
           - name: fog-view-store
-            image: "{{ $.Values.fogView.image.org | default $.Values.image.org }}/{{ $.Values.fogView.image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
-            imagePullPolicy: {{ $.Values.fogView.image.pullPolicy }}
+            image: "{{ .image.org | default $.Values.image.org }}/{{ .image.name }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+            imagePullPolicy: {{ .image.pullPolicy }}
             command: [ "/usr/bin/supervisord" ]
             ports:
             - name: view-grpc
@@ -304,62 +325,56 @@ spec:
               containerPort: 8000
             envFrom:
             - configMapRef:
-                name: fog-view
+                name: {{ include "fog-view.fullname" $ }}-store
             - secretRef:
                 name: ias
             env:
-            - name: RUST_BACKTRACE
-              value: {{ $.Values.fogView.rust.backtrace | quote }}
-            - name: RUST_LOG
-              value: {{ $.Values.fogView.rust.log | quote }}
             {{- if eq $.Values.jaegerTracing.enabled true }}
             - name: MC_TELEMETRY
               value: "true"
             {{- end }}
+            - name: RUST_BACKTRACE
+              value: {{ .rust.backtrace | quote }}
+            - name: RUST_LOG
+              value: {{ .rust.log | quote }}
             - name: FOG_VIEW_SENTRY_DSN
               valueFrom:
                 configMapKeyRef:
                   name: sentry
                   key: fog-view-sentry-dsn
+                  optional: true
             # Maps to Sentry Environment
             - name: MC_BRANCH
-              valueFrom:
-                configMapKeyRef:
-                  name: mobilecoin-network
-                  key: network
+              value: {{ $.Values.mobilecoin.network }}
             - name: MC_CHAIN_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: mobilecoin-network
-                  key: network
+              value: {{ $.Values.mobilecoin.network }}
             - name: FOGDB_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: fog-recovery-reader-0-postgresql
+                  name: {{ $.Values.fogView.externalConfigMaps.postgresReader.name }}
                   key: postgresql-hostname
             - name: FOGDB_USER
               valueFrom:
                 configMapKeyRef:
-                  name: fog-recovery-reader-0-postgresql
+                  name: {{ $.Values.fogView.externalConfigMaps.postgresReader.name }}
                   key: postgresql-username
             - name: FOGDB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: fog-recovery-postgresql
+                  name: {{ $.Values.fogView.externalSecrets.postgresReader.name }}
                   key: postgresql-password
             - name: FOGDB_DATABASE
               valueFrom:
                 configMapKeyRef:
-                  name: fog-recovery-reader-0-postgresql
+                  name: {{ $.Values.fogView.externalConfigMaps.postgresReader.name }}
                   key: postgresql-database
             - name: FOGDB_SSL_OPTIONS
               valueFrom:
                 configMapKeyRef:
-                  name: fog-recovery-reader-0-postgresql
+                  name: {{ $.Values.fogView.externalConfigMaps.postgresReader.name }}
                   key: postgresql-ssl-options
             - name: DATABASE_URL
               value: "postgres://$(FOGDB_USER):$(FOGDB_PASSWORD)@$(FOGDB_HOST)/$(FOGDB_DATABASE)$(FOGDB_SSL_OPTIONS)"
-             # Will wait for startup probe to succeed. When this passes k8s won't kill the service.
             livenessProbe:
               grpc:
                 port: 3225
@@ -367,7 +382,6 @@ spec:
               periodSeconds: 30
               timeoutSeconds: 1
               successThreshold: 1
-            # Hold liveness and readiness until this probe passes.
             startupProbe:
               grpc:
                 port: 3225
@@ -375,7 +389,6 @@ spec:
               periodSeconds: 30
               timeoutSeconds: 1
               successThreshold: 1
-            # Will wait for startup probe to succeed. When this passes services/ingress will pass traffic
             readinessProbe:
               grpc:
                 port: 3225
@@ -390,7 +403,7 @@ spec:
             - mountPath: /var/run/aesmd
               name: aesm-socket-dir
             resources:
-              {{- toYaml $.Values.fogView.resources | nindent 14 }}
+              {{- toYaml .resources | nindent 14 }}
           {{- if eq $.Values.jaegerTracing.enabled true }}
           - name: jaeger-agent
             image: jaegertracing/jaeger-agent:latest
@@ -425,12 +438,12 @@ spec:
             args:
               - --reporter.grpc.host-port={{ $.Values.jaegerTracing.collector }}
               - --reporter.type=grpc
-              - --agent.tags=cluster=undefined,container.name=fog-view,deployment.name={{ include "fogServices.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
+              - --agent.tags=cluster=undefined,container.name=fog-view,deployment.name={{ include "fog-view.fullname" $ }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ $.Release.Namespace }}
           {{- end }}
           nodeSelector:
-            {{- toYaml $.Values.fogView.nodeSelector | nindent 12 }}
+            {{- toYaml .nodeSelector | nindent 12 }}
           tolerations:
-            {{- toYaml $.Values.fogView.tolerations | nindent 12 }}
+          {{- toYaml .tolerations | nindent 10 }}
           volumes:
           - emptyDir: {}
             name: aesm-socket-dir
@@ -438,13 +451,13 @@ spec:
             projected:
               sources:
               - configMap:
-                  name: {{ include "fogServices.fullname" $ }}-supervisord-sgx
+                  name: {{ include "fog-view.fullname" $ }}-supervisord-sgx
               - configMap:
-                  name: {{ include "fogServices.fullname" $ }}-supervisord-daemon
+                  name: {{ include "fog-view.fullname" $ }}-supervisord-daemon
               - configMap:
-                  name: {{ include "fogServices.fullname" $ }}-supervisord-fog-view-store
+                  name: {{ include "fog-view.fullname" $ }}-supervisord-fog-view-store
               - configMap:
-                  name: {{ include "fogServices.fullname" $ }}-supervisord-admin
+                  name: {{ include "fog-view.fullname" $ }}-supervisord-admin
+  {{- end }}
 ---
-{{- end }}
 {{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-configmap.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "fog-view.fullname" . }}-router
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.fogView.router.configMap.data | nindent 2 }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-grpc-ingress.yaml
@@ -18,7 +18,7 @@ spec:
   tls:
   - hosts:
     - {{ $routerHosts.responderID }}
-    secretName: {{ include "fog-view.fullname" $ }}-tls
+    secretName: {{ include "fog-view.fullname" $ }}-tls-{{ $routerHosts.partner }}
   rules:
   - host: {{ $routerHosts.responderID }}
     http:

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-grpc-ingress.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-grpc-ingress.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- if .Values.fogView.router.ingress.enabled }}
+{{- range $routerHosts := $.Values.fogView.router.hosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fog-view.fullname" $ }}-router-grpc-{{ $routerHosts.partner }}
+  labels:
+    app: fog-view
+    {{- include "fog-view.labels" $ | nindent 4 }}
+  annotations:
+    {{- if $.Values.fogView.router.ingress.common.blocklist.enabled }}
+    haproxy.org/blacklist: {{ $.Values.fogView.router.ingress.common.blocklist.pattern }}
+    {{- end }}
+    {{ toYaml (tpl $.Values.fogView.router.ingress.common.annotations $ | fromYaml) | nindent 4 }}
+    {{ toYaml (tpl $.Values.fogView.router.ingress.grpc.annotations $ | fromYaml) | nindent 4 }}
+spec:
+  tls:
+  - hosts:
+    - {{ $routerHosts.responderID }}
+    secretName: {{ include "fog-view.fullname" $ }}-tls
+  rules:
+  - host: {{ $routerHosts.responderID }}
+    http:
+      paths:
+      - path: /fog_view.FogViewAPI
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "fog-view.fullname" $ }}-router-{{ $routerHosts.partner }}
+            port:
+              name: view-grpc
+---
+{{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-http-ingress.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-http-ingress.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- if .Values.fogView.router.ingress.enabled }}
+{{- range $routerHosts := $.Values.fogView.router.hosts }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fog-view.fullname" $ }}-router-http-{{ $routerHosts.partner }}
+  labels:
+    app: fog-view
+    {{- include "fog-view.labels" $ | nindent 4 }}
+  annotations:
+    {{- if $.Values.fogView.router.ingress.common.blocklist.enabled }}
+    haproxy.org/blacklist: {{ $.Values.fogView.router.ingress.common.blocklist.pattern }}
+    {{- end }}
+    {{ toYaml (tpl $.Values.fogView.router.ingress.common.annotations $ | fromYaml) | nindent 4 }}
+    {{ toYaml (tpl $.Values.fogView.router.ingress.http.annotations $ | fromYaml) | nindent 4 }}
+spec:
+  tls:
+  - hosts:
+    - {{ $routerHosts.responderID }}
+    secretName: {{ include "fog-view.fullname" $ }}-tls
+  rules:
+  - host: {{ $routerHosts.responderID }}
+    http:
+      paths:
+      - path: /gw/fog_view.FogViewAPI
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "fog-view.fullname" $ }}-router-{{ $routerHosts.partner }}
+            port:
+              name: view-http
+---
+{{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-http-ingress.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-http-ingress.yaml
@@ -18,7 +18,7 @@ spec:
   tls:
   - hosts:
     - {{ $routerHosts.responderID }}
-    secretName: {{ include "fog-view.fullname" $ }}-tls
+    secretName: {{ include "fog-view.fullname" $ }}-tls-{{ $routerHosts.partner }}
   rules:
   - host: {{ $routerHosts.responderID }}
     http:

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-service.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-service.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- range $routerHosts := $.Values.fogView.router.hosts }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fog-view.fullname" $ }}-router-{{ $routerHosts.partner }}
+  labels:
+    app: fog-view-router
+    partner: {{ $routerHosts.partner }}
+    {{- include "fog-view.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: fog-view-router
+    partner: {{ $routerHosts.partner }}
+    {{- include "fog-view.selectorLabels" $ | nindent 4 }}
+  ports:
+  - name: view-grpc
+    port: 3225
+    targetPort: view-grpc
+  - name: mgmt-http
+    port: 8000
+    targetPort: mgmt-http
+  - name: view-http
+    port: 8225
+    targetPort: view-http
+---
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-servicemonitor.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- $network := .Values.mobilecoin.network | required "mobilecoin.network is required." }}
+{{- $partner := .Values.mobilecoin.partner | required "mobilecoin.partner is required." }}
+{{- range $routerHosts := $.Values.fogView.router.hosts }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fog-view.fullname" $ }}-router
+  labels:
+    publish: grafana-cloud
+    app: fog-view-router
+    {{- include "fog-view.labels" $ | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: fog-view-router
+      {{- include "fog-view.selectorLabels" $ | nindent 6 }}
+  endpoints:
+  - port: mgmt-http
+    relabelings:
+    - targetLabel: network
+      replacement: {{ $network }}
+    - targetLabel: partner
+      replacement: {{ $partner }}
+---
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-store-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-store-configmap.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "fog-view.fullname" . }}-store
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.fogView.store.configMap.data | nindent 2 }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-store-service.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-store-service.yaml
@@ -1,18 +1,17 @@
-# Copyright (c) 2018-2022 The MobileCoin Foundation
-{{- if .Values.fogView.enabled }}
+# Copyright (c) 2018-2023 The MobileCoin Foundation
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "fogServices.fullname" . }}-fog-view-store
+  name: {{ include "fog-view.fullname" . }}-store
   labels:
     app: fog-view-store
-    {{- include "fogServices.labels" . | nindent 4 }}
+    {{- include "fog-view.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   clusterIP: None
   selector:
     app: fog-view-store
-    {{- include "fogServices.selectorLabels" . | nindent 4 }}
+    {{- include "fog-view.selectorLabels" . | nindent 4 }}
   ports:
     - name: view-grpc
       port: 3225
@@ -23,4 +22,3 @@ spec:
     - name: view-http
       port: 8225
       targetPort: view-http
-{{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-store-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-store-servicemonitor.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- $network := .Values.mobilecoin.network | required "mobilecoin.network is required." }}
+{{- $partner := .Values.mobilecoin.partner | required "mobilecoin.partner is required." }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "fog-view.fullname" . }}-store
+  labels:
+    publish: grafana-cloud
+    app: fog-view-store
+    {{- include "fog-view.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app: fog-view-store
+      {{- include "fog-view.selectorLabels" . | nindent 6 }}
+  endpoints:
+  - port: mgmt-http
+    relabelings:
+    - targetLabel: network
+      replacement: {{ $network }}
+    - targetLabel: partner
+      replacement: {{ $partner }}
+

--- a/.internal-ci/helm/fog-view/templates/fog-view-tls-certificate.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-tls-certificate.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+{{- if .Values.fogView.router.ingress.enabled }}
+{{- range $routerHosts := .Values.fogView.router.hosts }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "fog-view.fullname" $ }}-tls-{{ $routerHosts.partner }}
+  labels:
+    {{- include "fog-view.labels" $ | nindent 4 }}
+spec:
+  secretName: {{ include "fog-view.fullname" $ }}-tls-{{ $routerHosts.partner }}
+  privateKey:
+    size: 2048
+    algorithm: RSA
+    encoding: PKCS1
+  dnsNames:
+  - {{ $routerHosts.responderID }}
+  issuerRef:
+    name: {{ $.Values.fogView.router.ingress.common.tls.clusterIssuer }}
+    kind: ClusterIssuer
+{{- end }}
+{{- end }}

--- a/.internal-ci/helm/fog-view/templates/supervisord-admin-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/supervisord-admin-configmap.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-view.fullname" . }}-supervisord-admin
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  admin_http_gw.conf: |
+    [program:mc-admin-http-gateway]
+    priority=200
+    command=/usr/bin/mc-admin-http-gateway
+      --listen-host 0.0.0.0
+      --listen-port 8000
+      --admin-uri insecure-mca://127.0.0.1:8001/
+
+    stdout_logfile=/dev/fd/1
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/fd/2
+    stderr_logfile_maxbytes=0
+    autorestart=true

--- a/.internal-ci/helm/fog-view/templates/supervisord-daemon-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/supervisord-daemon-configmap.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-view.fullname" . }}-supervisord-daemon
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  supervisor.conf: |
+    [supervisord]
+    nodaemon=true

--- a/.internal-ci/helm/fog-view/templates/supervisord-fog-view-router-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/supervisord-fog-view-router-configmap.yaml
@@ -1,20 +1,18 @@
-{{- if .Values.fogView.enabled }}
+# Copyright (c) 2018-2023 The MobileCoin Foundation
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "fogServices.fullname" . }}-supervisord-fog-view-router
+  name: {{ include "fog-view.fullname" . }}-supervisord-fog-view-router
   labels:
-    {{- include "fogServices.labels" . | nindent 4 }}
+    {{- include "fog-view.labels" . | nindent 4 }}
 data:
   fog_view_router.conf: |
     [program:fogviewrouter]
     priority=100
     command=fog_view_router
-      --admin-listen-uri=insecure-mca://127.0.0.1:8001/
 
     stdout_logfile=/dev/fd/1
     stdout_logfile_maxbytes=0
     stderr_logfile=/dev/fd/2
     stderr_logfile_maxbytes=0
     autorestart=true
-{{- end }}

--- a/.internal-ci/helm/fog-view/templates/supervisord-fog-view-store-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/supervisord-fog-view-store-configmap.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-view.fullname" . }}-supervisord-fog-view-store
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  fog_view_store.conf: |
+    [program:fog-view-store]
+    priority=100
+    environment=MC_SENTRY_DSN="%(ENV_FOG_VIEW_SENTRY_DSN)s"
+    command=/usr/bin/fog_view_server
+      --client-listen-uri insecure-fog-view-store://0.0.0.0:3225/?responder-id=%(ENV_HOSTNAME)s.{{ include "fog-view.fullname" . }}-store.{{ .Release.Namespace }}:3225
+      --client-responder-id "%(ENV_HOSTNAME)s.{{ include "fog-view.fullname" . }}-store.{{ .Release.Namespace }}:3225"
+      --admin-listen-uri insecure-mca://127.0.0.1:8001/
+
+    stdout_logfile=/dev/fd/1
+    stdout_logfile_maxbytes=0
+    stderr_logfile=/dev/fd/2
+    stderr_logfile_maxbytes=0
+    autorestart=true

--- a/.internal-ci/helm/fog-view/templates/supervisord-sgx-configmap.yaml
+++ b/.internal-ci/helm/fog-view/templates/supervisord-sgx-configmap.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2018-2023 The MobileCoin Foundation
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fog-view.fullname" . }}-supervisord-sgx
+  labels:
+    {{- include "fog-view.labels" . | nindent 4 }}
+data:
+  sgx.conf: |
+    [program:aesm-service]
+    priority=10
+    command=/opt/intel/sgx-aesm-service/aesm/aesm_service --no-daemon
+    environment=AESM_PATH="/opt/intel/sgx-aesm-service/aesm",LD_LIBRARY_PATH="/opt/intel/sgx-aesm-service/aesm"
+
+    stdout_logfile=/dev/null
+    stderr_logfile=/dev/null
+    autorestart=true

--- a/.internal-ci/helm/fog-view/values.yaml
+++ b/.internal-ci/helm/fog-view/values.yaml
@@ -1,0 +1,218 @@
+imagePullSecrets:
+- name: docker-credentials
+
+# Pods share the image tag.
+image:
+  org: mobilecoin
+  tag: '' # Overrides the image tag whose default is the chart appVersion.
+
+# Mobilecoin network instance
+mobilecoin:
+  network: ''
+  partner: ''
+
+fogView:
+  # Stack configurations by network.
+  stackConfig:
+    network:
+      # Assume default is a dev network. We can always define a "network" value if needed.
+      default:
+        shardSize: 20_000
+        exceedBlockHeightBy: 5_000
+        shardOverlap: 0
+        count: 2
+        blockHeightRetrieval:
+          blockCountURL: 'https://node1.{{ .Release.Namespace }}.development.mobilecoin.com/gw/consensus_common.BlockchainAPI/GetLastBlockInfo'
+          responseJQ: '.index'
+          queryInterval: 1m
+          requestBody: ''
+      test:
+        shardSize: 400_000
+        exceedBlockHeightBy: 10_000
+        shardOverlap: 0
+        count: 2
+        blockHeightRetrieval:
+          blockCountURL: https://node1.test.mobilecoin.com/gw/consensus_common.BlockchainAPI/GetLastBlockInfo
+          responseJQ: '.index'
+          queryInterval: 5m
+          requestBody: ''
+      main:
+        shardSize: 400_000
+        exceedBlockHeightBy: 10_000
+        shardOverlap: 0
+        count: 3
+        blockHeightRetrieval:
+          blockCountURL: https://node1.prod.mobilecoinww.com/gw/consensus_common.BlockchainAPI/GetLastBlockInfo
+          responseJQ: '.index'
+          queryInterval: 5m
+          requestBody: ''
+
+  router:
+    ### list of fog-ledger-router hostnames (client responder ID)
+    hosts:
+    - partner: ''
+      responderID: ''
+
+    replicaCount: 1
+
+    image:
+      org: ''
+      name: fogview
+      pullPolicy: Always
+
+    resources:
+      limits:
+        intel.com/sgx: 5000
+        memory: 3Gi
+      requests:
+        intel.com/sgx: 5000
+        memory: 3Gi
+        cpu: 1100m
+
+    nodeSelector:
+      sgx-enabled-node: 'true'
+
+    tolerations:
+    - key: sgx
+      operator: Equal
+      value: 'true'
+      effect: NoSchedule
+
+    # disable affinity rules for single node testing
+    podManagementPolicy: Parallel
+    affinityEnabled: true
+    topologySpreadConstraintsEnabled: true
+
+    rust:
+      backtrace: full
+      log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+    podAnnotations:
+      fluentbit.io/include: 'true' # collect logs with fluentbit
+      fluentbit.io/exclude-jaeger-agent: 'true'
+
+    ingress:
+      enabled: true
+      common:
+        tls:
+          clusterIssuer: letsencrypt-production-http
+        blocklist:
+          enabled: true
+          pattern: patterns/blocked-countries
+        annotations: |-
+          haproxy.org/server-ssl: "false"             # The backend (server) is http
+          haproxy.org/timeout-client: 239s            # 4 min timeout on azure
+          haproxy.org/timeout-server: 239s
+          haproxy.org/timeout-http-keep-alive: 120s
+          haproxy.org/abortonclose: "true"
+          haproxy.org/backend-config-snippet: |-
+            http-reuse aggressive
+            dynamic-cookie-key {{ include "fog-view.grpcCookieSalt" . }}
+            cookie VIEW insert indirect nocache dynamic
+
+      grpc:
+        annotations: |-
+          haproxy.org/server-proto: "h2"              # Force GRPC/H2 mode
+
+      http:
+        annotations: |-
+          haproxy.org/path-rewrite: '/gw/(.*) /\1'    # Strip the /gw prefix
+
+    configMap:
+      data:
+        PLACEHOLDER: 'empty'
+
+  store:
+    replicaCount: 1
+
+    image:
+      org: ''
+      name: fogview
+      pullPolicy: Always
+
+    rust:
+      backtrace: full
+      log: info,rustls=warn,hyper=warn,tokio_reactor=warn,mio=warn,want=warn,reqwest=warn,rusoto_core=error,rusoto_signature=error,h2=error,rocket=warn,<unknown>=warn
+
+    podAnnotations:
+      fluentbit.io/include: 'true' # collect logs with fluentbit
+      fluentbit.io/exclude-jaeger-agent: 'true'
+
+    # disable affinity rules for single node testing
+    podManagementPolicy: Parallel
+    affinityEnabled: true
+    topologySpreadConstraintsEnabled: true
+
+    ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
+    resources:
+      limits:
+        intel.com/sgx: 5000
+        memory: 5Gi
+      requests:
+        intel.com/sgx: 5000
+        memory: 5Gi
+        cpu: 1100m
+
+    nodeSelector:
+      sgx-enabled-node: 'true'
+
+    tolerations:
+    - key: sgx
+      operator: Equal
+      value: 'true'
+      effect: NoSchedule
+
+    configMap:
+      data:
+        # https://docs.diesel.rs/diesel/r2d2/struct.Builder.html
+        POSTGRES_IDLE_TIMEOUT: '60'
+        POSTGRES_MAX_LIFETIME: '120'
+        POSTGRES_CONNECTION_TIMEOUT: '5'
+        POSTGRES_MAX_CONNECTIONS: '3'
+        MC_OMAP_CAPACITY: '4194304'
+
+  ### These configmaps and secrets must be deployed by external process to the namespace.
+  # override the name of the required configmaps
+  externalConfigMaps:
+    # Sentry is Optional
+    sentry:
+      name: sentry
+      ### required keys:
+      #   fog-view-sentry-dsn
+    postgresReader:
+      name: fog-recovery-reader-0-postgresql
+      ### required keys:
+      #   postgresql-ssl-options
+      #   postgresql-database
+      #   postgresql-username
+      #   postgresql-hostname
+
+  # override the name of the required secrets
+  externalSecrets:
+    postgresReader:
+      name: fog-recovery-reader-0-postgresql
+      ### required keys:
+      #   postgresql-password
+    ias:
+      name: ias
+      ### required keys:
+      #   MC_IAS_API_KEY
+      #   MC_IAS_SPID
+
+
+grpcGateway:
+  image:
+    org: ''
+    name: go-grpc-gateway
+    pullPolicy: Always
+
+  resources:
+    limits:
+      cpu: 1
+      memory: 256Mi
+    requests:
+      cpu: 256m
+      memory: 256Mi
+
+jaegerTracing:
+  enabled: false

--- a/.internal-ci/test/fog-test-client.sh
+++ b/.internal-ci/test/fog-test-client.sh
@@ -11,6 +11,7 @@ usage()
     echo "Usage --key-dir <dir> --token-id <num>"
     echo "    --key-dir - source keys directory (keys to test)"
     echo "    --token-id - token id to transfer"
+    echo "    --fog-hostname - fog view/ledger service hostname"
 }
 
 is_set()
@@ -43,6 +44,10 @@ do
             token_ids="${2}"
             shift 2
             ;;
+        --fog-hostname )
+            fog_hostname="${2}"
+            shift 2
+            ;;
         *)
             echo "${1} unknown option"
             usage
@@ -55,11 +60,17 @@ is_set key_dir
 is_set token_ids
 is_set NAMESPACE
 
-if [ -n "${CLIENT_AUTH_TOKEN_SECRET}" ]
+if [[ -n "${CLIENT_AUTH_TOKEN_SECRET}" ]]
 then
     echo "Generating Client Auth Creds"
     pw=$(mc-util-grpc-token-generator --shared-secret "${CLIENT_AUTH_TOKEN_SECRET}" --username user1 | grep Password: | awk '{print $2}')
     user="user1:${pw}@"
+fi
+
+if [[ -z "${fog_hostname}" ]]
+then
+    fog_hostname="fog.${NAMESPACE}.development.mobilecoin.com"
+    echo "using default hostname ${fog_hostname}"
 fi
 
 ### v2.0.0 has "--token-id", v3.0.0 has "--token-ids"
@@ -85,5 +96,5 @@ test_client \
     --num-transactions 32 \
     --consensus-wait 300 \
     --transfer-amount 20 \
-    --fog-view "fog-view://${user}fog.${NAMESPACE}.development.mobilecoin.com:443" \
+    --fog-view "fog-view://${user}${fog_hostname}:443" \
     --fog-ledger "fog-ledger://${user}fog.${NAMESPACE}.development.mobilecoin.com:443"


### PR DESCRIPTION
- Break out fog-view chart
- Add testing for additional router endpoints.

### Motivation

We need to be able to build fog instances that have multiple copies of fog-report, fog-view-router and fog-ledger-router with appropriate ingress and secret alignment.
