### PR TITLE
Add support for setting tx private key in tx builder, expose in mobilecoind api

### DIFF
--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
+// Copyright (c) 2018-2024 The MobileCoin Foundation
 
 #![allow(non_snake_case)]
 
@@ -140,6 +140,14 @@ impl RistrettoPrivate {
         let csprng = Hc128Rng::from_seed(nonce);
         let transcript = attach_rng(t, csprng);
         RistrettoSignature::from(keypair.sign(transcript))
+    }
+
+    /// Curve25519-dalek exposes Scalar::from_bytes_mod_order, which is helpful
+    /// for converting a hash into a valid scalar, and can be useful at API
+    /// boundaries. Callers need not import curve25519-dalek in order to
+    /// convert a hash to a valid scalar.
+    pub fn from_bytes_mod_order(src: &[u8; 32]) -> Self {
+        Self(Scalar::from_bytes_mod_order(*src))
     }
 }
 

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -118,6 +118,9 @@ enum TxStatus {
 message Outlay {
     uint64 value = 1;
     external.PublicAddress receiver = 2;
+    // Optional tx private key to use for this tx out. This can be chosen explicitly as a mechanism for idempotence.
+    // Must be 32 pseudorandom bytes or none. Will be reduced to curve25519 scalar mod order.
+    bytes tx_private_key = 3;
 }
 
 // Structure used in specifying the list of outputs in a transaction.
@@ -126,6 +129,9 @@ message OutlayV2 {
     uint64 value = 1;
     external.PublicAddress receiver = 2;
     uint64 token_id = 3;
+    // Optional tx private key to use for this tx out. This can be chosen explicitly as a mechanism for idempotence.
+    // Must be 32 pseudorandom bytes or none. Will be reduced to curve25519 scalar mod order.
+    bytes tx_private_key = 4;
 }
 
 // Structure used to refer to a TxOut in the ledger that is presumed to be spendable.

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -65,11 +65,8 @@ fn bytes_to_tx_private_key(bytes: &[u8]) -> Result<Option<RistrettoPrivate>, Con
         return Ok(None);
     }
 
-    if let Ok(bytes) = <&[u8; 32] as TryFrom<&[u8]>>::try_from(bytes) {
-        Ok(Some(RistrettoPrivate::from_bytes_mod_order(bytes)))
-    } else {
-        Err(ConversionError::ArrayCastError)
-    }
+    let bytes = <&[u8; 32] as TryFrom<&[u8]>>::try_from(bytes)?;
+    Ok(Some(RistrettoPrivate::from_bytes_mod_order(bytes)))
 }
 
 impl From<&Outlay> for api::Outlay {

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -333,8 +333,13 @@ mod test {
             PublicAddress::try_from(proto.get_receiver()).unwrap(),
             public_addr
         );
+    }
 
-        // Proto -> Rust
+    #[test]
+    fn test_outlay_conversion_with_tx_private_key() {
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+        let public_addr = AccountKey::random(&mut rng).default_subaddress();
+
         assert_eq!(rust, Outlay::try_from(&proto).unwrap());
 
         // Rust -> Proto, with tx private key

--- a/mobilecoind/src/conversions.rs
+++ b/mobilecoind/src/conversions.rs
@@ -333,14 +333,15 @@ mod test {
             PublicAddress::try_from(proto.get_receiver()).unwrap(),
             public_addr
         );
+
+        // Proto -> Rust
+        assert_eq!(rust, Outlay::try_from(&proto).unwrap());
     }
 
     #[test]
     fn test_outlay_conversion_with_tx_private_key() {
         let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
         let public_addr = AccountKey::random(&mut rng).default_subaddress();
-
-        assert_eq!(rust, Outlay::try_from(&proto).unwrap());
 
         // Rust -> Proto, with tx private key
         let rust = Outlay {

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -310,7 +310,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             .map(|outlay_v1| OutlayV2 {
                 receiver: outlay_v1.receiver.clone(),
                 amount: Amount::new(outlay_v1.value, token_id),
-                tx_private_key: outlay_v1.tx_private_key.clone(),
+                tx_private_key: outlay_v1.tx_private_key,
             })
             .collect();
 
@@ -1288,7 +1288,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 .add_output_with_tx_private_key(
                     outlay.amount,
                     &outlay.receiver,
-                    outlay.tx_private_key.clone(),
+                    outlay.tx_private_key,
                     rng,
                 )
                 .map_err(|err| Error::TxBuild(format!("failed adding output: {err}")))?;

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 The MobileCoin Foundation
+// Copyright (c) 2018-2024 The MobileCoin Foundation
 
 //! The mobilecoind Service
 //! * provides a GRPC server
@@ -1276,6 +1276,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let outlays = vec![Outlay {
             value: request.get_burn_amount(),
             receiver: burn_address(),
+            tx_private_key: None,
         }];
 
         // Create memo builder.
@@ -1337,6 +1338,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         let outlay = Outlay {
             receiver: account_key.default_subaddress(),
             value: request.value,
+            tx_private_key: None,
         };
 
         // Generate transaction.
@@ -4548,10 +4550,12 @@ mod test {
             Outlay {
                 value: 123,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 456,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 
@@ -4799,6 +4803,7 @@ mod test {
             request.set_outlay_list(RepeatedField::from_vec(vec![api::Outlay::from(&Outlay {
                 receiver: receiver1.default_subaddress(),
                 value: test_utils::DEFAULT_PER_RECIPIENT_AMOUNT * num_blocks,
+                tx_private_key: None,
             })]));
             assert!(client.generate_tx(&request).is_err());
         }
@@ -5710,10 +5715,12 @@ mod test {
             Outlay {
                 value: 123,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 456,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 
@@ -5962,10 +5969,12 @@ mod test {
             Outlay {
                 value: 123,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 456,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 
@@ -6147,10 +6156,12 @@ mod test {
             Outlay {
                 value: 10,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 20,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 
@@ -6291,10 +6302,12 @@ mod test {
             Outlay {
                 value: 123,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 456,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 
@@ -6415,10 +6428,12 @@ mod test {
             Outlay {
                 value: 123,
                 receiver: receiver1.default_subaddress(),
+                tx_private_key: None,
             },
             Outlay {
                 value: 456,
                 receiver: receiver2.default_subaddress(),
+                tx_private_key: None,
             },
         ];
 

--- a/transaction/builder/src/test_utils.rs
+++ b/transaction/builder/src/test_utils.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2022 The MobileCoin Foundation
+// Copyright (c) 2018-2024 The MobileCoin Foundation
 
 //! Utilities that help with testing the transaction builder and related objects
 
@@ -8,7 +8,7 @@ use crate::{
 };
 use alloc::vec::Vec;
 use mc_account_keys::{AccountKey, PublicAddress, DEFAULT_SUBADDRESS_INDEX};
-use mc_crypto_keys::RistrettoPublic;
+use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use mc_crypto_ring_signature_signer::{NoKeysRingSigner, OneTimeKeyDeriveData};
 use mc_fog_report_validation::FogPubkeyResolver;
 use mc_transaction_core::{
@@ -44,13 +44,14 @@ pub fn create_output<RNG: CryptoRng + RngCore, FPR: FogPubkeyResolver>(
 ) -> Result<(TxOut, RistrettoPublic), TxBuilderError> {
     let (hint, _pubkey_expiry) =
         crate::transaction_builder::create_fog_hint(recipient, fog_resolver, rng)?;
-    let (tx_out, shared_secret, _) = crate::transaction_builder::create_output_with_fog_hint(
+    let tx_private_key = RistrettoPrivate::from_random(rng);
+    let (tx_out, shared_secret) = crate::transaction_builder::create_output_with_fog_hint(
         block_version,
         amount,
         recipient,
         hint,
         |_| Ok(MemoPayload::default()),
-        rng,
+        &tx_private_key,
     )?;
     Ok((tx_out, shared_secret))
 }

--- a/transaction/builder/src/transaction_builder.rs
+++ b/transaction/builder/src/transaction_builder.rs
@@ -946,7 +946,7 @@ pub(crate) fn create_output_with_fog_hint(
         memo_fn,
     )?;
 
-    let shared_secret = create_shared_secret(recipient.view_public_key(), &tx_private_key);
+    let shared_secret = create_shared_secret(recipient.view_public_key(), tx_private_key);
     Ok((tx_out, shared_secret))
 }
 
@@ -1235,6 +1235,7 @@ pub mod transaction_builder_tests {
                     Amount::new(value - Mob::MINIMUM_FEE, token_id),
                     &recipient.default_subaddress(),
                     &fog_hint_address,
+                    None,
                     |_| Ok(Default::default()),
                     &mut rng,
                 )


### PR DESCRIPTION
This can be used to create a relatively easy to use idempotence strategy for mobilecoind payments.

From a vendor or an exchange's point of view, it's really nice if you can have an "idempotence key" in an API that sends money somewhere. Here idempotence means, if I make this request, and retry in case of connection failures, there's no way that it can lead to a payment being sent twice.

For example, in mobilecoind, there is a `SendPayment` API which is meant to be the easiest way to send money to a public address. However, there is no idempotence key on this API, and so if I make the request, then due to connectivity issues, the response is not delivered, but the request was handled successfully, a retry will cause a new payment to be sent, with new UTXOs selected. So in realistic deployment environments, this API cannot actually be used safely by an exchange or a vendor. Some fraction of the time, random networking issues will cause payments to be delivered twice, and loss of funds.

It's best for the idempotence mechanism to be grounded in blockchain rules, because local wallet state is comparatively ephemeral.

The mobilecoin blockchain does not have a built-in notion of idempotence keys, but it does have two points of exclusion for transactions -- a UTXO cannot be spent twice, due to the key image mechanism, and a TxOut public key is unique across the whole chain.

One way that an idempotence mechanism can be created is by fixing the tx private key of (one or more) TxOut's in a transaction that you create. The tx private key is the only random element used when the TxOut public key, target key, and amount commitment are generated for a given recipient, token id, and value, so fixing the recipient, amount, and tx private key, fixes these fields of the TxOut, in particular the public key.

From an exchange or vendor's point of view, fixing the tx private key has additional benefits -- if you know the tx private key, amount, and recipient, you can prove the amount and recipient of a TxOut that you sent, even if the recipient themselves does not cooperate. This can be helpful to resolve disputes. Alternative existing mechanisms like shared secret and confirmation number don't accomplish this, because they can only be checked by the recipient, whereas this tx private key mechanism can be checked by anyone.

Existing wallets do not expose the tx private key, it is generally discarded instead. This is perhaps very good from a privacy point of view, but it basically gives up on robust dispute resolution.

This PR gives an exchange or vendor a relatively easy way to get both things. Such a user could decide to derive the tx_private_key of a TxOut, for instance, by a hash of the payment id or withdrawal id, together with a 32 byte secret.

As an example, the private spend key could be the secret used in this hash, however, that has some unexpected consequences like, rotating your private key could cause a loss of idempotence. As an alternative, a user could even choose to use an entirely new secret here which is not derived from the mnemonic, so that they can still change their mnemonic without risking loss of idempotence (and loss of funds).

Instead of mandating any such mechanism, this PR allows the application developer to decide exactly how this should be done. The new `tx_private_key` field of an `Outlay` is optional, but when specified, is expected to be a 32-byte hash. When used this way, a call to the `SendPayment` API can become idempotent.

---

Note that, this is an alternative to an approach developed some time ago in the mobile SDKs, when mobile wallets needed to establish idempotence for payments. The alternative approach is to seed the RNG used with the transaction builder, in order to control the tx private keys. This seed was often a hash using the payment id.

The main drawback of this is that it is fairly brittle.

* Invoking transaction builder functions in a different order can break idempotence, so changing code that uses it may become hazardous.
* Upgrading the seeded CSPRNG algortihm can break idempotence, and so becomes hazardous.

Additionally, from the user point of view, it only accomplishes one of my goals. It is a strategy for controlling the tx private key, but it doesn't help me learn the tx private key, and none of the existing APIs return that value.

I believe that this approach is the simplest change that accomplishes both goals, and is backwards compatible from an API perspective. Application developers are free to use either approach to establish and maintain idempotence.