### PR TITLE
Fix cargo lock versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,7 +6563,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.40",
 ]
 
 [[package]]


### PR DESCRIPTION
It looks like when the update to `syn` and `mockall` were integrated
they happened to overlap slightly and it wasn't noticed until run in
`main`.
