### PR TITLE
make fog ingest/ledger poll time configurable

### DIFF
--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -102,6 +102,7 @@ fn main() {
         fog_report_id: config.fog_report_id.clone(),
         state_file: Some(StateFile::new(state_file_path)),
         enclave_path,
+        poll_interval: config.poll_interval,
     };
 
     let mut server = IngestServer::new(

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -117,7 +117,7 @@ pub struct IngestConfig {
     pub postgres_config: SqlRecoveryDbConnectionConfig,
 
     /// How many milliseconds to wait between polling.
-    #[clap(long, default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL")]
+    #[clap(long = "poll_interval_ms", default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL_MS")]
     pub poll_interval: Duration,
 }
 

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -9,7 +9,7 @@ use mc_common::ResponderId;
 use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
 use mc_fog_uri::{FogIngestUri, IngestPeerUri};
 use mc_mobilecoind_api::MobilecoindUri;
-use mc_util_parse::parse_duration_in_seconds;
+use mc_util_parse::{parse_duration_in_millis, parse_duration_in_seconds};
 use mc_util_uri::AdminUri;
 use serde::Serialize;
 use std::{path::PathBuf, time::Duration};
@@ -115,6 +115,10 @@ pub struct IngestConfig {
     /// Postgres config
     #[clap(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+
+    /// How many milliseconds to wait between polling.
+    #[clap(long, default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL")]
+    pub poll_interval: Duration,
 }
 
 #[cfg(test)]

--- a/fog/ingest/server/src/server.rs
+++ b/fog/ingest/server/src/server.rs
@@ -94,6 +94,9 @@ pub struct IngestServerConfig {
     /// During cargo tests we use a helper that searches the target/ dir for the
     /// enclave.so file.
     pub enclave_path: PathBuf,
+
+    /// Time to wait between ledger polls
+    pub poll_interval: Duration,
 }
 
 /// All of the state and grpcio objects and threads associated to the ingest
@@ -293,6 +296,7 @@ where
             self.controller.clone(),
             self.block_provider.clone(),
             self.config.watcher_timeout,
+            self.config.poll_interval,
             self.logger.clone(),
         ));
 

--- a/fog/ingest/server/test-utils/src/lib.rs
+++ b/fog/ingest/server/test-utils/src/lib.rs
@@ -228,6 +228,7 @@ impl IngestServerTestHelper {
             state_file: Some(StateFile::new(state_file_path.clone())),
             enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
             omap_capacity: OMAP_CAPACITY,
+            poll_interval: Duration::from_millis(250),
         };
 
         let ra_client = AttestClient::new("").expect("Failed to create IAS client");

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -10,7 +10,7 @@ use mc_attest_core::ProviderId;
 use mc_common::ResponderId;
 use mc_fog_uri::{FogLedgerUri, KeyImageStoreUri};
 use mc_mobilecoind_api::MobilecoindUri;
-use mc_util_parse::parse_duration_in_seconds;
+use mc_util_parse::{parse_duration_in_millis, parse_duration_in_seconds};
 use mc_util_uri::AdminUri;
 use serde::Serialize;
 use std::{path::PathBuf, str::FromStr, time::Duration};
@@ -160,6 +160,10 @@ pub struct LedgerStoreConfig {
     /// process.
     #[clap(long, default_value = "default", env = "MC_SHARDING_STRATEGY")]
     pub sharding_strategy: ShardingStrategy,
+
+    /// How many milliseconds to wait between polling.
+    #[clap(long, default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL")]
+    pub poll_interval: Duration,
 }
 
 /// Enum for parsing strategy from command line w/ clap

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -162,7 +162,7 @@ pub struct LedgerStoreConfig {
     pub sharding_strategy: ShardingStrategy,
 
     /// How many milliseconds to wait between polling.
-    #[clap(long, default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL")]
+    #[clap(long = "poll_interval_ms", default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL_MS")]
     pub poll_interval: Duration,
 }
 

--- a/fog/ledger/server/src/key_image_store_server.rs
+++ b/fog/ledger/server/src/key_image_store_server.rs
@@ -20,7 +20,10 @@ use mc_util_grpc::{
     AnonymousAuthenticator, Authenticator, ConnectionUriGrpcioServer, ReadinessIndicator,
     TokenAuthenticator,
 };
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 pub struct KeyImageStoreServer<E, SS, RC>
 where
@@ -73,6 +76,7 @@ where
             config.ias_spid,
             block_provider,
             sharding_strategy,
+            config.poll_interval,
             logger,
         )
     }
@@ -85,6 +89,7 @@ where
         ias_spid: ProviderId,
         block_provider: Box<dyn BlockProvider>,
         sharding_strategy: SS,
+        poll_interval: Duration,
         logger: Logger,
     ) -> KeyImageStoreServer<E, SS, RC> {
         let shared_state = Arc::new(Mutex::new(DbPollSharedState::default()));
@@ -111,6 +116,7 @@ where
             ra_client,
             ias_spid,
             sharding_strategy,
+            poll_interval,
             logger,
         )
     }
@@ -123,6 +129,7 @@ where
         ra_client: RC,
         ias_spid: ProviderId,
         sharding_strategy: SS,
+        poll_interval: Duration,
         logger: Logger,
     ) -> KeyImageStoreServer<E, SS, RC> {
         let readiness_indicator = ReadinessIndicator::default();
@@ -165,6 +172,7 @@ where
             sharding_strategy,
             key_image_service.get_db_poll_shared_state(),
             readiness_indicator,
+            poll_interval,
             logger.clone(),
         );
 

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -371,6 +371,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
                 client_auth_token_max_lifetime: Default::default(),
                 omap_capacity: OMAP_CAPACITY,
                 sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+                poll_interval: Duration::from_millis(250),
             };
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
@@ -948,6 +949,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 client_auth_token_max_lifetime: Default::default(),
                 omap_capacity: OMAP_CAPACITY,
                 sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+                poll_interval: Duration::from_millis(250),
             };
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -35,6 +35,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 use tempfile::TempDir;
 use url::Url;
@@ -71,6 +72,7 @@ fn create_store_config(
         client_auth_token_max_lifetime: Default::default(),
         omap_capacity,
         sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::new(block_range)),
+        poll_interval: Duration::from_millis(250),
     }
 }
 

--- a/fog/ledger/server/tests/store.rs
+++ b/fog/ledger/server/tests/store.rs
@@ -5,6 +5,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use mc_attest_ake::{AuthResponseInput, ClientInitiate, Start, Transition};
@@ -127,6 +128,7 @@ impl<R: RngCore + CryptoRng> TestingContext<R> {
             client_auth_token_max_lifetime: Default::default(),
             omap_capacity,
             sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+            poll_interval: Duration::from_millis(250),
         };
 
         Self {
@@ -194,6 +196,7 @@ pub fn direct_key_image_store_check(logger: Logger) {
         ias_client,
         store_config.ias_spid,
         EpochShardingStrategy::default(),
+        store_config.poll_interval,
         logger,
     );
     store_server.start();


### PR DESCRIPTION
When deploying the centralized mobilecoind configuration to testnet it appears we are overwhelming the single mobilecoind instance there by polling it from ~18 different services at a 10ms interval. This backs off the default polling duration to 250ms and also makes it configurable. 