### PR TITLE
add mc-sgx-urts to workspace and fix clippy issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ members = [
     "sgx/report-cache/api",
     "sgx/report-cache/untrusted",
     "sgx/slog-edl",
+    "sgx/urts",
     "t3/api",
     "t3/connection",
     "test-vectors/account-keys",

--- a/sgx/urts/Cargo.toml
+++ b/sgx/urts/Cargo.toml
@@ -6,9 +6,7 @@ license = "GPL-3.0"
 readme = "README.md"
 # TODO: Consider making sgx a self-contained workspace and get the value from there.
 rust-version = "1.83.0"
-
-[features]
-backtrace = []
+edition = "2021"
 
 [dependencies]
 mc-common = { path = "../../common", features = ["log"] }

--- a/sgx/urts/src/enclave.rs
+++ b/sgx/urts/src/enclave.rs
@@ -276,10 +276,6 @@ fn cstr(path: &Path) -> io::Result<CString> {
 #[derive(Default, Debug)]
 pub struct SgxEnclave {
     id: sgx_enclave_id_t,
-    #[cfg(feature = "backtrace")]
-    debug: i32,
-    #[cfg(feature = "backtrace")]
-    path: std::path::PathBuf,
 }
 
 impl SgxEnclave {
@@ -302,10 +298,6 @@ impl SgxEnclave {
         )
         .map(|eid| SgxEnclave {
             id: eid,
-            #[cfg(feature = "backtrace")]
-            debug,
-            #[cfg(feature = "backtrace")]
-            path: file_name.as_ref().to_owned(),
         })?;
 
         enclave.init();
@@ -324,27 +316,7 @@ impl SgxEnclave {
 
     fn exit(&self) {}
 
-    fn init(&self) {
-        // Store enclave id -> pathbuf in the map, for backtrace functionality
-        #[cfg(feature = "backtrace")]
-        self.store_id_and_path();
-    }
-
-    #[cfg(feature = "backtrace")]
-    fn store_id_and_path(&self) {
-        let mut lk = crate::backtrace::ENCLAVE_PATH_MAP
-            .lock()
-            .expect("Could not lock enclave path map!");
-        let maybe_old_path = lk.insert(self.id, self.path.clone());
-        if let Some(old_path) = maybe_old_path {
-            panic!(
-                "The eid is already in the enclave path map! eid: {} old_path: {} new_path: {}",
-                self.id,
-                old_path.display(),
-                self.path.display()
-            );
-        }
-    }
+    fn init(&self) {}
 }
 
 impl Drop for SgxEnclave {

--- a/sgx/urts/src/enclave.rs
+++ b/sgx/urts/src/enclave.rs
@@ -300,7 +300,6 @@ impl SgxEnclave {
             id: eid,
         })?;
 
-        enclave.init();
         Ok(enclave)
     }
 
@@ -313,15 +312,10 @@ impl SgxEnclave {
     pub fn geteid(&self) -> sgx_enclave_id_t {
         self.id
     }
-
-    fn exit(&self) {}
-
-    fn init(&self) {}
 }
 
 impl Drop for SgxEnclave {
     fn drop(&mut self) {
-        self.exit();
         let _ = rsgx_destroy_enclave(self.id);
     }
 }


### PR DESCRIPTION
`backtrace` support was removed 5 years ago in 20f701b8289ea0fe0df1c63e0aa433e60c853fdb, but this code was never linted since it wasn't part of the workspace