### PR TITLE
Upgrade Rust to 1.76.0-nightly

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,8 @@ fail-fast = false
 failure-output = "immediate-final"
 # Show failed, flaky and retried, and slow tests.
 status-level = "slow"
+# Add retires for flaky tests
+retries = { backoff = "exponential", count = 3, delay = "5s" }
 
 [profile.ci.junit]
 # Output a JUnit report under `target/nextest/ci/junit.xml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ checksum = "35b50dba0afdca80b187392b24f2499a88c336d5a8493e4b4ccfb608708be56a"
 dependencies = [
  "bitflags 2.4.2",
  "proc-macro2",
- "proc-macro2-diagnostics 0.10.1",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.52",
 ]
@@ -1834,7 +1834,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1883,7 +1883,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes 1.1.0",
  "headers-core",
- "http",
+ "http 0.2.1",
  "httpdate",
  "mime",
  "sha1",
@@ -1895,7 +1895,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.1",
 ]
 
 [[package]]
@@ -1928,6 +1928,12 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -2007,13 +2013,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "itoa 1.0.1",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
- "http",
+ "http 0.2.1",
  "pin-project-lite",
 ]
 
@@ -2046,7 +2063,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.1",
  "http-body",
  "httparse",
  "httpdate",
@@ -2065,7 +2082,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
+ "http 0.2.1",
  "hyper",
  "log",
  "rustls 0.20.7",
@@ -2081,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.1",
  "hyper",
  "rustls 0.21.11",
  "tokio",
@@ -2187,13 +2204,13 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.3.2",
- "rustix",
- "windows-sys 0.48.0",
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6589,16 +6606,15 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multer"
-version = "2.0.4"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed4198ce7a4cbd2a57af78d28c6fbb57d81ac5f1d6ad79ac6c5587419cbdf22"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
 dependencies = [
  "bytes 1.1.0",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.2.0",
  "httparse",
- "log",
  "memchr",
  "mime",
  "spin 0.9.6",
@@ -6747,7 +6763,7 @@ checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "http",
+ "http 0.2.1",
  "opentelemetry",
  "reqwest",
 ]
@@ -6762,7 +6778,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "headers",
- "http",
+ "http 0.2.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
@@ -6937,25 +6953,25 @@ dependencies = [
 
 [[package]]
 name = "pear"
-version = "0.2.3"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
- "yansi 0.5.0",
+ "yansi",
 ]
 
 [[package]]
 name = "pear_codegen"
-version = "0.2.3"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
 dependencies = [
  "proc-macro2",
- "proc-macro2-diagnostics 0.9.1",
+ "proc-macro2-diagnostics",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7178,19 +7194,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2-diagnostics"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
- "yansi 0.5.0",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
@@ -7199,7 +7202,7 @@ dependencies = [
  "quote",
  "syn 2.0.52",
  "version_check",
- "yansi 1.0.0-rc",
+ "yansi",
 ]
 
 [[package]]
@@ -7527,7 +7530,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.1",
  "http-body",
  "hyper",
  "hyper-rustls 0.24.1",
@@ -7614,9 +7617,9 @@ checksum = "5510dbde48c4c37bf69123b1f636b6dd5f8dffe1f4e358af03c46a4947dca219"
 
 [[package]]
 name = "rocket"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7bb57ccb26670d73b6a47396c83139447b9e7878cab627fdfe9ea8da489150"
+checksum = "a516907296a31df7dc04310e7043b61d71954d703b603cc6867a026d7e72d73f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7647,14 +7650,14 @@ dependencies = [
  "tokio-util",
  "ubyte",
  "version_check",
- "yansi 1.0.0-rc",
+ "yansi",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2238066abf75f21be6cd7dc1a09d5414a671f4246e384e49fe3f8a4936bd04c"
+checksum = "575d32d7ec1a9770108c879fc7c47815a80073f96ca07ff9525a94fcede1dd46"
 dependencies = [
  "devise",
  "glob",
@@ -7669,14 +7672,14 @@ dependencies = [
 
 [[package]]
 name = "rocket_http"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a1663694d059fe5f943ea5481363e48050acedd241d46deb2e27f71110389e"
+checksum = "e274915a20ee3065f611c044bd63c40757396b6dbc057d6046aec27f14f882b9"
 dependencies = [
  "cookie",
  "either",
  "futures",
- "http",
+ "http 0.2.1",
  "hyper",
  "indexmap",
  "log",
@@ -7714,7 +7717,7 @@ dependencies = [
  "bytes 1.1.0",
  "crc32fast",
  "futures",
- "http",
+ "http 0.2.1",
  "hyper",
  "hyper-rustls 0.23.2",
  "lazy_static",
@@ -7772,7 +7775,7 @@ dependencies = [
  "futures",
  "hex",
  "hmac 0.11.0",
- "http",
+ "http 0.2.1",
  "hyper",
  "log",
  "md-5",
@@ -8497,9 +8500,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smawk"
@@ -9772,15 +9775,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
-
-[[package]]
-name = "yansi"
-version = "1.0.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee746ad3851dd3bc40e4a028ab3b00b99278d929e48957bcb2d111874a7e43e"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 dependencies = [
  "is-terminal",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [profile.dev]
 opt-level = 0

--- a/admin-http-gateway/Cargo.toml
+++ b/admin-http-gateway/Cargo.toml
@@ -14,7 +14,7 @@ mc-util-uri = { path = "../util/uri" }
 
 clap = { version = "4.5", features = ["derive", "env"] }
 grpcio = "0.13"
-rocket = { version = "0.5.0", features = ["json"] }
+rocket = { version = "0.5.1", features = ["json"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/admin-http-gateway/src/main.rs
+++ b/admin-http-gateway/src/main.rs
@@ -4,18 +4,6 @@
 
 #![deny(missing_docs)]
 #![feature(proc_macro_hygiene, decl_macro)]
-// Needed due to the `FromForm` macro implementation in rocket
-// Without it one gets:
-//        --> admin-http-gateway/src/main.rs:93:1
-//         |
-//      93 | / struct SetRustLogForm {
-//      94 | |     rust_log: String,
-//      95 | | }
-//         | |_^
-//         |
-//         = note: `-D renamed-and-removed-lints` implied by `-D warnings`
-//         = help: to override `-D warnings` add `#[allow(renamed_and_removed_lints)]`
-#![allow(renamed_and_removed_lints)]
 
 use clap::Parser;
 use grpcio::ChannelBuilder;

--- a/attest/core/src/lib.rs
+++ b/attest/core/src/lib.rs
@@ -6,6 +6,10 @@
 #![no_std]
 #![feature(core_intrinsics)]
 #![allow(clippy::result_large_err)]
+// This is needed to use feature(core_intrinsics)
+// I believe were using the core_intrinsics feature for f64 abs support since we are in no_std.
+// This is IAS code so its almost dead.
+#![allow(internal_features)]
 
 extern crate alloc;
 #[macro_use]

--- a/consensus/enclave/impl/src/constant_time_token_map.rs
+++ b/consensus/enclave/impl/src/constant_time_token_map.rs
@@ -88,12 +88,12 @@ impl<T: ConditionallySelectable + Default> CtTokenMap<T> {
     }
 
     /// Iterate over all entries in the map.
-    pub fn iter(&self) -> impl Iterator<Item = &(TokenId, T)> + DoubleEndedIterator {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &(TokenId, T)> {
         self.storage.iter()
     }
 
     /// Get an iterator over the keys of this map.
-    pub fn keys(&self) -> impl Iterator<Item = &TokenId> + DoubleEndedIterator {
+    pub fn keys(&self) -> impl DoubleEndedIterator<Item = &TokenId> {
         self.storage.iter().map(|(key, _val)| key)
     }
 }

--- a/consensus/enclave/trusted/Cargo.toml
+++ b/consensus/enclave/trusted/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 [workspace]
 
 [workspace.package]
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/consensus/enclave/trusted/src/lib.rs
+++ b/consensus/enclave/trusted/src/lib.rs
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn mobileenclave_call(
         return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
     }
 
-    match catch_unwind(|| {
+    let c = catch_unwind(|| {
         let mut temp_outbuf_used = unsafe { *outbuf_used };
         let mut temp_outbuf_retry_id = unsafe { *outbuf_retry_id };
         let res = RETRY_BUFFER.call(
@@ -129,7 +129,9 @@ pub unsafe extern "C" fn mobileenclave_call(
             *outbuf_retry_id = temp_outbuf_retry_id;
         }
         res
-    }) {
+    });
+
+    match c {
         Ok(x) => match x {
             Ok(_) => sgx_status_t::SGX_SUCCESS,
             Err(retval) => retval,

--- a/fog/ingest/enclave/trusted/Cargo.toml
+++ b/fog/ingest/enclave/trusted/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 [workspace]
 
 [workspace.package]
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/fog/ingest/enclave/trusted/src/lib.rs
+++ b/fog/ingest/enclave/trusted/src/lib.rs
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn ingest_enclave_call(
         return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
     }
 
-    match catch_unwind(|| {
+    let c = catch_unwind(|| {
         let mut temp_outbuf_used = unsafe { *outbuf_used };
         let mut temp_outbuf_retry_id = unsafe { *outbuf_retry_id };
         let res = RETRY_BUFFER.call(
@@ -113,7 +113,9 @@ pub unsafe extern "C" fn ingest_enclave_call(
             *outbuf_retry_id = temp_outbuf_retry_id;
         }
         res
-    }) {
+    });
+
+    match c {
         Ok(x) => match x {
             Ok(_) => sgx_status_t::SGX_SUCCESS,
             Err(retval) => retval,

--- a/fog/ledger/enclave/trusted/Cargo.toml
+++ b/fog/ledger/enclave/trusted/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = { workspace = true }
 [workspace]
 
 [workspace.package]
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/fog/ledger/enclave/trusted/src/lib.rs
+++ b/fog/ledger/enclave/trusted/src/lib.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn ledger_enclave_call(
         return sgx_status_t::SGX_ERROR_INVALID_PARAMETER;
     }
 
-    match catch_unwind(|| {
+    let c = catch_unwind(|| {
         let mut temp_outbuf_used = unsafe { *outbuf_used };
         let mut temp_outbuf_retry_id = unsafe { *outbuf_retry_id };
         let res = RETRY_BUFFER.call(
@@ -135,7 +135,9 @@ pub unsafe extern "C" fn ledger_enclave_call(
             *outbuf_retry_id = temp_outbuf_retry_id;
         }
         res
-    }) {
+    });
+
+    match c {
         Ok(x) => match x {
             Ok(_) => sgx_status_t::SGX_SUCCESS,
             Err(retval) => retval,

--- a/fog/sql_recovery_db/src/lib.rs
+++ b/fog/sql_recovery_db/src/lib.rs
@@ -569,7 +569,7 @@ impl SqlRecoveryDb {
     ) -> Result<AddBlockDataStatus, Error> {
         let conn = &mut self.pool.get()?;
 
-        match conn
+        let res = conn
             .build_transaction()
             .read_write()
             .run(|conn| -> Result<(), Error> {
@@ -612,7 +612,9 @@ impl SqlRecoveryDb {
 
                 // Success.
                 Ok(())
-            }) {
+            });
+
+        match res {
             Ok(()) => Ok(AddBlockDataStatus {
                 block_already_scanned_with_this_key: false,
             }),

--- a/fog/view/enclave/trusted/Cargo.toml
+++ b/fog/view/enclave/trusted/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = { workspace = true }
 [workspace]
 
 [workspace.package]
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/ledger/sync/src/ledger_sync/ledger_sync_service.rs
+++ b/ledger/sync/src/ledger_sync/ledger_sync_service.rs
@@ -655,7 +655,7 @@ fn get_block_contents<TF: TransactionsFetcher + 'static>(
                                 block.index
                             );
 
-                            match thread_transactions_fetcher
+                            let results = thread_transactions_fetcher
                                 .get_block_data(thread_safe_responder_ids.as_slice(), &block)
                                 .map_err(LedgerSyncError::from)
                                 .and_then(|block_data| {
@@ -681,7 +681,9 @@ fn get_block_contents<TF: TransactionsFetcher + 'static>(
                                     } else {
                                         Ok(block_data)
                                     }
-                                }) {
+                                });
+
+                            match results {
                                 Ok(block_data) => {
                                     // Log
                                     log::trace!(

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-11-09"
+channel = "nightly-2023-12-21"

--- a/sgx/alloc/Cargo.toml
+++ b/sgx/alloc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [features]
 default = ["oom_panic"]

--- a/sgx/build/Cargo.toml
+++ b/sgx/build/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 cc = "1.0"

--- a/sgx/compat-edl/Cargo.toml
+++ b/sgx/compat-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-sgx-debug-edl = { path = "../debug-edl" }

--- a/sgx/compat/Cargo.toml
+++ b/sgx/compat/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 # All dependencies are optional
 [dependencies]

--- a/sgx/css-dump/Cargo.toml
+++ b/sgx/css-dump/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-sgx-css = { path = "../css" }

--- a/sgx/css/Cargo.toml
+++ b/sgx/css/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/debug-edl/Cargo.toml
+++ b/sgx/debug-edl/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 links = "sgx_debug_edl"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/debug/Cargo.toml
+++ b/sgx/debug/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"

--- a/sgx/enclave-id/Cargo.toml
+++ b/sgx/enclave-id/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-sgx-types = { path = "../types" }

--- a/sgx/panic-edl/Cargo.toml
+++ b/sgx/panic-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 links = "sgx_panic_edl"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/panic/Cargo.toml
+++ b/sgx/panic/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [features]
 default = ["alloc", "panic_abort"]

--- a/sgx/report-cache/api/Cargo.toml
+++ b/sgx/report-cache/api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/report-cache/untrusted/Cargo.toml
+++ b/sgx/report-cache/untrusted/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 edition = "2021"
 license = "GPL-3.0"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 displaydoc = { version = "0.2", default-features = false }

--- a/sgx/service/Cargo.toml
+++ b/sgx/service/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-sgx-types = { path = "../types" }

--- a/sgx/slog-edl/Cargo.toml
+++ b/sgx/slog-edl/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 links = "sgx_slog_edl"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [build-dependencies]
 cargo-emit = "0.2"

--- a/sgx/slog/Cargo.toml
+++ b/sgx/slog/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [features]
 default = []

--- a/sgx/sync/Cargo.toml
+++ b/sgx/sync/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-sgx-panic = { path = "../panic", optional = true }

--- a/sgx/types/Cargo.toml
+++ b/sgx/types/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "LICENSE"
 documentation = "https://dingelish.github.io/"
 description = "Rust SGX SDK provides the ability to write Intel SGX applications in Rust Programming Language."
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 include = [
     "LICENSE",

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["MobileCoin"]
 license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
-rust-version = "1.74.0"
+rust-version = "1.76.0"
 
 [dependencies]
 mc-common = { path = "../../common", features = ["log"] }


### PR DESCRIPTION
### Highlights

- Add retry config for flaky CI tests.  
- Update rust-version in `Cargo.toml` files. 
- update rocket to 0.5.1 and remove old clippy allow
- Add clippy allow for  `#![feature(core_intrinsics)]` in `attest/core/src/lib.rs` - I think we're using this here due to setting `#![no_std]` and needing the `abs()` function/method for `f64`.  This is almost dead IAS code, so didn't think it was worth spending time and testing refactoring. 

**`clippy::blocks-in-conditions`** - remove functions/closures that are in-line with match statements. I'm happy to change any of the variable names I made up when moving the closures.

- consensus/enclave/trusted/src/lib.rs
- fog/ledger/enclave/trusted/src/lib.rs
- fog/ingest/enclave/trusted/src/lib.rs
- fog/view/enclave/trusted/src/lib.rs
- ledger/sync/src/ledger_sync/ledger_sync_service.rs

**`clippy::implied_bounds_in_impls`** 
- consensus/enclave/impl/src/constant_time_token_map.rs

