### PR TITLE
mobilecoind: fix optimization tx's when using nonzero token ids

### DIFF
--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1778,12 +1778,12 @@ mod test {
             utxos[3].value = 300 * MILLIMOB_TO_PICOMOB;
             utxos[4].value = 2000 * MILLIMOB_TO_PICOMOB;
             utxos[5].value = 1000 * MILLIMOB_TO_PICOMOB;
-            utxo[0].token_id = eusd;
-            utxo[1].token_id = eusd;
-            utxo[2].token_id = eusd;
-            utxo[3].token_id = eusd;
-            utxo[4].token_id = eusd;
-            utxo[5].token_id = eusd;
+            utxos[0].token_id = *eusd;
+            utxos[1].token_id = *eusd;
+            utxos[2].token_id = *eusd;
+            utxos[3].token_id = *eusd;
+            utxos[4].token_id = *eusd;
+            utxos[5].token_id = *eusd;
 
             let selected_utxos = TransactionsManager::<
                 ThickClient<HardcodedCredentialsProvider>,

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 The MobileCoin Foundation
+// Copyright (c) 2018-2024 The MobileCoin Foundation
 
 //! Construct and submit transactions to the validator network.
 
@@ -618,7 +618,10 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let selected_utxos = {
             let inputs = self
                 .mobilecoind_db
-                .get_utxos_for_subaddress(monitor_id, subaddress_index)?;
+                .get_utxos_for_subaddress(monitor_id, subaddress_index)?
+                .into_iter()
+                .filter(|utxo| utxo.token_id == *token_id)
+                .collect::<Vec<_>>();
             Self::select_utxos_for_optimization(
                 num_blocks_in_ledger,
                 &inputs,
@@ -1759,6 +1762,38 @@ mod test {
                 selected_utxos,
                 vec![utxos[0].clone(), utxos[2].clone(), utxos[4].clone()]
             );
+        }
+    }
+
+    #[test]
+    fn test_select_utxos_for_optimization_works_with_eusd() {
+        // Optimizing with max_inputs=2 should select 100, 2000
+        {
+            let mut utxos = generate_utxos(6);
+            let eusd = TokenId::from(1);
+
+            utxos[0].value = 100 * MILLIMOB_TO_PICOMOB;
+            utxos[1].value = 200 * MILLIMOB_TO_PICOMOB;
+            utxos[2].value = 150 * MILLIMOB_TO_PICOMOB;
+            utxos[3].value = 300 * MILLIMOB_TO_PICOMOB;
+            utxos[4].value = 2000 * MILLIMOB_TO_PICOMOB;
+            utxos[5].value = 1000 * MILLIMOB_TO_PICOMOB;
+            utxo[0].token_id = eusd;
+            utxo[1].token_id = eusd;
+            utxo[2].token_id = eusd;
+            utxo[3].token_id = eusd;
+            utxo[4].token_id = eusd;
+            utxo[5].token_id = eusd;
+
+            let selected_utxos = TransactionsManager::<
+                ThickClient<HardcodedCredentialsProvider>,
+                MockFogPubkeyResolver,
+            >::select_utxos_for_optimization(
+                1000, &utxos, 2, eusd, Mob::MINIMUM_FEE
+            )
+            .unwrap();
+
+            assert_eq!(selected_utxos, vec![utxos[0].clone(), utxos[4].clone()]);
         }
     }
 


### PR DESCRIPTION
without this, we hit an error in "select_utxos_for_optimization"