### PR TITLE
Remove newlines from enclave panic message

### DIFF
--- a/sgx/urts/src/panic.rs
+++ b/sgx/urts/src/panic.rs
@@ -26,13 +26,13 @@ fn report_panic_message_impl(panic_msg_bytes: &[u8]) {
         // By logging to STDERR also we make sure the message gets to an OS
         // buffer before the process dies.
         Ok(v) => {
-            eprintln!("Enclave panic:\n{}", v);
-            global_log::crit!("Enclave panic:\n{}\n", v)
+            eprintln!("Enclave panic: {}", v);
+            global_log::crit!("Enclave panic: {}", v)
         },
         Err(e) => {
-            eprintln!("Enclave panic message contained invalid utf8:\n{}\n{:?}", e, panic_msg_bytes);
+            eprintln!("Enclave panic message contained invalid utf8: ({}) {:?}", e, panic_msg_bytes);
             global_log::crit!(
-                "Enclave panic message contained invalid utf8:\n{}\n{:?}",
+                "Enclave panic message contained invalid utf8: ({}) {:?}",
                 e,
                 panic_msg_bytes
             )


### PR DESCRIPTION
The enclave panic message is passed to a logger that doesn't work with
newlines. In order to keep the contents of the panic message from the
enclave a space is used to separate the "Enclave panic:" prefix and the
actual message.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
