### PR TITLE
Put service metrics behind a feature

### DIFF
--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 [dependencies]
 mc-common = { path = "../../common", features = ["loggers"] }
 mc-util-build-info = { path = "../build/info" }
-mc-util-metrics = { path = "../metrics" }
+mc-util-metrics = { path = "../metrics", features = ["service_metrics"] }
 mc-util-serial = { path = "../serial", features = ["std"] }
 mc-util-uri = { path = "../uri" }
 

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -6,11 +6,15 @@ edition = "2021"
 license = "GPL-3.0"
 rust-version = { workspace = true }
 
+[features]
+default = []
+service_metrics = ["dep:grpcio"]
+
 [dependencies]
 mc-common = { path = "../../common", features = ["log"] }
 
 chrono = "0.4"
-grpcio = "0.13"
+grpcio = { version = "0.13", optional = true }
 lazy_static = "1.4"
 prometheus = "0.13"
 protobuf = "2.27.1"

--- a/util/metrics/src/lib.rs
+++ b/util/metrics/src/lib.rs
@@ -9,6 +9,7 @@ pub use serde_json::json;
 // ------------------------------------
 mod json_encoder;
 mod op_counters;
+#[cfg(feature = "service_metrics")]
 mod service_metrics;
 
 pub use json_encoder::JsonEncoder as MetricsJsonEncoder;
@@ -19,4 +20,5 @@ pub use prometheus::{
     register, register_histogram, Histogram, HistogramOpts, HistogramVec, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec, Opts,
 };
+#[cfg(feature = "service_metrics")]
 pub use service_metrics::{GrpcMethodName, ServiceMetrics};


### PR DESCRIPTION
Previously service metrics were always available from `mc-util-metrics.
This resulted in crates like mc-sgx-report-cache-untrusted depending on
grpcio. Now service metrics are behind the feature `service_metrics` and
crates need to opt in to use it.
