### PR TITLE
support general config in fog-test-client chart 

### DIFF
--- a/.internal-ci/helm/fog-test-client/scripts/download_sigstruct.sh
+++ b/.internal-ci/helm/fog-test-client/scripts/download_sigstruct.sh
@@ -26,7 +26,10 @@ LEDGER_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${NETWORK}/productio
 curl -O https://enclave-distribution.${NETWORK}/${LEDGER_SIGSTRUCT_URI}
 VIEW_SIGSTRUCT_URI=$(curl -s https://enclave-distribution.${NETWORK}/production.json | grep view-enclave.css | awk '{print $2}' | tr -d \" | tr -d ,)
 curl -O https://enclave-distribution.${NETWORK}/${VIEW_SIGSTRUCT_URI}
-export CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css
-export INGEST_ENCLAVE_CSS=$(pwd)/ingest-enclave.css
-export LEDGER_ENCLAVE_CSS=$(pwd)/ledger-enclave.css
-export VIEW_ENCLAVE_CSS=$(pwd)/view-enclave.css
+
+CONSENSUS_ENCLAVE_CSS=$(pwd)/consensus-enclave.css
+INGEST_ENCLAVE_CSS=$(pwd)/ingest-enclave.css
+LEDGER_ENCLAVE_CSS=$(pwd)/ledger-enclave.css
+VIEW_ENCLAVE_CSS=$(pwd)/view-enclave.css
+
+export CONSENSUS_ENCLAVE_CSS INGEST_ENCLAVE_CSS LEDGER_ENCLAVE_CSS VIEW_ENCLAVE_CSS

--- a/.internal-ci/helm/fog-test-client/scripts/generate-k8s.sh
+++ b/.internal-ci/helm/fog-test-client/scripts/generate-k8s.sh
@@ -6,34 +6,24 @@ net="${1}"
 
 case ${net} in
     mc-testnet)
-        export CONSENSUS_VALIDATORS="mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/,mc://node3.test.mobilecoin.com/"
-        export FOG_VIEW="fog-view://fog.test.mobilecoin.com:443"
-        export FOG_LEDGER="fog-ledger://fog.test.mobilecoin.com:443"
-        export MC_PARTNER="mc"
-        export MC_NETWORK="test"
+        export MC_CONSENSUS="mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/,mc://node3.test.mobilecoin.com/"
+        export MC_FOG_VIEW="fog-view://fog.test.mobilecoin.com:443"
+        export MC_FOG_LEDGER="fog-ledger://fog.test.mobilecoin.com:443"
         ;;
     signal-testnet)
-        export CONSENSUS_VALIDATORS="mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/,mc://node3.test.mobilecoin.com/"
-        export FOG_VIEW="fog-view://service.fog.mob.staging.namda.net:443"
-        export FOG_LEDGER="fog-ledger://service.fog.mob.staging.namda.net:443"
-        export MC_PARTNER="signal"
-        export MC_NETWORK="test"
-        export CLIENT_AUTH_TOKEN_SECRET="${CLIENT_AUTH_TOKEN_SECRET}"
+        export MC_CONSENSUS="mc://node1.test.mobilecoin.com/,mc://node2.test.mobilecoin.com/,mc://node3.test.mobilecoin.com/"
+        export MC_FOG_VIEW="fog-view://fog.test.mobilecoin.com:443"
+        export MC_FOG_LEDGER="fog-ledger://fog.test.mobilecoin.com:443"
         ;;
     mc-mainnet)
-        export CONSENSUS_VALIDATORS="mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/,mc://node3.prod.mobilecoinww.com/"
-        export FOG_VIEW="fog-view://fog.prod.mobilecoinww.com:443"
-        export FOG_LEDGER="fog-ledger://fog.prod.mobilecoinww.com:443"
-        export MC_PARTNER="mc"
-        export MC_NETWORK="main"
+        export MC_CONSENSUS="mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/,mc://node3.prod.mobilecoinww.com/"
+        export MC_FOG_VIEW="fog-view://fog.prod.mobilecoinww.com:443"
+        export MC_FOG_LEDGER="fog-ledger://fog.prod.mobilecoinww.com:443"
         ;;
     signal-mainnet)
-        export CONSENSUS_VALIDATORS="mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/,mc://node3.prod.mobilecoinww.com/"
-        export FOG_VIEW="fog-view://service.fog.mob.production.namda.net:443"
-        export FOG_LEDGER="fog-ledger://service.fog.mob.production.namda.net:443"
-        export MC_PARTNER="signal"
-        export MC_NETWORK="main"
-        export CLIENT_AUTH_TOKEN_SECRET="${CLIENT_AUTH_TOKEN_SECRET}"
+        export MC_CONSENSUS="mc://node1.prod.mobilecoinww.com/,mc://node2.prod.mobilecoinww.com/,mc://node3.prod.mobilecoinww.com/"
+        export MC_FOG_VIEW="fog-view://fog.prod.mobilecoinww.com:443"
+        export MC_FOG_LEDGER="fog-ledger://fog.prod.mobilecoinww.com:443"
         ;;
     *)
         echo "Unknown network"
@@ -52,24 +42,12 @@ kubectl create configmap fog-test-client-measurements -o yaml --dry-run=client \
     | grep -v creationTimestamp > "${net_path}/k8s/fog-test-client-measurements-configMap.yaml"
 
 kubectl create configmap fog-test-client -o yaml --dry-run=client \
-    --from-literal=FOG_VIEW="${FOG_VIEW}" \
-    --from-literal=FOG_LEDGER="${FOG_LEDGER}" \
-    --from-literal=CONSENSUS_VALIDATORS="${CONSENSUS_VALIDATORS}" \
-    --from-literal=CONSENSUS_WAIT="20" \
+    --from-literal=MC_FOG_VIEW="${MC_FOG_VIEW}" \
+    --from-literal=MC_FOG_LEDGER="${MC_FOG_LEDGER}" \
+    --from-literal=MC_CONSENSUS="${MC_CONSENSUS}" \
+    --from-literal=MC_CONSENSUS_WAIT="20" \
     | grep -v creationTimestamp > "${net_path}/k8s/fog-test-client-configMap.yaml"
 
 kubectl create secret generic fog-test-client-keys -o yaml --dry-run=client \
     --from-file "${keys_path}" \
     | grep -v creationTimestamp > "${net_path}/k8s/fog-test-client-keys-secret.yaml"
-
-if [ -n "${CLIENT_AUTH_TOKEN_SECRET}" ]
-then
-    kubectl create secret generic fog-client-auth-token -o yaml --dry-run=client \
-        --from-literal=token="${CLIENT_AUTH_TOKEN_SECRET}" \
-        | grep -v creationTimestamp > "${net_path}/k8s/fog-client-auth-token-secret.yaml"
-fi
-
-kubectl create configmap mobilecoin-network -o yaml --dry-run=client \
-    --from-literal=network="${MC_NETWORK}" \
-    --from-literal=partner="${MC_PARTNER}" \
-    | grep -v creationTimestamp > "${net_path}/k8s/mobilecoin-network-configMap.yaml"

--- a/.internal-ci/helm/fog-test-client/scripts/setup.sh
+++ b/.internal-ci/helm/fog-test-client/scripts/setup.sh
@@ -10,7 +10,6 @@ tmp=/tmp
 all_nets="mc-mainnet mc-testnet signal-testnet signal-mainnet"
 test_nets="mc-testnet signal-testnet"
 prod_nets="mc-mainnet signal-mainnet"
-signal_nets="signal-mainnet signal-testnet"
 
 # Vaults
 wallet_vault="Fog-Test-Client Wallets"
@@ -55,7 +54,7 @@ do
     item=$(op get item "${uuid}")
     # list the fields for item - this contains the filenames (n) and contents (v)
     fields=$(echo "${item}" | jq -r '.details.sections[0].fields[].n')
-    
+
     # write values for each file
     for f in ${fields}
     do
@@ -72,20 +71,6 @@ do
             echo "${value}" > "${tmp}/nets/${n}/keys/${name}"
         fi
     done
-done
-
-echo "---- Get fog-client-auth-token-secrets"
-for n in ${signal_nets}
-do
-    # get uuid for fog-client-auth-secret by network
-    uuid=$(echo "${vault_items}" |jq -r ".[] | select(.overview.title | match(\"${n}/fog-client-auth-token-secret\")).uuid")
-    # get item details for uuid
-    item=$(op get item "${uuid}")
-    # get password for in item
-    value=$(echo "${item}" | jq -r '.details.fields[] | select(.name=="password").value')
-
-    # write value to file
-    echo -n "${value}" > "${tmp}/nets/${n}/fog-client-auth-token-secret"
 done
 
 echo "---- Generate k8s objects"

--- a/.internal-ci/helm/fog-test-client/templates/fog-test-client-deployment.yaml
+++ b/.internal-ci/helm/fog-test-client/templates/fog-test-client-deployment.yaml
@@ -34,41 +34,12 @@ spec:
             drop:
             - all
           readOnlyRootFilesystem: true
+        envFrom:
+        - configMapRef:
+            name: {{ .Values.fogTestClientConfig.configMap.name }}
         env:
-        - name: MC_FOG_VIEW
-          valueFrom:
-            configMapKeyRef:
-              name: {{ .Values.fogTestClientConfig.configMap.name }}
-              key: FOG_VIEW
-        - name: MC_FOG_LEDGER
-          valueFrom:
-            configMapKeyRef:
-              name: {{ .Values.fogTestClientConfig.configMap.name }}
-              key: FOG_LEDGER
-        - name: MC_CONSENSUS
-          valueFrom:
-            configMapKeyRef:
-              name: {{ .Values.fogTestClientConfig.configMap.name }}
-              key: CONSENSUS_VALIDATORS
-        - name: MC_CONSENSUS_WAIT
-          valueFrom:
-            configMapKeyRef:
-              name: {{ .Values.fogTestClientConfig.configMap.name }}
-              key: CONSENSUS_WAIT
-        - name: MC_TRANSFER_AMOUNT
-          value: "100000000000"
         - name: MC_CHAIN_ID
-          valueFrom:
-            configMapKeyRef:
-              name: mobilecoin-network
-              key: network
-        {{- if.Values.fogTestClientConfig.fogClientAuthTokenSecret.enabled }}
-        - name: CLIENT_AUTH_TOKEN_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.fogTestClientConfig.fogClientAuthTokenSecret.name }}
-              key: token
-        {{- end }}
+          value: "{{ .Values.mobileCoinNetwork.network }}"
         ports:
         - name: grpc-mgmt
           containerPort: 8001
@@ -122,42 +93,6 @@ spec:
             port: 9090
           initialDelaySeconds: 20
           periodSeconds: 20
-      {{- if eq .Values.jaegerTracing.enabled true }}
-      - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:latest
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 5775
-          name: zk-compact-trft
-          protocol: UDP
-        - containerPort: 5778
-          name: config-rest
-          protocol: TCP
-        - containerPort: 6831
-          name: jg-compact-trft
-          protocol: UDP
-        - containerPort: 6832
-          name: jg-binary-trft
-          protocol: UDP
-        - containerPort: 14271
-          name: admin-http
-          protocol: TCP
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
-        args:
-        - --reporter.grpc.host-port=dns:///jaeger-collector:14250
-        - --reporter.type=grpc
-        - --agent.tags=cluster=undefined,container.name=node,deployment.name={{ include "consensusNode.fullname" . }},host.ip=${HOST_IP:},pod.name=${POD_NAME:},pod.namespace={{ .Release.Namespace }}
-      {{- end }}
       nodeSelector:
         {{- toYaml .Values.fogTestClient.nodeSelector | nindent 8 }}
       affinity:

--- a/.internal-ci/helm/fog-test-client/values.yaml
+++ b/.internal-ci/helm/fog-test-client/values.yaml
@@ -26,6 +26,15 @@ fogTestClientConfig:
   #     | grep -v creationTimestamp > "fog-test-client-configMap.yaml"
   configMap:
     name: fog-test-client
+    ### Values:
+      # MC_CONSENSUS: ${consensus_validators}
+      # MC_CONSENSUS_WAIT: "20"
+      # MC_FOG_LEDGER: fog-ledger://${fog_hostname}:443
+      # MC_FOG_VIEW: fog-view://${fog_hostname}:443
+      # MC_TELEMETRY: "true"
+      # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.otel:4317
+      # OTEL_RESOURCE_ATTRIBUTES: deployment.environment=${partner}-${network}
+      # MC_TRANSFER_AMOUNT: "100000000000"
 
   ### populates enclave measurement .css files
   # Generate with:
@@ -35,17 +44,6 @@ fogTestClientConfig:
   measurementsConfigMap:
     name: fog-test-client-measurements
 
-  ### Enable for Signal Fog environments.
-  #   Secret used to generate token when communicating with signal view/ledger services.
-  # Generate with:
-  #   kubectl create secret generic fog-client-auth-token -o yaml --dry-run=client \
-  #     --from-literal=token="${CLIENT_AUTH_TOKEN_SECRET}" \
-  #     | grep -v creationTimestamp > fog-client-auth-token-secret.yaml
-  fogClientAuthTokenSecret:
-    name: fog-client-auth-token
-    enabled: false
-
-
 ### Deployments
 fogTestClient:
   replicaCount: 1
@@ -54,6 +52,7 @@ fogTestClient:
     tag: ""
   podAnnotations:
     fluentbit.io/include: 'true'
+    cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
   resources:
     requests:
       cpu: 1000m
@@ -63,9 +62,6 @@ fogTestClient:
   affinity: {}
 
 mobileCoinNetwork:
-  configMap:
-    external: true
-    name: mobilecoin-network
   # test, prod, alpha...
   network: ""
   # mc, mcww, signal...
@@ -73,6 +69,3 @@ mobileCoinNetwork:
 
 serviceMonitor:
   enabled: true
-
-jaegerTracing:
-  enabled: false


### PR DESCRIPTION
- Update fog-test-client chart to accept all env vars from the configmap.
- Clean up some of the support and k8s object generation scripts.
- Clean up options for CLIENT_AUTH_TOKEN, no environments use this now.
- Remove jaeger tracing