### PR TITLE
update servicemonitor to add stack labels

### DIFF
--- a/.internal-ci/helm/fog-ledger/templates/fog-ledger-router-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-ledger/templates/fog-ledger-router-servicemonitor.yaml
@@ -23,5 +23,9 @@ spec:
       replacement: {{ $network }}
     - targetLabel: partner
       replacement: {{ $partner }}
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_stack
+      targetLabel: ledger_stack
 ---
 {{- end }}

--- a/.internal-ci/helm/fog-ledger/templates/fog-ledger-store-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-ledger/templates/fog-ledger-store-servicemonitor.yaml
@@ -21,4 +21,8 @@ spec:
       replacement: {{ $network }}
     - targetLabel: partner
       replacement: {{ $partner }}
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_stack
+      targetLabel: ledger_stack
 

--- a/.internal-ci/helm/fog-view/templates/fog-view-router-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-router-servicemonitor.yaml
@@ -23,5 +23,9 @@ spec:
       replacement: {{ $network }}
     - targetLabel: partner
       replacement: {{ $partner }}
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_stack
+      targetLabel: view_stack
 ---
 {{- end }}

--- a/.internal-ci/helm/fog-view/templates/fog-view-store-servicemonitor.yaml
+++ b/.internal-ci/helm/fog-view/templates/fog-view-store-servicemonitor.yaml
@@ -21,4 +21,8 @@ spec:
       replacement: {{ $network }}
     - targetLabel: partner
       replacement: {{ $partner }}
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_stack
+      targetLabel: view_stack
 


### PR DESCRIPTION
### Motivation

Add stack label to Prometheus metrics so we can use it average metrics for things like block_height across stacks to find the overall state of the system.
