### PR TITLE
update gha workflow to restore alpha/v5.1.1-dev

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -416,6 +416,7 @@ jobs:
       ingest_color: blue
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}
+      minimum_block: '5946'
     secrets: inherit
 
   test-current-bv3-release:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -7,7 +7,8 @@ name: Mobilecoin CD
 env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
-  RELEASE_5X_TAG: v5.0.3-dev
+  RELEASE_5X_TAG: v5.1.1-dev
+  GH_SHORT_SHA: placeholder
 
 on:
   pull_request:

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -90,4 +90,5 @@ jobs:
       ingest_color: ${{ inputs.ingest_color }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.version }}
+      minimum_block: ${{ inputs.bootstrap_version == 'v5.1.1-dev' && '5946' || '500' }}
     secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -29,8 +29,8 @@ on:
         default: none
         options:
         - none
-        - v1.1.3-dev
-        - v3.0.0-dev
+        - v5.0.3-dev
+        - v5.1.1-dev
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice
@@ -50,7 +50,6 @@ on:
         required: true
         default: docker.io/mobilecoin
 
-
 jobs:
   list-values:
     name: 👾 Environment Info - ${{ inputs.namespace }} - ${{ inputs.version }} 👾
@@ -67,25 +66,13 @@ jobs:
       run: |
         .internal-ci/util/print_details.sh
 
-  bootstrap-v1-1-3-bv0:
+  bootstrap:
     needs:
     - list-values
-    if: inputs.bootstrap_version == 'v1.1.3-dev'
+    if: inputs.bootstrap_version != 'none'
     uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
     with:
-      block_version: 0
-      chart_repo: ${{ inputs.chart_repo }}
-      namespace: ${{ inputs.namespace }}
-      version: ${{ inputs.bootstrap_version }}
-    secrets: inherit
-
-  bootstrap-v3-0-0-bv2:
-    needs:
-    - list-values
-    if: inputs.bootstrap_version == 'v3.0.0-dev'
-    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
-    with:
-      block_version: 2
+      block_version: '3'
       chart_repo: ${{ inputs.chart_repo }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.bootstrap_version }}
@@ -94,8 +81,7 @@ jobs:
   deploy:
     if: '! failure()'
     needs:
-    - bootstrap-v1-1-3-bv0
-    - bootstrap-v3-0-0-bv2
+    - bootstrap
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:
       block_version: ${{ inputs.block_version }}

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -58,12 +58,21 @@ jobs:
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
         VERSION: ${{ inputs.version }}
+      shell: bash
       run: |
         for i in 1 2 3
         do
-          aws s3 cp --only-show-errors --recursive --acl public-read \
-            "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
-            "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com"
+            aws s3 cp --only-show-errors --recursive --acl public-read \
+              "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
+              "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com" &
+            # capture pids
+            pids[${i}]=$!
+        done
+
+        # wait for all pids to finish
+        for pid in ${pids[*]}
+        do
+            wait ${pid}
         done
 
   setup-environment:

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -407,4 +407,4 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
           /test/check-env-status.sh --minimum-block ${{ inputs.minimum_block }} \
-              -- namespace ${{ inputs.namespace }}
+              --namespace ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -33,6 +33,11 @@ on:
         description: "block_version"
         type: string
         required: true
+      minimum_block:
+        description: "The minimum block height before the enviroment is ready"
+        type: string
+        required: false
+        default: "500"
     secrets:
       DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -401,16 +406,5 @@ jobs:
         rancher_url: ${{ secrets.DEV_RANCHER_URL }}
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
-          # Get fog report
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
-          /test/check-ingress-ready.sh --url "https://fog-b.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
-
-          # Get fog ledger
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks"
-
-          # Get consensus client ports
-          /test/check-ingress-ready.sh --url "https://node1.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node2.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node3.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-
-          # no unauthenticated endpoints for view :(
+          /test/check-env-status.sh --minimum-block ${{ inputs.minimum_block }} \
+              -- namespace ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -155,7 +155,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@e4bf5bda9eec8f44ef7de540863aa06f12633566
+      uses: mobilecoinofficial/gha-k8s-toolbox@938fe9e58597a7f9a4b012996bf305bd681a6e39
       with:
         action: namespace-create
         namespace: ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -155,7 +155,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      uses: mobilecoinofficial/gha-k8s-toolbox@4515f1d3832affff3979f7abf36a6f060f9485a5
       with:
         action: namespace-create
         namespace: ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -155,7 +155,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@4515f1d3832affff3979f7abf36a6f060f9485a5
+      uses: mobilecoinofficial/gha-k8s-toolbox@e4bf5bda9eec8f44ef7de540863aa06f12633566
       with:
         action: namespace-create
         namespace: ${{ inputs.namespace }}

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -155,7 +155,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Create namespace
-      uses: mobilecoinofficial/gha-k8s-toolbox@938fe9e58597a7f9a4b012996bf305bd681a6e39
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
         action: namespace-create
         namespace: ${{ inputs.namespace }}

--- a/.internal-ci/test/check-env-status.sh
+++ b/.internal-ci/test/check-env-status.sh
@@ -38,7 +38,7 @@ done
 
 check()
 {
-    curl --max-time 5 --retry 2 --retry-all-errors -sSLf -X POST "${1}"
+    curl --max-time 5 --retry 2 -sSLf -X POST "${1}"
 }
 
 check_timeout()

--- a/.internal-ci/test/check-env-status.sh
+++ b/.internal-ci/test/check-env-status.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+#
+# check-env-status.sh - loop and wait for expected block height and active ingress endpoints.
+
+usage()
+{
+    echo "Usage: $0 --minimum-block "
+    echo "    --minimum - block height for environment to be considered ready."
+}
+
+while (( "$#" ))
+do
+    case "${1}" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        --minimum-block )
+            minimum_block="${2}"
+            shift 2
+            ;;
+        --namespace )
+            namespace="${2}"
+            shift 2
+            ;;
+        *)
+            echo "${1} unknown option"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Check to see if these vars are set
+: "${minimum_block:?}"
+: "${namespace:?}"
+
+check()
+{
+    curl --max-time 5 --retry 2 --retry-all-errors -sSLf -X POST "${1}"
+}
+
+check_timeout()
+{
+    if [[ ${1} -gt 300 ]]
+    then
+        echo "Failed to come up in 10m"
+        exit 1
+    fi
+    sleep 2
+}
+
+# check consensus nodes.
+for n in 1 2 3
+do
+    counter=0
+    block_height=0
+    echo "Waiting for consensus node${n}.${namespace}.development.mobilecoin.com"
+    while [[ ${block_height} -lt ${minimum_block} ]]
+    do
+        block_info=$(check https://node${n}.${namespace}.development.mobilecoin.com/gw/consensus_common.BlockchainAPI/GetLastBlockInfo)
+        block_height=$(jq -r -n --argjson data "${block_info}" '$data.index')
+        echo "  current: ${block_height} minimum: ${minimum_block}"
+
+        check_timeout $(( counter++ ))
+    done
+done
+
+# check report has a value...
+for r in fog fog-b fog-report-b
+do
+    counter=0
+    pubkey=""
+    while [[ -z "${pubkey}" ]]
+    do
+        echo "Waiting for fog-report fog://${r}.${namespace}.development.mobilecoin.com"
+        if report_info=$(/usr/local/bin/fog-report-cli -n -v -u "fog://${r}.${namespace}.development.mobilecoin.com")
+        then
+            pubkey=$(jq -r -n --argjson data "${report_info}" '$data.pubkey')
+        fi
+        check_timeout $(( counter++ ))
+    done
+        echo "  ${pubkey}"
+done
+
+# check ledger
+for l in fog fog-b
+do
+    counter=0
+    block_height=0
+    echo "Waiting for fog-ledger fog://${l}.${namespace}.development.mobilecoin.com"
+    while [[ ${block_height} -lt ${minimum_block} ]]
+    do
+        block_info=$(check https://${l}.${namespace}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks)
+        block_height=$(jq -r -n --argjson data "${block_info}" '$data.numBlocks')
+        echo "  current: ${block_height} minimum: ${minimum_block}"
+
+        check_timeout $(( counter++ ))
+    done
+done
+
+# no way to check view right now :(


### PR DESCRIPTION

### Motivation

- bump the bootstrap tags.
- allow restore of "alpha" (now v5.1.1-dev) history
- simplify the bootstrap options.  No need to support versions older than 5.0

