### PR TITLE
mobilecoind: include RTH memos by default and allow customizing them if desired

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -341,7 +341,7 @@ message ProcessedTxOut {
 
 // Recoverable Transaction History memo with an optional u64 specifying the
 // subaddress index to generate the sender memo credential from.
-// Defaults to the first subaddress of the monitor.
+// Defaults to the default subaddress of the monitor.
 // Allows optinally speciying a payment intent id or payment request id.
 message TransactionMemo_RTH {
     optional uint64 subaddress_index = 1;
@@ -362,7 +362,7 @@ message TransactionMemo_BurnRedemption {
 }
 
 // Memo type to use when building a transaction.
-// We will default to RTH from the first subaddress index if nothing else is explicitly specified.
+// We will default to RTH from the default subaddress if nothing else is explicitly specified.
 message TransactionMemo {
     oneof transaction_memo {
         TransactionMemo_RTH rth = 1;
@@ -640,6 +640,10 @@ message GenerateTxRequest {
 
     // List of SCIs to be added to the transaction
     repeated SciForTx scis = 8;
+
+    // TxOut memo to use for the transaction.
+    // This defaults to RTH authenticated sender from the default subaddress of the sender monitor.
+    TransactionMemo memo = 9;
 }
 
 message GenerateTxResponse {
@@ -1052,7 +1056,12 @@ message SendPaymentRequest {
 
     // Token id to transact in.
     uint64 token_id = 9;
+
+    // TxOut memo to use for the transaction.
+    // This defaults to RTH authenticated sender from the first subaddress index of the sender monitor.
+    TransactionMemo memo = 10;
 }
+
 message SendPaymentResponse {
     // Information the sender can use to check if the transaction landed in the ledger.
     SenderTxReceipt sender_tx_receipt = 1;

--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -338,6 +338,39 @@ message ProcessedTxOut {
     uint64 token_id = 8;
 }
 
+
+// Recoverable Transaction History memo with an optional u64 specifying the
+// subaddress index to generate the sender memo credential from.
+// Defaults to the first subaddress of the monitor.
+// Allows optinally speciying a payment intent id or payment request id.
+message TransactionMemo_RTH {
+    optional uint64 subaddress_index = 1;
+    oneof payment_id {
+        uint64 payment_intent_id = 2;
+        uint64 payment_request_id = 3;
+    }
+}
+
+// Empty transaction memo.
+message TransactionMemo_Empty {
+}
+
+// Burn redemption memo
+message TransactionMemo_BurnRedemption {
+    // The burn redemption memo data (64 bytes).
+    bytes memo_data = 1;
+}
+
+// Memo type to use when building a transaction.
+// We will default to RTH from the first subaddress index if nothing else is explicitly specified.
+message TransactionMemo {
+    oneof transaction_memo {
+        TransactionMemo_RTH rth = 1;
+        TransactionMemo_Empty empty = 2;
+        TransactionMemo_BurnRedemption burn_redemption = 3;
+    }
+}
+
 //*********************************
 //*
 //*  Requests and Responses for API

--- a/mobilecoind/src/lib.rs
+++ b/mobilecoind/src/lib.rs
@@ -17,6 +17,7 @@ mod monitor_store;
 mod processed_block_store;
 mod subaddress_store;
 mod sync;
+mod transaction_memo;
 mod utxo_store;
 pub use utxo_store::UnspentTxOut;
 

--- a/mobilecoind/src/payments.rs
+++ b/mobilecoind/src/payments.rs
@@ -274,8 +274,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
     /// * `opt_fee` - Transaction fee value in smallest representable units. If
     ///   zero, use network-reported minimum fee.
     /// * `opt_tombstone` - Tombstone block. If zero, sets to default.
-    /// * `opt_memo_builder` - Optional memo builder to use instead of the
-    ///   default one (EmptyMemoBuilder).
+    /// * `memo_builder` - Memo builder to use.
     pub fn build_transaction(
         &self,
         sender_monitor_id: &MonitorId,
@@ -286,7 +285,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         last_block_infos: &[BlockInfo],
         opt_fee: u64,
         opt_tombstone: u64,
-        opt_memo_builder: Option<Box<dyn MemoBuilder + 'static + Send + Sync>>,
+        memo_builder: Box<dyn MemoBuilder + 'static + Send + Sync>,
     ) -> Result<TxProposal, Error> {
         let logger = self.logger.new(o!("sender_monitor_id" => sender_monitor_id.to_string(), "outlays" => format!("{outlays:?}")));
         log::trace!(logger, "Building pending transaction...");
@@ -324,7 +323,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             last_block_infos,
             opt_fee,
             opt_tombstone,
-            opt_memo_builder,
+            Some(memo_builder),
         )
     }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -1077,7 +1077,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 &self.get_last_block_infos(),
                 request.fee,
                 request.tombstone,
-                Some(memo_builder),
+                memo_builder,
             )
             .map_err(|err| {
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
@@ -1392,7 +1392,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 &self.get_last_block_infos(),
                 request.fee,
                 request.tombstone,
-                Some(Box::new(memo_builder)),
+                Box::new(memo_builder),
             )
             .map_err(|err| {
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)
@@ -2360,7 +2360,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                 &self.get_last_block_infos(),
                 request.fee,
                 request.tombstone,
-                Some(memo_builder),
+                memo_builder,
             )
             .map_err(|err| {
                 rpc_internal_error("transactions_manager.build_transaction", err, &self.logger)

--- a/mobilecoind/src/transaction_memo.rs
+++ b/mobilecoind/src/transaction_memo.rs
@@ -1,0 +1,280 @@
+// Copyright (c) 2018-2024 The MobileCoin Foundation
+
+use mc_api::ConversionError;
+use mc_mobilecoind_api::{
+    mobilecoind_api, TransactionMemo_RTH_oneof_payment_id, TransactionMemo_oneof_transaction_memo,
+};
+use mc_transaction_extra::BurnRedemptionMemo;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TransactionMemo {
+    /// Recoverable Transaction History memo with an optional u64 specifying the
+    /// subaddress index to generate the sender memo credential from
+    RTH {
+        /// Optional subaddress index to generate the sender memo credential
+        /// from.
+        subaddress_index: Option<u64>,
+    },
+
+    RTHWithPaymentIntentId {
+        /// Optional subaddress index to generate the sender memo credential
+        /// from.
+        subaddress_index: Option<u64>,
+
+        /// The payment intent id to include in the memo.
+        payment_intent_id: u64,
+    },
+
+    RTHWithPaymentRequestId {
+        /// Optional subaddress index to generate the sender memo credential
+        /// from.
+        subaddress_index: Option<u64>,
+
+        /// The payment request id to include in the memo.
+        payment_request_id: u64,
+    },
+
+    /// Empty Transaction Memo.
+    Empty,
+
+    /// Burn Redemption memo.
+    BurnRedemption([u8; BurnRedemptionMemo::MEMO_DATA_LEN]),
+}
+
+impl TryFrom<&mobilecoind_api::TransactionMemo> for TransactionMemo {
+    type Error = ConversionError;
+
+    fn try_from(src: &mobilecoind_api::TransactionMemo) -> Result<Self, Self::Error> {
+        match src.transaction_memo.as_ref() {
+            // Default to RTH memo if nothing is explicitly specified
+            None => Ok(TransactionMemo::RTH {
+                subaddress_index: None,
+            }),
+
+            Some(TransactionMemo_oneof_transaction_memo::rth(rth)) => {
+                let subaddress_index = if rth.has_subaddress_index() {
+                    Some(rth.get_subaddress_index())
+                } else {
+                    None
+                };
+                match rth.payment_id.as_ref() {
+                    None => Ok(TransactionMemo::RTH { subaddress_index }),
+
+                    Some(TransactionMemo_RTH_oneof_payment_id::payment_intent_id(
+                        payment_intent_id,
+                    )) => Ok(TransactionMemo::RTHWithPaymentIntentId {
+                        subaddress_index,
+                        payment_intent_id: *payment_intent_id,
+                    }),
+
+                    Some(TransactionMemo_RTH_oneof_payment_id::payment_request_id(
+                        payment_request_id,
+                    )) => Ok(TransactionMemo::RTHWithPaymentRequestId {
+                        subaddress_index,
+                        payment_request_id: *payment_request_id,
+                    }),
+                }
+            }
+
+            Some(TransactionMemo_oneof_transaction_memo::empty(_)) => Ok(TransactionMemo::Empty),
+
+            Some(TransactionMemo_oneof_transaction_memo::burn_redemption(burn_redemption)) => {
+                if burn_redemption.memo_data.len() != BurnRedemptionMemo::MEMO_DATA_LEN {
+                    return Err(ConversionError::ArrayCastError);
+                }
+                let mut memo = [0u8; BurnRedemptionMemo::MEMO_DATA_LEN];
+                memo.copy_from_slice(&burn_redemption.memo_data);
+                Ok(TransactionMemo::BurnRedemption(memo))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transaction_memo_try_from_nothing() {
+        let src = mobilecoind_api::TransactionMemo::default();
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTH {
+                subaddress_index: None
+            }
+        );
+    }
+
+    #[test]
+    fn transaction_memo_try_from_rth_default() {
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(
+                mc_mobilecoind_api::TransactionMemo_RTH::default(),
+            )),
+            ..Default::default()
+        };
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTH {
+                subaddress_index: None
+            }
+        );
+    }
+
+    #[test]
+    fn transaction_memo_try_from_rth_explicit_subaddress_index() {
+        for subaddress_index in [0, 123, u64::MAX] {
+            let mut rth = mc_mobilecoind_api::TransactionMemo_RTH::default();
+            rth.set_subaddress_index(subaddress_index);
+            let src = mobilecoind_api::TransactionMemo {
+                transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(rth)),
+                ..Default::default()
+            };
+
+            let result = super::TransactionMemo::try_from(&src).unwrap();
+            assert_eq!(
+                result,
+                super::TransactionMemo::RTH {
+                    subaddress_index: Some(subaddress_index),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn transaction_memo_try_from_rth_payment_request_id() {
+        let mut rth = mc_mobilecoind_api::TransactionMemo_RTH::default();
+        rth.set_payment_request_id(123);
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(rth.clone())),
+            ..Default::default()
+        };
+
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTHWithPaymentRequestId {
+                subaddress_index: None,
+                payment_request_id: 123,
+            }
+        );
+
+        rth.set_subaddress_index(456);
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(rth)),
+            ..Default::default()
+        };
+
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTHWithPaymentRequestId {
+                subaddress_index: Some(456),
+                payment_request_id: 123,
+            }
+        );
+    }
+
+    #[test]
+    fn transaction_memo_try_from_rth_payment_intent_id() {
+        let mut rth = mc_mobilecoind_api::TransactionMemo_RTH::default();
+        rth.set_payment_intent_id(123);
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(rth.clone())),
+            ..Default::default()
+        };
+
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTHWithPaymentIntentId {
+                subaddress_index: None,
+                payment_intent_id: 123,
+            }
+        );
+
+        rth.set_subaddress_index(456);
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::rth(rth)),
+            ..Default::default()
+        };
+
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::RTHWithPaymentIntentId {
+                subaddress_index: Some(456),
+                payment_intent_id: 123,
+            }
+        );
+    }
+
+    #[test]
+    fn transaction_memo_try_from_empty() {
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::empty(
+                Default::default(),
+            )),
+            ..Default::default()
+        };
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(result, super::TransactionMemo::Empty);
+    }
+
+    #[test]
+    fn transaction_memo_try_from_burn_redemption() {
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::burn_redemption(
+                Default::default(),
+            )),
+            ..Default::default()
+        };
+        let result = super::TransactionMemo::try_from(&src).unwrap_err();
+        assert_eq!(result, ConversionError::ArrayCastError);
+
+        let burn_redemption = mc_mobilecoind_api::TransactionMemo_BurnRedemption {
+            memo_data: vec![],
+            ..Default::default()
+        };
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::burn_redemption(
+                burn_redemption,
+            )),
+            ..Default::default()
+        };
+        let result = super::TransactionMemo::try_from(&src).unwrap_err();
+        assert_eq!(result, ConversionError::ArrayCastError);
+
+        let burn_redemption = mc_mobilecoind_api::TransactionMemo_BurnRedemption {
+            memo_data: vec![1; BurnRedemptionMemo::MEMO_DATA_LEN - 1],
+            ..Default::default()
+        };
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::burn_redemption(
+                burn_redemption,
+            )),
+            ..Default::default()
+        };
+        let result = super::TransactionMemo::try_from(&src).unwrap_err();
+        assert_eq!(result, ConversionError::ArrayCastError);
+
+        let burn_redemption = mc_mobilecoind_api::TransactionMemo_BurnRedemption {
+            memo_data: vec![1; BurnRedemptionMemo::MEMO_DATA_LEN],
+            ..Default::default()
+        };
+        let src = mobilecoind_api::TransactionMemo {
+            transaction_memo: Some(TransactionMemo_oneof_transaction_memo::burn_redemption(
+                burn_redemption,
+            )),
+            ..Default::default()
+        };
+
+        let result = super::TransactionMemo::try_from(&src).unwrap();
+        assert_eq!(
+            result,
+            super::TransactionMemo::BurnRedemption([1; BurnRedemptionMemo::MEMO_DATA_LEN])
+        );
+    }
+}

--- a/mobilecoind/src/transaction_memo.rs
+++ b/mobilecoind/src/transaction_memo.rs
@@ -14,13 +14,13 @@ use mc_transaction_extra::{BurnRedemptionMemo, SenderMemoCredential};
 pub enum TransactionMemo {
     /// Recoverable Transaction History memo with an optional u64 specifying the
     /// subaddress index to generate the sender memo credential from
-    RTH {
+    Rth {
         /// Optional subaddress index to generate the sender memo credential
         /// from.
         subaddress_index: Option<u64>,
     },
 
-    RTHWithPaymentIntentId {
+    RthWithPaymentIntentId {
         /// Optional subaddress index to generate the sender memo credential
         /// from.
         subaddress_index: Option<u64>,
@@ -29,7 +29,7 @@ pub enum TransactionMemo {
         payment_intent_id: u64,
     },
 
-    RTHWithPaymentRequestId {
+    RthWithPaymentRequestId {
         /// Optional subaddress index to generate the sender memo credential
         /// from.
         subaddress_index: Option<u64>,
@@ -49,11 +49,11 @@ impl TransactionMemo {
     pub fn memo_builder(&self, account_key: &AccountKey) -> Box<dyn MemoBuilder + Send + Sync> {
         match self {
             Self::Empty => Box::<EmptyMemoBuilder>::default(),
-            Self::RTH { subaddress_index } => {
+            Self::Rth { subaddress_index } => {
                 let memo_builder = generate_rth_memo_builder(subaddress_index, account_key);
                 Box::new(memo_builder)
             }
-            Self::RTHWithPaymentIntentId {
+            Self::RthWithPaymentIntentId {
                 subaddress_index,
                 payment_intent_id,
             } => {
@@ -61,7 +61,7 @@ impl TransactionMemo {
                 memo_builder.set_payment_intent_id(*payment_intent_id);
                 Box::new(memo_builder)
             }
-            Self::RTHWithPaymentRequestId {
+            Self::RthWithPaymentRequestId {
                 subaddress_index,
                 payment_request_id,
             } => {
@@ -102,7 +102,7 @@ impl TryFrom<&mobilecoind_api::TransactionMemo> for TransactionMemo {
     fn try_from(src: &mobilecoind_api::TransactionMemo) -> Result<Self, Self::Error> {
         match src.transaction_memo.as_ref() {
             // Default to RTH memo if nothing is explicitly specified
-            None => Ok(TransactionMemo::RTH {
+            None => Ok(TransactionMemo::Rth {
                 subaddress_index: None,
             }),
 
@@ -113,18 +113,18 @@ impl TryFrom<&mobilecoind_api::TransactionMemo> for TransactionMemo {
                     None
                 };
                 match rth.payment_id.as_ref() {
-                    None => Ok(TransactionMemo::RTH { subaddress_index }),
+                    None => Ok(TransactionMemo::Rth { subaddress_index }),
 
                     Some(TransactionMemo_RTH_oneof_payment_id::payment_intent_id(
                         payment_intent_id,
-                    )) => Ok(TransactionMemo::RTHWithPaymentIntentId {
+                    )) => Ok(TransactionMemo::RthWithPaymentIntentId {
                         subaddress_index,
                         payment_intent_id: *payment_intent_id,
                     }),
 
                     Some(TransactionMemo_RTH_oneof_payment_id::payment_request_id(
                         payment_request_id,
-                    )) => Ok(TransactionMemo::RTHWithPaymentRequestId {
+                    )) => Ok(TransactionMemo::RthWithPaymentRequestId {
                         subaddress_index,
                         payment_request_id: *payment_request_id,
                     }),
@@ -155,7 +155,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTH {
+            super::TransactionMemo::Rth {
                 subaddress_index: None
             }
         );
@@ -172,7 +172,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTH {
+            super::TransactionMemo::Rth {
                 subaddress_index: None
             }
         );
@@ -191,7 +191,7 @@ mod tests {
             let result = super::TransactionMemo::try_from(&src).unwrap();
             assert_eq!(
                 result,
-                super::TransactionMemo::RTH {
+                super::TransactionMemo::Rth {
                     subaddress_index: Some(subaddress_index),
                 }
             );
@@ -210,7 +210,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTHWithPaymentRequestId {
+            super::TransactionMemo::RthWithPaymentRequestId {
                 subaddress_index: None,
                 payment_request_id: 123,
             }
@@ -225,7 +225,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTHWithPaymentRequestId {
+            super::TransactionMemo::RthWithPaymentRequestId {
                 subaddress_index: Some(456),
                 payment_request_id: 123,
             }
@@ -244,7 +244,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTHWithPaymentIntentId {
+            super::TransactionMemo::RthWithPaymentIntentId {
                 subaddress_index: None,
                 payment_intent_id: 123,
             }
@@ -259,7 +259,7 @@ mod tests {
         let result = super::TransactionMemo::try_from(&src).unwrap();
         assert_eq!(
             result,
-            super::TransactionMemo::RTHWithPaymentIntentId {
+            super::TransactionMemo::RthWithPaymentIntentId {
                 subaddress_index: Some(456),
                 payment_intent_id: 123,
             }

--- a/mobilecoind/src/transaction_memo.rs
+++ b/mobilecoind/src/transaction_memo.rs
@@ -1,10 +1,12 @@
 // Copyright (c) 2018-2024 The MobileCoin Foundation
 
+use mc_account_keys::AccountKey;
 use mc_api::ConversionError;
 use mc_mobilecoind_api::{
     mobilecoind_api, TransactionMemo_RTH_oneof_payment_id, TransactionMemo_oneof_transaction_memo,
 };
-use mc_transaction_extra::BurnRedemptionMemo;
+use mc_transaction_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+use mc_transaction_extra::{BurnRedemptionMemo, SenderMemoCredential};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TransactionMemo {
@@ -39,6 +41,57 @@ pub enum TransactionMemo {
 
     /// Burn Redemption memo.
     BurnRedemption([u8; BurnRedemptionMemo::MEMO_DATA_LEN]),
+}
+
+impl TransactionMemo {
+    pub fn memo_builder(&self, account_key: &AccountKey) -> Box<dyn MemoBuilder + Send + Sync> {
+        match self {
+            Self::Empty => Box::<EmptyMemoBuilder>::default(),
+            Self::RTH { subaddress_index } => {
+                let memo_builder = generate_rth_memo_builder(subaddress_index, account_key);
+                Box::new(memo_builder)
+            }
+            Self::RTHWithPaymentIntentId {
+                subaddress_index,
+                payment_intent_id,
+            } => {
+                let mut memo_builder = generate_rth_memo_builder(subaddress_index, account_key);
+                memo_builder.set_payment_intent_id(*payment_intent_id);
+                Box::new(memo_builder)
+            }
+            Self::RTHWithPaymentRequestId {
+                subaddress_index,
+                payment_request_id,
+            } => {
+                let mut memo_builder = generate_rth_memo_builder(subaddress_index, account_key);
+                memo_builder.set_payment_request_id(*payment_request_id);
+                Box::new(memo_builder)
+            }
+            Self::BurnRedemption(memo_data) => {
+                let mut memo_builder = BurnRedemptionMemoBuilder::new(*memo_data);
+                memo_builder.enable_destination_memo();
+                Box::new(memo_builder)
+            }
+        }
+    }
+}
+
+fn generate_rth_memo_builder(
+    subaddress_index: &Option<u64>,
+    account_key: &AccountKey,
+) -> RTHMemoBuilder {
+    let mut memo_builder = RTHMemoBuilder::default();
+    let sender_memo_credential = match subaddress_index {
+        Some(subaddress_index) => SenderMemoCredential::new_from_address_and_spend_private_key(
+            &account_key.subaddress(*subaddress_index),
+            account_key.subaddress_spend_private(*subaddress_index),
+        ),
+        None => SenderMemoCredential::from(account_key),
+    };
+    memo_builder.set_sender_credential(sender_memo_credential);
+    memo_builder.enable_destination_memo();
+
+    memo_builder
 }
 
 impl TryFrom<&mobilecoind_api::TransactionMemo> for TransactionMemo {

--- a/mobilecoind/src/transaction_memo.rs
+++ b/mobilecoind/src/transaction_memo.rs
@@ -5,7 +5,9 @@ use mc_api::ConversionError;
 use mc_mobilecoind_api::{
     mobilecoind_api, TransactionMemo_RTH_oneof_payment_id, TransactionMemo_oneof_transaction_memo,
 };
-use mc_transaction_builder::{BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder};
+use mc_transaction_builder::{
+    BurnRedemptionMemoBuilder, EmptyMemoBuilder, MemoBuilder, RTHMemoBuilder,
+};
 use mc_transaction_extra::{BurnRedemptionMemo, SenderMemoCredential};
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
### Motivation

Right now `mobilecoind` does not include memos in transactions it generates (except burn redemption transactions). `full-service`, Sentz, and some other clients already include these memos and it would be better of `mobilecoind` includes them as well.

I opted to build this in a way that defaults to including the RTH memos unless the user explicitly does not want them. This is in line with `full-service` and other clients behavior, and simplifies upgrading since existing `mobilecoind` users will not need to change anything to start including the memos.