### PR TITLE
Fix incremental builds

### DIFF
--- a/util/build/info/build.rs
+++ b/util/build/info/build.rs
@@ -133,10 +133,6 @@ pub fn sgx_mode() -> &'static str {{ "{sgx_mode}" }}
     // Check the current contents and see if they are different
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR environment not set?"));
     let out_file = out_dir.join("build_info_generated.rs");
-    println!(
-        "cargo:rerun-if-changed={}",
-        out_file.clone().into_os_string().into_string().unwrap()
-    );
     if let Ok(current_contents) = fs::read_to_string(out_file.clone()) {
         eprintln!("current contents:\n{current_contents}");
         eprintln!("gen contents:\n{gen_contents}");


### PR DESCRIPTION
Previously the build info was marking its output file to re-run if
changed. This forced a subsequent cargo run to re-run, because the
initial generation of the build info was a change. Now the build info
output is not used to re-run cargo for the build info build step.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
