### PR TITLE
Add missing license call outs in crates

### DIFF
--- a/attest/verifier/config/Cargo.toml
+++ b/attest/verifier/config/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-attest-verifier-config"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 description = "A JSON schema for basic attestation configs"
 readme = "README.md"
 

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-connection-test-utils"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-crypto-digestible-derive-test"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/crypto/memo-mac/Cargo.toml
+++ b/crypto/memo-mac/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-crypto-memo-mac"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 
 [features]
 test-only = []

--- a/light-client/relayer/Cargo.toml
+++ b/light-client/relayer/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-light-client-relayer"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 
 [[bin]]
 name = "mc-light-client-relayer"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-transaction-core-test-utils"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [dependencies]

--- a/transaction/summary/Cargo.toml
+++ b/transaction/summary/Cargo.toml
@@ -3,6 +3,7 @@ name = "mc-transaction-summary"
 version = "6.0.0"
 authors = ["MobileCoin"]
 edition = "2021"
+license = "Apache-2.0"
 readme = "README.md"
 
 [features]


### PR DESCRIPTION
Previously some of the MobileCoin crates were missing the license entry
in their Cargo.toml file. Now all the crates have the license specified.
