### PR TITLE
Remove markdown exclusion for PR CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,10 @@ name: CI
 
 on:
   pull_request:
-    paths-ignore:
-    - '**.md'
   push:
     branches:
-      - master
       - main
-      - develop
+      - 'release/**'
     paths-ignore:
     - '**.md'
   workflow_dispatch:


### PR DESCRIPTION
Previously the CI runs excluded changes to markdown files. The
repository is currently set up to require certain CI steps to succeed in
order to merge into `main`. When these CI steps don't run because only a
markdown file was changed then it requires a repository admin to do the
merge. Now Ci runs will execute when only a markdown file is changed.
This uses some CI resources, but prevents getting a repository admin to
force merge.
