### PR TITLE
Remove fog view router omap

### DIFF
--- a/fog/view/server/src/bin/router.rs
+++ b/fog/view/server/src/bin/router.rs
@@ -37,7 +37,7 @@ fn main() {
     let sgx_enclave = SgxViewEnclave::new(
         enclave_path,
         config.client_responder_id.clone(),
-        config.omap_capacity,
+        0,
         logger.clone(),
     );
 

--- a/fog/view/server/src/config.rs
+++ b/fog/view/server/src/config.rs
@@ -134,19 +134,6 @@ pub struct FogViewRouterConfig {
     #[clap(long, env = "MC_IAS_SPID")]
     pub ias_spid: ProviderId,
 
-    /// The capacity to build the OMAP (ORAM hash table) with.
-    /// About 75% of this capacity can be used.
-    /// The hash table will overflow when there are more TxOut's than this,
-    /// and the server will have to be restarted with a larger number.
-    ///
-    /// Note: At time of writing, the hash table will be allocated to use all
-    /// available SGX EPC memory, and then beyond that it will be allocated on
-    /// the heap in the untrusted side. Once the needed capacity exceeds RAM,
-    /// you will either get killed by OOM killer, or it will start being swapped
-    /// to disk by linux kernel.
-    #[clap(long, default_value = "1048576", env = "MC_OMAP_CAPACITY")]
-    pub omap_capacity: u64,
-
     /// Router admin listening URI.
     #[clap(long, env = "MC_ADMIN_LISTEN_URI")]
     pub admin_listen_uri: AdminUri,

--- a/fog/view/server/test-utils/src/lib.rs
+++ b/fog/view/server/test-utils/src/lib.rs
@@ -92,7 +92,6 @@ impl RouterTestEnvironment {
             client_listen_uri: RouterClientListenUri::Streaming(router_uri.clone()),
             client_auth_token_max_lifetime: Default::default(),
             client_auth_token_secret: None,
-            omap_capacity,
             admin_listen_uri,
         };
         let router_server = Self::create_router_server(config, store_clients, &logger);
@@ -132,7 +131,6 @@ impl RouterTestEnvironment {
             client_listen_uri: RouterClientListenUri::Unary(router_uri.clone()),
             client_auth_token_max_lifetime: Default::default(),
             client_auth_token_secret: None,
-            omap_capacity,
             admin_listen_uri,
         };
         let router_server = Self::create_router_server(config, store_clients, &logger);
@@ -155,7 +153,7 @@ impl RouterTestEnvironment {
         let enclave = SgxViewEnclave::new(
             get_enclave_path(mc_fog_view_enclave::ENCLAVE_FILE),
             config.client_responder_id.clone(),
-            config.omap_capacity,
+            0,
             logger.clone(),
         );
         let ra_client =


### PR DESCRIPTION
Previously the fog view router allocated 30MB of OMAP. This was a hold over from when fog view router was fog view. Only the view stores need OMAP and fog view router does not need OMAP.