### PR TITLE
serialize/deserialize u64 subaddress [index] as quoted decimal string

### DIFF
--- a/transaction/signer/src/types.rs
+++ b/transaction/signer/src/types.rs
@@ -53,6 +53,7 @@ pub struct TxoSyncReq {
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct TxoUnsynced {
     /// Subaddress for unsynced TxOut
+    #[serde(with = "string")]
     pub subaddress: u64,
 
     /// tx_out_public_key for unsynced TxOut
@@ -206,6 +207,29 @@ impl From<[u8; 32]> for AccountId {
 impl From<&[u8; 32]> for AccountId {
     fn from(value: &[u8; 32]) -> Self {
         Self(*value)
+    }
+}
+
+/// u64 string encoding for serde
+pub(crate) mod string {
+    use std::fmt::Display;
+    use std::str::FromStr;
+
+    use serde::{de, Serializer, Deserialize, Deserializer};
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where T: Display,
+              S: Serializer
+    {
+        serializer.collect_str(value)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+        where T: FromStr,
+              T::Err: Display,
+              D: Deserializer<'de>
+    {
+        String::deserialize(deserializer)?.parse().map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
<!-- List changes here -->
When serializing the `TxoUnsynced` struct, the `subaddress` member, which is a `u64`, should be represented as a `string` containing the decimal numeric representation of the `u64`, rather than as an unquoted decimal number directly, and when deserializing it, parse the `subaddress` as a string containing a decimal number.

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
Currently, the `subaddress` member is being serialized as a number. This is unsafe in the face of parsers that do not allocate enough bits to parsing numbers, for example many JavaScript JSON parsers, resulting in loss of precision, and thereby alteration of the value, as rounding occurs. 

This is an issue that we have encountered in general with serialized `u64`s, and specifically with the serializing of the `TxoUnsynced` struct. Our common practice has become to serialize `u64`s as strings containing the decimal numeric value of the `u64` so as to be human readable while surviving intermediate parsing and processing intact, prior to be deserialized again.