### PR TITLE
bugfix: mobilecoind should return a grpc NOT_FOUND error code when ledger data is not found

### DIFF
--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -809,7 +809,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                             RpcStatusCode::NOT_FOUND,
                             format!("tx_out {idx} not found"),
                         ),
-                        _ => rpc_internal_error("ledger_error", err, &self.logger),
+                        _ => rpc_internal_error("get_tx_out_index_by_hash", err, &self.logger),
                     })
             })
             .collect::<Result<Vec<u64>, RpcStatus>>()?;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -593,7 +593,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .get_tx_out_index_by_public_key(&compressed_tx_public_key)
             .map_err(|err| match err {
                 LedgerError::NotFound => {
-                    RpcStatus::with_message(RpcStatusCode::NOT_FOUND, format!("tx_out not found"))
+                    RpcStatus::with_message(RpcStatusCode::NOT_FOUND, "tx_out not found".into())
                 }
                 _ => rpc_internal_error(
                     "ledger_db.get_tx_out_index_by_public_key",

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -599,9 +599,16 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 )
             })?;
 
-        let tx_out = self.ledger_db.get_tx_out_by_index(index).map_err(|err| {
-            rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger)
-        })?;
+        let tx_out = self
+            .ledger_db
+            .get_tx_out_by_index(index)
+            .map_err(|err| match err {
+                LedgerError::NotFound => RpcStatus::with_message(
+                    RpcStatusCode::NOT_FOUND,
+                    format!("tx_out {index} not found"),
+                ),
+                _ => rpc_internal_error("ledger_db.get_tx_out_by_index", err, &self.logger),
+            })?;
 
         // Use bip39 or root entropy to construct AccountKey.
         let account_key = if !transfer_payload.get_bip39_entropy().is_empty() {
@@ -793,9 +800,19 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
 
         let excluded_indexes = excluded
             .iter()
-            .map(|tx_out| self.ledger_db.get_tx_out_index_by_hash(&tx_out.hash()))
-            .collect::<Result<Vec<u64>, LedgerError>>()
-            .map_err(|e| rpc_internal_error("ledger_error", e, &self.logger))?; // TODO better error handling
+            .enumerate()
+            .map(|(idx, tx_out)| {
+                self.ledger_db
+                    .get_tx_out_index_by_hash(&tx_out.hash())
+                    .map_err(|err| match err {
+                        LedgerError::NotFound => RpcStatus::with_message(
+                            RpcStatusCode::NOT_FOUND,
+                            format!("tx_out {idx} not found"),
+                        ),
+                        _ => rpc_internal_error("ledger_error", err, &self.logger),
+                    })
+            })
+            .collect::<Result<Vec<u64>, RpcStatus>>()?;
 
         let mixins_with_proofs: Vec<(TxOut, TxOutMembershipProof)> = self
             .transactions_manager
@@ -830,9 +847,15 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .get_indices()
                 .iter()
                 .map(|idx| {
-                    self.ledger_db.get_tx_out_by_index(*idx).map_err(|err| {
-                        rpc_invalid_arg_error("get_tx_out_by_index", err, &self.logger)
-                    })
+                    self.ledger_db
+                        .get_tx_out_by_index(*idx)
+                        .map_err(|err| match err {
+                            LedgerError::NotFound => RpcStatus::with_message(
+                                RpcStatusCode::NOT_FOUND,
+                                format!("tx_out {idx} not found"),
+                            ),
+                            _ => rpc_invalid_arg_error("get_tx_out_by_index", err, &self.logger),
+                        })
                 })
                 .collect::<Result<Vec<TxOut>, RpcStatus>>()?,
 


### PR DESCRIPTION
Previously, mobilecoind returned a GRPC INVALID_ARGUMENT error when certain calls were made to the ledger database and the data requested wasn't found. 
NOT_FOUND is a more correct error code in such cases, and is required for correct behavior of the new remote-mobilecoind fog `BlockProvider` (see https://github.com/mobilecoinfoundation/mobilecoin/blob/feature/bugfix-ledger-notfound-err-code/fog/block_provider/src/error.rs#L38-L39 and https://github.com/mobilecoinfoundation/mobilecoin/blob/feature/bugfix-ledger-notfound-err-code/fog/ledger/server/src/merkle_proof_service.rs#L156)

To verify this results in the expected behavior I hacked together a client that calls `get_outputs` on the fog merkleproof service. Prior to this change, I got this result:
```
Rpc(RpcFailure(RpcStatus { code: 13-INTERNAL, message: "Database Error: GRPC: RpcFailure: 3-INVALID_ARGUMENT get_tx_out_by_index: Record not found", details: [], debug_error_string: "UNKNOWN:Error received from peer  {created_time:\"2023-12-11T11:44:49.535884-08:00\", grpc_status:13, grpc_message:\"Database Error: GRPC: RpcFailure: 3-INVALID_ARGUMENT get_tx_out_by_index: Record not found\"}" }))
```

And after the change:
```
GetOutputsResponse { results: [OutputResult { index: 505555455555555555, result_code: 1, output: TxOut { masked_amount: None, target_key: CompressedRistrettoPublic(0000000000000000000000000000000000000000000000000000000000000000), public_key: CompressedRistrettoPublic(0000000000000000000000000000000000000000000000000000000000000000), e_fog_hint: EncryptedFogHint(000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000), e_memo: None }, proof: TxOutMembershipProof { index: 0, highest_index: 0, elements: [] } }], num_blocks: 6030, global_txo_count: 138904, latest_block_version: 3, max_block_version: 3 }
```

Note that `result_code` 1 is NotFound (https://github.com/mobilecoinfoundation/mobilecoin/blob/feature/bugfix-ledger-notfound-err-code/fog/api/proto/ledger.proto#L173)