### PR TITLE
Merge 5.2 to main

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -7,7 +7,8 @@ name: Mobilecoin CD
 env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
-  RELEASE_5X_TAG: v5.0.3-dev
+  RELEASE_5X_TAG: v5.1.1-dev
+  GH_SHORT_SHA: placeholder
 
 on:
   pull_request:
@@ -414,6 +415,7 @@ jobs:
       ingest_color: blue
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.tag }}
+      minimum_block: '5946'
     secrets: inherit
 
   test-current-bv3-release:

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -29,8 +29,8 @@ on:
         default: none
         options:
         - none
-        - v1.1.3-dev
-        - v3.0.0-dev
+        - v5.0.3-dev
+        - v5.1.1-dev
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice
@@ -50,7 +50,6 @@ on:
         required: true
         default: docker.io/mobilecoin
 
-
 jobs:
   list-values:
     name: 👾 Environment Info - ${{ inputs.namespace }} - ${{ inputs.version }} 👾
@@ -67,25 +66,13 @@ jobs:
       run: |
         .internal-ci/util/print_details.sh
 
-  bootstrap-v1-1-3-bv0:
+  bootstrap:
     needs:
     - list-values
-    if: inputs.bootstrap_version == 'v1.1.3-dev'
+    if: inputs.bootstrap_version != 'none'
     uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
     with:
-      block_version: 0
-      chart_repo: ${{ inputs.chart_repo }}
-      namespace: ${{ inputs.namespace }}
-      version: ${{ inputs.bootstrap_version }}
-    secrets: inherit
-
-  bootstrap-v3-0-0-bv2:
-    needs:
-    - list-values
-    if: inputs.bootstrap_version == 'v3.0.0-dev'
-    uses: ./.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
-    with:
-      block_version: 2
+      block_version: '3'
       chart_repo: ${{ inputs.chart_repo }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.bootstrap_version }}
@@ -94,8 +81,7 @@ jobs:
   deploy:
     if: '! failure()'
     needs:
-    - bootstrap-v1-1-3-bv0
-    - bootstrap-v3-0-0-bv2
+    - bootstrap
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     with:
       block_version: ${{ inputs.block_version }}
@@ -104,4 +90,5 @@ jobs:
       ingest_color: ${{ inputs.ingest_color }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.version }}
+      minimum_block: ${{ inputs.bootstrap_version == 'v5.1.1-dev' && '5946' || '500' }}
     secrets: inherit

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -58,12 +58,21 @@ jobs:
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
         VERSION: ${{ inputs.version }}
+      shell: bash
       run: |
         for i in 1 2 3
         do
-          aws s3 cp --only-show-errors --recursive --acl public-read \
-            "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
-            "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com"
+            aws s3 cp --only-show-errors --recursive --acl public-read \
+              "s3://${BUCKET}/prebuilt/${VERSION}/chain/node${i}" \
+              "s3://${BUCKET}/node${i}.${NAMESPACE}.development.mobilecoin.com" &
+            # capture pids
+            pids[${i}]=$!
+        done
+
+        # wait for all pids to finish
+        for pid in ${pids[*]}
+        do
+            wait ${pid}
         done
 
   setup-environment:

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -33,6 +33,11 @@ on:
         description: "block_version"
         type: string
         required: true
+      minimum_block:
+        description: "The minimum block height before the enviroment is ready"
+        type: string
+        required: false
+        default: "500"
     secrets:
       DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -401,16 +406,5 @@ jobs:
         rancher_url: ${{ secrets.DEV_RANCHER_URL }}
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         command: |
-          # Get fog report
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
-          /test/check-ingress-ready.sh --url "https://fog-b.${{ inputs.namespace }}.development.mobilecoin.com/gw/report.ReportAPI/GetReports"
-
-          # Get fog ledger
-          /test/check-ingress-ready.sh --url "https://fog.${{ inputs.namespace }}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks"
-
-          # Get consensus client ports
-          /test/check-ingress-ready.sh --url "https://node1.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node2.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-          /test/check-ingress-ready.sh --url "https://node3.${{ inputs.namespace }}.development.mobilecoin.com/gw/consensus_client.ConsensusClientAPI/GetNodeConfig"
-
-          # no unauthenticated endpoints for view :(
+          /test/check-env-status.sh --minimum-block ${{ inputs.minimum_block }} \
+              --namespace ${{ inputs.namespace }}

--- a/.internal-ci/test/check-env-status.sh
+++ b/.internal-ci/test/check-env-status.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright (c) 2018-2022 The MobileCoin Foundation
+#
+# check-env-status.sh - loop and wait for expected block height and active ingress endpoints.
+
+usage()
+{
+    echo "Usage: $0 --minimum-block "
+    echo "    --minimum - block height for environment to be considered ready."
+}
+
+while (( "$#" ))
+do
+    case "${1}" in
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        --minimum-block )
+            minimum_block="${2}"
+            shift 2
+            ;;
+        --namespace )
+            namespace="${2}"
+            shift 2
+            ;;
+        *)
+            echo "${1} unknown option"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Check to see if these vars are set
+: "${minimum_block:?}"
+: "${namespace:?}"
+
+check()
+{
+    curl --max-time 5 --retry 2 -sSLf -X POST "${1}"
+}
+
+check_timeout()
+{
+    if [[ ${1} -gt 300 ]]
+    then
+        echo "Failed to come up in 10m"
+        exit 1
+    fi
+    sleep 2
+}
+
+# check consensus nodes.
+for n in 1 2 3
+do
+    counter=0
+    block_height=0
+    echo "Waiting for consensus node${n}.${namespace}.development.mobilecoin.com"
+    while [[ ${block_height} -lt ${minimum_block} ]]
+    do
+        block_info=$(check https://node${n}.${namespace}.development.mobilecoin.com/gw/consensus_common.BlockchainAPI/GetLastBlockInfo)
+        block_height=$(jq -r -n --argjson data "${block_info}" '$data.index')
+        echo "  current: ${block_height} minimum: ${minimum_block}"
+
+        check_timeout $(( counter++ ))
+    done
+done
+
+# check report has a value...
+for r in fog fog-b fog-report-b
+do
+    counter=0
+    pubkey=""
+    while [[ -z "${pubkey}" ]]
+    do
+        echo "Waiting for fog-report fog://${r}.${namespace}.development.mobilecoin.com"
+        if report_info=$(/usr/local/bin/fog-report-cli -n -v -u "fog://${r}.${namespace}.development.mobilecoin.com")
+        then
+            pubkey=$(jq -r -n --argjson data "${report_info}" '$data.pubkey')
+        fi
+        check_timeout $(( counter++ ))
+    done
+        echo "  ${pubkey}"
+done
+
+# check ledger
+for l in fog fog-b
+do
+    counter=0
+    block_height=0
+    echo "Waiting for fog-ledger fog://${l}.${namespace}.development.mobilecoin.com"
+    while [[ ${block_height} -lt ${minimum_block} ]]
+    do
+        block_info=$(check https://${l}.${namespace}.development.mobilecoin.com/gw/fog_ledger.FogBlockAPI/GetBlocks)
+        block_height=$(jq -r -n --argjson data "${block_info}" '$data.numBlocks')
+        echo "  current: ${block_height} minimum: ${minimum_block}"
+
+        check_timeout $(( counter++ ))
+    done
+done
+
+# no way to check view right now :(

--- a/consensus/scp/tests/mock_network/mod.rs
+++ b/consensus/scp/tests/mock_network/mod.rs
@@ -641,6 +641,7 @@ pub fn build_and_test(network_config: &NetworkConfig, test_options: &TestOptions
                 );
                 last_log = Instant::now();
             }
+            std::thread::sleep(Duration::from_millis(1));
         }
 
         // check that all submitted values are externalized at least once

--- a/mobilecoind/src/sync.rs
+++ b/mobilecoind/src/sync.rs
@@ -41,15 +41,13 @@ use mc_transaction_core::{
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::{
+    cmp::min,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
     },
     thread,
 };
-
-///  The maximal number of blocks a worker thread would process at once.
-const MAX_BLOCKS_PROCESSING_CHUNK_SIZE: usize = 5;
 
 /// Message type the our crossbeam channel used to communicate with the worker
 /// thread pull.
@@ -94,7 +92,9 @@ impl SyncThread {
         // Create worker threads.
         let mut worker_join_handles = Vec::new();
 
-        for idx in 0..num_workers.unwrap_or_else(num_cpus::get) {
+        let num_workers = num_workers.unwrap_or_else(num_cpus::get);
+
+        for idx in 0..num_workers {
             let thread_ledger_db = ledger_db.clone();
             let thread_mobilecoind_db = mobilecoind_db.clone();
             let thread_sender = sender.clone();
@@ -110,6 +110,7 @@ impl SyncThread {
                         thread_sender,
                         thread_receiver,
                         thread_queued_monitor_ids,
+                        num_workers,
                         thread_logger,
                     );
                 })
@@ -238,12 +239,19 @@ fn sync_thread_entry_point(
     sender: crossbeam_channel::Sender<SyncMsg>,
     receiver: crossbeam_channel::Receiver<SyncMsg>,
     queued_monitor_ids: Arc<Mutex<HashSet<MonitorId>>>,
+    num_workers: usize,
     logger: Logger,
 ) {
     for msg in receiver.iter() {
         match msg {
             SyncMsg::SyncMonitor(monitor_id) => {
-                match sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger) {
+                match sync_monitor(
+                    &ledger_db,
+                    &mobilecoind_db,
+                    &monitor_id,
+                    num_workers,
+                    &logger,
+                ) {
                     // Success - No more blocks are currently available.
                     Ok(SyncMonitorOk::NoMoreBlocks) => {
                         // Remove the monitor id from the list of queued ones so that the main
@@ -286,55 +294,108 @@ fn sync_thread_entry_point(
     }
 }
 
-/// Sync a single monitor.
+/// Sync a single monitor, spawning parallel jobs to perform block scanning if
+/// it is many blocks behind. This allows us to use all the CPU cores scanning
+/// even when we only have a single monitor to work on, and all the blocks are
+/// pretty small (only 2 or 3 UTXOs), which is a very common situation.
 fn sync_monitor(
     ledger_db: &LedgerDB,
     mobilecoind_db: &Database,
     monitor_id: &MonitorId,
+    num_workers: usize,
     logger: &Logger,
 ) -> Result<SyncMonitorOk, Error> {
-    for _ in 0..MAX_BLOCKS_PROCESSING_CHUNK_SIZE {
-        // Get the monitor data. If it is no longer available, the monitor has been
-        // removed and we can simply return.
-        let monitor_data = mobilecoind_db.get_monitor_data(monitor_id)?;
-        let block_contents = match ledger_db.get_block_contents(monitor_data.next_block) {
-            Ok(block_contents) => block_contents,
-            Err(mc_ledger_db::Error::NotFound) => {
-                return Ok(SyncMonitorOk::NoMoreBlocks);
+    let monitor_data = mobilecoind_db.get_monitor_data(monitor_id)?;
+    let num_blocks = ledger_db.num_blocks()?;
+
+    // If the next block is out of bounds of [0, num_blocks), then there is no more
+    // work to do on this monitor. (Blocks count up from index 0)
+    if monitor_data.next_block >= num_blocks {
+        return Ok(SyncMonitorOk::NoMoreBlocks);
+    }
+    let blocks_remaining_for_monitor = (num_blocks - monitor_data.next_block) as usize;
+
+    // We will try to load and scan a number of blocks which is not more than the
+    // amount of work we can potentially do, or the number of workers.
+    let num_blocks_to_load = min(num_workers, blocks_remaining_for_monitor);
+
+    // Each worker will try to call
+    // ledger_db.get_block_contents(monitor_data.next_block + worker_idx)
+    // and then
+    // match_tx_outs_into_utxos
+    // in parallel.
+    //
+    // At the end we collect the results and add them to the database in order,
+    // because the database needs that to be done sequentially. But the scanning
+    // is the slow part here, so this is fine.
+    let parallel_results = (0..num_blocks_to_load)
+        .into_par_iter()
+        .map(
+            |worker_idx| -> Result<(Vec<UnspentTxOut>, Vec<KeyImage>), Error> {
+                // We don't expect to get Error::NotFound here, since we earlier tested
+                // ledger_db.num_blocks(). The other error cases are not common
+                // either.
+                let block_idx = monitor_data.next_block + worker_idx as u64;
+                let block_contents = ledger_db.get_block_contents(block_idx)?;
+
+                log::trace!(
+                    logger,
+                    "processing {} outputs and {} key images from block {} for monitor_id {}",
+                    block_contents.outputs.len(),
+                    block_contents.key_images.len(),
+                    block_idx,
+                    monitor_id,
+                );
+
+                // Match tx outs into UTXOs.
+                let utxos = match_tx_outs_into_utxos(
+                    mobilecoind_db,
+                    &block_contents.outputs,
+                    monitor_id,
+                    &monitor_data,
+                    logger,
+                )?;
+
+                Ok((utxos, block_contents.key_images))
+            },
+        )
+        .collect::<Vec<Result<(Vec<UnspentTxOut>, Vec<KeyImage>), Error>>>();
+
+    // For diagnostics, we want to keep track of which workers were successful.
+    // Usually it should be all of them, but if sometimes a worker in the middle
+    // fails and later ones don't, that will harm performance.
+    let worker_successes = parallel_results
+        .iter()
+        .map(|result| if result.is_ok() { 1 } else { 0 })
+        .collect::<Vec<usize>>();
+
+    // Now add everything to the database
+    for (worker_idx, result) in parallel_results.into_iter().enumerate() {
+        if let Err(err) = result.and_then(|(utxos, key_images)| {
+            // Update database.
+            mobilecoind_db.block_processed(
+                monitor_id,
+                monitor_data.next_block + worker_idx as u64,
+                &utxos,
+                &key_images,
+            )
+        }) {
+            // Unfortunately, we have to abandon any work that could have been accomplished
+            // successfully by the threads after this one. To track this,
+            // we'll log a warning about work being abandoned.
+            let abandoned_successes: usize = worker_successes.iter().skip(worker_idx + 1).sum();
+            if abandoned_successes > 0 {
+                log::warn!(logger, "Due to an error while parallel scanning, had to abandon {} successful block scanning results", abandoned_successes);
             }
-            Err(err) => {
-                return Err(err.into());
-            }
-        };
-
-        log::trace!(
-            logger,
-            "processing {} outputs and {} key images from block {} for monitor_id {}",
-            block_contents.outputs.len(),
-            block_contents.key_images.len(),
-            monitor_data.next_block,
-            monitor_id,
-        );
-
-        // Match tx outs into UTXOs.
-        let utxos = match_tx_outs_into_utxos(
-            mobilecoind_db,
-            &block_contents.outputs,
-            monitor_id,
-            &monitor_data,
-            logger,
-        )?;
-
-        // Update database.
-        mobilecoind_db.block_processed(
-            monitor_id,
-            monitor_data.next_block,
-            &utxos,
-            &block_contents.key_images,
-        )?;
+            return Err(err);
+        }
     }
 
-    Ok(SyncMonitorOk::MoreBlocksPotentiallyAvailable)
+    Ok(if blocks_remaining_for_monitor == num_blocks_to_load {
+        SyncMonitorOk::NoMoreBlocks
+    } else {
+        SyncMonitorOk::MoreBlocksPotentiallyAvailable
+    })
 }
 
 /// Helper function for matching a list of TxOuts to a given monitor.
@@ -437,6 +498,8 @@ mod test {
     use rand::{rngs::StdRng, SeedableRng};
     use std::time::Instant;
 
+    const TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE: usize = 5;
+
     #[test_with_logger]
     fn test_sync_monitor(logger: Logger) {
         let mut rng: StdRng = SeedableRng::from_seed([98u8; 32]);
@@ -460,8 +523,8 @@ mod test {
             .collect();
 
         // Generate a test database with a number blocks that does not divide evenly by
-        // MAX_BLOCKS_PROCESSING_CHUNK_SIZE.
-        let num_blocks = (MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) + 1;
+        // TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE.
+        let num_blocks = (TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) + 1;
         let (mut ledger_db, mobilecoind_db) = get_test_databases(
             BlockVersion::MAX,
             0,
@@ -500,8 +563,15 @@ mod test {
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(monitor_data.next_block, 0);
 
-        // Process the first MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        // Process the first TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::MoreBlocksPotentiallyAvailable);
 
         // We should now discover some outputs. Each block has 1 output per recipient,
@@ -509,13 +579,13 @@ mod test {
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(
             monitor_data.next_block,
-            MAX_BLOCKS_PROCESSING_CHUNK_SIZE as u64
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE as u64
         );
 
         let utxos = mobilecoind_db
             .get_utxos_for_subaddress(&monitor_id, DEFAULT_SUBADDRESS_INDEX)
             .unwrap();
-        assert_eq!(utxos.len(), MAX_BLOCKS_PROCESSING_CHUNK_SIZE);
+        assert_eq!(utxos.len(), TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE);
 
         // Sanity test the utxos.
         for utxo in utxos {
@@ -525,20 +595,27 @@ mod test {
             assert_eq!(utxo.attempted_spend_height, 0);
         }
 
-        // Process the second MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        // Process the second TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::MoreBlocksPotentiallyAvailable);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(
             monitor_data.next_block,
-            (MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) as u64
+            (TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) as u64
         );
 
         let utxos = mobilecoind_db
             .get_utxos_for_subaddress(&monitor_id, DEFAULT_SUBADDRESS_INDEX)
             .unwrap();
-        assert_eq!(utxos.len(), MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2);
+        assert_eq!(utxos.len(), TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2);
 
         // Sanity test the utxos.
         for utxo in utxos {
@@ -549,7 +626,14 @@ mod test {
         }
 
         // Process the last remaining block.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
@@ -569,7 +653,14 @@ mod test {
         }
 
         // Calling sync_monitor again should not change the results.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
@@ -604,7 +695,14 @@ mod test {
         )
         .unwrap();
 
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         let utxos = mobilecoind_db
@@ -643,8 +741,8 @@ mod test {
             .collect();
 
         // Generate a test database with a number blocks that does not divide evenly by
-        // MAX_BLOCKS_PROCESSING_CHUNK_SIZE.
-        let num_blocks = (MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) + 1;
+        // TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE.
+        let num_blocks = (TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) + 1;
         let (mut ledger_db, mobilecoind_db) = get_test_databases(
             BlockVersion::MAX,
             0,
@@ -683,8 +781,15 @@ mod test {
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(monitor_data.next_block, 0);
 
-        // Process the first MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        // Process the first TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::MoreBlocksPotentiallyAvailable);
 
         // We should now discover some outputs. Each block has 1 output per recipient,
@@ -692,13 +797,13 @@ mod test {
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(
             monitor_data.next_block,
-            MAX_BLOCKS_PROCESSING_CHUNK_SIZE as u64
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE as u64
         );
 
         let utxos = mobilecoind_db
             .get_utxos_for_subaddress(&monitor_id, DEFAULT_SUBADDRESS_INDEX)
             .unwrap();
-        assert_eq!(utxos.len(), MAX_BLOCKS_PROCESSING_CHUNK_SIZE);
+        assert_eq!(utxos.len(), TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE);
 
         // Sanity test the utxos.
         for utxo in utxos {
@@ -708,20 +813,27 @@ mod test {
             assert_eq!(utxo.attempted_spend_height, 0);
         }
 
-        // Process the second MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        // Process the second TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE blocks.
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::MoreBlocksPotentiallyAvailable);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
         assert_eq!(
             monitor_data.next_block,
-            (MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) as u64
+            (TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2) as u64
         );
 
         let utxos = mobilecoind_db
             .get_utxos_for_subaddress(&monitor_id, DEFAULT_SUBADDRESS_INDEX)
             .unwrap();
-        assert_eq!(utxos.len(), MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2);
+        assert_eq!(utxos.len(), TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE * 2);
 
         // Sanity test the utxos.
         for utxo in utxos {
@@ -732,7 +844,14 @@ mod test {
         }
 
         // Process the last remaining block.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
@@ -752,7 +871,14 @@ mod test {
         }
 
         // Calling sync_monitor again should not change the results.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         let monitor_data = mobilecoind_db.get_monitor_data(&monitor_id).unwrap();
@@ -799,7 +925,14 @@ mod test {
 
         let start = Instant::now();
 
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
 
         let sync_monitor_time = start.elapsed();
         log::info!(logger, "sync_monitor took {sync_monitor_time:?}");
@@ -842,7 +975,14 @@ mod test {
         assert_eq!(mobilecoind_db.add_monitor(&data).unwrap(), monitor_id);
 
         // Sync.
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         // Should have a single non-zero utxo for our monitor.
@@ -864,7 +1004,14 @@ mod test {
         )
         .unwrap();
 
-        let result = sync_monitor(&ledger_db, &mobilecoind_db, &monitor_id, &logger).unwrap();
+        let result = sync_monitor(
+            &ledger_db,
+            &mobilecoind_db,
+            &monitor_id,
+            TEST_MAX_BLOCKS_PROCESSING_CHUNK_SIZE,
+            &logger,
+        )
+        .unwrap();
         assert_eq!(result, SyncMonitorOk::NoMoreBlocks);
 
         // We should now have only a zero utxo.

--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -26,13 +26,13 @@ fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
         // By logging to STDERR also we make sure the message gets to an OS
         // buffer before the process dies.
         Ok(v) => {
-            eprintln!("Enclave panic:\n{}", v);
-            global_log::crit!("Enclave panic:\n{}\n", v)
+            eprintln!("Enclave panic: {}", v);
+            global_log::crit!("Enclave panic: {}", v)
         },
         Err(e) => {
-            eprintln!("Enclave panic message contained invalid utf8:\n{}\n{:?}", e, panic_msg_bytes);
+            eprintln!("Enclave panic message contained invalid utf8: ({}) {:?}", e, panic_msg_bytes);
             global_log::crit!(
-                "Enclave panic message contained invalid utf8:\n{}\n{:?}",
+                "Enclave panic message contained invalid utf8: ({}) {:?}",
                 e,
                 panic_msg_bytes
             )


### PR DESCRIPTION
- Fog ledger update prometheus metrics in main loop (#3649)
- break out fog-report chart (#3643)
- fog-view - Helm chart improvements for consolidating fog instances (#3662)
- bump grpcio to 0.13 (#3674)
- fog-ledger - Helm chart improvements for consolidating fog instances (#3668)
- Remove fog-services charts. (#3675)
- Update changelog for 5.1.0 release (#3676)
- Bump versions to 5.1.0 (#3677)
- fix port alignment for fog-ledger-router and grpc-gateway (#3687)
- Update changelog for 5.1.1 (#3688)
- Bump versions to 5.1.1 (#3689)
- Improve parallel processing when there is only a single monitor (#3673)
- Remove newlines from enclave panic message (#3706)
- update gha workflow to restore alpha/v5.1.1-dev (#3703)
- Add sleep to main thread of mock network (#3713)
