### PR TITLE
less strict dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ curve25519-dalek = { version = "4", default-features = false }
 der = { version = "0.7", default-features = false }
 diesel = "2"
 diesel-derive-enum = "2"
-diesel_migrations = "2.1.0"
+diesel_migrations = "2"
 digest = { version = "0.10", default-features = false }
 dirs = "5"
 displaydoc = { version = "0.2", default-features = false }
@@ -342,7 +342,7 @@ tiny-bip39 = "1"
 tokio = "1"
 toml = "0.8"
 url = "2"
-walkdir = "2.4"
+walkdir = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 x25519-dalek = { version = "2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,161 +196,161 @@ rust-version = "1.83.0"
 
 [workspace.dependencies]
 aead = { version = "0.5", default-features = false }
-aes = "0.8.4"
-aes-gcm = "0.10.3"
-aligned-cmov = "2.3"
-anyhow = "1.0.80"
-assert_cmd = "2.0.14"
-assert_matches = "1.5.0"
+aes = "0.8"
+aes-gcm = "0.10"
+aligned-cmov = "2"
+anyhow = "1"
+assert_cmd = "2"
+assert_matches = "1"
 async-channel = "2"
 backtrace = "0.3"
-balanced-tree-index = "2.3"
+balanced-tree-index = "2"
 base64 = { version = "0.21", default-features = false }
-bincode = "1.3"
-bitflags = { version = "2.4", default-features = false }
-blake2 = { version = "0.10.6", default-features = false }
-bs58 = "0.4.0"
+bincode = "1"
+bitflags = { version = "2", default-features = false }
+blake2 = { version = "0.10", default-features = false }
+bs58 = "0.4"
 bulletproofs-og = { version = "3.0.0-pre.1", default-features = false }
-cargo-emit = "0.2.1"
+cargo-emit = "0.2"
 cargo_metadata = "0.18"
 cc = "1"
-cfg-if = "1.0"
-chrono = { version = "0.4.34", default-features = false }
-clap = "4.5.1"
-clio = "0.3.5"
+cfg-if = "1"
+chrono = { version = "0.4", default-features = false }
+clap = "4"
+clio = "0.3"
 cookie = "0.18"
-crc = { version = "3.0.1", default-features = false }
+crc = { version = "3", default-features = false }
 criterion = "0.5"
 crossbeam-channel = "0.5"
-ctr = "0.9.2"
-ctrlc = "3.4"
-curve25519-dalek = { version = "4.1.3", default-features = false }
-der = { version = "0.7.8", default-features = false }
-diesel = "2.1.4"
-diesel-derive-enum = "2.1.0"
+ctr = "0.9"
+ctrlc = "3"
+curve25519-dalek = { version = "4", default-features = false }
+der = { version = "0.7", default-features = false }
+diesel = "2"
+diesel-derive-enum = "2"
 diesel_migrations = "2.1.0"
-digest = { version = "0.10.1", default-features = false }
-dirs = "5.0"
+digest = { version = "0.10", default-features = false }
+dirs = "5"
 displaydoc = { version = "0.2", default-features = false }
-dyn-clone = "1.0.17"
-ed25519 = { version = "2.2.3", default-features = false }
-ed25519-dalek = { version = "2.1.1", default-features = false }
-fs_extra = "1.3"
+dyn-clone = "1"
+ed25519 = { version = "2", default-features = false }
+ed25519-dalek = { version = "2", default-features = false }
+fs_extra = "1"
 futures = "0.3"
-generic-array = { version = "0.14.7", default-features = false }
+generic-array = { version = "0.14", default-features = false }
 getrandom = "0.2"
-grpcio = "0.13.0"
-hashbrown = { version = "0.14.3", default-features = false }
-heapless = { version = "0.8.0", default-features = false }
-hex = { version = "0.4.3", default-features = false }
-hex-literal = "0.4.1"
+grpcio = "0.13"
+hashbrown = { version = "0.14", default-features = false }
+heapless = { version = "0.8", default-features = false }
+hex = { version = "0.4", default-features = false }
+hex-literal = "0.4"
 hex_fmt = "0.3"
-hkdf = "0.12.4"
+hkdf = "0.12"
 hmac = "0.12"
-hostname = "0.3.1"
-itertools = "0.12.1"
+hostname = "0.3"
+itertools = "0.12"
 json = "0.12"
-lazy_static = "1.4.0"
+lazy_static = "1"
 libc = "0.2"
-libz-sys = "1.1.15"
-link-cplusplus = "1.0"
-lmdb-rkv = "0.14.0"
-log = "0.4.21"
-maplit = "1.0.2"
-mbedtls = { version = "0.8.1", default-features = false }
-mbedtls-sys-auto = "2.26.1"
-mc-attestation-verifier = "0.4.4"
-mc-oblivious-aes-gcm = { version = "0.10.1", default-features = false }
-mc-oblivious-map = "2.3"
-mc-oblivious-ram = "2.3"
-mc-oblivious-traits = "2.3"
-mc-rand = "1.1.0"
-mc-sgx-core-sys-types = "0.12.0"
-mc-sgx-core-types = "0.12.0"
-mc-sgx-dcap-ql = "0.12.0"
-mc-sgx-dcap-quoteverify = "0.12.0"
-mc-sgx-dcap-sys-types = { version = "0.12.0", default-features = false }
-mc-sgx-dcap-types = { version = "0.12.0", default-features = false }
-merlin = { version = "3.0", default-features = false }
-mockall = "0.12.1"
+libz-sys = "1"
+link-cplusplus = "1"
+lmdb-rkv = "0.14"
+log = "0.4"
+maplit = "1"
+mbedtls = { version = "0.8", default-features = false }
+mbedtls-sys-auto = "2"
+mc-attestation-verifier = "0.4"
+mc-oblivious-aes-gcm = { version = "0.10", default-features = false }
+mc-oblivious-map = "2"
+mc-oblivious-ram = "2"
+mc-oblivious-traits = "2"
+mc-rand = "1"
+mc-sgx-core-sys-types = "0.12"
+mc-sgx-core-types = "0.12"
+mc-sgx-dcap-ql = "0.12"
+mc-sgx-dcap-quoteverify = "0.12"
+mc-sgx-dcap-sys-types = { version = "0.12", default-features = false }
+mc-sgx-dcap-types = { version = "0.12", default-features = false }
+merlin = { version = "3", default-features = false }
+mockall = "0.12"
 more-asserts = "0.3"
-num_cpus = "1.16"
-once_cell = { version = "1.19", default-features = false }
-opentelemetry = "0.21.0"
-opentelemetry-jaeger = "0.20.0"
-opentelemetry_sdk = "0.21.2"
-p256 = { version = "0.13.0", default-features = false }
-pem = "3.0"
-percent-encoding = "2.3.1"
+num_cpus = "1"
+once_cell = { version = "1", default-features = false }
+opentelemetry = "0.21"
+opentelemetry-jaeger = "0.20"
+opentelemetry_sdk = "0.21"
+p256 = { version = "0.13", default-features = false }
+pem = "3"
+percent-encoding = "2"
 pkg-config = "0.3"
-portpicker = "0.1.1"
+portpicker = "0.1"
 predicates = "3"
-primitive-types = "0.12.2"
-proc-macro2 = "1.0.8"
-prometheus = "0.13.3"
-proptest = { version = "1.4", default-features = false }
+primitive-types = "0.12"
+proc-macro2 = "1"
+prometheus = "0.13"
+proptest = { version = "1", default-features = false }
 prost = { version = "0.12", default-features = false }
 prost-build = "0.12"
-protobuf = "2.27.1"
-protoc-grpcio = "3.0.0"
-quote = "1.0.2"
-r2d2 = "0.8.10"
-rand = { version = "0.8.5", default-features = false }
+protobuf = "2"
+protoc-grpcio = "3"
+quote = "1"
+r2d2 = "0.8"
+rand = { version = "0.8", default-features = false }
 rand_chacha = "0.3"
-rand_core = { version = "0.6.4", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 rand_hc = { version = "0.3", default-features = false }
-rayon = "1.9"
+rayon = "1"
 regex = "1"
 reqwest = { version = "0.11", default-features = false }
-retry = "2.0"
-rjson = "0.3.1"
-rocket = "0.5.1"
-rusoto_core = { version = "0.48.0", default-features = false }
-rusoto_s3 = { version = "0.48.0", default-features = false }
+retry = "2"
+rjson = "0.3"
+rocket = "0.5"
+rusoto_core = { version = "0.48", default-features = false }
+rusoto_s3 = { version = "0.48", default-features = false }
 schnorrkel-og = { version = "0.11.0-pre.0", default-features = false }
-scoped_threadpool = "0.1.*"
+scoped_threadpool = "0.1"
 secrecy = "0.8"
-semver = "1.0"
+semver = "1"
 sentry = { version = "0.32", default-features = false }
-serde = { version = "1.0.197", default-features = false }
-serde_cbor = { version = "0.11.1", default-features = false }
-serde_derive = "1.0"
-serde_json = { version = "1.0.114", default-features = false }
-serde_with = { version = "3.6", default-features = false }
-serial_test = "3.0"
-sha2 = { version = "0.10.8", default-features = false }
+serde = { version = "1", default-features = false }
+serde_cbor = { version = "0.11", default-features = false }
+serde_derive = "1"
+serde_json = { version = "1", default-features = false }
+serde_with = { version = "3", default-features = false }
+serial_test = "3"
+sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 signal-hook = "0.3"
-signature = { version = "2.1.0", default-features = false }
-siphasher = "1.0"
+signature = { version = "2", default-features = false }
+siphasher = "1"
 slip10_ed25519 = "0.1"
-slog = { version = "2.7", default-features = false }
-slog-async = "2.8"
-slog-atomic = "3.1"
-slog-envlogger = "2.2"
-slog-json = "2.6"
-slog-scope = "4.4.0"
-slog-stdlog = "4.1.1"
-slog-term = "2.9"
-static_assertions = "1.1.0"
+slog = { version = "2", default-features = false }
+slog-async = "2"
+slog-atomic = "3"
+slog-envlogger = "2"
+slog-json = "2"
+slog-scope = "4"
+slog-stdlog = "4"
+slog-term = "2"
+static_assertions = "1"
 stdext = "0.3"
-subtle = { version = "2.4.1", default-features = false }
-syn = "2.0"
-tempfile = "3.10.1"
+subtle = { version = "2", default-features = false }
+syn = "2"
+tempfile = "3"
 textwrap = "0.16"
-tiny-bip39 = "1.0"
-tokio = "1.36"
+tiny-bip39 = "1"
+tokio = "1"
 toml = "0.8"
-url = "2.5.0"
+url = "2"
 walkdir = "2.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
-x25519-dalek = { version = "2.0.1", default-features = false }
-x509-cert = { version = "0.2.5", default-features = false }
+x25519-dalek = { version = "2", default-features = false }
+x509-cert = { version = "0.2", default-features = false }
 x509-signature = "0.5"
 yaml-rust = "0.4"
-yare = "2.0.0"
-zeroize = { version = "1.8", default-features = false }
+yare = "2"
+zeroize = { version = "1", default-features = false }
 
 mc-account-keys = { path = "account-keys", default-features = false }
 mc-account-keys-types = { path = "account-keys/types" }


### PR DESCRIPTION
Now that crate dependencies are mostly in one place (except the enclave `Cargo.toml` files), we can loosen up the version requirements to make it easier for people submoduling this repository to work with the dependency versions of their choosing.
This should also make it easier for us to update some of the dependencies that have stricter version requirements in their `Cargo.toml` files.