### PR TITLE
mobilecoind: add tx_out_view_key_match api (#4016)

### DIFF
--- a/mobilecoind/api/proto/mobilecoind_api.proto
+++ b/mobilecoind/api/proto/mobilecoind_api.proto
@@ -33,6 +33,7 @@ service MobilecoindAPI {
     rpc GetPublicAddress (GetPublicAddressRequest) returns (GetPublicAddressResponse) {}
     rpc GetShortAddressHash (GetShortAddressHashRequest) returns (GetShortAddressHashResponse) {}
     rpc ValidateAuthenticatedSenderMemo (ValidateAuthenticatedSenderMemoRequest) returns (ValidateAuthenticatedSenderMemoResponse) {}
+    rpc TxOutViewKeyMatch (TxOutViewKeyMatchRequest) returns (TxOutViewKeyMatchResponse) {}
 
     // b58 Codes
     rpc ParseRequestCode (ParseRequestCodeRequest) returns (ParseRequestCodeResponse) {}
@@ -507,6 +508,25 @@ message ValidateAuthenticatedSenderMemoRequest {
 
 message ValidateAuthenticatedSenderMemoResponse {
     bool success = 1;
+}
+
+message TxOutViewKeyMatchRequest {
+    external.TxOut txo = 1;
+    external.RistrettoPrivate view_private_key = 2;
+}
+
+message TxOutViewKeyMatchResponse {
+    // Whether the tx out belongs to the provided view private key.
+    bool matched = 1;
+
+    // The value of the tx out, only valid if matched is true.
+    uint64 value = 2;
+
+    // The token_id of the tx out, only valid if matched is true.
+    uint64 token_id = 3;
+
+    // The tx out shared secret, only valid if matched is true.
+    external.CompressedRistretto shared_secret = 4;
 }
 
 //


### PR DESCRIPTION
see PR #4016 from @eranrund:

### Motivation
>We needed to have the ability to do view key matching on some txo data and we are already running mobilecoind, so instead of having to link in a lot of the mobilecoin Rust code, we added an endpoint to mobilecoind to do this.
>
> We're using it and can confirm it works, and we also added a unit test for it.

We merged #4016 into a side branch of release/6.1 in our main repo so that it could receive a full scan by CI/CD via this PR before merging into the release/6.1 branch.