### PR TITLE
Limit test threads in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,8 @@ fail-fast = false
 failure-output = "immediate-final"
 # Show failed, flaky and retried, and slow tests.
 status-level = "slow"
+# Limit the number of threads for now to prevent saturating the CI machines.
+test-threads = 16
 
 [profile.ci.junit]
 # Output a JUnit report under `target/nextest/ci/junit.xml`.


### PR DESCRIPTION
Previously the tests would block each other. The hypothesis is that there are enough tests running that are trying to write to disk that they block each other on IO and time out. Now the number of concurrent tests is being limited to try and prevent this contention issue.
