### PR TITLE
helm - set exceed by for ledger, keep ingest from being evicted by accident

### DIFF
--- a/.internal-ci/helm/fog-ingest/values.yaml
+++ b/.internal-ci/helm/fog-ingest/values.yaml
@@ -32,6 +32,7 @@ fogIngest:
     fluentbit.io/exclude-jaeger-agent: 'true'
     # This is the container name that needs to use sgx resources
     sgx.intel.com/quote-provider: fog-ingest
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 
   ### Intel SGX extended resources are defined with: https://github.com/sebva/sgx-device-plugin
   resources:

--- a/.internal-ci/helm/fog-ledger/values.yaml
+++ b/.internal-ci/helm/fog-ledger/values.yaml
@@ -18,7 +18,7 @@ fogLedger:
       # Assume default is a dev network. We can always define a "network" value if needed.
       default:
         shardSize: 20_000
-        exceedBlockHeightBy: 0
+        exceedBlockHeightBy: 5_000
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -28,7 +28,7 @@ fogLedger:
           requestBody: ''
       test:
         shardSize: 400_000
-        exceedBlockHeightBy: 0
+        exceedBlockHeightBy: 10_000
         shardOverlap: 0
         count: 2
         blockHeightRetrieval:
@@ -38,7 +38,7 @@ fogLedger:
           requestBody: ''
       main:
         shardSize: 400_000
-        exceedBlockHeightBy: 0
+        exceedBlockHeightBy: 10_000
         shardOverlap: 0
         count: 3
         blockHeightRetrieval:


### PR DESCRIPTION
### Motivation

Two changes to the included helm charts.
- fog-ledger - set `exceedBlockHeightBy` to scale new stores before we hit the block boundary.
- fog-ingest - set annotation to make sure the cluster autoscaler doesn't reclaim VMs running fog-ingest and evict the pods (loosing keys)
