### PR TITLE
Add distribitued tracing through fog ledger router

### DIFF
--- a/fog/ledger/server/Cargo.toml
+++ b/fog/ledger/server/Cargo.toml
@@ -63,6 +63,7 @@ rand = { workspace = true }
 retry = { workspace = true }
 serde = { workspace = true, features = ["alloc", "derive"] }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 url = { workspace = true }
 
 [build-dependencies]

--- a/fog/ledger/server/src/bin/key_image_store.rs
+++ b/fog/ledger/server/src/bin/key_image_store.rs
@@ -18,6 +18,28 @@ fn main() {
     mc_common::setup_panic_handler();
     let config = LedgerStoreConfig::parse();
 
+    let _runtime = if mc_util_telemetry::telemetry_enabled() {
+        // Create a Tokio runtime for telemetry OTLP exporter
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        Some(runtime)
+    } else {
+        None
+    };
+
+    let _runtime_guard = _runtime.as_ref().map(|runtime| runtime.enter());
+
+    let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
+        env!("CARGO_PKG_NAME"),
+        &[(
+            "client_responser_id",
+            config.client_responder_id.to_string(),
+        )],
+    )
+    .expect("Failed setting telemetry tracer");
+
     let enclave_path = env::current_exe()
         .expect("Could not get the path of our executable")
         .with_file_name(ENCLAVE_FILE);

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -16,6 +16,28 @@ fn main() {
     mc_common::setup_panic_handler();
     let config = LedgerRouterConfig::parse();
 
+    let _runtime = if mc_util_telemetry::telemetry_enabled() {
+        // Create a Tokio runtime for telemetry OTLP exporter
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime");
+        Some(runtime)
+    } else {
+        None
+    };
+
+    let _runtime_guard = _runtime.as_ref().map(|runtime| runtime.enter());
+
+    let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
+        env!("CARGO_PKG_NAME"),
+        &[(
+            "client_responser_id",
+            config.client_responder_id.to_string(),
+        )],
+    )
+    .expect("Failed setting telemetry tracer");
+
     let enclave_path = env::current_exe()
         .expect("Could not get the path of our executable")
         .with_file_name(ENCLAVE_FILE);

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -12,6 +12,7 @@ use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_ledger_enclave_api::{Error as EnclaveError, UntrustedKeyImageQueryResponse};
 use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
 use mc_util_grpc::{rpc_logger, rpc_permissions_error, send_result, Authenticator};
+use mc_util_telemetry::{Context, KeyValue, TraceContextExt, Tracer};
 use std::{
     sync::{Arc, Mutex},
     time::Instant,
@@ -107,6 +108,9 @@ impl<E: LedgerEnclaveProxy> KeyImageService<E> {
         &mut self,
         request: attest::NonceMessage,
     ) -> Result<attest::NonceMessage, EnclaveError> {
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard =
+            Context::current_with_span(tracer.start("check_key_image_store_auth")).attach();
         log::trace!(self.logger, "Getting encrypted request");
 
         let untrusted_query_response = self.prepare_untrusted_query();
@@ -125,6 +129,13 @@ impl<E: LedgerEnclaveProxy> KeyImageService<E> {
         fog_ledger_store_uri: KeyImageStoreUri,
         queries: Vec<attest::NonceMessage>,
     ) -> MultiKeyImageStoreResponse {
+        let tracer = mc_util_telemetry::tracer!();
+        let span = tracer
+            .span_builder("process_queries")
+            .with_attributes([KeyValue::new("query_count", queries.len() as i64)])
+            .start(&tracer);
+        let _guard = Context::current_with_span(span).attach();
+
         let mut response = MultiKeyImageStoreResponse {
             // The router needs our own URI, in case auth fails / hasn't been started yet.
             store_uri: fog_ledger_store_uri.url().to_string(),
@@ -173,6 +184,10 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
         sink: grpcio::UnarySink<AuthMessage>,
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard = mc_util_telemetry::extract_context(&ctx)
+            .with_span(tracer.start("auth"))
+            .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = self.authenticator.authenticate_rpc(&ctx) {
                 return send_result(ctx, sink, err.into(), logger);
@@ -204,6 +219,11 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
         sink: grpcio::UnarySink<MultiKeyImageStoreResponse>,
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard = mc_util_telemetry::extract_context(&ctx)
+            .with_span(tracer.start("multi_key_image_store_query"))
+            .attach();
+
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = self.authenticator.authenticate_rpc(&ctx) {
                 return send_result(ctx, sink, err.into(), logger);

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -6,7 +6,9 @@ use crate::{
     SVC_COUNTERS,
 };
 use futures::{future::try_join_all, SinkExt, TryStreamExt};
-use grpcio::{ChannelBuilder, DuplexSink, RequestStream, RpcStatus, WriteFlags};
+use grpcio::{
+    CallOption, ChannelBuilder, DuplexSink, MetadataBuilder, RequestStream, RpcStatus, WriteFlags,
+};
 use mc_attest_api::attest;
 use mc_attest_enclave_api::{EnclaveMessage, NonceSession};
 use mc_common::{
@@ -21,7 +23,9 @@ use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::{ConnectionUri, KeyImageStoreUri};
 use mc_util_grpc::{rpc_invalid_arg_error, ConnectionUriGrpcioChannel, ResponseStatus};
 use mc_util_metrics::GrpcMethodName;
-use mc_util_telemetry::{create_context, tracer, BoxedTracer, FutureExt, Tracer};
+use mc_util_telemetry::{
+    create_context, tracer, BoxedTracer, Context, FutureExt, InjectContext, Tracer,
+};
 use std::{collections::BTreeMap, str::FromStr, sync::Arc};
 
 /// Handles a series of requests sent by the Fog Ledger Router client,
@@ -361,7 +365,13 @@ async fn query_shard(
     request: &MultiKeyImageStoreRequest,
     shard_client: Arc<KeyImageStoreApiClient>,
 ) -> Result<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse), RouterServerError> {
-    let client_unary_receiver = shard_client.multi_key_image_store_query_async(request)?;
+    let mut meta_builder = MetadataBuilder::new();
+    // We ignore the error here as it only affects distributed tracing and
+    // shouldn't prevent the request from being processed.
+    let _ = meta_builder.inject_context(&Context::current());
+    let call_opt = CallOption::default().headers(meta_builder.build());
+    let client_unary_receiver =
+        shard_client.multi_key_image_store_query_async_opt(request, call_opt)?;
     let response = client_unary_receiver.await?;
     Ok((shard_client, response))
 }

--- a/fog/ledger/server/src/router_service.rs
+++ b/fog/ledger/server/src/router_service.rs
@@ -16,7 +16,7 @@ use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::KeyImageStoreUri;
 use mc_util_grpc::{rpc_internal_error, rpc_logger};
 use mc_util_metrics::ServiceMetrics;
-use mc_util_telemetry::tracer;
+use mc_util_telemetry::{tracer, TraceContextExt, Tracer};
 
 use std::{
     collections::HashMap,
@@ -138,6 +138,11 @@ where
 impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
     fn check_key_images(&mut self, ctx: RpcContext, request: Message, sink: UnarySink<Message>) {
         let _timer = SVC_COUNTERS.req(&ctx);
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard = mc_util_telemetry::extract_context(&ctx)
+            .with_span(tracer.start("check_key_images"))
+            .attach();
+
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let logger = logger.clone();
             let shards = self.shards.read().expect("RwLock poisoned");
@@ -160,6 +165,11 @@ impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
 
     fn auth(&mut self, ctx: RpcContext, request: AuthMessage, sink: UnarySink<AuthMessage>) {
         let _timer = SVC_COUNTERS.req(&ctx);
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard = mc_util_telemetry::extract_context(&ctx)
+            .with_span(tracer.start("auth"))
+            .attach();
+
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let logger = logger.clone();
             let result = handle_auth_request(self.enclave.clone(), request, logger.clone());

--- a/fog/ledger/server/src/untrusted_tx_out_service.rs
+++ b/fog/ledger/server/src/untrusted_tx_out_service.rs
@@ -10,6 +10,7 @@ use mc_util_grpc::{
     check_request_chain_id, rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result,
     Authenticator,
 };
+use mc_util_telemetry::{TraceContextExt, Tracer};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -37,6 +38,7 @@ impl UntrustedTxOutService {
 
     fn get_tx_outs_impl(&mut self, request: TxOutRequest) -> Result<TxOutResponse, RpcStatus> {
         mc_common::trace_time!(self.logger, "Get Blocks");
+        let tracer = mc_util_telemetry::tracer!();
 
         let tx_out_pub_keys = request
             .tx_out_pubkeys
@@ -48,12 +50,13 @@ impl UntrustedTxOutService {
         let TxOutInfoByPublicKeyResponse {
             results,
             latest_block,
-        } = self
-            .block_provider
-            .get_tx_out_info_by_public_key(tx_out_pub_keys.as_slice())
-            .map_err(|err| {
-                rpc_internal_error("get_tX_out_info_by_public_key", err, &self.logger)
-            })?;
+        } = tracer.in_span("get_tx_out_info_by_public_key", |_| {
+            self.block_provider
+                .get_tx_out_info_by_public_key(tx_out_pub_keys.as_slice())
+                .map_err(|err| {
+                    rpc_internal_error("get_tx_out_info_by_public_key", err, &self.logger)
+                })
+        })?;
 
         Ok(TxOutResponse {
             num_blocks: latest_block.index + 1,
@@ -71,6 +74,10 @@ impl FogUntrustedTxOutApi for UntrustedTxOutService {
         sink: UnarySink<TxOutResponse>,
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
+        let tracer = mc_util_telemetry::tracer!();
+        let _guard = mc_util_telemetry::extract_context(&ctx)
+            .with_span(tracer.start("get_tx_outs"))
+            .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = check_request_chain_id(&self.chain_id, &ctx) {
                 return send_result(ctx, sink, Err(err), logger);


### PR DESCRIPTION
Previously fog ledger router didn't support tracing. Now it supports
propagating the tracing context from the caller all the way to the
shards.
