### PR TITLE
Change ledger distribution start block logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4990,14 +4990,17 @@ dependencies = [
  "mc-ledger-db",
  "mc-transaction-core",
  "mc-util-telemetry",
+ "mc-util-test-helper",
  "protobuf",
  "retry",
  "rusoto_core",
  "rusoto_s3",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -9269,9 +9272,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["rt-multi-thread"] }
 url = "2.5"
 
 [dev-dependencies]
+mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 mc-util-test-helper = { path = "../../util/test-helper" }
 tempfile = "3"
-mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
 walkdir = "2"

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -31,3 +31,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 url = "2.5"
+
+[dev-dependencies]
+mc-util-test-helper = { path = "../../util/test-helper" }
+tempfile = "3"
+mc-ledger-db = { path = "../../ledger/db", features = ["test_utils"] }
+walkdir = "2"

--- a/tools/local-network/local_network.py
+++ b/tools/local-network/local_network.py
@@ -302,7 +302,6 @@ class Node:
             f'cd {PROJECT_DIR} && exec {TARGET_DIR}/ledger-distribution',
             f'--ledger-path {self.ledger_dir}',
             f'--dest "file://{self.ledger_distribution_dir}"',
-            f'--state-file {WORK_DIR}/ledger-distribution-state-{self.node_num}',
         ])
         print(f'Starting local ledger distribution: {cmd}')
         self.ledger_distribution_process = subprocess.Popen(cmd, shell=True)


### PR DESCRIPTION
Previously ledger distribution required an argument and potentially a
state file in order to know what block to start uploading from. Now
ledger distribution will look at the current local ledger database and
walk back from the highest block finding which block has not been
uploaded yet.
