### PR TITLE
Fix fog ledger distributed tracing

### DIFF
--- a/fog/ledger/server/src/bin/key_image_store.rs
+++ b/fog/ledger/server/src/bin/key_image_store.rs
@@ -32,7 +32,7 @@ fn main() {
     let _runtime_guard = _runtime.as_ref().map(|runtime| runtime.enter());
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
-        env!("CARGO_PKG_NAME"),
+        "fog_ledger_store",
         &[(
             "client_responser_id",
             config.client_responder_id.to_string(),

--- a/fog/ledger/server/src/bin/router.rs
+++ b/fog/ledger/server/src/bin/router.rs
@@ -30,7 +30,7 @@ fn main() {
     let _runtime_guard = _runtime.as_ref().map(|runtime| runtime.enter());
 
     let _tracer = mc_util_telemetry::setup_default_tracer_with_tags(
-        env!("CARGO_PKG_NAME"),
+        "fog_ledger_router",
         &[(
             "client_responser_id",
             config.client_responder_id.to_string(),

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -185,8 +185,9 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let _guard = mc_util_telemetry::extract_context(&ctx)
-            .with_span(tracer.start("auth"))
+        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = tracing_ctx
+            .with_span(tracer.start_with_context("auth", &tracing_ctx))
             .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = self.authenticator.authenticate_rpc(&ctx) {
@@ -220,8 +221,9 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let _guard = mc_util_telemetry::extract_context(&ctx)
-            .with_span(tracer.start("multi_key_image_store_query"))
+        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = tracing_ctx
+            .with_span(tracer.start_with_context("multi_key_image_store_query", &tracing_ctx))
             .attach();
 
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {

--- a/fog/ledger/server/src/key_image_service.rs
+++ b/fog/ledger/server/src/key_image_service.rs
@@ -185,9 +185,9 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
-        let _guard = tracing_ctx
-            .with_span(tracer.start_with_context("auth", &tracing_ctx))
+        let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = parent_ctx
+            .with_span(tracer.start_with_context("auth", &parent_ctx))
             .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = self.authenticator.authenticate_rpc(&ctx) {
@@ -221,9 +221,9 @@ impl<E: LedgerEnclaveProxy> KeyImageStoreApi for KeyImageService<E> {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
-        let _guard = tracing_ctx
-            .with_span(tracer.start_with_context("multi_key_image_store_query", &tracing_ctx))
+        let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = parent_ctx
+            .with_span(tracer.start_with_context("multi_key_image_store_query", &parent_ctx))
             .attach();
 
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {

--- a/fog/ledger/server/src/router_handlers.rs
+++ b/fog/ledger/server/src/router_handlers.rs
@@ -354,9 +354,10 @@ async fn route_query(
     request: &MultiKeyImageStoreRequest,
     shard_clients: Vec<Arc<KeyImageStoreApiClient>>,
 ) -> Result<Vec<(Arc<KeyImageStoreApiClient>, MultiKeyImageStoreResponse)>, RouterServerError> {
-    let responses = shard_clients
-        .into_iter()
-        .map(|shard_client| query_shard(request, shard_client));
+    let tracer = mc_util_telemetry::tracer!();
+    let responses = shard_clients.into_iter().map(|shard_client| {
+        query_shard(request, shard_client).with_context(create_context(&tracer, "query_shard"))
+    });
     try_join_all(responses).await
 }
 

--- a/fog/ledger/server/src/router_service.rs
+++ b/fog/ledger/server/src/router_service.rs
@@ -16,7 +16,7 @@ use mc_fog_ledger_enclave::LedgerEnclaveProxy;
 use mc_fog_uri::KeyImageStoreUri;
 use mc_util_grpc::{rpc_internal_error, rpc_logger};
 use mc_util_metrics::ServiceMetrics;
-use mc_util_telemetry::{tracer, TraceContextExt, Tracer};
+use mc_util_telemetry::{tracer, FutureExt as TraceFutureExt, TraceContextExt, Tracer};
 
 use std::{
     collections::HashMap,
@@ -139,9 +139,9 @@ impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
     fn check_key_images(&mut self, ctx: RpcContext, request: Message, sink: UnarySink<Message>) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let _guard = mc_util_telemetry::extract_context(&ctx)
-            .with_span(tracer.start("check_key_images"))
-            .attach();
+        let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+        let tracing_ctx =
+            parent_ctx.with_span(tracer.start_with_context("check_key_images", &parent_ctx));
 
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let logger = logger.clone();
@@ -155,6 +155,7 @@ impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
                 shards.values().cloned().collect(),
                 logger.clone(),
             )
+            .with_context(tracing_ctx)
             .map_err(move |err| log::error!(&logger, "failed to reply: {}", err))
             // TODO: Do more with the error than just push it to the log.
             .map(|_| ());
@@ -166,9 +167,8 @@ impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
     fn auth(&mut self, ctx: RpcContext, request: AuthMessage, sink: UnarySink<AuthMessage>) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let _guard = mc_util_telemetry::extract_context(&ctx)
-            .with_span(tracer.start("auth"))
-            .attach();
+        let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+        let tracing_ctx = parent_ctx.with_span(tracer.start_with_context("auth", &parent_ctx));
 
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             let logger = logger.clone();
@@ -188,6 +188,7 @@ impl<E: LedgerEnclaveProxy> FogKeyImageApi for LedgerRouterService<E> {
                 },
                 Err(rpc_status) => sink.fail(rpc_status),
             }
+            .with_context(tracing_ctx)
             .map_err(move |err| log::error!(&logger, "failed to reply: {}", err))
             .map(|_| ());
             ctx.spawn(future);

--- a/fog/ledger/server/src/untrusted_tx_out_service.rs
+++ b/fog/ledger/server/src/untrusted_tx_out_service.rs
@@ -75,8 +75,9 @@ impl FogUntrustedTxOutApi for UntrustedTxOutService {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let _guard = mc_util_telemetry::extract_context(&ctx)
-            .with_span(tracer.start("get_tx_outs"))
+        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = tracing_ctx
+            .with_span(tracer.start_with_context("get_tx_outs", &tracing_ctx))
             .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = check_request_chain_id(&self.chain_id, &ctx) {

--- a/fog/ledger/server/src/untrusted_tx_out_service.rs
+++ b/fog/ledger/server/src/untrusted_tx_out_service.rs
@@ -75,9 +75,9 @@ impl FogUntrustedTxOutApi for UntrustedTxOutService {
     ) {
         let _timer = SVC_COUNTERS.req(&ctx);
         let tracer = mc_util_telemetry::tracer!();
-        let tracing_ctx = mc_util_telemetry::extract_context(&ctx);
-        let _guard = tracing_ctx
-            .with_span(tracer.start_with_context("get_tx_outs", &tracing_ctx))
+        let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+        let _guard = parent_ctx
+            .with_span(tracer.start_with_context("get_tx_outs", &parent_ctx))
             .attach();
         mc_common::logger::scoped_global_logger(&rpc_logger(&ctx, &self.logger), |logger| {
             if let Err(err) = check_request_chain_id(&self.chain_id, &ctx) {

--- a/util/telemetry/src/otlp.rs
+++ b/util/telemetry/src/otlp.rs
@@ -1,6 +1,6 @@
 use displaydoc::Display;
 use opentelemetry::{global, global::BoxedTracer, trace::TraceError, KeyValue};
-use opentelemetry_sdk::{trace, Resource};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace, Resource};
 
 #[derive(Debug, Display)]
 pub enum Error {
@@ -35,6 +35,8 @@ pub fn setup_default_tracer_with_tags(
     if !telemetry_enabled() {
         return Ok(None);
     }
+
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
     let local_hostname = hostname::get().map_err(Error::GetHostname)?;
 


### PR DESCRIPTION
Previously the traces in fog ledger were not properly propagating the
trace context through. Now they are.
