### PR TITLE
defaults for pubkey expire

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -137,6 +137,7 @@ jobs:
           -p mc-fog-report-server \
           -p mc-fog-sql-recovery-db \
           -p mc-fog-test-client \
+          -p mc-fog-view-load-test \
           -p mc-fog-view-server \
           -p mc-ledger-distribution \
           -p mc-ledger-from-archive \

--- a/.internal-ci/docker/Dockerfile.bootstrap-tools
+++ b/.internal-ci/docker/Dockerfile.bootstrap-tools
@@ -43,6 +43,7 @@ COPY ${RUST_BIN_PATH}/mc-util-seeded-ed25519-key-gen /usr/local/bin/
 COPY ${RUST_BIN_PATH}/fog-report-cli /usr/local/bin/
 COPY ${RUST_BIN_PATH}/read-pubfile /usr/local/bin/
 COPY ${RUST_BIN_PATH}/mc-util-grpc-token-generator /usr/local/bin/
+COPY ${RUST_BIN_PATH}/fog-view-load-test /usr/local/bin/
 
 # Test wrappers and util scripts
 COPY .internal-ci/test/ /test/

--- a/.internal-ci/helm/fog-ingest/values.yaml
+++ b/.internal-ci/helm/fog-ingest/values.yaml
@@ -57,8 +57,6 @@ fogIngest:
       POSTGRES_MAX_LIFETIME: '120'
       POSTGRES_CONNECTION_TIMEOUT: '5'
       POSTGRES_MAX_CONNECTIONS: '3'
-      FOG_PUBKEY_EXPIRY_WINDOW: '10'
-
 
   externalConfigMaps:
     # sentry is optional

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -90,7 +90,7 @@ pub struct IngestConfig {
 
     /// The amount we add to current block height to compute pubkey_expiry in
     /// reports
-    #[clap(long, default_value = "100", env = "MC_PUBKEY_EXPIRY_WINDOW")]
+    #[clap(long, default_value = "10", env = "MC_PUBKEY_EXPIRY_WINDOW")]
     pub pubkey_expiry_window: u64,
 
     /// How often the active server checks up on each of the peer backups


### PR DESCRIPTION
### Motivation

- Make fog-ingest pub key expiry default to 10 
- (secondary) add fog-view-load-test to the toolbox container for future testing. 
