### PR TITLE
Make CD deployment region configurable

### DIFF
--- a/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-dispatch-dev-deploy.yaml
@@ -69,6 +69,11 @@ on:
         options:
         - blue
         - green
+      deployment_region:
+        description: "cloud deployment region"
+        type: string
+        required: true
+        default: italynorth
 
 jobs:
   list-values:
@@ -111,4 +116,5 @@ jobs:
       shard_size: ${{ inputs.shard_size }}
       shard_exceed_block_height_by: ${{ inputs.shard_exceed_block_height_by }}
       tokens_file: ${{ inputs.tokens_file }}
+      deployment_region: ${{ inputs.deployment_region }}
     secrets: inherit

--- a/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
+++ b/.github/workflows/mobilecoin-workflow-dev-deploy.yaml
@@ -52,6 +52,11 @@ on:
         description: "Tokens File"
         type: string
         required: true
+      deployment_region:
+        description: "cloud deployment region"
+        type: string
+        required: false
+        default: italynorth
     secrets:
       DEV_RANCHER_CLUSTER:
         description: "Rancher cluster name"
@@ -332,7 +337,7 @@ jobs:
         fogView:
           responderID: fog.${{ inputs.namespace }}.development.mobilecoin.com
           color: green
-          zone: westeurope-1
+          zone: ${{ inputs.deployment_region }}-1
 
           stackConfig:
             network:
@@ -372,7 +377,7 @@ jobs:
         fogView:
           responderID: fog.${{ inputs.namespace }}.development.mobilecoin.com
           color: green
-          zone: westeurope-2
+          zone: ${{ inputs.deployment_region }}-2
 
           stackConfig:
             network:
@@ -459,7 +464,7 @@ jobs:
         fogLedger:
           responderID: fog.${{ inputs.namespace }}.development.mobilecoin.com
           color: green
-          zone: westeurope-1
+          zone: ${{ inputs.deployment_region }}-1
 
           stackConfig:
             network:
@@ -499,7 +504,7 @@ jobs:
         fogLedger:
           responderID: fog.${{ inputs.namespace }}.development.mobilecoin.com
           color: green
-          zone: westeurope-2
+          zone: ${{ inputs.deployment_region }}-2
 
           stackConfig:
             network:


### PR DESCRIPTION
Make CD deployment region configurable.  Set default to `italynorth`

### Motivation

We moved the dev deployment region to Italy North for cost and VM sku availability.

