### PR TITLE
Fix build issues that happen when a project submodules this repo and only depends on mc-common.

### DIFF
--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -17,7 +17,7 @@ default = ["alloc", "serde", "prost", "mc-util-repr-bytes/default", "curve25519-
 [dependencies]
 
 base64 = { version = "0.21", default-features = false }
-curve25519-dalek = { version = "4.0.0-rc.1", default-features = false, features = ["rand_core"] }
+curve25519-dalek = { version = "4.0.0-rc.1", default-features = false, features = ["rand_core", "legacy_compatibility"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }
 ed25519 = { version = "2.2.0", default-features = false }
@@ -38,7 +38,7 @@ sha2 = { version = "0.10", default-features = false }
 signature = { version = "2.0.0", default-features = false, features = ["digest"] }
 static_assertions = "1.1.0"
 subtle = { version = "2", default-features = false }
-x25519-dalek = { version = "2.0.0-pre.2", default-features = false }
+x25519-dalek = { version = "2.0.0-pre.2", default-features = false, features = ["static_secrets"] }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -377,7 +377,7 @@ impl KexEphemeralPrivate for X25519EphemeralPrivate {
 
 impl FromRandom for X25519EphemeralPrivate {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> X25519EphemeralPrivate {
-        X25519EphemeralPrivate(EphemeralSecret::new(csprng))
+        X25519EphemeralPrivate(EphemeralSecret::random_from_rng(csprng))
     }
 }
 
@@ -400,7 +400,7 @@ impl PrivateKey for X25519Private {
 
 impl FromRandom for X25519Private {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> X25519Private {
-        X25519Private(StaticSecret::new(csprng))
+        X25519Private(StaticSecret::random_from_rng(csprng))
     }
 }
 


### PR DESCRIPTION
Without this, I ran into the following build issues:
```
   Compiling mc-crypto-keys v5.2.2 (/Users/eran/Projects/mc/swapomatic/mobilecoin/crypto/keys)
error[E0432]: unresolved import `x25519_dalek::StaticSecret`
  --> mobilecoin/crypto/keys/src/x25519.rs:32:80
   |
32 | use x25519_dalek::{EphemeralSecret, PublicKey as DalekPublicKey, SharedSecret, StaticSecret};
   |                                                                                ^^^^^^^^^^^^
   |                                                                                |
   |                                                                                no `StaticSecret` in the root
   |                                                                                help: a similar name exists in the module: `SharedSecret`

warning: use of deprecated associated function `x25519_dalek::EphemeralSecret::new`: Renamed to `random_from_rng`. This will be removed in 2.1.0
   --> mobilecoin/crypto/keys/src/x25519.rs:380:49
    |
380 |         X25519EphemeralPrivate(EphemeralSecret::new(csprng))
    |                                                 ^^^
    |
    = note: `#[warn(deprecated)]` on by default

For more information about this error, try `rustc --explain E0432`.
warning: `mc-crypto-keys` (lib) generated 1 warning
error: could not compile `mc-crypto-keys` (lib) due to previous error; 1 warning emitted
```