### PR TITLE
static ingress cookie salt values

### DIFF
--- a/.internal-ci/helm/fog-ledger/templates/_helpers.tpl
+++ b/.internal-ci/helm/fog-ledger/templates/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* grpcCookieSalt */}}
 {{- define "fog-ledger.grpcCookieSalt" -}}
-{{- randAlphaNum 8 }}
+{{- .Values.fogLedger.router.ingress.common.cookieSalt | default (randAlphaNum 8) }}
 {{- end }}
 
 {{/* stackConfig - get "network" name of fall back to default */}}

--- a/.internal-ci/helm/fog-ledger/values.yaml
+++ b/.internal-ci/helm/fog-ledger/values.yaml
@@ -106,6 +106,8 @@ fogLedger:
     ingress:
       enabled: true
       common:
+        # Set a static salt for the dynamic cookie. See helpers for more info.
+        # cookieSalt: ''
         tls:
           clusterIssuer: letsencrypt-production-http
         blocklist:

--- a/.internal-ci/helm/fog-view/templates/_helpers.tpl
+++ b/.internal-ci/helm/fog-view/templates/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* grpcCookieSalt */}}
 {{- define "fog-view.grpcCookieSalt" -}}
-{{- randAlphaNum 8 }}
+{{- .Values.fogView.router.ingress.common.cookieSalt | default (randAlphaNum 8) }}
 {{- end }}
 
 {{/* stackConfig - get "network" name of fall back to default */}}

--- a/.internal-ci/helm/fog-view/values.yaml
+++ b/.internal-ci/helm/fog-view/values.yaml
@@ -96,6 +96,8 @@ fogView:
     ingress:
       enabled: true
       common:
+        # Set a static salt for the dynamic cookie. See helpers for more info.
+        # cookieSalt: ''
         tls:
           clusterIssuer: letsencrypt-production-http
         blocklist:


### PR DESCRIPTION
### Motivation

Right now ledger and view cookie salts are regenerated on every deploy. This means clients may be routed to different backends, requiring new attestation when we change deployment parameters and scale services.  

This change allows us to optionally set a static value for those cookie generation salts. 

