### PR TITLE
Allow ledger from archive to update a ledger database

### DIFF
--- a/ledger/from-archive/src/config.rs
+++ b/ledger/from-archive/src/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[clap(
     name = "ledger_from_archive",
-    about = "Create local ledger db from archive."
+    about = "Create, or update, local ledger db from archive."
 )]
 pub struct LedgerFromArchiveConfig {
     /// Path to ledger db (lmdb).

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -5,12 +5,12 @@
 
 mod config;
 
-use std::path::Path;
 use clap::Parser;
 use config::LedgerFromArchiveConfig;
-use mc_common::logger::{create_app_logger, log, Logger, o};
+use mc_common::logger::{create_app_logger, log, o, Logger};
 use mc_ledger_db::{create_ledger_in, Ledger, LedgerDB};
 use mc_ledger_sync::ReqwestTransactionsFetcher;
+use std::path::Path;
 
 fn main() {
     let (logger, _global_logger_guard) = create_app_logger(o!());
@@ -25,7 +25,9 @@ fn main() {
     let mut local_ledger = ledger_db(&logger, config.ledger_db, &transactions_fetcher);
 
     // Sync all blocks
-    let mut block_index = local_ledger.num_blocks().expect("Should have blocks in the ledger");
+    let mut block_index = local_ledger
+        .num_blocks()
+        .expect("Should have blocks in the ledger");
     loop {
         if let Some(block_limit) = config.num_blocks {
             if block_index >= block_limit {
@@ -61,23 +63,31 @@ fn main() {
     }
 }
 
-fn ledger_db(logger: &Logger, ledger_path: impl AsRef<Path>, transactions_fetcher: &ReqwestTransactionsFetcher) -> LedgerDB {
+fn ledger_db(
+    logger: &Logger,
+    ledger_path: impl AsRef<Path>,
+    transactions_fetcher: &ReqwestTransactionsFetcher,
+) -> LedgerDB {
     match ledger_path.as_ref().exists() {
         true => {
-            log::info!(logger, "Opening existing ledger at {}", ledger_path.as_ref().display());
+            log::info!(
+                logger,
+                "Opening existing ledger at {}",
+                ledger_path.as_ref().display()
+            );
             LedgerDB::open(ledger_path.as_ref()).expect("Could not open existing ledger")
         }
-        false => create_ledger_db(logger, ledger_path, transactions_fetcher)
+        false => create_ledger_db(logger, ledger_path, transactions_fetcher),
     }
 }
 
-fn create_ledger_db(logger: &Logger, ledger_path: impl AsRef<Path>, transactions_fetcher: &ReqwestTransactionsFetcher) -> LedgerDB {
+fn create_ledger_db(
+    logger: &Logger,
+    ledger_path: impl AsRef<Path>,
+    transactions_fetcher: &ReqwestTransactionsFetcher,
+) -> LedgerDB {
     let ledger_path = ledger_path.as_ref();
-    log::info!(
-        logger,
-        "Creating local ledger at {}",
-        ledger_path.display()
-    );
+    log::info!(logger, "Creating local ledger at {}", ledger_path.display());
     let mut local_ledger = create_ledger_in(ledger_path);
 
     // Sync Origin Block

--- a/ledger/from-archive/src/main.rs
+++ b/ledger/from-archive/src/main.rs
@@ -68,14 +68,16 @@ fn ledger_db(
     ledger_path: impl AsRef<Path>,
     transactions_fetcher: &ReqwestTransactionsFetcher,
 ) -> LedgerDB {
-    match ledger_path.as_ref().exists() {
+    let ledger_path = ledger_path.as_ref();
+    let db_file = ledger_path.join("data.mdb");
+    match db_file.exists() {
         true => {
             log::info!(
                 logger,
                 "Opening existing ledger at {}",
-                ledger_path.as_ref().display()
+                ledger_path.display()
             );
-            LedgerDB::open(ledger_path.as_ref()).expect("Could not open existing ledger")
+            LedgerDB::open(ledger_path).expect("Could not open existing ledger")
         }
         false => create_ledger_db(logger, ledger_path, transactions_fetcher),
     }


### PR DESCRIPTION
Previously mc-ledger-from-archive would always create a new ledger from
the origin block. Now mc-ledger-from-archive will update a pre-existing
ledger database.