### PR TITLE
Fix fog-ledger-fsg chart dupe labels

### DIFF
--- a/.internal-ci/helm/fog-ledger-fsg/templates/fog-ledger-fsg-fogshardrangegenerator.yaml
+++ b/.internal-ci/helm/fog-ledger-fsg/templates/fog-ledger-fsg-fogshardrangegenerator.yaml
@@ -106,7 +106,6 @@ spec:
             stack: {{ include "fog-ledger-fsg.fullname" $ }}-{{ $stackCount }}
             color: {{ $color }}
             zone: {{ $zone }}
-            {{- include "fog-ledger-fsg.selectorLabels" $ | nindent 12 }}
             {{- include "fog-ledger-fsg.labels" $ | nindent 12 }}
         spec:
           {{- if $store.affinityEnabled }}


### PR DESCRIPTION
Standard helm linting will ignore duplicate keys, unfortunately fluxcd will fail a chart with dupe keys.
