### PR TITLE
reduce ledger router/store k8s memory requests

### DIFF
--- a/.internal-ci/helm/fog-ledger/values.yaml
+++ b/.internal-ci/helm/fog-ledger/values.yaml
@@ -63,10 +63,10 @@ fogLedger:
     resources:
       limits:
         intel.com/sgx: 5000
-        memory: 5Gi
+        memory: 2Gi
       requests:
         intel.com/sgx: 5000
-        memory: 5Gi
+        memory: 2Gi
         cpu: 1100m
 
     nodeSelector:
@@ -167,10 +167,10 @@ fogLedger:
     resources:
       limits:
         intel.com/sgx: 5000
-        memory: 5Gi
+        memory: 3Gi
       requests:
         intel.com/sgx: 5000
-        memory: 5Gi
+        memory: 3Gi
         cpu: 1100m
 
     nodeSelector:


### PR DESCRIPTION
### Motivation

Moving to a remote mobilecoind configuration reduces the memory needs on each router/store instance. We may be able to schedule more pods per node with a reduced memory footprint.

