### PR TITLE
Remove some stray traces/spans

### DIFF
--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -39,7 +39,6 @@ use mc_transaction_core::{
     Amount, FeeMap, TokenId,
 };
 use mc_transaction_extra::{MemoType, SenderMemoCredential, SignedContingentInput};
-use mc_util_telemetry::{block_span_builder, telemetry_static_key, tracer, Key, Span};
 use mc_util_uri::{ConnectionUri, FogUri};
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
@@ -47,9 +46,6 @@ use std::collections::{HashMap, HashSet};
 /// Default number of blocks used for calculating transaction tombstone block
 /// number. See `new_tx_block_attempts` below.
 const DEFAULT_NEW_TX_BLOCK_ATTEMPTS: u16 = 50;
-
-/// Telemetry: block index the transaction is expected to land at.
-const TELEMETRY_BLOCK_INDEX_KEY: Key = telemetry_static_key!("block-index");
 
 /// Represents the entire sample paykit object, capable of balance checks and
 /// sending transactions
@@ -187,8 +183,6 @@ impl Client {
     /// get refreshed key image data before attempting to create another
     /// transaction.
     pub fn send_transaction(&mut self, transaction: &Tx) -> Result<u64> {
-        let start_time = std::time::SystemTime::now();
-
         let block_count = self
             .consensus_service_conn
             .propose_tx(transaction)
@@ -217,14 +211,6 @@ impl Client {
 
                 err
             })?;
-
-        let tracer = tracer!();
-        let mut span = block_span_builder(&tracer, "send_transaction", block_count)
-            .with_start_time(start_time)
-            .start(&tracer);
-
-        span.set_attribute(TELEMETRY_BLOCK_INDEX_KEY.i64(block_count as i64));
-        span.end();
 
         Ok(block_count)
     }

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -2700,11 +2700,18 @@ macro_rules! build_api {
                     request: $service_request_type,
                     sink: UnarySink<$service_response_type>,
                 ) {
-                    let tracer = mc_util_telemetry::tracer!();
                     let parent_ctx = mc_util_telemetry::extract_context(&ctx);
-                    let _guard = parent_ctx
-                        .with_span(tracer.start_with_context(stringify!($service_function_name), &parent_ctx))
-                        .attach();
+                    // Mobilecoind is often called by polling threads that don't
+                    // have a trace context (e.g. db polling thread). In those
+                    // cases, we don't want to record spans as they would be orphaned.
+                    let _guard = if parent_ctx.span().span_context().is_valid() {
+                        let tracer = mc_util_telemetry::tracer!();
+                        Some(parent_ctx
+                            .with_span(tracer.start_with_context(stringify!($service_function_name), &parent_ctx))
+                            .attach())
+                    } else {
+                        None
+                    };
                     let logger = rpc_logger(&ctx, &self.logger);
                     send_result(
                         ctx,


### PR DESCRIPTION
Previously all of the Mobilecoind API was creating spans. This was a bit
noisy when the caller wasn't propagating a trace context. Now
Moibilecoind will only create spans if it was provided a propagated
trace context.
