### PR TITLE
Various improvements to fog-test-client

### DIFF
--- a/fog/enclave_connection/src/error.rs
+++ b/fog/enclave_connection/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2018-2022 The MobileCoin Foundation
 
 use displaydoc::Display;
-
+use grpcio::RpcStatusCode;
 use mc_attest_ake::Error as AkeError;
 use mc_connection::AttestationError;
 use mc_crypto_noise::CipherError;
@@ -30,6 +30,11 @@ impl AttestationError for Error {
 
     fn should_retry(&self) -> bool {
         match self {
+            Error::Rpc(grpcio::Error::RpcFailure(rpc_status)) => {
+                // Retry but only if the error code is not RESOURCE_EXHAUSTED, which is what is
+                // returned when the response size is too large
+                rpc_status.code() != RpcStatusCode::RESOURCE_EXHAUSTED
+            }
             Error::Rpc(_) | Error::Cipher(_) | Error::ProtoDecode(_) => true,
             Error::Ake(AkeError::ReportVerification(_)) => false,
             Error::Ake(_) => true,

--- a/fog/ledger/connection/src/block.rs
+++ b/fog/ledger/connection/src/block.rs
@@ -2,7 +2,7 @@
 
 use super::Error;
 use grpcio::{ChannelBuilder, Environment};
-use mc_common::logger::Logger;
+use mc_common::{logger::Logger, trace_time};
 use mc_fog_api::{fog_common::BlockRange, ledger, ledger_grpc, ledger_grpc::FogBlockApiClient};
 use mc_fog_uri::{ConnectionUri, FogLedgerUri};
 use mc_util_grpc::{BasicCredentials, ConnectionUriGrpcioChannel, GrpcRetryConfig};
@@ -15,7 +15,6 @@ pub struct FogBlockGrpcClient {
     blocks_client: FogBlockApiClient,
     creds: BasicCredentials,
     grpc_retry_config: GrpcRetryConfig,
-    #[allow(dead_code)]
     logger: Logger,
 }
 
@@ -46,6 +45,8 @@ impl FogBlockGrpcClient {
         &mut self,
         missed_block_ranges: Vec<BlockRange>,
     ) -> Result<ledger::BlockResponse, Error> {
+        trace_time!(self.logger, "FogBlockGrpcClient::get_missed_block_ranges");
+
         let mut request = ledger::BlockRequest::new();
         request.ranges = RepeatedField::from_vec(missed_block_ranges);
 

--- a/fog/ledger/connection/src/key_image.rs
+++ b/fog/ledger/connection/src/key_image.rs
@@ -5,7 +5,10 @@ use displaydoc::Display;
 use grpcio::{ChannelBuilder, Environment};
 use mc_attest_verifier::Verifier;
 use mc_blockchain_types::BlockIndex;
-use mc_common::logger::{o, Logger};
+use mc_common::{
+    logger::{o, Logger},
+    trace_time,
+};
 use mc_fog_api::{ledger::KeyImageResultCode, ledger_grpc::FogKeyImageApiClient};
 use mc_fog_enclave_connection::EnclaveConnection;
 use mc_fog_types::ledger::{
@@ -21,6 +24,7 @@ pub struct FogKeyImageGrpcClient {
     conn: EnclaveConnection<FogLedgerUri, FogKeyImageApiClient>,
     grpc_retry_config: GrpcRetryConfig,
     uri: FogLedgerUri,
+    logger: Logger,
 }
 
 impl FogKeyImageGrpcClient {
@@ -49,9 +53,16 @@ impl FogKeyImageGrpcClient {
         let grpc_client = FogKeyImageApiClient::new(ch);
 
         Self {
-            conn: EnclaveConnection::new(chain_id, uri.clone(), grpc_client, verifier, logger),
+            conn: EnclaveConnection::new(
+                chain_id,
+                uri.clone(),
+                grpc_client,
+                verifier,
+                logger.clone(),
+            ),
             grpc_retry_config,
             uri,
+            logger,
         }
     }
 
@@ -60,6 +71,8 @@ impl FogKeyImageGrpcClient {
         &mut self,
         key_images: &[KeyImage],
     ) -> Result<CheckKeyImagesResponse, Error> {
+        trace_time!(self.logger, "FogKeyImageGrpcClient::check_key_images");
+
         let request = CheckKeyImagesRequest {
             queries: key_images
                 .iter()

--- a/fog/ledger/connection/src/merkle_proof.rs
+++ b/fog/ledger/connection/src/merkle_proof.rs
@@ -4,7 +4,10 @@ use super::Error;
 use displaydoc::Display;
 use grpcio::{ChannelBuilder, Environment};
 use mc_attest_verifier::Verifier;
-use mc_common::logger::{o, Logger};
+use mc_common::{
+    logger::{o, Logger},
+    trace_time,
+};
 use mc_fog_api::ledger_grpc::FogMerkleProofApiClient;
 use mc_fog_enclave_connection::EnclaveConnection;
 use mc_fog_types::ledger::{GetOutputsRequest, GetOutputsResponse, OutputResult};
@@ -21,6 +24,8 @@ pub struct FogMerkleProofGrpcClient {
     grpc_retry_config: GrpcRetryConfig,
     /// Uri to connect to
     uri: FogLedgerUri,
+    /// Logger
+    logger: Logger,
 }
 
 impl FogMerkleProofGrpcClient {
@@ -49,9 +54,16 @@ impl FogMerkleProofGrpcClient {
         let grpc_client = FogMerkleProofApiClient::new(ch);
 
         Self {
-            conn: EnclaveConnection::new(chain_id, uri.clone(), grpc_client, verifier, logger),
+            conn: EnclaveConnection::new(
+                chain_id,
+                uri.clone(),
+                grpc_client,
+                verifier,
+                logger.clone(),
+            ),
             grpc_retry_config,
             uri,
+            logger,
         }
     }
 
@@ -61,6 +73,8 @@ impl FogMerkleProofGrpcClient {
         indices: Vec<u64>,
         merkle_root_block: u64,
     ) -> Result<GetOutputsResponse, Error> {
+        trace_time!(self.logger, "FogMerkeProofGrpcClient::get_outputs");
+
         let request = GetOutputsRequest {
             indices,
             merkle_root_block,

--- a/fog/ledger/connection/src/router_client.rs
+++ b/fog/ledger/connection/src/router_client.rs
@@ -8,7 +8,10 @@ use mc_attest_ake::{
 };
 use mc_attest_core::VerificationReport;
 use mc_attest_verifier::Verifier;
-use mc_common::{logger::{log, o, Logger}, trace_time};
+use mc_common::{
+    logger::{log, o, Logger},
+    trace_time,
+};
 use mc_crypto_keys::X25519;
 use mc_crypto_noise::CipherError;
 use mc_fog_api::{

--- a/fog/ledger/connection/src/router_client.rs
+++ b/fog/ledger/connection/src/router_client.rs
@@ -8,7 +8,7 @@ use mc_attest_ake::{
 };
 use mc_attest_core::VerificationReport;
 use mc_attest_verifier::Verifier;
-use mc_common::logger::{log, o, Logger};
+use mc_common::{logger::{log, o, Logger}, trace_time};
 use mc_crypto_keys::X25519;
 use mc_crypto_noise::CipherError;
 use mc_fog_api::{
@@ -136,7 +136,8 @@ impl LedgerGrpcClient {
         &mut self,
         key_images: &[KeyImage],
     ) -> Result<CheckKeyImagesResponse, Error> {
-        log::trace!(self.logger, "Check key images was called");
+        trace_time!(self.logger, "LedgerGrpcClient::check_key_images");
+
         if !self.is_attested() {
             let verification_report = self.attest().await;
             verification_report?;

--- a/fog/ledger/connection/src/untrusted.rs
+++ b/fog/ledger/connection/src/untrusted.rs
@@ -3,7 +3,7 @@
 use super::Error;
 use grpcio::{ChannelBuilder, Environment};
 use mc_blockchain_types::BlockIndex;
-use mc_common::logger::Logger;
+use mc_common::{logger::Logger, trace_time};
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_fog_api::{fog_common::BlockRange, ledger, ledger_grpc};
 use mc_fog_uri::FogLedgerUri;
@@ -56,6 +56,8 @@ impl FogUntrustedLedgerGrpcClient {
         &self,
         block_ranges: impl IntoIterator<Item = &'a Range<BlockIndex>>,
     ) -> Result<ledger::BlockResponse, Error> {
+        trace_time!(self.logger, "FogUntrustedLedgerGrpcClient::get_blocks");
+
         let mut request = ledger::BlockRequest::new();
         for iter_range in block_ranges.into_iter() {
             request.ranges.push({
@@ -84,6 +86,8 @@ impl FogUntrustedLedgerGrpcClient {
         &self,
         tx_out_pubkeys: impl IntoIterator<Item = CompressedRistrettoPublic>,
     ) -> Result<ledger::TxOutResponse, Error> {
+        trace_time!(self.logger, "FogUntrustedLedgerGrpcClient::get_tx_outs");
+
         let mut request = ledger::TxOutRequest::new();
         for pubkey in tx_out_pubkeys.into_iter() {
             // Convert to external::CompressedRistretto


### PR DESCRIPTION
While trying to figure out why the testnet fog-test-client is taking much more time than my local machine to do a balance check on the same account I ran into an issue where I was seeing `message size too large` errors returned from fog-view. 
I've also been looking into why old accounts with many TxOuts take longer to do a balance check even after the initial slow-but-expected sync.

This let me to dig deeper, and this PR is a collection of improvements I made along the way:
1. Make the GRPC `RESOURCE_EXHAUSTED` error, which is the error you get when the server is trying to send you too large of a reply, non-retriable. This is due to the assumption that retrying the same request will result in the same reply.
2. Add a bunch of `trace_time!` logs to client GRPC calls so that I can have better visibility into where time is being spent.
3. Gate a log message that is extremely verbose but sometimes useful with an environment variable. We don't do this often, but this is a test utility and sometimes we are going to want this log and sometimes not (it was very useful for me during one-fog work, but it is too noisy for the old testnet accounts with half a million TxOuts)
4. Skip calling `get_missed_block_ranges` if there are no missed block ranges. No point in a GRPC call that will return an empty array.
5. Lower the limit on the `request_multiplier` that is used to calculate the number of fog-view search keys when polling fog-view. At first I lowered it because I ran into the `message size too large` issue, but then I noticed that we actually get better performance with even lower values (so more round-trips to fog-view but for whatever reason it performs better). More research is needed, but for now I don't see a reason to not make fog-test-client faster. Hopefully this reproduces on the k8 cluster and not just my local machine (we will find out!). Another change to the `request_multiplier` calculation is it now takes into account the number of live rngs we will be producing search keys for, such that the total number of search keys is below a certain limit (previously the limit was per rng so more rngs would result in more search keys).