### PR TITLE
Fix fog ledger router returning incorrect block number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "mc-watcher-api",
+ "serde",
  "yare 2.0.0",
 ]
 

--- a/fog/ledger/enclave/api/src/lib.rs
+++ b/fog/ledger/enclave/api/src/lib.rs
@@ -22,6 +22,7 @@ use mc_attest_enclave_api::{
 };
 use mc_common::ResponderId;
 use mc_crypto_keys::X25519Public;
+use mc_fog_types::common::BlockRange;
 pub use mc_fog_types::ledger::{
     CheckKeyImagesResponse, GetOutputsResponse, KeyImageResult, KeyImageResultCode, OutputResult,
 };
@@ -51,7 +52,7 @@ pub struct OutputContext {
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct UntrustedKeyImageQueryResponse {
     /// The number of blocks at the time that the request was evaluated.
-    pub highest_processed_block_count: u64,
+    pub processed_block_range: BlockRange,
 
     /// The cumulative txo count of the last known block.
     pub last_known_block_cumulative_txo_count: u64,

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -32,6 +32,7 @@ mc-oblivious-traits = "2.3"
 # fog
 mc-fog-ledger-enclave-api = { path = "../api", default-features = false }
 mc-fog-types = { path = "../../../types" }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 mc-common = { path = "../../../../common", features = ["loggers"] }

--- a/fog/ledger/enclave/impl/src/lib.rs
+++ b/fog/ledger/enclave/impl/src/lib.rs
@@ -32,14 +32,25 @@ use mc_fog_ledger_enclave_api::{
     Error, KeyImageData, KeyImageResult, LedgerEnclave, OutputContext, Result,
     UntrustedKeyImageQueryResponse,
 };
-use mc_fog_types::ledger::{
-    CheckKeyImagesRequest, CheckKeyImagesResponse, GetOutputsRequest, GetOutputsResponse,
+use mc_fog_types::{
+    common::BlockRange,
+    ledger::{
+        CheckKeyImagesRequest, CheckKeyImagesResponse, GetOutputsRequest, GetOutputsResponse,
+    },
 };
 use mc_oblivious_traits::ORAMStorageCreator;
 use mc_sgx_compat::sync::Mutex;
 use mc_sgx_report_cache_api::{ReportableEnclave, Result as ReportableEnclaveResult};
+use serde::{Deserialize, Serialize};
 
 mod oblivious_utils;
+
+#[derive(Debug, Serialize, Deserialize)]
+/// Response from a shard enclave to a router enclave for the key image query
+struct ShardKeyImageResponse {
+    untrusted_response: UntrustedKeyImageQueryResponse,
+    results: Vec<KeyImageResult>,
+}
 
 /// In-enclave state associated to the ledger enclaves
 pub struct SgxLedgerEnclave<OSC>
@@ -161,7 +172,9 @@ where
         })?;
 
         let mut resp = CheckKeyImagesResponse {
-            num_blocks: untrusted_key_image_query_response.highest_processed_block_count,
+            num_blocks: untrusted_key_image_query_response
+                .processed_block_range
+                .end_block,
             results: Default::default(),
             global_txo_count: untrusted_key_image_query_response
                 .last_known_block_cumulative_txo_count,
@@ -252,40 +265,29 @@ where
             .into_iter()
             .map(|(responder_id, query_response)| {
                 let plaintext_bytes = self.ake.backend_decrypt(&responder_id, &query_response)?;
-                let query_response: CheckKeyImagesResponse =
-                    mc_util_serial::decode(&plaintext_bytes)?;
+                let query_response: ShardKeyImageResponse =
+                    mc_util_serial::deserialize(&plaintext_bytes)?;
 
                 Ok(query_response)
             })
-            .collect::<Result<Vec<CheckKeyImagesResponse>>>()?;
+            .collect::<Result<Vec<_>>>()?;
 
-        let num_blocks = shard_query_responses
-            .iter()
-            .map(|query_response| query_response.num_blocks)
-            .min()
-            .expect("this is only None when the iterator is empty but we early-exit in that case");
-        let global_txo_count = shard_query_responses
-            .iter()
-            .map(|query_response| query_response.global_txo_count)
-            .min()
-            .expect("this is only None when the iterator is empty but we early-exit in that case");
-        let latest_block_version = shard_query_responses
-            .iter()
-            .map(|query_response| query_response.latest_block_version)
-            .max()
-            .expect("this is only None when the iterator is empty but we early-exit in that case");
+        let untrusted_response =
+            merge_untrusted_responses(shard_query_responses.iter().map(|r| &r.untrusted_response));
+        let num_blocks = untrusted_response.processed_block_range.end_block;
+        let global_txo_count = untrusted_response.last_known_block_cumulative_txo_count;
+        let latest_block_version = untrusted_response.latest_block_version;
+        let max_block_version = max(latest_block_version, *MAX_BLOCK_VERSION);
 
-        let plaintext_results: Vec<KeyImageResult> = shard_query_responses
+        let plaintext_results = shard_query_responses
             .into_iter()
             .flat_map(|query_response| query_response.results)
-            .collect();
+            .collect::<Vec<_>>();
 
         let oblivious_results = oblivious_utils::collate_shard_key_image_search_results(
             client_query_request.queries,
             &plaintext_results,
         );
-
-        let max_block_version = max(latest_block_version, *MAX_BLOCK_VERSION);
 
         let client_query_response = CheckKeyImagesResponse {
             num_blocks,
@@ -315,13 +317,9 @@ where
             Error::ProstDecode
         })?;
 
-        let mut resp = CheckKeyImagesResponse {
-            num_blocks: untrusted_key_image_query_response.highest_processed_block_count,
+        let mut resp = ShardKeyImageResponse {
+            untrusted_response: untrusted_key_image_query_response,
             results: Default::default(),
-            global_txo_count: untrusted_key_image_query_response
-                .last_known_block_cumulative_txo_count,
-            latest_block_version: untrusted_key_image_query_response.latest_block_version,
-            max_block_version: untrusted_key_image_query_response.max_block_version,
         };
 
         {
@@ -336,7 +334,7 @@ where
         }
 
         // Encrypt for return to router
-        let response_plaintext_bytes = mc_util_serial::encode(&resp);
+        let response_plaintext_bytes = mc_util_serial::serialize(&resp)?;
         let response = self
             .ake
             .frontend_encrypt(&channel_id, &[], &response_plaintext_bytes)?;
@@ -352,14 +350,59 @@ where
     }
 }
 
+fn merge_untrusted_responses<'a>(
+    untrusted_responses: impl IntoIterator<Item = &'a UntrustedKeyImageQueryResponse>,
+) -> UntrustedKeyImageQueryResponse {
+    let default_response = UntrustedKeyImageQueryResponse {
+        processed_block_range: BlockRange::new(0, 0),
+        last_known_block_cumulative_txo_count: 0,
+        latest_block_version: 0,
+        max_block_version: 0,
+    };
+
+    let mut untrusted_responses = [default_response]
+        .into_iter()
+        .chain(untrusted_responses.into_iter().cloned())
+        .collect::<Vec<_>>();
+
+    untrusted_responses.sort_by(|a, b| a.processed_block_range.cmp(&b.processed_block_range));
+
+    // This logic will remove fully contained overlaps. For example:
+    //   5-----------------20      Range 1
+    //       12--------15          Range 2
+    // The second range is fully contained in the first, so it is removed. This
+    // could happen in instances when the shards overlap but the newer shard is
+    // still catching up
+
+    // Note that
+    // [`dedup_by`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.dedup_by)
+    // states:
+    // > The elements are passed in opposite order from their order in the slice
+    untrusted_responses
+        .dedup_by(|a, b| a.processed_block_range.end_block <= b.processed_block_range.end_block);
+
+    let (index, block_range) =
+        BlockRange::merge_from_ranges(untrusted_responses.iter().map(|r| &r.processed_block_range))
+            .expect(
+                "Failed to merge block ranges, shouldn't happen, we always pass 1 valid range in",
+            );
+
+    let mut untrusted_response = untrusted_responses[index].clone();
+    untrusted_response.processed_block_range = block_range;
+    untrusted_response
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use key_image_store::KeyImageStore;
     use mc_common::logger::create_root_logger;
     use mc_fog_ledger_enclave_api::KeyImageData;
     use mc_oblivious_traits::HeapORAMStorageCreator;
     use mc_transaction_core::ring_signature::KeyImage;
+    use yare::parameterized;
+
     // Test that we were able to add key image record to the oram
     #[test]
     fn test_add_record() {
@@ -456,5 +499,43 @@ mod tests {
             v_keyimagenotfound.key_image_result_code,
             mc_fog_types::ledger::KeyImageResultCode::NotSpent as u32
         );
+    }
+
+    type UntrustedResponseTuple = ((u64, u64), u64, u32, u32);
+    #[parameterized(
+        all_consecutive = { vec![((0, 5), 15, 0, 0), ((5, 8), 24, 1, 2)], ((0, 8), 24, 1, 2) },
+        gap_at_start_block = { vec![((1, 8), 24, 1, 2)], ((0, 0), 0, 0, 0) },
+        gap_in_middle = { vec![((0, 5), 15, 0, 0), ((8, 10), 24, 1, 2)], ((0, 5), 15, 0, 0) },
+        contained_overlap_before = { vec![((5, 8), 24, 1, 2), ((0, 10), 30, 3, 3)], ((0, 10), 30, 3, 3) },
+        contained_overlap_after = { vec![((0, 10), 30, 3, 3), ((5, 8), 24, 1, 2)], ((0, 10), 30, 3, 3) },
+        contained_overlap_intermediate = { vec![((0, 10), 30, 3, 3), ((5, 8), 24, 1, 2), ((7, 12), 36, 4, 4)], ((0, 12), 36, 4, 4) },
+        unsorted = { vec![((5, 8), 24, 1, 2), ((8, 10), 30, 2, 3), ((0, 5), 15, 0, 0)], ((0, 10), 30, 2, 3) },
+    )]
+    fn merge_the_untrusted_responses(
+        untrusted_responses: Vec<UntrustedResponseTuple>,
+        expected_response: UntrustedResponseTuple,
+    ) {
+        let untrusted_responses = untrusted_responses
+            .iter()
+            .map(
+                |(block_range, txo_count, latest_block_version, max_block_version)| {
+                    UntrustedKeyImageQueryResponse {
+                        processed_block_range: BlockRange::new(block_range.0, block_range.1),
+                        last_known_block_cumulative_txo_count: *txo_count,
+                        latest_block_version: *latest_block_version,
+                        max_block_version: *max_block_version,
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+
+        let expected = UntrustedKeyImageQueryResponse {
+            processed_block_range: BlockRange::new(expected_response.0 .0, expected_response.0 .1),
+            last_known_block_cumulative_txo_count: expected_response.1,
+            latest_block_version: expected_response.2,
+            max_block_version: expected_response.3,
+        };
+
+        assert_eq!(merge_untrusted_responses(&untrusted_responses), expected);
     }
 }

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.26",
+ "syn 2.0.50",
  "which",
 ]
 
@@ -431,7 +431,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -490,7 +490,7 @@ checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -968,7 +968,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -1485,6 +1485,7 @@ dependencies = [
  "mc-transaction-core",
  "mc-util-serial",
  "mc-watcher-api",
+ "serde",
 ]
 
 [[package]]
@@ -2129,7 +2130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2143,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -2177,7 +2178,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.26",
+ "syn 2.0.50",
  "tempfile",
  "which",
 ]
@@ -2192,7 +2193,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2206,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2406,9 +2407,9 @@ checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -2424,13 +2425,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2463,7 +2464,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -2574,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/fog/ledger/server/src/db_fetcher.rs
+++ b/fog/ledger/server/src/db_fetcher.rs
@@ -172,6 +172,10 @@ impl<
         let mut next_block_index = block_range.start_block;
         loop {
             loop {
+                if self.stop_requested.load(Ordering::SeqCst) {
+                    break;
+                }
+
                 let Some(num_blocks) = self.load_block_data(&mut next_block_index) else {
                     std::thread::sleep(Self::ERROR_RETRY_FREQUENCY);
                     continue;
@@ -186,10 +190,6 @@ impl<
                 }
 
                 if end <= next_block_index {
-                    break;
-                }
-
-                if self.stop_requested.load(Ordering::SeqCst) {
                     break;
                 }
             }

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -84,21 +84,17 @@ impl<E: LedgerEnclaveProxy> KeyImageService<E> {
     /// for use in [KeyImageService::check_key_images_auth()]
     /// and [KeyImageService::check_key_image_store_auth()]
     fn prepare_untrusted_query(&mut self) -> UntrustedKeyImageQueryResponse {
-        let (
-            highest_processed_block_count,
-            last_known_block_cumulative_txo_count,
-            latest_block_version,
-        ) = {
+        let (processed_block_range, last_known_block_cumulative_txo_count, latest_block_version) = {
             let shared_state = self.db_poll_shared_state.lock().expect("mutex poisoned");
             (
-                shared_state.highest_processed_block_count,
+                shared_state.processed_block_range.clone(),
                 shared_state.last_known_block_cumulative_txo_count,
                 shared_state.latest_block_version,
             )
         };
 
         UntrustedKeyImageQueryResponse {
-            highest_processed_block_count,
+            processed_block_range,
             last_known_block_cumulative_txo_count,
             latest_block_version,
             max_block_version: latest_block_version.max(*MAX_BLOCK_VERSION),

--- a/fog/ledger/server/src/lib.rs
+++ b/fog/ledger/server/src/lib.rs
@@ -5,6 +5,7 @@ pub use block_service::BlockService;
 pub use config::{LedgerRouterConfig, LedgerStoreConfig, ShardingStrategy};
 pub use key_image_service::KeyImageService;
 pub use key_image_store_server::KeyImageStoreServer;
+use mc_fog_types::common::BlockRange;
 pub use merkle_proof_service::MerkleProofService;
 pub use router_server::LedgerRouterServer;
 pub use untrusted_tx_out_service::UntrustedTxOutService;
@@ -35,9 +36,9 @@ lazy_static::lazy_static! {
 /// State that we want to expose from the db poll thread
 #[derive(Debug, Default)]
 pub struct DbPollSharedState {
-    /// The highest block count for which we can guarantee we have loaded all
-    /// available data.
-    pub highest_processed_block_count: u64,
+    /// The block range we have loaded blocks for.
+    /// When no blocks have been loaded this will be an empty range (0-0).
+    pub processed_block_range: BlockRange,
 
     /// The cumulative txo count of the last known block.
     pub last_known_block_cumulative_txo_count: u64,

--- a/fog/ledger/server/tests/router_integration.rs
+++ b/fog/ledger/server/tests/router_integration.rs
@@ -15,7 +15,7 @@ use mc_fog_ledger_server::{
     LedgerRouterServer, LedgerStoreConfig, ShardingStrategy,
 };
 use mc_fog_test_infra::get_enclave_path;
-use mc_fog_types::common::BlockRange;
+use mc_fog_types::{common::BlockRange, ledger::KeyImageResult};
 use mc_fog_uri::{FogLedgerUri, KeyImageStoreUri};
 use mc_ledger_db::{test_utils::recreate_ledger_db, LedgerDB};
 use mc_rand::{CryptoRng, RngCore};
@@ -39,6 +39,25 @@ use url::Url;
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 const TEST_URL: &str = "http://www.my_url1.com";
 const CHAIN_ID: &str = "local";
+
+fn assert_key_image_unspent(key: &KeyImage, result: &KeyImageResult) {
+    assert_eq!(result.key_image, *key);
+    // None in the status means not spent.
+    assert_eq!(result.status(), Ok(None));
+    assert_eq!(
+        result.timestamp_result_code,
+        TimestampResultCode::TimestampFound as u32
+    );
+}
+
+fn assert_key_image_spent(key: &KeyImage, result: &KeyImageResult, block_index: u64) {
+    assert_eq!(result.key_image, *key);
+    assert_eq!(result.status(), Ok(Some(block_index)));
+    assert_eq!(
+        result.timestamp_result_code,
+        TimestampResultCode::TimestampFound as u32
+    );
+}
 
 fn setup_watcher_db(path: PathBuf, logger: Logger) -> WatcherDB {
     let url = Url::parse(TEST_URL).unwrap();
@@ -115,22 +134,24 @@ fn seed_block_provider(block_provider: &mut LocalBlockProvider<LedgerDB>) {
     add_block_to_ledger(block_provider, &recipients, &[], &mut rng);
 }
 
-fn populate_block_provider(
+fn populate_block_provider<'a>(
     block_provider: &mut LocalBlockProvider<LedgerDB>,
-    blocks_config: &BlockConfig,
+    blocks_config: impl IntoIterator<Item = &'a HashMap<PublicAddress, Vec<KeyImage>>>,
 ) {
     let mut rng = thread_rng();
 
-    for block in blocks_config {
+    for block in blocks_config.into_iter() {
         let recipients: Vec<_> = block.keys().cloned().collect();
         let key_images: Vec<_> = block.values().flat_map(|x| x.clone()).collect();
 
         add_block_to_ledger(block_provider, &recipients, &key_images, &mut rng);
     }
 
-    // The stores are running on separate threads. We wait twice as long as
-    // their POLL_INTERVAL to ensure they've had time to process the new blocks
-    std::thread::sleep(POLL_INTERVAL * 2);
+    // The stores are running on separate threads. We wait 16 times the
+    // their POLL_INTERVAL to account for number of threads in CI.
+    // This helps to ensure all the stores have had time to process the new
+    // blocks
+    std::thread::sleep(POLL_INTERVAL * 16);
 }
 
 fn create_store(
@@ -288,8 +309,6 @@ struct StoreConfig {
     omap_capacity: u64,
 }
 
-type BlockConfig = Vec<HashMap<PublicAddress, Vec<KeyImage>>>;
-
 fn free_sockaddr() -> SocketAddr {
     let port = portpicker::pick_unused_port().unwrap();
     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), port)
@@ -299,12 +318,18 @@ fn free_sockaddr() -> SocketAddr {
 async fn smoke_test() {
     let logger = mc_common::logger::create_test_logger(stdext::function_name!().to_string());
     log::info!(logger, "test");
+    let genesis_store = StoreConfig {
+        address: free_sockaddr(),
+        block_range: BlockRange::new_from_length(0, 1),
+        omap_capacity: 1000,
+    };
+    let mut stores_config = vec![genesis_store];
+
     // Three stores, correct config, each stores three blocks,
     // each has three users with three keys each
     let num_stores = 3;
     let blocks_per_store = 3;
     let mut rng = RngType::from_seed([0u8; 32]);
-    let mut stores_config = vec![];
     for i in 0..num_stores {
         let store = StoreConfig {
             address: free_sockaddr(),
@@ -342,38 +367,63 @@ async fn smoke_test() {
     let grpc_env = Arc::new(grpcio::EnvBuilder::new().build());
 
     let mut test_environment = create_env(config, grpc_env, logger.clone());
-    populate_block_provider(&mut test_environment.block_provider, &blocks_config);
 
     let new_transactions = users_per_block * blocks_to_add;
-    // Check that we can get all the key images from each store
-    let keys_per_block = users_per_block * keys_per_user;
-    for i in 0..key_index {
-        let key = KeyImage::from(i);
-        let response = test_environment
-            .router_client
-            .check_key_images(&[key])
-            .await
-            .expect("check_key_images failed");
-        assert_eq!(response.results.len(), 1);
-        assert_eq!(response.results[0].key_image, key);
-        assert_eq!(
-            response.results[0].status(),
-            Ok(Some((i / keys_per_block) + 1))
-        );
-        assert_eq!(
-            response.results[0].timestamp_result_code,
-            TimestampResultCode::TimestampFound as u32
-        );
-        // The genesis block will add 1 to the total number of blocks, it has
-        // one transaction which will also add 1 to the total number of
-        // transactions
-        assert_eq!(response.num_blocks, blocks_to_add + 1);
-        assert_eq!(response.global_txo_count, new_transactions + 1);
-        assert_eq!(response.latest_block_version, *BlockVersion::MAX);
-        assert_eq!(response.max_block_version, *BlockVersion::MAX);
+    for (block_index, block) in blocks_config
+        .iter()
+        .enumerate()
+        .map(|(i, e)| ((i + 1) as u64, e))
+    {
+        for keys in block.values() {
+            for key in keys {
+                let response = test_environment
+                    .router_client
+                    .check_key_images(&[*key])
+                    .await
+                    .expect("check_key_images failed");
+                // We should always get a result to prevent side channel
+                // attacks from determining whether a key image was spent.
+                assert_eq!(response.results.len(), 1);
+                assert_key_image_unspent(key, &response.results[0]);
+
+                assert_eq!(response.num_blocks, block_index);
+                assert_eq!(
+                    response.global_txo_count,
+                    ((block_index - 1) * users_per_block) + 1
+                );
+                let expected_block_version = if block_index == 1 {
+                    0
+                } else {
+                    *BlockVersion::MAX
+                };
+                assert_eq!(response.latest_block_version, expected_block_version);
+                assert_eq!(response.max_block_version, *BlockVersion::MAX);
+            }
+        }
+        populate_block_provider(&mut test_environment.block_provider, [block]);
+        for keys in block.values() {
+            for key in keys {
+                let response = test_environment
+                    .router_client
+                    .check_key_images(&[*key])
+                    .await
+                    .expect("check_key_images failed");
+                assert_eq!(response.results.len(), 1);
+                assert_key_image_spent(key, &response.results[0], block_index);
+
+                assert_eq!(response.num_blocks, block_index + 1);
+                assert_eq!(
+                    response.global_txo_count,
+                    (block_index * users_per_block) + 1
+                );
+                assert_eq!(response.latest_block_version, *BlockVersion::MAX);
+                assert_eq!(response.max_block_version, *BlockVersion::MAX);
+            }
+        }
     }
 
     // Grab them all at once
+    let keys_per_block = users_per_block * keys_per_user;
     let keys: Vec<_> = (0..key_index).map(KeyImage::from).collect();
     let response = test_environment
         .router_client
@@ -383,35 +433,10 @@ async fn smoke_test() {
     assert_eq!(response.results.len(), key_index as usize);
     for i in 0..key_index {
         let key = KeyImage::from(i);
-        assert_eq!(response.results[i as usize].key_image, key);
-        assert_eq!(
-            response.results[i as usize].status(),
-            Ok(Some((i / keys_per_block) + 1))
-        );
-        assert_eq!(
-            response.results[i as usize].timestamp_result_code,
-            TimestampResultCode::TimestampFound as u32
-        );
-    }
-    assert_eq!(response.num_blocks, blocks_to_add + 1);
-    assert_eq!(response.global_txo_count, new_transactions + 1);
-    assert_eq!(response.latest_block_version, *BlockVersion::MAX);
-    assert_eq!(response.max_block_version, *BlockVersion::MAX);
 
-    // Check that an unspent key image is unspent
-    let key = KeyImage::from(126u64);
-    let response = test_environment
-        .router_client
-        .check_key_images(&[key])
-        .await
-        .expect("check_key_images failed");
-    assert_eq!(response.results.len(), 1);
-    assert_eq!(response.results[0].key_image, key);
-    assert_eq!(response.results[0].status(), Ok(None)); // Not spent
-    assert_eq!(
-        response.results[0].timestamp_result_code,
-        TimestampResultCode::TimestampFound as u32
-    );
+        let block_index = (i / keys_per_block) + 1;
+        assert_key_image_spent(&key, &response.results[i as usize], block_index);
+    }
     assert_eq!(response.num_blocks, blocks_to_add + 1);
     assert_eq!(response.global_txo_count, new_transactions + 1);
     assert_eq!(response.latest_block_version, *BlockVersion::MAX);
@@ -422,13 +447,19 @@ async fn smoke_test() {
 async fn overlapping_stores() {
     let logger = mc_common::logger::create_test_logger(stdext::function_name!().to_string());
     log::info!(logger, "test");
+    let genesis_store = StoreConfig {
+        address: free_sockaddr(),
+        block_range: BlockRange::new_from_length(0, 1),
+        omap_capacity: 1000,
+    };
+    let mut stores_config = vec![genesis_store];
+
     // Three stores, correct config, each stores three blocks,
     // each has three users with three keys each - but the blocks overlap (so
     // total of 5 blocks)
     let num_stores = 3;
     let blocks_per_store = 3;
     let mut rng = RngType::from_seed([0u8; 32]);
-    let mut stores_config = vec![];
     for i in 0..num_stores {
         let store = StoreConfig {
             address: free_sockaddr(),
@@ -464,37 +495,64 @@ async fn overlapping_stores() {
 
     let grpc_env = Arc::new(grpcio::EnvBuilder::new().build());
 
-    let mut test_environment = create_env(config, grpc_env, logger.clone());
-    populate_block_provider(&mut test_environment.block_provider, &blocks_config);
-
     let new_transactions = users_per_block * blocks_to_add;
 
-    // Check that we can get all the key images from each store
-    let keys_per_block = users_per_block * keys_per_user;
-    for i in 0..key_index {
-        let key = KeyImage::from(i);
-        let response = test_environment
-            .router_client
-            .check_key_images(&[key])
-            .await
-            .expect("check_key_images failed");
-        assert_eq!(response.results.len(), 1);
-        assert_eq!(response.results[0].key_image, key);
-        assert_eq!(
-            response.results[0].status(),
-            Ok(Some((i / keys_per_block) + 1))
-        );
-        assert_eq!(
-            response.results[0].timestamp_result_code,
-            TimestampResultCode::TimestampFound as u32
-        );
-        assert_eq!(response.num_blocks, blocks_to_add + 1);
-        assert_eq!(response.global_txo_count, new_transactions + 1);
-        assert_eq!(response.latest_block_version, *BlockVersion::MAX);
-        assert_eq!(response.max_block_version, *BlockVersion::MAX);
+    let mut test_environment = create_env(config, grpc_env, logger.clone());
+    for (block_index, block) in blocks_config
+        .iter()
+        .enumerate()
+        .map(|(i, e)| ((i + 1) as u64, e))
+    {
+        for keys in block.values() {
+            for key in keys {
+                let response = test_environment
+                    .router_client
+                    .check_key_images(&[*key])
+                    .await
+                    .expect("check_key_images failed");
+                // We should always get a result to prevent side channel
+                // attacks from determining whether a key image was spent.
+                assert_eq!(response.results.len(), 1);
+                assert_key_image_unspent(key, &response.results[0]);
+
+                assert_eq!(response.num_blocks, block_index);
+                assert_eq!(
+                    response.global_txo_count,
+                    ((block_index - 1) * users_per_block) + 1
+                );
+                let expected_block_version = if block_index == 1 {
+                    0
+                } else {
+                    *BlockVersion::MAX
+                };
+                assert_eq!(response.latest_block_version, expected_block_version);
+                assert_eq!(response.max_block_version, *BlockVersion::MAX);
+            }
+        }
+        populate_block_provider(&mut test_environment.block_provider, [block]);
+        for keys in block.values() {
+            for key in keys {
+                let response = test_environment
+                    .router_client
+                    .check_key_images(&[*key])
+                    .await
+                    .expect("check_key_images failed");
+                assert_eq!(response.results.len(), 1);
+                assert_key_image_spent(key, &response.results[0], block_index);
+
+                assert_eq!(response.num_blocks, block_index + 1);
+                assert_eq!(
+                    response.global_txo_count,
+                    (block_index * users_per_block) + 1
+                );
+                assert_eq!(response.latest_block_version, *BlockVersion::MAX);
+                assert_eq!(response.max_block_version, *BlockVersion::MAX);
+            }
+        }
     }
 
     // Grab them all at once
+    let keys_per_block = users_per_block * keys_per_user;
     let keys: Vec<_> = (0..key_index).map(KeyImage::from).collect();
     let response = test_environment
         .router_client
@@ -514,25 +572,6 @@ async fn overlapping_stores() {
             TimestampResultCode::TimestampFound as u32
         );
     }
-    assert_eq!(response.num_blocks, blocks_to_add + 1);
-    assert_eq!(response.global_txo_count, new_transactions + 1);
-    assert_eq!(response.latest_block_version, *BlockVersion::MAX);
-    assert_eq!(response.max_block_version, *BlockVersion::MAX);
-
-    // Check that an unspent key image is unspent
-    let key = KeyImage::from(126u64);
-    let response = test_environment
-        .router_client
-        .check_key_images(&[key])
-        .await
-        .expect("check_key_images failed");
-    assert_eq!(response.results.len(), 1);
-    assert_eq!(response.results[0].key_image, key);
-    assert_eq!(response.results[0].status(), Ok(None)); // Not spent
-    assert_eq!(
-        response.results[0].timestamp_result_code,
-        TimestampResultCode::TimestampFound as u32
-    );
     assert_eq!(response.num_blocks, blocks_to_add + 1);
     assert_eq!(response.global_txo_count, new_transactions + 1);
     assert_eq!(response.latest_block_version, *BlockVersion::MAX);

--- a/fog/ledger/server/tests/store.rs
+++ b/fog/ledger/server/tests/store.rs
@@ -267,21 +267,17 @@ pub fn direct_key_image_store_check(logger: Logger) {
     println!("Nonce session on message is {:?}", query.channel_id);
 
     // Get an untrusted query
-    let (
-        highest_processed_block_count,
-        last_known_block_cumulative_txo_count,
-        latest_block_version,
-    ) = {
+    let (processed_block_range, last_known_block_cumulative_txo_count, latest_block_version) = {
         let shared_state = shared_state.lock().expect("mutex poisoned");
         (
-            shared_state.highest_processed_block_count,
+            shared_state.processed_block_range.clone(),
             shared_state.last_known_block_cumulative_txo_count,
             shared_state.latest_block_version,
         )
     };
 
     let untrusted_kiqr = UntrustedKeyImageQueryResponse {
-        highest_processed_block_count,
+        processed_block_range,
         last_known_block_cumulative_txo_count,
         latest_block_version,
         max_block_version: latest_block_version.max(*MAX_BLOCK_VERSION),


### PR DESCRIPTION
Previously when a fog ledger store was spun up prior to the block chain
having blocks in its block range it would return back 0 for the block
number. This resulted in the collated response having 0 for the total
number of blocks. Now stores will respond back with the range of
blocks that they have processed and the collation logic will combine the
overlapping ranges to come up with the highest available block count.
