### PR TITLE
Merge 5.2.2

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -136,6 +136,7 @@ jobs:
           -p mc-fog-report-server \
           -p mc-fog-sql-recovery-db \
           -p mc-fog-test-client \
+          -p mc-fog-view-load-test \
           -p mc-fog-view-server \
           -p mc-ledger-distribution \
           -p mc-ledger-from-archive \

--- a/.internal-ci/docker/Dockerfile.bootstrap-tools
+++ b/.internal-ci/docker/Dockerfile.bootstrap-tools
@@ -43,6 +43,7 @@ COPY ${RUST_BIN_PATH}/mc-util-seeded-ed25519-key-gen /usr/local/bin/
 COPY ${RUST_BIN_PATH}/fog-report-cli /usr/local/bin/
 COPY ${RUST_BIN_PATH}/read-pubfile /usr/local/bin/
 COPY ${RUST_BIN_PATH}/mc-util-grpc-token-generator /usr/local/bin/
+COPY ${RUST_BIN_PATH}/fog-view-load-test /usr/local/bin/
 
 # Test wrappers and util scripts
 COPY .internal-ci/test/ /test/

--- a/.internal-ci/helm/fog-ingest/values.yaml
+++ b/.internal-ci/helm/fog-ingest/values.yaml
@@ -57,8 +57,6 @@ fogIngest:
       POSTGRES_MAX_LIFETIME: '120'
       POSTGRES_CONNECTION_TIMEOUT: '5'
       POSTGRES_MAX_CONNECTIONS: '3'
-      FOG_PUBKEY_EXPIRY_WINDOW: '10'
-
 
   externalConfigMaps:
     # sentry is optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [5.2.2]
+
+### Changed
+
+- Changed default for fog pubkey expiry from 100 to 10 ([#3773])
+
+### Fixed
+
+- Fog ledger shard last known block info ([#3771])
+
+[#3771]: https://github.com/mobilecoinfoundation/mobilecoin/pull/3771
+[#3773]: https://github.com/mobilecoinfoundation/mobilecoin/pull/3773
+
+## [5.2.1]
+
+### Changed
+
+- Made polling interval of fog ledger block fetching configurable ([#3764])
+- Improved performance of fog ledger shard block fetching ([#3765])
+
+[#3764]: https://github.com/mobilecoinfoundation/mobilecoin/pull/3764
+[#3765]: https://github.com/mobilecoinfoundation/mobilecoin/pull/3765
+
 ## [5.2.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2484,14 +2484,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "grpcio",
@@ -2506,7 +2506,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_matches",
  "bs58",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "assert_matches",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "bincode",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2691,7 +2691,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-config"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_matches",
  "displaydoc",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_matches",
  "base64 0.21.5",
@@ -2785,7 +2785,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "cargo-emit",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-common",
@@ -3174,7 +3174,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "chrono",
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.11",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-tool"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "grpcio",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "clap 4.4.11",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "digest 0.10.7",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "digest 0.10.7",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "blake2",
  "digest 0.10.7",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "curve25519-dalek",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "hmac 0.12.1",
  "mc-crypto-keys",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3522,7 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3573,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "clap 4.4.11",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -3619,7 +3619,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-block-provider"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "dyn-clone",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "crossbeam-channel",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_cmd",
  "clap 4.4.11",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3860,7 +3860,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "der",
  "displaydoc",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "dirs",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-blockchain-test-utils",
  "mc-blockchain-types",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "digest 0.10.7",
  "displaydoc",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "der",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "clap 4.4.11",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "http",
  "hyper",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "grpcio",
@@ -4225,14 +4225,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.11",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4389,7 +4389,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-blockchain-test-utils",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "clap 4.4.11",
@@ -4528,7 +4528,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-verifier-types",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "clap 4.4.11",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "clap 4.4.11",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "digest 0.10.7",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "der",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "itertools 0.12.0",
@@ -4833,7 +4833,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4846,7 +4846,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "ctrlc",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "grpcio",
  "mc-attestation-verifier",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4996,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "dirs",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-api",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "lmdb-rkv",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "clap 4.4.11",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "async-channel",
  "clap 4.4.11",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "grpcio",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "grpcio",
  "hex",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5485,7 +5485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "hex_fmt",
@@ -5637,21 +5637,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5691,21 +5691,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
 
 [[package]]
 name = "mc-sgx-urts"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5722,7 +5722,7 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "assert_matches",
@@ -5869,7 +5869,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "clap 4.4.11",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "hex",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cargo_metadata",
@@ -6015,7 +6015,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "json",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -6042,7 +6042,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -6053,7 +6053,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-util-build-info",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "displaydoc",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "displaydoc",
@@ -6085,18 +6085,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-account-keys",
@@ -6115,7 +6115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.11",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "grpcio",
@@ -6160,7 +6160,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-common",
@@ -6171,11 +6171,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "clap 4.4.11",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -6231,7 +6231,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "grpcio",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "hex",
  "itertools 0.12.0",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "mc-crypto-keys",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "prost",
  "protobuf",
@@ -6289,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -6301,7 +6301,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "clap 4.4.11",
  "itertools 0.12.0",
@@ -6314,7 +6314,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6331,11 +6331,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-uri"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64 0.21.5",
  "displaydoc",
@@ -6353,7 +6353,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -6361,14 +6361,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "getrandom",
  "mc-account-keys",
@@ -6383,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "clap 4.4.11",
@@ -6433,7 +6433,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "gRPC APIs for encrypted communications with an enclave"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform remote

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = """
 no_std structs used commonly in enclave api's in connection with attestation and key exchange

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform verification of

--- a/attest/verifier/config/Cargo.toml
+++ b/attest/verifier/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-config"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "A JSON schema for basic attestation configs"

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating an enclave.

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = '''
 This crate contains the actual implementation of a mobilenode enclave.

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "MobileCoin Consensus Enclave - Application Code"
 edition = "2021"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -973,14 +973,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "digest",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
@@ -1539,11 +1539,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1648,29 +1648,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1700,14 +1700,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1728,7 +1728,7 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1817,14 +1817,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "prost",
  "serde",
@@ -1843,11 +1843,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/mint-client/types/Cargo.toml
+++ b/consensus/mint-client/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Stellar Consensus Protocol"
 edition = "2021"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "Apache-2.0"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/tool/Cargo.toml
+++ b/consensus/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-tool"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Core Library"

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Core Types"

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/memo-mac/Cargo.toml
+++ b/crypto/memo-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-memo-mac"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "MobileCoin multi-signature implementations"
 edition = "2021"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Verification of X509 certificate chains"
 edition = "2021"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-api"

--- a/fog/block_provider/Cargo.toml
+++ b/fog/block_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-block-provider"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Provide blocks from a local or remote ledger database"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "MobileCoin Ingest Enclave - Measurement"
 edition = "2021"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1003,14 +1003,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "digest",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1530,14 +1530,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-digestible",
@@ -1580,14 +1580,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1665,11 +1665,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1774,36 +1774,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1833,14 +1833,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1861,7 +1861,7 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1950,14 +1950,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "prost",
  "serde",
@@ -1976,11 +1976,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
 ]

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/src/bin/main.rs
+++ b/fog/ingest/server/src/bin/main.rs
@@ -97,6 +97,7 @@ fn main() {
         fog_report_id: config.fog_report_id.clone(),
         state_file: Some(StateFile::new(state_file_path)),
         enclave_path,
+        poll_interval: config.poll_interval,
     };
 
     let mut server = IngestServer::new(server_config, recovery_db, block_provider, logger.clone());

--- a/fog/ingest/server/src/config.rs
+++ b/fog/ingest/server/src/config.rs
@@ -8,7 +8,7 @@ use mc_common::ResponderId;
 use mc_fog_sql_recovery_db::SqlRecoveryDbConnectionConfig;
 use mc_fog_uri::{FogIngestUri, IngestPeerUri};
 use mc_mobilecoind_api::MobilecoindUri;
-use mc_util_parse::parse_duration_in_seconds;
+use mc_util_parse::{parse_duration_in_millis, parse_duration_in_seconds};
 use mc_util_uri::AdminUri;
 use serde::Serialize;
 use std::{path::PathBuf, time::Duration};
@@ -81,7 +81,7 @@ pub struct IngestConfig {
 
     /// The amount we add to current block height to compute pubkey_expiry in
     /// reports
-    #[clap(long, default_value = "100", env = "MC_PUBKEY_EXPIRY_WINDOW")]
+    #[clap(long, default_value = "10", env = "MC_PUBKEY_EXPIRY_WINDOW")]
     pub pubkey_expiry_window: u64,
 
     /// How often the active server checks up on each of the peer backups
@@ -106,6 +106,10 @@ pub struct IngestConfig {
     /// Postgres config
     #[clap(flatten)]
     pub postgres_config: SqlRecoveryDbConnectionConfig,
+
+    /// How many milliseconds to wait between polling.
+    #[clap(long = "poll_interval_ms", default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL_MS")]
+    pub poll_interval: Duration,
 }
 
 #[cfg(test)]

--- a/fog/ingest/server/src/server.rs
+++ b/fog/ingest/server/src/server.rs
@@ -89,6 +89,9 @@ pub struct IngestServerConfig {
     /// During cargo tests we use a helper that searches the target/ dir for the
     /// enclave.so file.
     pub enclave_path: PathBuf,
+
+    /// Time to wait between ledger polls
+    pub poll_interval: Duration,
 }
 
 /// All of the state and grpcio objects and threads associated to the ingest
@@ -281,6 +284,7 @@ where
             self.controller.clone(),
             self.block_provider.clone(),
             self.config.watcher_timeout,
+            self.config.poll_interval,
             self.logger.clone(),
         ));
 

--- a/fog/ingest/server/src/worker.rs
+++ b/fog/ingest/server/src/worker.rs
@@ -30,8 +30,6 @@ pub struct IngestWorker {
 }
 
 impl IngestWorker {
-    /// Poll for new data every 10 ms
-    const POLLING_FREQUENCY: Duration = Duration::from_millis(10);
     /// If a database invariant is violated, e.g. we get block but not block
     /// contents, it typically will not be fixed and so we won't be able to
     /// proceed. But bringing the server down is costly from ops POV because
@@ -49,6 +47,9 @@ impl IngestWorker {
     /// Arguments:
     /// * Controller for this ingest server
     /// * BlockProvider to read blocks and timestamps from
+    /// * Watcher timeout (how long before we log a warning about failing to get
+    ///   a timestamp)
+    /// * Polling interval (how long to wait between polls)
     /// * Logger to send log messages to
     ///
     /// Returns a freshly started IngestWorker thread handle
@@ -56,6 +57,7 @@ impl IngestWorker {
         controller: Arc<IngestController<DB>>,
         block_provider: Box<dyn BlockProvider>,
         watcher_timeout: Duration,
+        poll_interval: Duration,
         logger: Logger,
     ) -> Self
     where
@@ -80,7 +82,7 @@ impl IngestWorker {
                     }
 
                     if is_idle {
-                        std::thread::sleep(Self::POLLING_FREQUENCY);
+                        std::thread::sleep(poll_interval);
                         continue;
                     }
 
@@ -108,7 +110,7 @@ impl IngestWorker {
                             } else {
                                 last_not_found_log = Some(LastNotFound::new(next_block_index));
                             }
-                            std::thread::sleep(Self::POLLING_FREQUENCY)
+                            std::thread::sleep(poll_interval)
                         }
                         Err(e) => {
                             log::error!(

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/src/lib.rs
+++ b/fog/ingest/server/test-utils/src/lib.rs
@@ -226,6 +226,7 @@ impl IngestServerTestHelper {
             state_file: Some(StateFile::new(state_file_path.clone())),
             enclave_path: get_enclave_path(mc_fog_ingest_enclave::ENCLAVE_FILE),
             omap_capacity: OMAP_CAPACITY,
+            poll_interval: Duration::from_millis(250),
         };
 
         let mut server = IngestServer::new(

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating a ledger enclave.

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the actual implementation of a ledger enclave."

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "MobileCoin Ledger Enclave - Measurement"
 edition = "2021"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -997,14 +997,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "digest",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1520,14 +1520,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1544,14 +1544,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1629,11 +1629,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1738,36 +1738,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1797,14 +1797,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1825,7 +1825,7 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1914,14 +1914,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "prost",
  "serde",
@@ -1940,18 +1940,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/server/src/config.rs
+++ b/fog/ledger/server/src/config.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use mc_common::ResponderId;
 use mc_fog_uri::{FogLedgerUri, KeyImageStoreUri};
 use mc_mobilecoind_api::MobilecoindUri;
-use mc_util_parse::parse_duration_in_seconds;
+use mc_util_parse::{parse_duration_in_millis, parse_duration_in_seconds};
 use mc_util_uri::AdminUri;
 use serde::Serialize;
 use std::{path::PathBuf, str::FromStr, time::Duration};
@@ -143,6 +143,10 @@ pub struct LedgerStoreConfig {
     /// process.
     #[clap(long, default_value = "default", env = "MC_SHARDING_STRATEGY")]
     pub sharding_strategy: ShardingStrategy,
+
+    /// How many milliseconds to wait between polling.
+    #[clap(long = "poll_interval_ms", default_value = "250", value_parser = parse_duration_in_millis, env = "MC_POLL_INTERVAL_MS")]
+    pub poll_interval: Duration,
 }
 
 /// Enum for parsing strategy from command line w/ clap

--- a/fog/ledger/server/src/key_image_store_server.rs
+++ b/fog/ledger/server/src/key_image_store_server.rs
@@ -18,7 +18,10 @@ use mc_util_grpc::{
     AnonymousAuthenticator, Authenticator, ConnectionUriGrpcioServer, ReadinessIndicator,
     TokenAuthenticator,
 };
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 pub struct KeyImageStoreServer<E, SS>
 where
@@ -64,6 +67,7 @@ where
             enclave,
             block_provider,
             sharding_strategy,
+            config.poll_interval,
             logger,
         )
     }
@@ -74,6 +78,7 @@ where
         enclave: E,
         block_provider: Box<dyn BlockProvider>,
         sharding_strategy: SS,
+        poll_interval: Duration,
         logger: Logger,
     ) -> KeyImageStoreServer<E, SS> {
         let shared_state = Arc::new(Mutex::new(DbPollSharedState::default()));
@@ -98,6 +103,7 @@ where
             enclave,
             block_provider,
             sharding_strategy,
+            poll_interval,
             logger,
         )
     }
@@ -108,6 +114,7 @@ where
         enclave: E,
         block_provider: Box<dyn BlockProvider>,
         sharding_strategy: SS,
+        poll_interval: Duration,
         logger: Logger,
     ) -> KeyImageStoreServer<E, SS> {
         let readiness_indicator = ReadinessIndicator::default();
@@ -150,6 +157,7 @@ where
             sharding_strategy,
             key_image_service.get_db_poll_shared_state(),
             readiness_indicator,
+            poll_interval,
             logger.clone(),
         );
 

--- a/fog/ledger/server/tests/router_connection.rs
+++ b/fog/ledger/server/tests/router_connection.rs
@@ -354,6 +354,7 @@ fn fog_ledger_key_images_test(logger: Logger) {
                 client_auth_token_max_lifetime: Default::default(),
                 omap_capacity: OMAP_CAPACITY,
                 sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+                poll_interval: Duration::from_millis(250),
             };
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),
@@ -903,6 +904,7 @@ fn fog_router_unary_key_image_test(logger: Logger) {
                 client_auth_token_max_lifetime: Default::default(),
                 omap_capacity: OMAP_CAPACITY,
                 sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+                poll_interval: Duration::from_millis(250),
             };
             let store_enclave = LedgerSgxEnclave::new(
                 get_enclave_path(mc_fog_ledger_enclave::ENCLAVE_FILE),

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -33,6 +33,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
+    time::Duration,
 };
 use tempfile::TempDir;
 use url::Url;
@@ -67,6 +68,7 @@ fn create_store_config(
         client_auth_token_max_lifetime: Default::default(),
         omap_capacity,
         sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::new(block_range)),
+        poll_interval: Duration::from_millis(250),
     }
 }
 

--- a/fog/ledger/server/tests/store.rs
+++ b/fog/ledger/server/tests/store.rs
@@ -5,6 +5,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use mc_attest_ake::{AuthResponseInput, ClientInitiate, Start, Transition};
@@ -122,6 +123,7 @@ impl<R: RngCore + CryptoRng> TestingContext<R> {
             client_auth_token_max_lifetime: Default::default(),
             omap_capacity,
             sharding_strategy: ShardingStrategy::Epoch(EpochShardingStrategy::default()),
+            poll_interval: Duration::from_millis(250),
         };
 
         Self {
@@ -175,6 +177,7 @@ pub fn direct_key_image_store_check(logger: Logger) {
         enclave.clone(),
         LocalBlockProvider::new(ledger, watcher),
         EpochShardingStrategy::default(),
+        store_config.poll_interval,
         logger,
     );
     store_server.start();

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Create and verify fog authority signatures"
 edition = "2021"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Create and verify fog report signatures"
 edition = "2021"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "MobileCoin Fog View Enclave - Application Code"
 edition = "2021"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1003,14 +1003,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "digest",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1445,14 +1445,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-digestible",
@@ -1495,14 +1495,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1667,11 +1667,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1785,36 +1785,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1844,14 +1844,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1872,7 +1872,7 @@ checksum = "2afaa76b1049c04f4caa75b378656dabb079a0d8be350084bd3f1ac8426e179e"
 
 [[package]]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1961,14 +1961,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "prost",
  "serde",
@@ -1987,11 +1987,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 dependencies = [
  "serde",
 ]

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "The MobileCoin Fog user-facing server's enclave entry point."
 edition = "2021"

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/server/test-utils/Cargo.toml
+++ b/fog/view/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "5.2.0"
+version = "5.2.2"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 rust-version = { workspace = true }

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/signer/Cargo.toml
+++ b/transaction/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-signer"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/summary/Cargo.toml
+++ b/transaction/summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-summary"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 readme = "README.md"

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Cargo build-script assistance, from MobileCoin."
 edition = "2021"

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"
 edition = "2021"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-ffi"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "A trait for constructing an object from a random number generator."
 edition = "2021"

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "Runtime gRPC Utilities"
 edition = "2021"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/u64-ratio/Cargo.toml
+++ b/util/u64-ratio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-u64-ratio"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "A helper for computing with ratios of u64 numbers"
 edition = "2021"

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 description = "A map object based on heapless Vec"
 edition = "2021"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "5.2.0"
+version = "5.2.2"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
- make fog ingest/ledger poll time configurable (#3764)
- Update changelog for 5.2.1 (#3766)
- Optimize ledger shard block fetching (#3765)
- Bump versions to 5.2.1 (#3767)
- Update changelog for 5.2.2 (#3774)
- Fix ledger stores not updating latest block info (#3771)
- defaults for pubkey expire (#3773)
- Bump versions to 5.2.2 (#3772)
