### PR TITLE
make consensus node startupProbe configurable

### DIFF
--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -88,7 +88,7 @@ spec:
             command:
             - '/usr/local/bin/grpc_health_probe'
             - '-addr=:8443'
-          failureThreshold: 120
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           periodSeconds: 30
           initialDelaySeconds: 30
         envFrom:

--- a/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-deployment.yaml
@@ -88,7 +88,7 @@ spec:
             command:
             - '/usr/local/bin/grpc_health_probe'
             - '-addr=:8443'
-          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          failureThreshold: {{ .Values.node.startupProbe.failureThreshold }}
           periodSeconds: 30
           initialDelaySeconds: 30
         envFrom:

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -46,6 +46,10 @@ node:
 
   initContainers: []
 
+  startupProbe:
+    # wait 2 hours on startup
+    failureThreshold: 240
+
   persistence:
     enabled: true
     spec:


### PR DESCRIPTION
<!-- List changes here -->

### Motivation

Make the consensus node startupProbe wait longer (more cycles) and  make the threshold configurable.


