### PR TITLE
add do not evict annotations view/ledger stores

### DIFF
--- a/.internal-ci/helm/fog-ledger-fsg/values.yaml
+++ b/.internal-ci/helm/fog-ledger-fsg/values.yaml
@@ -133,6 +133,7 @@ fogLedger:
       fluentbit.io/include: 'true' # collect logs with fluentbit
       # This is the container name that needs to use sgx resources
       sgx.intel.com/quote-provider: fog-ledger-store
+      cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 
     # disable affinity rules for single node testing
     podManagementPolicy: Parallel

--- a/.internal-ci/helm/fog-view-fsg/values.yaml
+++ b/.internal-ci/helm/fog-view-fsg/values.yaml
@@ -132,6 +132,7 @@ fogView:
       fluentbit.io/include: 'true' # collect logs with fluentbit
       # This is the container name that needs to use sgx resources
       sgx.intel.com/quote-provider: fog-view-store
+      cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 
     # disable affinity rules for single node testing
     podManagementPolicy: Parallel


### PR DESCRIPTION
Add `cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'` annotation to view and ledger stores.
