### PR TITLE
Add sleep to main thread of mock network

### DIFF
--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -641,6 +641,7 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
                 );
                 last_log = Instant::now();
             }
+            std::thread::sleep(Duration::from_millis(1));
         }
 
         // check that all submitted values are externalized at least once


### PR DESCRIPTION
For the single node mesh and cycle SCP network tests if the main thread doesn't sleep then it will be constantly fighting the node for the lock on shared data. Making the main thread wait 1 millisecond between polls allows the tests to finish in under 5 seconds, where before they would timeout at 8 minutes.
