### PR TITLE
Revert enclave change

### DIFF
--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -26,13 +26,13 @@ fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
         // By logging to STDERR also we make sure the message gets to an OS
         // buffer before the process dies.
         Ok(v) => {
-            eprintln!("Enclave panic: {}", v);
-            global_log::crit!("Enclave panic: {}", v)
+            eprintln!("Enclave panic:\n{}", v);
+            global_log::crit!("Enclave panic:\n{}\n", v)
         },
         Err(e) => {
-            eprintln!("Enclave panic message contained invalid utf8: ({}) {:?}", e, panic_msg_bytes);
+            eprintln!("Enclave panic message contained invalid utf8:\n{}\n{:?}", e, panic_msg_bytes);
             global_log::crit!(
-                "Enclave panic message contained invalid utf8: ({}) {:?}",
+                "Enclave panic message contained invalid utf8:\n{}\n{:?}",
                 e,
                 panic_msg_bytes
             )


### PR DESCRIPTION
This reverts commit 2392fcbadcd13c0c23d381cc06400e456371872f. The enclaves aren't meant to change for the 5.2 release, reverting this change helps to keep the compiled version of the enclaves the same as those from the 5.1.0 release.
