### PR TITLE
update mcd version and remove partner uploads

### DIFF
--- a/.github/workflows/refresh-ledger-bootstrap.yaml
+++ b/.github/workflows/refresh-ledger-bootstrap.yaml
@@ -56,7 +56,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         mkdir -p "${DOWNLOAD_DIR}"
-        gh release download v5.0.8 \
+        gh release download v6.0.1 \
             -p '${{ matrix.network.chain_id }}net-mobilecoind-linux-x86_64-*.tar.gz' \
             -O "${DOWNLOAD_DIR}/linux.tar.gz"
 
@@ -145,15 +145,3 @@ jobs:
         pushd "${MC_WATCHER_DB}"
 
         az storage blob upload -f ./data.mdb -c ${{ matrix.network.chain_id }} -n mcd/watcher/data.mdb --overwrite
-
-        # Switch and sync to partner
-        export AZURE_STORAGE_CONNECTION_STRING='${{ secrets.S_LEDGER_DB_AZURE_STORAGE_CONNECTION_STRING }}'
-
-        pushd "${MC_LEDGER_DB}"
-
-        az storage blob upload -f ./data.mdb -c ${{ matrix.network.chain_id }} -n mcd/ledger/data.mdb --overwrite
-
-        pushd "${MC_WATCHER_DB}"
-
-        az storage blob upload -f ./data.mdb -c ${{ matrix.network.chain_id }} -n mcd/watcher/data.mdb --overwrite
-


### PR DESCRIPTION
### Motivation

- update mobilecoind ledger bootstrap to use v6.0.1
- remove old partner uploads.

