### PR TITLE
Use `serial` backend for curve25519-dalek

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,16 +5,16 @@
 # ...so instead we list all target triples (Tier 1 64-bit platforms)
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="serial"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-pc-windows-gnu]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="serial"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="serial"', '--cfg=feature="precomputed-tables"']
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="serial"', '--cfg=feature="precomputed-tables"']
 
 [cargo-new]
 name = "MobileCoin"

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -248,7 +248,7 @@ impl Builder {
                 "--cfg",
                 "features=\"precomputed-tables\"",
                 "--cfg",
-                "curve25519_dalek_backend=\"simd\"",
+                "curve25519_dalek_backend=\"serial\"",
             ]);
 
         Ok(Self {


### PR DESCRIPTION
Previously the `curve25519-dalek` was using the `simd` backend. This
backend performed slower than the `serila` in debug builds. Looking at
the release builds there doesn't seem to be any difference in
performance. Of note is that the release build removed all of the rust
intrinsic function calls, while the debug builds kept them around. Now
the `serial` backend is used for curve25519-dalek to allow for the debug
builds to run better.

With `simd` debug test runs of
`transaction_builder::transaction_builder_tests::test_max_transaction_size`
would take ~80 seconds. Using the `serial` backend this test takes ~15
seconds.