### PR TITLE
7.0 - Fix release scripts for non-enclave releases

### DIFF
--- a/tools/release/.shared_functions
+++ b/tools/release/.shared_functions
@@ -106,13 +106,21 @@ export ENCLAVE_DIR="${TMP_DIR}/${CHAIN_ID}net-enclaves-${ENCLAVE_TAG}"
 export ENCLAVE_SIGNED_DIR="${TMP_DIR}/${CHAIN_ID}net-signed.so-${ENCLAVE_TAG}"
 export MEASUREMENTS_DIR="${TMP_DIR}/${CHAIN_ID}net-measurements-${ENCLAVE_TAG}"
 
+export CURRENT_TAG_SIGNED_DIR="${TMP_DIR}/${CHAIN_ID}net-signed.so-${GIT_TAG}"
+export CURRENT_TAG_MEASUREMENTS_DIR="${TMP_DIR}/${CHAIN_ID}net-measurements-${GIT_TAG}"
+
 # Tarballs
 export ENCLAVE_TAR="${TMP_DIR}/${CHAIN_ID}net-enclaves-${ENCLAVE_TAG}.tar.gz"
 export ENCLAVE_SIGNED_TAR="${TMP_DIR}/${CHAIN_ID}net-signed.so-${ENCLAVE_TAG}.tar.gz"
-export MEASUREMENTS_TAR="${TMP_DIR}/${CHAIN_ID}net-measurements-${ENCLAVE_TAG}.tar.gz"
+export ENCLAVE_MEASUREMENTS_TAR="${TMP_DIR}/${CHAIN_ID}net-measurements-${ENCLAVE_TAG}.tar.gz"
+export ENCLAVE_PRODUCTION_JSON="${TMP_DIR}/${CHAIN_ID}net-${ENCLAVE_TAG}.json"
+
+export SIGNED_TAR="${TMP_DIR}/${CHAIN_ID}net-signed.so-${GIT_TAG}.tar.gz"
+export MEASUREMENTS_TAR="${TMP_DIR}/${CHAIN_ID}net-measurements-${GIT_TAG}.tar.gz"
 export PRODUCTION_JSON="${TMP_DIR}/${CHAIN_ID}net-${GIT_TAG}.json"
 
 # Log file for the build process
+export ENCLAVE_LOG="${TMP_DIR}/${CHAIN_ID}net-build-${ENCLAVE_TAG}.log"
 export LOG="${TMP_DIR}/${CHAIN_ID}net-build-${GIT_TAG}.log"
 
 # Set Cargo environment

--- a/tools/release/01-build-enclaves.sh
+++ b/tools/release/01-build-enclaves.sh
@@ -12,7 +12,7 @@ source "${location}/.shared_functions"
 
 if [[ "${ENCLAVE_RELEASE}" == "false" ]]
 then
-    red "This is not an enclave release tag. No need to build enclaves. Download the tarball from the enclave release page."
+    red "This is not an enclave release tag. No need to build enclaves. Skip ahead to 03-populate-release.sh."
     exit 1
 fi
 

--- a/tools/release/02-build-signed.sh
+++ b/tools/release/02-build-signed.sh
@@ -12,7 +12,7 @@ source "${location}/.shared_functions"
 
 if [[ "${ENCLAVE_RELEASE}" == "false" ]]
 then
-    red "This is not an enclave release tag. No need to build enclaves. Download the tarball from the enclave release page."
+    red "This is not an enclave release tag. No need to build signed enclaves. Skip ahead to 03-populate-release.sh."
     exit 1
 fi
 

--- a/tools/release/03-populate-release.sh
+++ b/tools/release/03-populate-release.sh
@@ -14,27 +14,39 @@ command -v gh >/dev/null 2>&1 || { red "GitHub CLI (gh) is not installed. Aborti
 
 if [[ "${ENCLAVE_RELEASE}" == "true" ]]
 then
-    yellow "Using local artifact files to create a release"
+    yellow "Using local artifact files to create a release."
 
-    check_file "${ENCLAVE_SIGNED_TAR}"
+    check_file "${SIGNED_TAR}"
     check_file "${MEASUREMENTS_TAR}"
     check_file "${PRODUCTION_JSON}"
     check_file "${LOG}"
 else
-    yellow "Downloading artifacts from the latest enclave release"
-    # download artifacts from the latest enclave release
+    yellow "Downloading artifacts from the latest enclave release."
     gh release download --clobber \
         --pattern "$(basename "${ENCLAVE_SIGNED_TAR}")" \
-        --pattern "$(basename "${MEASUREMENTS_TAR}")" \
-        --pattern "$(basename "${PRODUCTION_JSON}")" \
-        --pattern "$(basename "${LOG}")" \
+        --pattern "$(basename "${ENCLAVE_MEASUREMENTS_TAR}")" \
+        --pattern "$(basename "${ENCLAVE_PRODUCTION_JSON}")" \
+        --pattern "$(basename "${ENCLAVE_LOG}")" \
         "${ENCLAVE_TAG}" -D "${TMP_DIR}"
-fi
 
-yellow "extract the signed enclaves"
-pushd "${TMP_DIR}" >/dev/null
-tar xvzf "${ENCLAVE_SIGNED_TAR}"
-popd >/dev/null
+    pushd "${TMP_DIR}" 2>/dev/null || exit 1
+    yellow "Extract and rename signed directory to match current tag."
+    rm -rf "${CURRENT_TAG_SIGNED_DIR}"
+    tar -xvzf "${ENCLAVE_SIGNED_TAR}"
+    mv "${ENCLAVE_SIGNED_DIR}" "${CURRENT_TAG_SIGNED_DIR}"
+    tar -cvzf "${SIGNED_TAR}" "$(basename "${CURRENT_TAG_SIGNED_DIR}")"
+
+    yellow "Extract and rename measurements directory to match current tag."
+    rm -rf "${CURRENT_TAG_MEASUREMENTS_DIR}"
+    tar -xvzf "${ENCLAVE_MEASUREMENTS_TAR}"
+    mv "${MEASUREMENTS_DIR}" "${CURRENT_TAG_MEASUREMENTS_DIR}"
+    tar -cvzf "${MEASUREMENTS_TAR}" "$(basename "${CURRENT_TAG_MEASUREMENTS_DIR}")"
+    popd || exit 1
+
+    yellow "Rename production JSON and log files to match current tag."
+    mv "${ENCLAVE_PRODUCTION_JSON}" "${PRODUCTION_JSON}"
+    mv "${ENCLAVE_LOG}" "${LOG}"
+fi
 
 # get mrenclave from production.json
 mrenclave_consensus=$(jq -r '.consensus.mrenclave' "${PRODUCTION_JSON}")
@@ -99,7 +111,7 @@ else
 fi
 
 gh release upload --clobber "${GIT_TAG}" \
-    "${ENCLAVE_SIGNED_TAR}" \
+    "${SIGNED_TAR}" \
     "${MEASUREMENTS_TAR}" \
     "${PRODUCTION_JSON}" \
     "${LOG}" \


### PR DESCRIPTION
Scripts worked for an "Enclave" build tag "v7.0.0", but filenames were misaligned for non-enclave (minor/point) tags. 

- Fix release scripts to match GH Workflow expected tarball contents.
- Add better warnings to 01/02 scripts. Tell users to skip to 03 for non-enclave tags.
