### PR TITLE
Move the enclaves into the same build directory

### DIFF
--- a/consensus/enclave/measurement/build.rs
+++ b/consensus/enclave/measurement/build.rs
@@ -16,6 +16,7 @@ const CONSENSUS_ENCLAVE_PRODUCT_ID: u16 = 1;
 const CONSENSUS_ENCLAVE_SECURITY_VERSION: u16 = 8;
 const CONSENSUS_ENCLAVE_NAME: &str = "consensus-enclave";
 const CONSENSUS_ENCLAVE_DIR: &str = "../trusted";
+const CONSENSUS_ENCLAVE_BUILD_DIR: &str = "enclave";
 
 fn main() {
     let env = Environment::default();
@@ -71,7 +72,7 @@ fn main() {
     }
 
     builder
-        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_NAME).as_path())
+        .target_dir(env.target_dir().join(CONSENSUS_ENCLAVE_BUILD_DIR).as_path())
         .config_builder
         .debug(sgx.sgx_mode() == SgxMode::Simulation || env.profile() != "release")
         .prod_id(CONSENSUS_ENCLAVE_PRODUCT_ID)

--- a/fog/ingest/enclave/measurement/build.rs
+++ b/fog/ingest/enclave/measurement/build.rs
@@ -16,6 +16,7 @@ const INGEST_ENCLAVE_PRODUCT_ID: u16 = 4;
 const INGEST_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const INGEST_ENCLAVE_NAME: &str = "ingest-enclave";
 const INGEST_ENCLAVE_DIR: &str = "../trusted";
+const INGEST_ENCLAVE_BUILD_DIR: &str = "enclave";
 
 fn main() {
     let env = Environment::default();
@@ -71,7 +72,7 @@ fn main() {
     }
 
     builder
-        .target_dir(env.target_dir().join(INGEST_ENCLAVE_NAME).as_path())
+        .target_dir(env.target_dir().join(INGEST_ENCLAVE_BUILD_DIR).as_path())
         .config_builder
         .debug(sgx.sgx_mode() == SgxMode::Simulation || env.profile() != "release")
         .prod_id(INGEST_ENCLAVE_PRODUCT_ID)

--- a/fog/ledger/enclave/measurement/build.rs
+++ b/fog/ledger/enclave/measurement/build.rs
@@ -16,6 +16,7 @@ const LEDGER_ENCLAVE_PRODUCT_ID: u16 = 2;
 const LEDGER_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const LEDGER_ENCLAVE_NAME: &str = "ledger-enclave";
 const LEDGER_ENCLAVE_DIR: &str = "../trusted";
+const LEDGER_ENCLAVE_BUILD_DIR: &str = "enclave";
 
 fn main() {
     let env = Environment::default();
@@ -71,7 +72,7 @@ fn main() {
     }
 
     builder
-        .target_dir(env.target_dir().join(LEDGER_ENCLAVE_NAME).as_path())
+        .target_dir(env.target_dir().join(LEDGER_ENCLAVE_BUILD_DIR).as_path())
         .config_builder
         .debug(sgx.sgx_mode() == SgxMode::Simulation || env.profile() != "release")
         .prod_id(LEDGER_ENCLAVE_PRODUCT_ID)

--- a/fog/view/enclave/measurement/build.rs
+++ b/fog/view/enclave/measurement/build.rs
@@ -16,6 +16,7 @@ const VIEW_ENCLAVE_PRODUCT_ID: u16 = 3;
 const VIEW_ENCLAVE_SECURITY_VERSION: u16 = 7;
 const VIEW_ENCLAVE_NAME: &str = "view-enclave";
 const VIEW_ENCLAVE_DIR: &str = "../trusted";
+const VIEW_ENCLAVE_BUILD_DIR: &str = "enclave";
 
 fn main() {
     let env = Environment::default();
@@ -71,7 +72,7 @@ fn main() {
     }
 
     builder
-        .target_dir(env.target_dir().join(VIEW_ENCLAVE_NAME).as_path())
+        .target_dir(env.target_dir().join(VIEW_ENCLAVE_BUILD_DIR).as_path())
         .config_builder
         .debug(sgx.sgx_mode() == SgxMode::Simulation || env.profile() != "release")
         .prod_id(VIEW_ENCLAVE_PRODUCT_ID)

--- a/util/build/enclave/src/lib.rs
+++ b/util/build/enclave/src/lib.rs
@@ -154,7 +154,7 @@ pub struct Builder {
     /// The target architecture
     target_arch: String,
 
-    /// The CARGO_TARGET_DIR path
+    /// The CARGO_TARGET_DIR path for the enclave
     target_dir: PathBuf,
 
     /// The CARGO_TARGET_DIR/profile path
@@ -258,7 +258,7 @@ impl Builder {
             staticlib,
             target_arch: env.target_arch().to_owned(),
             out_dir: env.out_dir().to_owned(),
-            target_dir: env.target_dir().to_owned(),
+            target_dir: env.target_dir().join(enclave_name),
             profile_target_dir: env.profile_target_dir().to_owned(),
             profile: env.profile().to_owned(),
             sgx_version: sgx_version.to_owned(),
@@ -279,6 +279,7 @@ impl Builder {
 
     /// Set a new "base" target dir to use when building an enclave
     pub fn target_dir(&mut self, target_dir: &Path) -> &mut Self {
+        self.target_dir = target_dir.to_owned();
         self.cargo_builder.target_dir(target_dir);
         self
     }
@@ -650,8 +651,7 @@ impl Builder {
             SgxMode::Simulation => "_sim",
         };
 
-        // "target/mc_foo_enclave"
-        let staticlib_target_dir = self.target_dir.join(&self.name);
+        let staticlib_target_dir = &self.target_dir;
 
         // e.g. "mc_foo_enclave_trusted"
         let staticlib_crate_name = self.staticlib.workspace_members[0]


### PR DESCRIPTION
Moving the enclaves into the same build directory reduces compilation
times on this developer's machine from 7m45s to 6m31s. Which is ~15%
improvement. It also reduces the build directory from 76GiB to 71GiB.
