### PR TITLE
6.1.0 - bump cargo versions and update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 The crates in this repository do not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) at this time.
 
+## [6.1.0]
+
+### Changed
+
+- make fog-view db polling configurable ([#4005])
+
+#### CI/CD
+
+- fix ledger bootstrap job ([#4002])
+- static ingress cookie salt values ([#4006])
+- clean up deprecated charts ([#4007])
+- configuration for "big" network testing ([#4008])
+- fog-view - blue/green and zone based deployments. ([#4009])
+
 ## [6.0.2]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "go-grpc-gateway-testing"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "criterion",
  "curve25519-dalek",
@@ -2469,14 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-admin-http-gateway"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "grpcio",
@@ -2491,7 +2491,7 @@ dependencies = [
 
 [[package]]
 name = "mc-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_matches",
  "bs58",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "assert_matches",
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-config"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_matches",
  "displaydoc",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_matches",
  "base64 0.21.7",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-common",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-validators"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-connection-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-blockchain-types",
  "mc-connection",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "cargo-emit",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -3037,7 +3037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-mock"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-core",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-mint-client-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crossbeam-channel",
  "maplit",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-play"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-common",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "chrono",
@@ -3240,7 +3240,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-service-config"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "clap 4.5.1",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-tool"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "grpcio",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -3321,7 +3321,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "digest 0.10.7",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "digest 0.10.7",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive-test"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-digestible-test-utils",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "serde_json",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "blake2",
  "digest 0.10.7",
@@ -3414,7 +3414,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "curve25519-dalek",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "hmac 0.12.1",
  "mc-crypto-keys",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-sig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-test-vectors"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "clap 4.5.1",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-x509-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-crypto-keys",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-block-provider"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "dyn-clone",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-distribution"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "crossbeam-channel",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-enclave-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "cookie",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-client"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_cmd",
  "clap 4.5.1",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -3804,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-account-keys",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-report"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "der",
  "displaydoc",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "dirs",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-server-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-blockchain-test-utils",
  "mc-blockchain-types",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "digest 0.10.7",
  "displaydoc",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "der",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4051,7 +4051,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -4085,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-server"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "clap 4.5.1",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-test-infra"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-attest-core",
  "mc-attest-enclave-api",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-load-testing"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "grpcio",
@@ -4208,14 +4208,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-fog-ocall-oram-storage-trusted",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -4244,7 +4244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "lazy_static",
  "mc-common",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-overseer-server"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -4325,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-api-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-util-serial",
  "prost",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-cli"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "clap 4.5.1",
@@ -4357,7 +4357,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "grpcio",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-resolver"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-attest-verifier",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-server"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-blockchain-test-utils",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-validation-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-fog-report-validation",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sample-paykit"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "clap 4.5.1",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
  "mc-util-from-random",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-report"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-verifier-types",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "clap 4.5.1",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "clap 4.5.1",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-client"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-test-infra"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "digest 0.10.7",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-uri"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-util-uri",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "der",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "criterion",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "itertools 0.12.1",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-attest-core",
@@ -4829,7 +4829,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-load-test"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "ctrlc",
@@ -4848,7 +4848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-protocol"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-server-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "grpcio",
  "mc-attestation-verifier",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-db"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "lazy_static",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-distribution"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "dirs",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-from-archive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-api",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-migration"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "lmdb-rkv",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "mc-ledger-sync"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-light-client-cli"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "clio",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "mc-light-client-relayer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "mc-light-client-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "clap 4.5.1",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-dev-faucet"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "async-channel",
  "clap 4.5.1",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "mc-mobilecoind-json"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "grpcio",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "mc-peers-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "grpcio",
  "hex",
@@ -5405,7 +5405,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-types",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -5473,7 +5473,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css-dump"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "hex_fmt",
@@ -5624,21 +5624,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5650,7 +5650,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-report-cache-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -5678,21 +5678,21 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
 
 [[package]]
 name = "mc-sgx-urts"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-sgx-build",
@@ -5709,7 +5709,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-t3-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "futures",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "mc-t3-connection"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "futures",
@@ -5737,7 +5737,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5749,7 +5749,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-b58-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-api",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-definitions"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-util-test-vector",
  "serde",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-memos"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "mc-test-vectors-tx-out-records"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "hex",
  "mc-account-keys",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-builder"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5837,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "assert_matches",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-account-keys",
  "mc-crypto-keys",
@@ -5899,7 +5899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "assert_matches",
  "cfg-if 1.0.0",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -5965,7 +5965,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
@@ -5984,7 +5984,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-b58-decoder"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "hex",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cargo_metadata",
@@ -6029,7 +6029,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -6037,7 +6037,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "json",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-cli"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-util-build-info",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-dump-ledger"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "displaydoc",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -6099,18 +6099,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-ffi"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-generate-sample-ledger"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-account-keys",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "clap 4.5.1",
@@ -6163,7 +6163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-admin-tool"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "grpcio",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-grpc-token-generator"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-common",
@@ -6185,11 +6185,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-host-cert"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-keyfile"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "clap 4.5.1",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-lmdb"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "lmdb-rkv",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metered-channel"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crossbeam-channel",
  "mc-util-metrics",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-metrics"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "grpcio",
@@ -6258,7 +6258,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-parse"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "hex",
  "itertools 0.12.1",
@@ -6267,7 +6267,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "mc-crypto-keys",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "prost",
  "protobuf",
@@ -6303,7 +6303,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-telemetry"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "clap 4.5.1",
  "itertools 0.12.1",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-vector"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -6336,7 +6336,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-with-data"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6345,11 +6345,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-uri"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64 0.21.7",
  "displaydoc",
@@ -6367,7 +6367,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-vec-map"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -6375,14 +6375,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-wasm-test"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "getrandom",
  "mc-account-keys",
@@ -6397,7 +6397,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "clap 4.5.1",
@@ -6447,7 +6447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-watcher-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/account-keys/types/Cargo.toml
+++ b/account-keys/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-admin-http-gateway"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/attest/ake/Cargo.toml
+++ b/attest/ake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/api/Cargo.toml
+++ b/attest/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "gRPC APIs for encrypted communications with an enclave"
 edition = "2021"

--- a/attest/core/Cargo.toml
+++ b/attest/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform remote

--- a/attest/enclave-api/Cargo.toml
+++ b/attest/enclave-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = """
 no_std structs used commonly in enclave api's in connection with attestation and key exchange

--- a/attest/trusted/Cargo.toml
+++ b/attest/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/untrusted/Cargo.toml
+++ b/attest/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/attest/verifier/Cargo.toml
+++ b/attest/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains necessary functions and utilities to perform verification of

--- a/attest/verifier/config/Cargo.toml
+++ b/attest/verifier/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-config"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/attest/verifier/types/Cargo.toml
+++ b/attest/verifier/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the type definitions for attestation"

--- a/blockchain/test-utils/Cargo.toml
+++ b/blockchain/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/blockchain/types/Cargo.toml
+++ b/blockchain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/blockchain/validators/Cargo.toml
+++ b/blockchain/validators/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-blockchain-validators"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/connection/Cargo.toml
+++ b/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/connection/test-utils/Cargo.toml
+++ b/connection/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-connection-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/consensus/api/Cargo.toml
+++ b/consensus/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/consensus/enclave/Cargo.toml
+++ b/consensus/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Consensus Enclave - Application Code"

--- a/consensus/enclave/api/Cargo.toml
+++ b/consensus/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating an enclave.

--- a/consensus/enclave/edl/Cargo.toml
+++ b/consensus/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/impl/Cargo.toml
+++ b/consensus/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = '''
 This crate contains the actual implementation of a mobilenode enclave.

--- a/consensus/enclave/measurement/Cargo.toml
+++ b/consensus/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "MobileCoin Consensus Enclave - Application Code"
 edition = "2021"

--- a/consensus/enclave/mock/Cargo.toml
+++ b/consensus/enclave/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-mock"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/enclave/trusted/Cargo.lock
+++ b/consensus/enclave/trusted/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -973,14 +973,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "hex",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "digest",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-message-cipher"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
@@ -1539,11 +1539,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1553,7 +1553,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1648,29 +1648,29 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1700,14 +1700,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1728,7 +1728,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1784,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1817,14 +1817,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1843,11 +1843,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
 ]

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "The MobileCoin Consensus Service's internal enclave entry point."

--- a/consensus/mint-client/Cargo.toml
+++ b/consensus/mint-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/mint-client/types/Cargo.toml
+++ b/consensus/mint-client/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-mint-client-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Stellar Consensus Protocol"
 edition = "2021"

--- a/consensus/scp/play/Cargo.toml
+++ b/consensus/scp/play/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-play"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/scp/types/Cargo.toml
+++ b/consensus/scp/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2018"
 license = "Apache-2.0"

--- a/consensus/service/Cargo.toml
+++ b/consensus/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/service/config/Cargo.toml
+++ b/consensus/service/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-service-config"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/consensus/tool/Cargo.toml
+++ b/consensus/tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-consensus-tool"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Core Library"

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Core Types"

--- a/crypto/ake/enclave/Cargo.toml
+++ b/crypto/ake/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/box/Cargo.toml
+++ b/crypto/box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/Cargo.toml
+++ b/crypto/digestible/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/Cargo.toml
+++ b/crypto/digestible/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/derive/test/Cargo.toml
+++ b/crypto/digestible/derive/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-derive-test"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/digestible/signature/Cargo.toml
+++ b/crypto/digestible/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Digestible Signatures"

--- a/crypto/digestible/test-utils/Cargo.toml
+++ b/crypto/digestible/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-digestible-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "MobileCoin Diffie-Hellman Key Exchange and Digital Signatures"

--- a/crypto/memo-mac/Cargo.toml
+++ b/crypto/memo-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-memo-mac"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/message-cipher/Cargo.toml
+++ b/crypto/message-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-message-cipher"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/crypto/multisig/Cargo.toml
+++ b/crypto/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "MobileCoin multi-signature implementations"
 edition = "2021"

--- a/crypto/noise/Cargo.toml
+++ b/crypto/noise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/ring-signature/signer/Cargo.toml
+++ b/crypto/ring-signature/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/sig/Cargo.toml
+++ b/crypto/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-sig"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/x509/test-vectors/Cargo.toml
+++ b/crypto/x509/test-vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-test-vectors"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Utilities for generating certificates and chains for unit tests"

--- a/crypto/x509/utils/Cargo.toml
+++ b/crypto/x509/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-crypto-x509-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Verification of X509 certificate chains"
 edition = "2021"

--- a/enclave-boundary/Cargo.toml
+++ b/enclave-boundary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/api/Cargo.toml
+++ b/fog/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-api"

--- a/fog/block_provider/Cargo.toml
+++ b/fog/block_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-block-provider"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Provide blocks from a local or remote ledger database"

--- a/fog/distribution/Cargo.toml
+++ b/fog/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-distribution"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/enclave_connection/Cargo.toml
+++ b/fog/enclave_connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-enclave-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/client/Cargo.toml
+++ b/fog/ingest/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-client"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/Cargo.toml
+++ b/fog/ingest/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/api/Cargo.toml
+++ b/fog/ingest/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/edl/Cargo.toml
+++ b/fog/ingest/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ingest_enclave_edl"

--- a/fog/ingest/enclave/impl/Cargo.toml
+++ b/fog/ingest/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/enclave/measurement/Cargo.toml
+++ b/fog/ingest/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "MobileCoin Ingest Enclave - Measurement"
 edition = "2021"

--- a/fog/ingest/enclave/trusted/Cargo.lock
+++ b/fog/ingest/enclave/trusted/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1003,14 +1003,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "digest",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ingest-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1530,14 +1530,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-digestible",
@@ -1580,14 +1580,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1665,11 +1665,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1774,36 +1774,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1833,14 +1833,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1861,7 +1861,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1950,14 +1950,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1976,11 +1976,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
 ]

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/report/Cargo.toml
+++ b/fog/ingest/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-report"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ingest/server/Cargo.toml
+++ b/fog/ingest/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ingest/server/test-utils/Cargo.toml
+++ b/fog/ingest/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ingest-server-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/kex_rng/Cargo.toml
+++ b/fog/kex_rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-kex-rng"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/ledger/connection/Cargo.toml
+++ b/fog/ledger/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/Cargo.toml
+++ b/fog/ledger/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/enclave/api/Cargo.toml
+++ b/fog/ledger/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = """
 The ECALL API declarations and API for operating a ledger enclave.

--- a/fog/ledger/enclave/edl/Cargo.toml
+++ b/fog/ledger/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "ledger_enclave_edl"

--- a/fog/ledger/enclave/impl/Cargo.toml
+++ b/fog/ledger/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "This crate contains the actual implementation of a ledger enclave."

--- a/fog/ledger/enclave/measurement/Cargo.toml
+++ b/fog/ledger/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "MobileCoin Ledger Enclave - Measurement"
 edition = "2021"

--- a/fog/ledger/enclave/trusted/Cargo.lock
+++ b/fog/ledger/enclave/trusted/Cargo.lock
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -997,14 +997,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cfg-if",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if",
  "displaydoc",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "digest",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1393,7 +1393,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ledger-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1521,14 +1521,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1545,14 +1545,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1630,11 +1630,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if",
  "mc-sgx-alloc",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1739,36 +1739,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if",
  "mc-common",
@@ -1798,14 +1798,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1826,7 +1826,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1915,14 +1915,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1941,18 +1941,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "serde",

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-server"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ledger/test_infra/Cargo.toml
+++ b/fog/ledger/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ledger-test-infra"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/load_testing/Cargo.toml
+++ b/fog/load_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-load-testing"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/edl/Cargo.toml
+++ b/fog/ocall_oram_storage/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "fog_ocall_oram_storage_edl"

--- a/fog/ocall_oram_storage/testing/Cargo.toml
+++ b/fog/ocall_oram_storage/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-testing"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/trusted/Cargo.toml
+++ b/fog/ocall_oram_storage/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/ocall_oram_storage/untrusted/Cargo.toml
+++ b/fog/ocall_oram_storage/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-ocall-oram-storage-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/overseer/server/Cargo.toml
+++ b/fog/overseer/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-overseer-server"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/recovery_db_iface/Cargo.toml
+++ b/fog/recovery_db_iface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-recovery-db-iface"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/api/Cargo.toml
+++ b/fog/report/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "mc-fog-report-api"

--- a/fog/report/api/test-utils/Cargo.toml
+++ b/fog/report/api/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-api-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/cli/Cargo.toml
+++ b/fog/report/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-cli"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/connection/Cargo.toml
+++ b/fog/report/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/resolver/Cargo.toml
+++ b/fog/report/resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-resolver"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/server/Cargo.toml
+++ b/fog/report/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-server"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/report/types/Cargo.toml
+++ b/fog/report/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/Cargo.toml
+++ b/fog/report/validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/report/validation/test-utils/Cargo.toml
+++ b/fog/report/validation/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-report-validation-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sample-paykit/Cargo.toml
+++ b/fog/sample-paykit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sample-paykit"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/sig/Cargo.toml
+++ b/fog/sig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Verify Fog Signatures"

--- a/fog/sig/authority/Cargo.toml
+++ b/fog/sig/authority/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Create and verify fog authority signatures"
 edition = "2021"

--- a/fog/sig/report/Cargo.toml
+++ b/fog/sig/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sig-report"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Create and verify fog report signatures"
 edition = "2021"

--- a/fog/sql_recovery_db/Cargo.toml
+++ b/fog/sql_recovery_db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/sql_recovery_db/cleanup/Cargo.toml
+++ b/fog/sql_recovery_db/cleanup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-sql-recovery-db-cleanup"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["Mobilecoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test-client/Cargo.toml
+++ b/fog/test-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-client"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/test_infra/Cargo.toml
+++ b/fog/test_infra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-test-infra"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/types/Cargo.toml
+++ b/fog/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/uri/Cargo.toml
+++ b/fog/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-uri"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/connection/Cargo.toml
+++ b/fog/view/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/Cargo.toml
+++ b/fog/view/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/api/Cargo.toml
+++ b/fog/view/enclave/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/edl/Cargo.toml
+++ b/fog/view/enclave/edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 links = "view_enclave_edl"

--- a/fog/view/enclave/impl/Cargo.toml
+++ b/fog/view/enclave/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/enclave/measurement/Cargo.toml
+++ b/fog/view/enclave/measurement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-measurement"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "MobileCoin Fog View Enclave - Application Code"
 edition = "2021"

--- a/fog/view/enclave/trusted/Cargo.lock
+++ b/fog/view/enclave/trusted/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1003,14 +1003,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-attest-ake"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "cargo-emit",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "bitflags 2.4.1",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-ake",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cfg-if 1.0.0",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "displaydoc",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ake-enclave"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes-gcm",
  "digest",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "digest",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "curve25519-dalek",
@@ -1293,7 +1293,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "signature",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "blake2",
  "digest",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-noise"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-enclave-boundary"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-common",
  "mc-rand",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-kex-rng"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -1445,14 +1445,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-fog-ocall-oram-storage-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "aligned-cmov",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-recovery-db-iface"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "chrono",
  "displaydoc",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-report-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-attest-verifier-types",
  "mc-crypto-digestible",
@@ -1495,14 +1495,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-fog-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-util-build-script",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-impl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aligned-cmov",
  "mc-attest-core",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-view-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "lazy_static",
@@ -1667,11 +1667,11 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-alloc"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cc",
  "lazy_static",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-sgx-alloc",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-compat-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "mc-sgx-debug-edl",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-sgx-core-types",
@@ -1785,36 +1785,36 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-debug"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-debug-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-enclave-id"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-types",
 ]
 
 [[package]]
 name = "mc-sgx-panic"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "displaydoc",
  "mc-attest-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-service"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-build",
  "mc-sgx-types",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "mc-common",
@@ -1844,14 +1844,14 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-sgx-sync"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-panic",
  "mc-sgx-types",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "mc-sgx-core-sys-types",
 ]
@@ -1872,7 +1872,7 @@ checksum = "b3c237bec3e33530c4b1a171c8c078ad5d525d5fae177ac9d62e8e454b3fffb7"
 
 [[package]]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "aes",
  "bulletproofs-og",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "cargo-emit",
  "cc",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "base64",
  "displaydoc",
@@ -1961,14 +1961,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "prost",
  "serde",
@@ -1987,11 +1987,11 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 dependencies = [
  "serde",
 ]

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-enclave-trusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "The MobileCoin Fog user-facing server's enclave entry point."
 edition = "2021"

--- a/fog/view/load-test/Cargo.toml
+++ b/fog/view/load-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-load-test"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/protocol/Cargo.toml
+++ b/fog/view/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-protocol"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/fog/view/server/Cargo.toml
+++ b/fog/view/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/fog/view/server/test-utils/Cargo.toml
+++ b/fog/view/server/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-fog-view-server-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/go-grpc-gateway/testing/Cargo.toml
+++ b/go-grpc-gateway/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "go-grpc-gateway-testing"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/db/Cargo.toml
+++ b/ledger/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-db"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/distribution/Cargo.toml
+++ b/ledger/distribution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-distribution"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/from-archive/Cargo.toml
+++ b/ledger/from-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-from-archive"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/migration/Cargo.toml
+++ b/ledger/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-migration"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/ledger/sync/Cargo.toml
+++ b/ledger/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-ledger-sync"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/light-client/cli/Cargo.toml
+++ b/light-client/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-light-client-cli"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/light-client/relayer/Cargo.toml
+++ b/light-client/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-light-client-relayer"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/light-client/verifier/Cargo.toml
+++ b/light-client/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-light-client-verifier"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/mobilecoind-dev-faucet/Cargo.toml
+++ b/mobilecoind-dev-faucet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-dev-faucet"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind-json/Cargo.toml
+++ b/mobilecoind-json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-json"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/Cargo.toml
+++ b/mobilecoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/mobilecoind/api/Cargo.toml
+++ b/mobilecoind/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-mobilecoind-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/peers/Cargo.toml
+++ b/peers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/peers/test-utils/Cargo.toml
+++ b/peers/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-peers-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-alloc"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-build"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-compat"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css-dump"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-css"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-debug"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-enclave-id"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-panic"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-report-cache-untrusted"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-service"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog-edl"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-slog"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-sync"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MobileCoin"]
 name = "mc-sgx-types"
-version = "6.0.2"
+version = "6.1.0"
 repository = "https://github.com/baidu/rust-sgx-sdk"
 license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-sgx-urts"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"

--- a/t3/api/Cargo.toml
+++ b/t3/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-t3-api"
-version = "6.0.2"
+version = "6.1.0"
 edition = "2021"
 authors = ["MobileCoin"]
 license = "GPL-3.0"

--- a/t3/connection/Cargo.toml
+++ b/t3/connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-t3-connection"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/account-keys/Cargo.toml
+++ b/test-vectors/account-keys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-account-keys"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/b58-encodings/Cargo.toml
+++ b/test-vectors/b58-encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-b58-encodings"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/definitions/Cargo.toml
+++ b/test-vectors/definitions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-definitions"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/memos/Cargo.toml
+++ b/test-vectors/memos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-memos"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/test-vectors/tx-out-records/Cargo.toml
+++ b/test-vectors/tx-out-records/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-test-vectors-tx-out-records"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/transaction/builder/Cargo.toml
+++ b/transaction/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-builder"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/core/test-utils/Cargo.toml
+++ b/transaction/core/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-core-test-utils"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/extra/Cargo.toml
+++ b/transaction/extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-extra"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/signer/Cargo.toml
+++ b/transaction/signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-signer"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/summary/Cargo.toml
+++ b/transaction/summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-summary"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/transaction/types/Cargo.toml
+++ b/transaction/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-transaction-types"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/b58-decoder/Cargo.toml
+++ b/util/b58-decoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-b58-decoder"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/build/enclave/Cargo.toml
+++ b/util/build/enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-enclave"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Enclave build assistance, from MobileCoin."

--- a/util/build/grpc/Cargo.toml
+++ b/util/build/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-grpc"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/build/info/Cargo.toml
+++ b/util/build/info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-info"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 build = "build.rs"
 edition = "2021"

--- a/util/build/script/Cargo.toml
+++ b/util/build/script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-script"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Cargo build-script assistance, from MobileCoin."
 edition = "2021"

--- a/util/build/sgx/Cargo.toml
+++ b/util/build/sgx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-build-sgx"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "SGX utilities assistance, from MobileCoin."

--- a/util/cli/Cargo.toml
+++ b/util/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-cli"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/dump-ledger/Cargo.toml
+++ b/util/dump-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-dump-ledger"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/encodings/Cargo.toml
+++ b/util/encodings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-encodings"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Support for various simple encodings (hex strings, base64 strings, Intel x86_64 structures, etc.)"
 edition = "2021"

--- a/util/ffi/Cargo.toml
+++ b/util/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-ffi"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/from-random/Cargo.toml
+++ b/util/from-random/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-from-random"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "A trait for constructing an object from a random number generator."
 edition = "2021"

--- a/util/generate-sample-ledger/Cargo.toml
+++ b/util/generate-sample-ledger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-generate-sample-ledger"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-admin-tool/Cargo.toml
+++ b/util/grpc-admin-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-admin-tool"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc-token-generator/Cargo.toml
+++ b/util/grpc-token-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc-token-generator"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/grpc/Cargo.toml
+++ b/util/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-grpc"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "Runtime gRPC Utilities"
 edition = "2021"

--- a/util/host-cert/Cargo.toml
+++ b/util/host-cert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-host-cert"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/keyfile/Cargo.toml
+++ b/util/keyfile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-keyfile"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/lmdb/Cargo.toml
+++ b/util/lmdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-lmdb"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/logger-macros/Cargo.toml
+++ b/util/logger-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-logger-macros"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metered-channel/Cargo.toml
+++ b/util/metered-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metered-channel"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/metrics/Cargo.toml
+++ b/util/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-metrics"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/parse/Cargo.toml
+++ b/util/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-parse"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "Helpers for parsing, particularly, for use with Clap and similar"

--- a/util/repr-bytes/Cargo.toml
+++ b/util/repr-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-repr-bytes"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/seeded-ed25519-key-gen/Cargo.toml
+++ b/util/seeded-ed25519-key-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-seeded-ed25519-key-gen"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/serial/Cargo.toml
+++ b/util/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-serial"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/telemetry/Cargo.toml
+++ b/util/telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-telemetry"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-helper/Cargo.toml
+++ b/util/test-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-helper"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-vector/Cargo.toml
+++ b/util/test-vector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-vector"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/test-with-data/Cargo.toml
+++ b/util/test-with-data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-test-with-data"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/util/u64-ratio/Cargo.toml
+++ b/util/u64-ratio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-u64-ratio"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "A helper for computing with ratios of u64 numbers"
 edition = "2021"

--- a/util/uri/Cargo.toml
+++ b/util/uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-uri"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"

--- a/util/vec-map/Cargo.toml
+++ b/util/vec-map/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-vec-map"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 description = "A map object based on heapless Vec"
 edition = "2021"

--- a/util/zip-exact/Cargo.toml
+++ b/util/zip-exact/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-util-zip-exact"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 description = "An iterator helper"

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-wasm-test"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/Cargo.toml
+++ b/watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"

--- a/watcher/api/Cargo.toml
+++ b/watcher/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mc-watcher-api"
-version = "6.0.2"
+version = "6.1.0"
 authors = ["MobileCoin"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
### Motivation

- Update versions in Cargo.toml
- add 6.1.0 changes to changelog.



