### PR TITLE
option to warm up local consensus database.

### DIFF
--- a/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
+++ b/.internal-ci/docker/support/node_hw/bin/wrapper-ledger-distribution.sh
@@ -11,16 +11,11 @@ set -e
 is_set()
 {
     var_name="${1}"
-    if [ -z "${!var_name}" ]
+    if [[ -z "${!var_name}" ]]
     then
         echo "${var_name} is not set."
         exit 1
     fi
-}
-
-archive_curl()
-{
-    /usr/bin/curl -IfsSL --retry 3 "${1}00/00/00/00/00/00/00/0000000000000000.pb" -o /dev/null
 }
 
 is_set MC_DEST
@@ -35,35 +30,6 @@ is_set MC_BRANCH
 
 # Default vars
 export MC_LEDGER_PATH=${MC_LEDGER_PATH:-"/ledger"}
-export MC_STATE_FILE=${MC_STATE_FILE:-"${MC_LEDGER_PATH}/.distribution-state"}
 export MC_SENTRY_DSN=${LEDGER_DISTRIBUTION_SENTRY_DSN}
-
-if [[ -f "${MC_STATE_FILE}" ]]
-then
-    # Check for valid state file
-    echo "mc.app:wrapper-ledger-distribution - State file found MC_START_FROM=last"
-    echo "mc.app:wrapper-ledger-distribution - Check for valid next_block"
-
-    next_block=$(jq -r .next_block "${MC_STATE_FILE}")
-    if [[ "${next_block}" -le 0 ]]
-    then
-        echo "mc.app:wrapper-ledger-distribution - Invalid next_block <= 0"
-        exit 1
-    fi
-
-    export MC_START_FROM=last
-else
-    echo "mc.app:wrapper-ledger-distribution - no state file found."
-    echo "mc.app:wrapper-ledger-distribution - checking for an existing block 0 in s3"
-
-    if archive_curl "${MC_TX_SOURCE_URL}"
-    then
-        echo "mc.app:wrapper-ledger-distribution - block 0 found in s3 MC_START_FROM=next"
-        export MC_START_FROM=next
-    else
-        echo "mc.app:wrapper-ledger-distribution - no s3 archive found MC_START_FROM=zero"
-        export MC_START_FROM=zero
-    fi
-fi
 
 /usr/bin/ledger-distribution

--- a/.internal-ci/helm/consensus-node/templates/node-configmap.yaml
+++ b/.internal-ci/helm/consensus-node/templates/node-configmap.yaml
@@ -9,3 +9,6 @@ data:
   MC_BLOCK_VERSION: {{ .Values.node.config.blockVersion | squote }}
   MC_CLIENT_RESPONDER_ID: "{{ .Values.node.config.clientHostname }}:443"
   MC_PEER_RESPONDER_ID: "{{ .Values.node.config.peerHostname }}:443"
+  {{- if .Values.node.config.ledgerFromArchiveOnly }}
+  MC_LEDGER_FROM_ARCHIVE_ONLY: "true"
+  {{- end }}

--- a/.internal-ci/helm/consensus-node/values.yaml
+++ b/.internal-ci/helm/consensus-node/values.yaml
@@ -64,6 +64,9 @@ node:
     clientHostname: ''
     peerHostname: ''
     blockVersion: '4'
+    # When true we don't start the consensus or ledger-distribution services,
+    # just run ledger-from-archive and wait.
+    ledgerFromArchiveOnly: false
 
   ingress:
     enabled: true


### PR DESCRIPTION
### Motivation

It can take a long time to pull down and populate the consensus lmdb from S3.  This adds an option to the container entrypoint scripts to just run ledger-from-archive in a loop and populate the local db without bringing consensus online.

in standalone container: set `MC_LEDGER_FROM_ARCHIVE_ONLY` to any value 
or 
in helm: `--set node.config.ledgerFromArchiveOnly="true"` 

- add MC_LEDGER_FROM_ARCHIVE_ONLY option
- remove old ledger-distribution `zero,next,last` logic