### PR TITLE
Propagate trace context through mobilecoind block_provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3798,6 +3798,7 @@ dependencies = [
  "mc-mobilecoind-api",
  "mc-transaction-core",
  "mc-util-grpc",
+ "mc-util-telemetry",
  "mc-watcher",
  "mc-watcher-api",
 ]

--- a/fog/block_provider/Cargo.toml
+++ b/fog/block_provider/Cargo.toml
@@ -17,6 +17,7 @@ mc-ledger-db = { workspace = true }
 mc-mobilecoind-api = { workspace = true }
 mc-transaction-core = { workspace = true }
 mc-util-grpc = { workspace = true }
+mc-util-telemetry = { workspace = true }
 mc-watcher = { workspace = true }
 mc-watcher-api = { workspace = true }
 

--- a/fog/block_provider/src/mobilecoind.rs
+++ b/fog/block_provider/src/mobilecoind.rs
@@ -3,7 +3,7 @@
 use crate::{
     BlockDataWithTimestamp, BlockProvider, BlocksDataResponse, Error, TxOutInfoByPublicKeyResponse,
 };
-use grpcio::{ChannelBuilder, EnvBuilder};
+use grpcio::{CallOption, ChannelBuilder, EnvBuilder, MetadataBuilder};
 use mc_api::watcher::TimestampResultCode;
 use mc_blockchain_types::{Block, BlockData, BlockIndex};
 use mc_common::logger::{log, Logger};
@@ -14,6 +14,7 @@ use mc_mobilecoind_api::{
 };
 use mc_transaction_core::tx::{TxOut, TxOutMembershipProof};
 use mc_util_grpc::ConnectionUriGrpcioChannel;
+use mc_util_telemetry::{Context, InjectContext};
 use mc_watcher::watcher_db::{
     POLL_BLOCK_TIMESTAMP_ERROR_RETRY_FREQUENCY, POLL_BLOCK_TIMESTAMP_POLLING_FREQUENCY,
 };
@@ -193,10 +194,17 @@ impl BlockProvider for MobilecoindBlockProvider {
         &self,
         tx_out_pub_keys: &[CompressedRistrettoPublic],
     ) -> Result<TxOutInfoByPublicKeyResponse, Error> {
+        let mut meta_builder = MetadataBuilder::new();
+        // We ignore the error here as it only affects distributed tracing and
+        // shouldn't prevent the request from being processed.
+        let _ = meta_builder.inject_context(&Context::current());
+        let call_opt = CallOption::default().headers(meta_builder.build());
         let request = GetTxOutResultsByPubKeyRequest {
             tx_out_public_keys: tx_out_pub_keys.iter().map(|pk| pk.into()).collect(),
         };
-        let response = self.client.get_tx_out_results_by_pub_key(&request)?;
+        let response = self
+            .client
+            .get_tx_out_results_by_pub_key_opt(&request, call_opt)?;
 
         let latest_block = Block::try_from(
             response

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -53,6 +53,7 @@ use mc_util_grpc::{
     rpc_internal_error, rpc_invalid_arg_error, rpc_logger, send_result, AdminService,
     BuildInfoService, ConnectionUriGrpcioServer,
 };
+use mc_util_telemetry::{TraceContextExt, Tracer};
 use mc_watcher::watcher_db::WatcherDB;
 use mc_watcher_api::TimestampResultCode;
 use std::sync::{Arc, Mutex, RwLock};
@@ -2699,6 +2700,11 @@ macro_rules! build_api {
                     request: $service_request_type,
                     sink: UnarySink<$service_response_type>,
                 ) {
+                    let tracer = mc_util_telemetry::tracer!();
+                    let parent_ctx = mc_util_telemetry::extract_context(&ctx);
+                    let _guard = parent_ctx
+                        .with_span(tracer.start_with_context(stringify!($service_function_name), &parent_ctx))
+                        .attach();
                     let logger = rpc_logger(&ctx, &self.logger);
                     send_result(
                         ctx,


### PR DESCRIPTION
Previously the trace context was lost once a request was made to the
mobilecoind block provider. Now the trace context propagates through to
the Mobilecoind backend.
