### PR TITLE
Make PrintableWrapper::b58_encode infallible

### DIFF
--- a/api/src/display.rs
+++ b/api/src/display.rs
@@ -42,12 +42,12 @@ fn calculate_checksum(data: &[u8]) -> [u8; 4] {
 /// encoded string, with a checksum prepended to it.
 impl printable::PrintableWrapper {
     /// Converts the proto to bytes and then encodes as b58
-    pub fn b58_encode(&self) -> Result<String, Error> {
+    pub fn b58_encode(&self) -> String {
         let wrapper_bytes = self.encode_to_vec();
         let mut bytes_vec = Vec::new();
         bytes_vec.extend_from_slice(&calculate_checksum(&wrapper_bytes));
         bytes_vec.extend_from_slice(&wrapper_bytes);
-        Ok(bs58::encode(&bytes_vec[..]).into_string())
+        bs58::encode(&bytes_vec[..]).into_string()
     }
 
     /// Converts a b58 string to bytes and then decodes to a proto
@@ -102,7 +102,7 @@ mod display_tests {
         let wrapper = PrintableWrapper {
             wrapper: Some(printable_wrapper::Wrapper::PublicAddress(public_address)),
         };
-        let encoded = wrapper.b58_encode().unwrap();
+        let encoded = wrapper.b58_encode();
         let decoded = PrintableWrapper::b58_decode(encoded).unwrap();
         assert_eq!(wrapper, decoded);
     }
@@ -127,7 +127,7 @@ mod display_tests {
     #[test_with_data(B58EncodePublicAddressWithoutFog::from_jsonl("../test-vectors/vectors"))]
     fn test_b58_encode_public_address_without_fog(case: B58EncodePublicAddressWithoutFog) {
         let wrapper = printable_wrapper_from_b58_encode_public_address_without_fog(&case);
-        assert_eq!(wrapper.b58_encode().unwrap(), case.b58_encoded);
+        assert_eq!(wrapper.b58_encode(), case.b58_encoded);
     }
 
     #[test_with_data(B58EncodePublicAddressWithoutFog::from_jsonl("../test-vectors/vectors"))]
@@ -160,7 +160,7 @@ mod display_tests {
     #[test_with_data(B58EncodePublicAddressWithFog::from_jsonl("../test-vectors/vectors"))]
     fn test_b58_encode_public_address_with_fog(case: B58EncodePublicAddressWithFog) {
         let wrapper = printable_wrapper_from_b58_encode_public_address_with_fog(&case);
-        assert_eq!(wrapper.b58_encode().unwrap(), case.b58_encoded);
+        assert_eq!(wrapper.b58_encode(), case.b58_encoded);
     }
 
     #[test_with_data(B58EncodePublicAddressWithFog::from_jsonl("../test-vectors/vectors"))]
@@ -184,7 +184,7 @@ mod display_tests {
         let wrapper = PrintableWrapper {
             wrapper: Some(printable_wrapper::Wrapper::PaymentRequest(payment_request)),
         };
-        let encoded = wrapper.b58_encode().unwrap();
+        let encoded = wrapper.b58_encode();
         let decoded = PrintableWrapper::b58_decode(encoded).unwrap();
         assert_eq!(wrapper, decoded);
     }
@@ -206,7 +206,7 @@ mod display_tests {
                 transfer_payload.clone(),
             )),
         };
-        let encoded = wrapper.b58_encode().unwrap();
+        let encoded = wrapper.b58_encode();
         let decoded = PrintableWrapper::b58_decode(encoded).unwrap();
         assert_eq!(wrapper, decoded);
     }
@@ -218,7 +218,7 @@ mod display_tests {
         let wrapper = PrintableWrapper {
             wrapper: Some(printable_wrapper::Wrapper::PublicAddress(public_address)),
         };
-        let encoded = wrapper.b58_encode().unwrap();
+        let encoded = wrapper.b58_encode();
 
         // Change the checksum
         let mut vec_encoded = bs58::decode(encoded).into_vec().unwrap();

--- a/consensus/mint-client/src/printers.rs
+++ b/consensus/mint-client/src/printers.rs
@@ -67,7 +67,7 @@ pub fn print_mint_tx_prefix(prefix: &MintTxPrefix, indent: usize) {
             (&recipient).into(),
         )),
     };
-    let b58_recipient = wrapper.b58_encode().expect("failed encoding b58 address");
+    let b58_recipient = wrapper.b58_encode();
 
     let mut indent_str = INDENT_STR.repeat(indent);
     println!("{indent_str}MintTxPrefix:");

--- a/fog/sample-paykit/src/client.rs
+++ b/fog/sample-paykit/src/client.rs
@@ -964,7 +964,7 @@ impl Client {
             )),
         };
 
-        wrapper.b58_encode().unwrap()
+        wrapper.b58_encode()
     }
 }
 

--- a/mobilecoind/src/service.rs
+++ b/mobilecoind/src/service.rs
@@ -497,9 +497,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
         // Return response.
         Ok(api::GetPublicAddressResponse {
             public_address: Some((&subaddress).into()),
-            b58_code: wrapper
-                .b58_encode()
-                .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?,
+            b58_code: wrapper.b58_encode(),
         })
     }
 
@@ -667,9 +665,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             wrapper: Some(printable_wrapper::Wrapper::PaymentRequest(payment_request)),
         };
 
-        let encoded = wrapper
-            .b58_encode()
-            .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
+        let encoded = wrapper.b58_encode();
 
         Ok(api::CreateRequestCodeResponse { b58_code: encoded })
     }
@@ -846,9 +842,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             )),
         };
 
-        let encoded = transfer_wrapper
-            .b58_encode()
-            .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
+        let encoded = transfer_wrapper.b58_encode();
 
         Ok(api::CreateTransferCodeResponse { b58_code: encoded })
     }
@@ -895,9 +889,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             )),
         };
 
-        let encoded = wrapper
-            .b58_encode()
-            .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
+        let encoded = wrapper.b58_encode();
 
         Ok(api::CreateAddressCodeResponse { b58_code: encoded })
     }
@@ -1560,9 +1552,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
             )),
         };
 
-        let b58_code = transfer_wrapper
-            .b58_encode()
-            .map_err(|err| rpc_internal_error("b58_encode", err, &self.logger))?;
+        let b58_code = transfer_wrapper.b58_encode();
 
         // Construct response.
         Ok(api::GenerateTransferCodeTxResponse {
@@ -2264,9 +2254,7 @@ impl<T: BlockchainConnection + UserTxConnection + 'static, FPR: FogPubkeyResolve
                         (&subaddress).into(),
                     )),
                 };
-                let encoded = wrapper
-                    .b58_encode()
-                    .map_err(|err| rpc_internal_error("wrapper.b58_encode", err, &self.logger))?;
+                let encoded = wrapper.b58_encode();
                 Ok(api::ProcessedTxOut {
                     monitor_id: monitor_id.to_vec(),
                     subaddress_index: src.subaddress_index,
@@ -3485,7 +3473,7 @@ mod test {
                 (&account_key.subaddress(10)).into(),
             )),
         };
-        let b58_code = wrapper.b58_encode().unwrap();
+        let b58_code = wrapper.b58_encode();
         assert_eq!(response.b58_code, b58_code,);
 
         // Subaddress that is out of index or an invalid monitor id should error.
@@ -7371,7 +7359,7 @@ mod test {
                 (&receiver_public_address).into(),
             )),
         };
-        let b58_code = wrapper.b58_encode().unwrap();
+        let b58_code = wrapper.b58_encode();
 
         // Call pay address code.
         let request = api::PayAddressCodeRequest {
@@ -7441,7 +7429,7 @@ mod test {
                 (&receiver_public_address).into(),
             )),
         };
-        let b58_code = wrapper.b58_encode().unwrap();
+        let b58_code = wrapper.b58_encode();
 
         let test_amount = 345;
 

--- a/test-vectors/b58-encodings/build.rs
+++ b/test-vectors/b58-encodings/build.rs
@@ -14,7 +14,7 @@ fn main() {
                         (&public_address).into(),
                     )),
                 };
-                let b58_encoded = wrapper.b58_encode().unwrap();
+                let b58_encoded = wrapper.b58_encode();
                 B58EncodePublicAddressWithoutFog {
                     view_public_key: public_address.view_public_key().to_bytes(),
                     spend_public_key: public_address.spend_public_key().to_bytes(),
@@ -40,7 +40,7 @@ fn main() {
                         (&public_address).into(),
                     )),
                 };
-                let b58_encoded = wrapper.b58_encode().unwrap();
+                let b58_encoded = wrapper.b58_encode();
                 B58EncodePublicAddressWithFog {
                     view_public_key: public_address.view_public_key().to_bytes(),
                     spend_public_key: public_address.spend_public_key().to_bytes(),

--- a/util/keyfile/src/lib.rs
+++ b/util/keyfile/src/lib.rs
@@ -114,7 +114,7 @@ pub fn write_b58pubfile<P: AsRef<Path>>(
         wrapper: Some(printable_wrapper::Wrapper::PublicAddress(addr.into())),
     };
 
-    let data = wrapper.b58_encode().map_err(to_io_error)?;
+    let data = wrapper.b58_encode();
 
     File::create(path)?.write_all(data.as_ref())?;
     Ok(())

--- a/util/keyfile/tests/b58-length.rs
+++ b/util/keyfile/tests/b58-length.rs
@@ -33,7 +33,7 @@ fn test_b58pub_length<T: RngCore + CryptoRng>(
             wrapper: Some(printable_wrapper::Wrapper::PublicAddress((&addr).into())),
         };
 
-        let data = wrapper.b58_encode().unwrap();
+        let data = wrapper.b58_encode();
 
         if data.len() >= B58_ADDRESS_LIMIT {
             return true;


### PR DESCRIPTION
previously the PrintableWrapper::b58_encode would return a result. This
was a hold over from when the protobuf crate was used to encode the
PrintableWrapper to a byte vector internally, which could fail. Now
PrintableWrapper::b58_encode is infallible and returns a String.
