### PR TITLE
Use postgres service in gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,18 @@ jobs:
       NUM_RUNNERS: ${{ matrix.num_runners }}
       RUNNER_INDEX: ${{ matrix.runner_index }}
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -258,8 +270,6 @@ jobs:
           then
             echo '-p mc-util-keyfile -p mc-util-generate-sample-ledger' >> /tmp/fog-test-packages
           fi
-      - name: Start postgres
-        run: service postgresql start
       - name: Run tests
         uses: ./.github/actions/run-mc-tests
         with:
@@ -270,20 +280,30 @@ jobs:
         env:
           # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
           # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+          TEST_DATABASE_URL: postgres://postgres@postgres
 
 
   fog-ingest-tests:
     runs-on: [self-hosted, Linux, large]
     container: mobilecoin/builder-install:v0.0.32
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
-      - name: Start postgres
-        run: service postgresql start
       - name: Run tests
         uses: ./.github/actions/run-mc-tests
         with:
@@ -293,12 +313,24 @@ jobs:
         env:
           # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
           # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+          TEST_DATABASE_URL: postgres://postgres@postgres
 
 
   fog-conformance-tests:
     runs-on: [self-hosted, Linux, large]
     container: mobilecoin/builder-install:v0.0.32
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Check out code
@@ -306,9 +338,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          # FIXME: This fails with Python 3.10: "AttributeError: module
-          # 'importlib' has no attribute 'abc'. Did you mean: '_abc'?"
-          python-version: '3.9'
+          python-version: '3'
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
       - name: Set up environment
@@ -320,13 +350,11 @@ jobs:
           pip install -r requirements.txt
           ./build.sh
 
-          service postgresql start
       - name: fog_conformance_tests.py
         working-directory: tools/fog-local-network
         env:
-          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
-          # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+          PGHOST: postgres
+          PGUSER: postgres
         run: |
           . ./env/bin/activate
           python3 fog_conformance_tests.py --release
@@ -339,6 +367,18 @@ jobs:
   fog-local-network-tests:
     runs-on: [self-hosted, Linux, large]
     container: mobilecoin/builder-install:v0.0.32
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Check out code
@@ -397,12 +437,10 @@ jobs:
           # Generate sample Fog keys.
           "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root "$FOG_AUTHORITY_ROOT"
 
-          service postgresql start
       - name: Run local network
         env:
-          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
-          # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+          PGHOST: postgres
+          PGUSER: postgres
         run: |
           BIN_DIR="$PWD/target/release"
           SCRIPT_DIR="$PWD/tools/fog-local-network"
@@ -527,6 +565,18 @@ jobs:
     runs-on: [self-hosted, Linux, large]
     container: mobilecoin/builder-install:v0.0.32
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -584,12 +634,10 @@ jobs:
           # Generate sample Fog keys.
           "$BIN_DIR/sample-keys" --num 4 --output-dir fog_keys --fog-report-url 'insecure-fog://localhost:6200' --fog-authority-root "$FOG_AUTHORITY_ROOT"
 
-          service postgresql start
       - name: Run local network
         env:
-          # TEST_DATABASE_URL points at the server, as Fog recovery DB tests
-          # create and drop PG databases.
-          TEST_DATABASE_URL: postgres://localhost
+          PGHOST: postgres
+          PGUSER: postgres
         run: |
           BIN_DIR="$PWD/target/release"
           SCRIPT_DIR="$PWD/tools/fog-local-network"

--- a/tools/fog-local-network/requirements.txt
+++ b/tools/fog-local-network/requirements.txt
@@ -1,2 +1,2 @@
-grpcio==1.53.0
-grpcio-tools==1.36.1
+grpcio==1.60.0
+grpcio-tools==1.60.0


### PR DESCRIPTION
Previously the CI runs would start the postgres service inside of the container doing tests. This would result in intermittent failures when postgres wasn't able to start up. Now a service container is used for postgres as described in https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers.