### PR TITLE
Updated dev deploy workflow for release/v5.2

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,5 @@ self-hosted-runner:
   - small
   - large
   - large-cd
+  - mcf-dev-small-x64
+  - mcf-dev-large-x64

--- a/.github/workflows/android-bindings-dispatch.yml
+++ b/.github/workflows/android-bindings-dispatch.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_publish:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     container: gcr.io/mobilenode-211420/android-bindings-builder:1_4
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   build-dev:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   build-prod:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   build-and-test-wasm:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -77,7 +77,7 @@ jobs:
         run: wasm-pack test --node wasm-test
 
   lint-rust:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -94,7 +94,7 @@ jobs:
 
 
   build-and-test-go:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -128,7 +128,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   docs:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -147,7 +147,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   mc-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     strategy:
@@ -190,7 +190,7 @@ jobs:
 
 
   consensus-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     strategy:
@@ -223,7 +223,7 @@ jobs:
 
 
   fog-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     strategy:
@@ -274,7 +274,7 @@ jobs:
 
 
   fog-ingest-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -297,7 +297,7 @@ jobs:
 
 
   fog-conformance-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -337,7 +337,7 @@ jobs:
 
 
   fog-local-network-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -524,7 +524,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   minting-and-burning-tests:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     steps:
@@ -661,7 +661,7 @@ jobs:
         uses: ./.github/actions/check-dirty-git
 
   publish-test-results:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     if: success() || failure()
     needs:
       - mc-tests

--- a/.github/workflows/dependent-repos.yml
+++ b/.github/workflows/dependent-repos.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   android-bindings:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     permissions:
@@ -29,7 +29,7 @@ jobs:
         buildCmd: cargo build
 
   full-service:
-    runs-on: [self-hosted, Linux, large]
+    runs-on: mcf-dev-large-x64
     container: mobilecoin/builder-install:v0.0.25
 
     permissions:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -8,7 +8,7 @@ env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
   RELEASE_5X_TAG: v5.1.1-dev
-  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.5946
+  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.5947
   GH_SHORT_SHA: placeholder
 
 on:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -8,6 +8,7 @@ env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
   RELEASE_5X_TAG: v5.1.1-dev
+  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.6317
   GH_SHORT_SHA: placeholder
 
 on:
@@ -38,7 +39,7 @@ jobs:
   generate-metadata:
     if: ${{ ! startsWith(github.head_ref, 'dependabot/') }}
     name: 👾 Environment Info 👾
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     outputs:
       namespace: ${{ steps.meta.outputs.namespace }}
       tag: ${{ steps.meta.outputs.tag }}
@@ -46,6 +47,7 @@ jobs:
       docker_org: ${{ env.DOCKER_ORG }}
       chart_repo: ${{ env.CHART_REPO }}
       release_5x_tag: ${{ env.RELEASE_5X_TAG }}
+      bootstrap_version: ${{ env.BOOTSTRAP_VERSION }}
 
     steps:
     - name: Checkout
@@ -72,7 +74,7 @@ jobs:
   build-rust-hardware-projects:
     needs:
     - generate-metadata
-    runs-on: [self-hosted, Linux, large-cd]
+    runs-on: mcf-dev-large-x64
     container:
       image: mobilecoin/rust-sgx-base:v0.0.25
 
@@ -187,7 +189,7 @@ jobs:
         path: rust_build_artifacts/
 
   build-go-projects:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - generate-metadata
     container:
@@ -237,7 +239,7 @@ jobs:
 # Create/Refresh base runtime image
 ########################################
   docker-base:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - generate-metadata
     steps:
@@ -279,7 +281,7 @@ jobs:
 # Build/Publish public artifacts
 #########################################
   docker:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - build-go-projects
     - build-rust-hardware-projects
@@ -351,7 +353,7 @@ jobs:
         tags: ${{ steps.docker_meta.outputs.tags }}
 
   charts:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - docker
     - generate-metadata
@@ -398,6 +400,7 @@ jobs:
       chart_repo: ${{ needs.generate-metadata.outputs.chart_repo }}
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
       version: ${{ needs.generate-metadata.outputs.release_5x_tag }}
+      bootstrap_version: ${{ needs.generate-metadata.outputs.bootstrap_version }}
     secrets: inherit
 
 ###############################################
@@ -466,7 +469,7 @@ jobs:
 
   mobilecoin-cd-complete:
     # Dummy step for a standard GHA Check that won't change when we update the tests.
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - test-current-bv3-release
     steps:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -8,7 +8,7 @@ env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
   RELEASE_5X_TAG: v5.1.1-dev
-  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.6317
+  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.5946
   GH_SHORT_SHA: placeholder
 
 on:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -8,7 +8,7 @@ env:
   CHART_REPO: https://harbor.mobilecoin.com/chartrepo/mobilecoinfoundation-public
   DOCKER_ORG: mobilecoin
   RELEASE_5X_TAG: v5.1.1-dev
-  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.5947
+  BOOTSTRAP_VERSION: v5.1.1-dev.alpha.5946
   GH_SHORT_SHA: placeholder
 
 on:

--- a/.github/workflows/mobilecoin-dev-cd.yaml
+++ b/.github/workflows/mobilecoin-dev-cd.yaml
@@ -431,7 +431,7 @@ jobs:
       fog_distribution: false
       ingest_color: blue
       namespace: ${{ needs.generate-metadata.outputs.namespace }}
-      testing_block_v0: false
+      testing_block_v0: true
       testing_block_v2: false
       testing_block_v3: true
       generate_and_submit_mint_config_tx_uses_json: true

--- a/.github/workflows/mobilecoin-dev-delete.yaml
+++ b/.github/workflows/mobilecoin-dev-delete.yaml
@@ -9,7 +9,7 @@ on: delete
 jobs:
   metadata:
     if: startsWith(github.event.ref, 'feature/')
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     outputs:
       namespace: ${{ steps.meta.outputs.namespace }}
 

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -39,7 +39,7 @@ on:
         default: '500'
         options:
         - '500'
-        - '5947'
+        - '5946'
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -31,7 +31,7 @@ on:
         - none
         - v5.0.3-dev
         - v5.1.1-dev
-        - v5.1.1-dev.alpha.6317
+        - v5.1.1-dev.alpha.5946
       minimum_block:
         description: "Minimum block to wait for"
         type: choice
@@ -40,7 +40,6 @@ on:
         options:
         - '500'
         - '5946'
-        - '6317'
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -31,7 +31,7 @@ on:
         - none
         - v5.0.3-dev
         - v5.1.1-dev
-        - v5.1.1-dev.alpha.5946
+        - v5.1.1-dev.alpha.5947
       minimum_block:
         description: "Minimum block to wait for"
         type: choice
@@ -39,7 +39,7 @@ on:
         default: '500'
         options:
         - '500'
-        - '5946'
+        - '5947'
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -31,6 +31,16 @@ on:
         - none
         - v5.0.3-dev
         - v5.1.1-dev
+        - v5.1.1-dev.alpha.6317
+      minimum_block:
+        description: "Minimum block to wait for"
+        type: choice
+        required: false
+        default: '500'
+        options:
+        - '500'
+        - '5946'
+        - '6317'
       ingest_color:
         description: "Fog Ingest blue/green"
         type: choice
@@ -53,7 +63,7 @@ on:
 jobs:
   list-values:
     name: 👾 Environment Info - ${{ inputs.namespace }} - ${{ inputs.version }} 👾
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -75,7 +85,8 @@ jobs:
       block_version: '3'
       chart_repo: ${{ inputs.chart_repo }}
       namespace: ${{ inputs.namespace }}
-      version: ${{ inputs.bootstrap_version }}
+      version: ${{ inputs.version }}
+      bootstrap_version: ${{ inputs.bootstrap_version }}
     secrets: inherit
 
   deploy:
@@ -90,5 +101,5 @@ jobs:
       ingest_color: ${{ inputs.ingest_color }}
       namespace: ${{ inputs.namespace }}
       version: ${{ inputs.version }}
-      minimum_block: ${{ inputs.bootstrap_version == 'v5.1.1-dev' && '5946' || '500' }}
+      minimum_block: ${{ inputs.minimum_block }}
     secrets: inherit

--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -31,7 +31,7 @@ on:
         - none
         - v5.0.3-dev
         - v5.1.1-dev
-        - v5.1.1-dev.alpha.5947
+        - v5.1.1-dev.alpha.5946
       minimum_block:
         description: "Minimum block to wait for"
         type: choice

--- a/.github/workflows/mobilecoin-dispatch-mainnet-build.yaml
+++ b/.github/workflows/mobilecoin-dispatch-mainnet-build.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   list-values:
-    runs-on: [self-hosted, small, Linux]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: values
       run: |

--- a/.github/workflows/mobilecoin-dispatch-testnet-build.yaml
+++ b/.github/workflows/mobilecoin-dispatch-testnet-build.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   list-values:
-    runs-on: [self-hosted, small, Linux]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: values
       run: |

--- a/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-bootstrap.yaml
@@ -24,6 +24,10 @@ on:
         description: "Chart Version"
         type: string
         required: true
+      bootstrap_version:
+        description: "Bootstrap Blockchain from selected version"
+        type: string
+        required: true
     secrets:
       DEV_LEDGER_AWS_ACCESS_KEY_ID:
         description: "Ledger AWS S3 access"
@@ -44,7 +48,7 @@ jobs:
     secrets: inherit
 
   restore-s3-archive:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - reset
     container:
@@ -57,7 +61,7 @@ jobs:
         AWS_DEFAULT_REGION: eu-central-1
         BUCKET: mobilecoin.eu.development.chain
         NAMESPACE: ${{ inputs.namespace }}
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ inputs.bootstrap_version }}
       shell: bash
       run: |
         for i in 1 2 3
@@ -89,7 +93,7 @@ jobs:
   #  We now have a db with setup-environment
   #  Note this only works if we are in the same cluster as the dev env.
   restore-db-from-archive:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - setup-environment
     container:
@@ -105,7 +109,7 @@ jobs:
         PGHOST: fog-recovery-postgresql-primary.${{ inputs.namespace }}
         PGPASSWORD: ${{ secrets.DEV_POSTGRESQL_FOG_RECOVERY_PASSWORD }}
         PGUSER: postgres
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ inputs.bootstrap_version }}
       run: |
         # Copy sql from S3
         aws s3 cp --only-show-errors \

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -34,7 +34,7 @@ on:
         type: string
         required: true
       minimum_block:
-        description: "The minimum block height before the enviroment is ready"
+        description: "The minimum block height before the environment is ready"
         type: string
         required: false
         default: "500"
@@ -66,7 +66,7 @@ jobs:
   consensus-deploy:
     needs:
     - setup-environment
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     strategy:
       matrix:
         release_name:
@@ -115,7 +115,7 @@ jobs:
   mobilecoind-deploy:
     needs:
     - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate mobilecoind values file
       run: |
@@ -154,7 +154,7 @@ jobs:
   fog-report-deploy-a:
     needs:
     - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate fog-report values file
       run: |
@@ -198,7 +198,7 @@ jobs:
   fog-report-deploy-b:
     needs:
     - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate fog-report-b values file
       run: |
@@ -243,7 +243,7 @@ jobs:
   fog-view-deploy:
     needs:
     - consensus-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate fog-view values file
       run: |
@@ -289,7 +289,7 @@ jobs:
     needs:
     - consensus-deploy
     - mobilecoind-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate fog-ledger values file
       run: |
@@ -336,7 +336,7 @@ jobs:
     needs:
     - consensus-deploy
     - mobilecoind-deploy
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Generate fog-ingest values file
       run: |
@@ -404,7 +404,7 @@ jobs:
     - fog-ledger-deploy
     - fog-report-deploy-a
     - fog-report-deploy-b
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Check end points up.
       uses: mobilecoinofficial/gha-k8s-toolbox@v1.0.13

--- a/.github/workflows/mobilecoin-workflow-dev-reset.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-reset.yaml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   reset-helm:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     strategy:
       matrix:
         chart:
@@ -67,7 +67,7 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   reset-k8s:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - reset-helm
     steps:
@@ -91,7 +91,7 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
 
   reset-s3:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     container:
       image: mobilecoin/gha-s3-pg-helper:v0
     steps:

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -149,7 +149,7 @@ env:
 
 jobs:
   setup-environment:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-setup-environment.yaml
@@ -103,9 +103,6 @@ on:
       DEV_RANCHER_TOKEN:
         description: "Rancher access token"
         required: true
-      DEV_TOKENS_CONFIG_V1_JSON:
-        description: "dev signed tokens config json"
-        required: true
       DEV_TOKENS_CONFIG_V2_JSON:
         description: "dev signed tokens config json"
         required: true
@@ -118,23 +115,11 @@ on:
       MAIN_IAS_SPID:
         description: "MainNet IAS"
         required: true
-      MAIN_TOKENS_CONFIG_V1_JSON:
-        description: "MainNet signed tokens config json"
-        required: true
-      MAIN_TOKENS_CONFIG_V2_JSON:
-        description: "MainNet signed tokens config json"
-        required: true
       TEST_IAS_KEY:
         description: "TestNet IAS"
         required: true
       TEST_IAS_SPID:
         description: "TestNet IAS"
-        required: true
-      TEST_TOKENS_CONFIG_V1_JSON:
-        description: "TestNet signed tokens config json"
-        required: true
-      TEST_TOKENS_CONFIG_V2_JSON:
-        description: "TestNet signed tokens config json"
         required: true
 
 env:
@@ -225,12 +210,7 @@ jobs:
 
     - name: Write tokens.signed.json
       env:
-        DEV_TOKENS_CONFIG_V1_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}
         DEV_TOKENS_CONFIG_V2_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}
-        MAIN_TOKENS_CONFIG_V1_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V1_JSON }}
-        MAIN_TOKENS_CONFIG_V2_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V2_JSON }}
-        TEST_TOKENS_CONFIG_V1_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V1_JSON }}
-        TEST_TOKENS_CONFIG_V2_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V2_JSON }}
       run: |
         # Create base path
         mkdir -p "${BASE_PATH}"
@@ -400,21 +380,6 @@ jobs:
         rancher_token: ${{ secrets.DEV_RANCHER_TOKEN }}
         object_name: fog-mobilecoind
         src: ${{ env.MOBILECOIND_BASE_PATH }}
-
-    - name: Write tokens.signed.json
-      env:
-        DEV_TOKENS_CONFIG_V1_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V1_JSON }}
-        DEV_TOKENS_CONFIG_V2_JSON: ${{ secrets.DEV_TOKENS_CONFIG_V2_JSON }}
-        MAIN_TOKENS_CONFIG_V1_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V1_JSON }}
-        MAIN_TOKENS_CONFIG_V2_JSON: ${{ secrets.MAIN_TOKENS_CONFIG_V2_JSON }}
-        TEST_TOKENS_CONFIG_V1_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V1_JSON }}
-        TEST_TOKENS_CONFIG_V2_JSON: ${{ secrets.TEST_TOKENS_CONFIG_V2_JSON }}
-      run: |
-        # Create base path
-        mkdir -p "${BASE_PATH}"
-
-        # Set dev/main/test tokens file based on semver tag.
-        .internal-ci/util/set_tokens_config_version.sh ${{ inputs.version }} > "${TOKENS_PATH}"
 
     - name: Deploy PostgreSQL instance
       uses: mobilecoinofficial/gha-k8s-toolbox@v1

--- a/.github/workflows/mobilecoin-workflow-dev-test.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-test.yaml
@@ -89,7 +89,7 @@ on:
 
 jobs:
   cd-integration-tests:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     env:
       SRC_KEYS_DIR: /tmp/sample_data/keys
       SRC_FOG_KEYS_DIR: /tmp/sample_data/fog_keys

--- a/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-update-consensus.yaml
@@ -46,7 +46,7 @@ jobs:
     secrets: inherit
 
   consensus-restart:
-    runs-on: [self-hosted, Linux, small]
+    runs-on: mcf-dev-small-x64
     needs:
     - setup-environment
     strategy:


### PR DESCRIPTION
### Motivation

Update dev deploy workflow to restore v5 alpha network at 5946 block height for testing.  Adding to release 5.2 branch just in case we need to make any patches before 6.0 is released in main. 

### Future Work

Will PR similar changes to release/v6.0. Not going directly to 6.0 with this change since current v6.0 charts and workflows won't be compatible with v5 artifacts and testing process. 

