### PR TITLE
impl TryFrom<String> trait for AccountId

### DIFF
--- a/transaction/signer/src/types.rs
+++ b/transaction/signer/src/types.rs
@@ -182,6 +182,16 @@ impl AsRef<[u8; 32]> for AccountId {
     }
 }
 
+/// Create [AccountId] object from hex-encoded string
+impl From<String> for AccountId {
+    fn from(value: String) -> Self {
+        let mut byte_array = [0u8; 32];
+        hex::decode_to_slice(value, &mut byte_array)
+            .expect("failed to decode account_id hex string");
+        Self(byte_array)
+    }
+}
+
 /// Create [AccountId] object from raw hash
 impl From<[u8; 32]> for AccountId {
     fn from(value: [u8; 32]) -> Self {

--- a/transaction/signer/src/types.rs
+++ b/transaction/signer/src/types.rs
@@ -183,12 +183,15 @@ impl AsRef<[u8; 32]> for AccountId {
 }
 
 /// Create [AccountId] object from hex-encoded string
-impl From<String> for AccountId {
-    fn from(value: String) -> Self {
+impl TryFrom<String> for AccountId {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
         let mut byte_array = [0u8; 32];
-        hex::decode_to_slice(value, &mut byte_array)
-            .expect("failed to decode account_id hex string");
-        Self(byte_array)
+        match hex::decode_to_slice(value, &mut byte_array) {
+            Ok(()) => Ok(Self(byte_array)),
+            Err(e) => Err(e),
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

The external transaction signer data types includes a 32 byte `AccountId` which is typically conveyed in JSON and other external code as a 64 digit hex string.  It is useful to be able to create an AccountId from such a representation.

### Changes

* this PR adds a `From<String>` implementation for `AccountId` allowing an object to be instantiated from a 64 character hex string.

