### PR TITLE
Remove fog ledger router omap

### DIFF
--- a/.internal-ci/helm/fog-ledger/values.yaml
+++ b/.internal-ci/helm/fog-ledger/values.yaml
@@ -130,7 +130,6 @@ fogLedger:
 
     configMap:
       data:
-        MC_OMAP_CAPACITY: '4194304'
         MC_LEDGER_DB_URL: ''
         MC_WATCHER_DB_URL: ''
 

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -44,7 +44,8 @@ fn main() {
     let enclave = LedgerSgxEnclave::new(
         enclave_path,
         &config.client_responder_id,
-        config.omap_capacity,
+        // The router doesn't use the OMAP, so we can set it to 0.
+        0,
         logger.clone(),
     );
 

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -72,20 +72,6 @@ pub struct LedgerRouterConfig {
     /// Path to watcher db (lmdb) - includes block timestamps
     #[clap(long, env = "MC_WATCHER_DB")]
     pub watcher_db: PathBuf,
-
-    // TODO: Add store instance uris which are of type Vec<FogLedgerStoreUri>.
-    /// The capacity to build the OMAP (ORAM hash table) with.
-    /// About 75% of this capacity can be used.
-    /// The hash table will overflow when there are more TxOut's than this,
-    /// and the server will have to be restarted with a larger number.
-    ///
-    /// Note: At time of writing, the hash table will be allocated to use all
-    /// available SGX EPC memory, and then beyond that it will be allocated on
-    /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
-    /// you will either get killed by OOM killer, or it will start being swapped
-    /// to disk by linux kernel.
-    #[clap(long, default_value = "1048576", env = "MC_OMAP_CAPACITY")]
-    pub omap_capacity: u64,
 }
 
 /// Configuration parameters for the Fog Ledger Store service.

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -136,13 +136,12 @@ fn fog_ledger_merkle_proofs_test(logger: Logger) {
                 client_auth_token_secret: None,
                 client_auth_token_max_lifetime: Default::default(),
                 query_retries: 3,
-                omap_capacity: OMAP_CAPACITY,
             };
 
             let enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
                 &config.client_responder_id,
-                OMAP_CAPACITY,
+                0,
                 logger.clone(),
             );
 
@@ -374,7 +373,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
                 &store_config.client_responder_id,
-                OMAP_CAPACITY,
+                store_config.omap_capacity,
                 logger.clone(),
             );
             let ra_client =
@@ -416,13 +415,12 @@ fn fog_ledger_key_images_test(logger: Logger) {
                 client_auth_token_secret: None,
                 client_auth_token_max_lifetime: Default::default(),
                 query_retries: 3,
-                omap_capacity: OMAP_CAPACITY,
             };
 
             let enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
                 &router_config.client_responder_id,
-                OMAP_CAPACITY,
+                0,
                 logger.clone(),
             );
 
@@ -616,13 +614,12 @@ fn fog_ledger_blocks_api_test(logger: Logger) {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Default::default(),
             query_retries: 3,
-            omap_capacity: OMAP_CAPACITY,
         };
 
         let enclave = LedgerSgxEnclave::new(
             get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
             &config.client_responder_id,
-            OMAP_CAPACITY,
+            0,
             logger.clone(),
         );
 
@@ -781,13 +778,12 @@ fn fog_ledger_untrusted_tx_out_api_test(logger: Logger) {
             client_auth_token_secret: None,
             client_auth_token_max_lifetime: Default::default(),
             query_retries: 3,
-            omap_capacity: OMAP_CAPACITY,
         };
 
         let enclave = LedgerSgxEnclave::new(
             get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
             &config.client_responder_id,
-            OMAP_CAPACITY,
+            0,
             logger.clone(),
         );
 
@@ -954,7 +950,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
                 &store_config.client_responder_id,
-                OMAP_CAPACITY,
+                store_config.omap_capacity,
                 logger.clone(),
             );
             let ra_client =
@@ -996,13 +992,12 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 client_auth_token_secret: None,
                 client_auth_token_max_lifetime: Default::default(),
                 query_retries: 3,
-                omap_capacity: OMAP_CAPACITY,
             };
 
             let enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
                 &router_config.client_responder_id,
-                OMAP_CAPACITY,
+                0,
                 logger.clone(),
             );
 

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -225,13 +225,12 @@ fn create_router(
         client_auth_token_secret: None,
         client_auth_token_max_lifetime: Default::default(),
         query_retries: 3,
-        omap_capacity: test_config.omap_capacity,
     };
 
     let enclave = LedgerSgxEnclave::new(
         get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
         &config.client_responder_id,
-        config.omap_capacity,
+        0,
         logger.clone(),
     );
 
@@ -341,7 +340,6 @@ struct TestEnvironmentConfig {
     router_address: SocketAddr,
     router_admin_address: SocketAddr,
     shards: Vec<ShardConfig>,
-    omap_capacity: u64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -398,7 +396,6 @@ async fn smoke_test() {
         router_address: free_sockaddr(),
         router_admin_address: free_sockaddr(),
         shards: shards_config,
-        omap_capacity: 1000,
     };
 
     let mut blocks_config = vec![];
@@ -515,7 +512,6 @@ async fn overlapping_stores() {
         router_address: free_sockaddr(),
         router_admin_address: free_sockaddr(),
         shards: shards_config,
-        omap_capacity: 1000,
     };
 
     let mut blocks_config = vec![];


### PR DESCRIPTION
Previously the fog ledger router allocated 30MB of OMAP. This was a hold over from when fog ledger router was fog ledger. Only the key image stores need OMAP and fog ledger router does not need OMAP.