### PR TITLE
Use the current job id in the uploaded core dump name

### DIFF
--- a/.github/actions/upload-core-dumps/action.yml
+++ b/.github/actions/upload-core-dumps/action.yml
@@ -7,6 +7,6 @@ runs:
     - name: Upload core dumps
       uses: mobilecoinofficial/gh-actions/upload-artifact@v0
       with:
-        name: core_dumps
+        name: ${{ github.job }}_core_dumps
         path: core*
         if-no-files-found: ignore


### PR DESCRIPTION
The newer upload artifacts requires a unique name for artifacts. In
order to ensure that multiple failing test steps can upload core dumps
the artifact name has been prefixed with the
[job id](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->

### Future Work
<!--
* Out of scope non-goals for this PR
* These should be links to tickets. If the tickets do not exist, make them.
-->

[Soundtrack of this PR]()
