### PR TITLE
Set block_version to 4 and exceed by to 0 in charts.

### DIFF
--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -342,14 +342,14 @@ jobs:
 ###############################################
 # Deploy current version to namespace block v3
 ###############################################
-  deploy-current-bv3-release:
+  deploy-current-bv4-release:
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml
     needs:
     - bootstrap-v5-bv3
     - charts
     - generate-metadata
     with:
-      block_version: 3
+      block_version: 4
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       docker_image_org: ${{ needs.generate-metadata.outputs.docker_org }}
       ingest_color: blue
@@ -358,10 +358,10 @@ jobs:
       minimum_block: '5946'
     secrets: inherit
 
-  test-current-bv3-release:
+  test-current-bv4-release:
     uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
     needs:
-    - deploy-current-bv3-release
+    - deploy-current-bv4-release
     - generate-metadata
     with:
       fog_distribution: false
@@ -382,13 +382,13 @@ jobs:
   #   - test-current-bv2-release
   #   - generate-metadata
   #   with:
-  #     block_version: 3
+  #     block_version: 4
   #     chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
   #     namespace: ${{ needs.generate-metadata.outputs.namespace }}
   #     version: ${{ needs.generate-metadata.outputs.tag }}
   #   secrets: inherit
 
-  # test-current-bv3-release:
+  # test-current-bv4-release:
   #   uses: ./.github/workflows/mobilecoin-workflow-dev-test.yaml
   #   needs:
   #   - update-current-to-bv3
@@ -407,7 +407,7 @@ jobs:
     # Dummy step for a standard GHA Check that won't change when we update the tests.
     runs-on: mcf-dev-small-x64
     needs:
-    - test-current-bv3-release
+    - test-current-bv4-release
     steps:
       - name: CD is Complete
         run: 'true'
@@ -421,7 +421,7 @@ jobs:
   cleanup-after-tag:
     if: github.ref_type == 'tag'
     needs:
-    - test-current-bv3-release
+    - test-current-bv4-release
     - generate-metadata
     uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
     with:
@@ -432,7 +432,7 @@ jobs:
   cleanup-after-pr-to-release-branch:
     if: github.event_name == 'pull_request' && startsWith(github.base_ref, 'release/')
     needs:
-    - test-current-bv3-release
+    - test-current-bv4-release
     - generate-metadata
     uses: ./.github/workflows/mobilecoin-workflow-dev-reset.yaml
     with:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -340,7 +340,7 @@ jobs:
     secrets: inherit
 
 ###############################################
-# Deploy current version to namespace block v3
+# Deploy current version to namespace block v4
 ###############################################
   deploy-current-bv4-release:
     uses: ./.github/workflows/mobilecoin-workflow-dev-deploy.yaml

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -21,7 +21,7 @@ on:
         description: "Consensus block_version"
         type: string
         required: true
-        default: '3'
+        default: '4'
       bootstrap_version:
         description: "Bootstrap Blockchain from selected version"
         type: choice

--- a/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-update-consensus.yaml
@@ -21,7 +21,7 @@ on:
         description: "Block Version"
         type: string
         required: true
-        default: '3'
+        default: '4'
       chart_repo:
         description: "Chart Repo URL"
         type: string

--- a/.internal-ci/README.md
+++ b/.internal-ci/README.md
@@ -105,24 +105,3 @@ This workflow watches the head(latest) commit for the current push and parses th
 ### `[tag=]` Flag
 
 The `[tag=]` flag will override the automatically generated docker/helm tag and deploy the specified version in the `current-release-*` steps.
-
-### `[skip *]` Flags
-
-⚠️ Using skip flags may lead to incomplete and/or broken builds.
-
-Available skips:
-
-- `[skip ci]` - GHA built-in to skip all workflow steps.
-- `[skip build]` - Skip rust/go builds.
-- `[skip docker]` - Skip docker image build/publish.
-- `[skip charts]` - Skip helm chart build/publish.
-- `[skip deploy-v1-bv0-release]` - Skip deploy of v1 at block_version 0
-- `[skip test-v1-bv0-release]` - Skip test of v1 at block_version 0
-- `[skip deploy-v2-bv0-release]` - Skip deploy of v2 at block_version 0
-- `[skip test-v2-bv0-release]` - Skip test of v2 at block_version 0
-- `[skip update-v2-to-bv2-release]` - Skip update of v2 at block_version 2
-- `[skip test-v2-bv2-release]` - Skip test of v2 at block_version 2
-- `[skip deploy-current-bv2-release]` - Skip deploy of current at block_version 2
-- `[skip test-current-bv2-release]` - Skip test of current at block_version 2
-- `[skip update-current-to-bv3]` - Skip update of current at block_version 3
-- `[skip test-current-bv3-release]` - Skip test of current at block_version 3

--- a/.internal-ci/helm/consensus-node-config/values.yaml
+++ b/.internal-ci/helm/consensus-node-config/values.yaml
@@ -26,7 +26,7 @@ global:
     ### Node configuration settings
     nodeConfig:
       ### Block version - set to upgrade block version.
-      blockVersion: 0
+      blockVersion: 4
 
     ### Ledger distribution settings. The default for awsPath is auto-generated based on
     #   this values, but can be overridden.

--- a/.internal-ci/helm/fog-ledger/values.yaml
+++ b/.internal-ci/helm/fog-ledger/values.yaml
@@ -18,7 +18,7 @@ fogLedger:
       # Assume default is a dev network. We can always define a "network" value if needed.
       default:
         shardSize: 20_000
-        exceedBlockHeightBy: 5_000
+        exceedBlockHeightBy: 0
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -28,7 +28,7 @@ fogLedger:
           requestBody: ''
       test:
         shardSize: 400_000
-        exceedBlockHeightBy: 10_000
+        exceedBlockHeightBy: 0
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -38,7 +38,7 @@ fogLedger:
           requestBody: ''
       main:
         shardSize: 400_000
-        exceedBlockHeightBy: 10_000
+        exceedBlockHeightBy: 0
         shardOverlap: 0
         count: 3
         blockHeightRetrieval:

--- a/.internal-ci/helm/fog-view/values.yaml
+++ b/.internal-ci/helm/fog-view/values.yaml
@@ -18,7 +18,7 @@ fogView:
       # Assume default is a dev network. We can always define a "network" value if needed.
       default:
         shardSize: 20_000
-        exceedBlockHeightBy: 5_000
+        exceedBlockHeightBy: 0
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -28,7 +28,7 @@ fogView:
           requestBody: ''
       test:
         shardSize: 400_000
-        exceedBlockHeightBy: 10_000
+        exceedBlockHeightBy: 0
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:

--- a/.internal-ci/helm/fog-view/values.yaml
+++ b/.internal-ci/helm/fog-view/values.yaml
@@ -18,7 +18,7 @@ fogView:
       # Assume default is a dev network. We can always define a "network" value if needed.
       default:
         shardSize: 20_000
-        exceedBlockHeightBy: 0
+        exceedBlockHeightBy: 5_000
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -28,7 +28,7 @@ fogView:
           requestBody: ''
       test:
         shardSize: 400_000
-        exceedBlockHeightBy: 0
+        exceedBlockHeightBy: 10_000
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:


### PR DESCRIPTION
### Motivation

Setting good defaults for the release. 

- Block version set to `4`
- Set the scale up `exceedBlockHeightBy` to `0` to work around ledger store reporting 0 when no blocks in the latest store.
