### PR TITLE
Add a GetAllUnspentTxOuts API call to mobilecoind (#3663)

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -23,6 +23,7 @@ service MobilecoindAPI {
     rpc GetMonitorList (google.protobuf.Empty) returns (GetMonitorListResponse) {}
     rpc GetMonitorStatus (GetMonitorStatusRequest) returns (GetMonitorStatusResponse) {}
     rpc GetUnspentTxOutList (GetUnspentTxOutListRequest) returns (GetUnspentTxOutListResponse) {}
+    rpc GetAllUnspentTxOut (GetAllUnspentTxOutRequest) returns (GetAllUnspentTxOutResponse) {}
 
     // Utilities
     rpc GenerateRootEntropy (google.protobuf.Empty) returns (GenerateRootEntropyResponse) {}
@@ -356,6 +357,14 @@ message GetUnspentTxOutListRequest {
     uint64 token_id = 3;
 }
 message GetUnspentTxOutListResponse {
+    repeated UnspentTxOut output_list = 1;
+}
+
+// Get a list of all UnspentTxOuts for a given monitor, without any filtering
+message GetAllUnspentTxOutRequest {
+    bytes monitor_id = 1;
+}
+message GetAllUnspentTxOutResponse {
     repeated UnspentTxOut output_list = 1;
 }
 

--- a/mobilecoind/src/database.rs
+++ b/mobilecoind/src/database.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
+// Copyright (c) 2018-2023 The MobileCoin Foundation
 
 //! The mobilecoind database
 
@@ -217,6 +217,14 @@ impl Database {
     ) -> Result<Vec<UnspentTxOut>, Error> {
         let db_txn = self.env.begin_ro_txn()?;
         self.utxo_store.get_utxos(&db_txn, monitor_id, index)
+    }
+
+    pub fn get_utxos_for_monitor(
+        &self,
+        monitor_id: &MonitorId,
+    ) -> Result<Vec<UnspentTxOut>, Error> {
+        let db_txn = self.env.begin_ro_txn()?;
+        self.utxo_store.get_utxos_for_monitor(&db_txn, monitor_id)
     }
 
     pub fn update_attempted_spend(


### PR DESCRIPTION
This brings in PR #3663 into the current release branch

---


* Add a GetAllUnspentTxOuts API call to mobilecoind

Currently, there is no easy way to get all of the unspent tx outs associated to a given monitor id. This is a very normal thing to want to do if you are managing a wallet with many subaddresses, because you have no way to subscribe to updates when payments come in, so you would like to be able to poll for them efficiently.

The GetUnspentTxOutList API call exists, but it only allows you to search for UTXOs one subaddress and token id at a time.

You get use the GetProcessedBlock API call, which allows you to be more efficient, but it still creates a lot of extra work on the caller side, because now you have to think about blocks and keep track of a cursor as you advance through the chain.

There are other things about this API that are annoying -- the ProcessedTxOut tells you that you sent or received a TxOut in a particular block, but not whether you still have it. And many of the other calls, like GenerateTx, require you to provide an UnspentTxOut for the InputList argument, but you can't get an UnspentTxOut from a ProcessedTxOut, so you will have to make another call to GetUnspentTxOutList if you want to do that.

---

By making a version of GetUnspentTxOutList that doesn't impose any filtering, and just gives me all UTXOs that exist against my monitor, it becomes much easier to determine if there was new activity on my monitor.

I don't have to think about blocks anymore.

If I'm building an exchange, my loop can be like:

* Check if I got any new UTXOs
* If I got UTXOs on subaddress > 0, then that's a deposit
  * Report the deposit, using part of the UTXO as the inbound tx id.
  * Remote services can ignore it if it was a duplicate
* Sweep it to subaddress zero
  * Now I won't pick it up again and report it again if I get restarted
* Maybe make an optimization tx if subaddress 0 has many UTXOs.

This feels much simpler to me conceptually and much closer to how I intuitively want an exchange integration to work, compared to the GetProcessedBlock based approach.

---

Fortunately, it was extremely easy to implement this API and did not require any changes to the mobilecoind database. This is because of properties of how lmdb orders keys and how lmdb cursors work.

I was able to implement this in the time that I had to wait for either of mobilecoind or full-service to finish downloading and syncing the ledger, so that I can test other things.

If this PR is accepted, it will allow me to simplify a bunch of other code that I had to write.

* fix clippies


